### PR TITLE
daemon/logger/local: add support for extra attributes in "local" logger

### DIFF
--- a/daemon/logger/internal/logdriver/entry.pb.go
+++ b/daemon/logger/internal/logdriver/entry.pb.go
@@ -22,19 +22,72 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+type LogAttr struct {
+	Key   string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Value string `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+}
+
+func (m *LogAttr) Reset()         { *m = LogAttr{} }
+func (m *LogAttr) String() string { return proto.CompactTextString(m) }
+func (*LogAttr) ProtoMessage()    {}
+func (*LogAttr) Descriptor() ([]byte, []int) {
+	return fileDescriptor_daa6c5b6c627940f, []int{0}
+}
+func (m *LogAttr) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *LogAttr) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_LogAttr.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *LogAttr) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LogAttr.Merge(m, src)
+}
+func (m *LogAttr) XXX_Size() int {
+	return m.Size()
+}
+func (m *LogAttr) XXX_DiscardUnknown() {
+	xxx_messageInfo_LogAttr.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_LogAttr proto.InternalMessageInfo
+
+func (m *LogAttr) GetKey() string {
+	if m != nil {
+		return m.Key
+	}
+	return ""
+}
+
+func (m *LogAttr) GetValue() string {
+	if m != nil {
+		return m.Value
+	}
+	return ""
+}
+
 type LogEntry struct {
 	Source             string                   `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty"`
 	TimeNano           int64                    `protobuf:"varint,2,opt,name=time_nano,json=timeNano,proto3" json:"time_nano,omitempty"`
 	Line               []byte                   `protobuf:"bytes,3,opt,name=line,proto3" json:"line,omitempty"`
 	Partial            bool                     `protobuf:"varint,4,opt,name=partial,proto3" json:"partial,omitempty"`
 	PartialLogMetadata *PartialLogEntryMetadata `protobuf:"bytes,5,opt,name=partial_log_metadata,json=partialLogMetadata,proto3" json:"partial_log_metadata,omitempty"`
+	Attrs              []*LogAttr               `protobuf:"bytes,6,rep,name=attrs,proto3" json:"attrs,omitempty"`
 }
 
 func (m *LogEntry) Reset()         { *m = LogEntry{} }
 func (m *LogEntry) String() string { return proto.CompactTextString(m) }
 func (*LogEntry) ProtoMessage()    {}
 func (*LogEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_daa6c5b6c627940f, []int{0}
+	return fileDescriptor_daa6c5b6c627940f, []int{1}
 }
 func (m *LogEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -98,6 +151,13 @@ func (m *LogEntry) GetPartialLogMetadata() *PartialLogEntryMetadata {
 	return nil
 }
 
+func (m *LogEntry) GetAttrs() []*LogAttr {
+	if m != nil {
+		return m.Attrs
+	}
+	return nil
+}
+
 type PartialLogEntryMetadata struct {
 	Last    bool   `protobuf:"varint,1,opt,name=last,proto3" json:"last,omitempty"`
 	Id      string `protobuf:"bytes,2,opt,name=id,proto3" json:"id,omitempty"`
@@ -108,7 +168,7 @@ func (m *PartialLogEntryMetadata) Reset()         { *m = PartialLogEntryMetadata
 func (m *PartialLogEntryMetadata) String() string { return proto.CompactTextString(m) }
 func (*PartialLogEntryMetadata) ProtoMessage()    {}
 func (*PartialLogEntryMetadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_daa6c5b6c627940f, []int{1}
+	return fileDescriptor_daa6c5b6c627940f, []int{2}
 }
 func (m *PartialLogEntryMetadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -159,6 +219,7 @@ func (m *PartialLogEntryMetadata) GetOrdinal() int32 {
 }
 
 func init() {
+	proto.RegisterType((*LogAttr)(nil), "LogAttr")
 	proto.RegisterType((*LogEntry)(nil), "LogEntry")
 	proto.RegisterType((*PartialLogEntryMetadata)(nil), "PartialLogEntryMetadata")
 }
@@ -166,23 +227,63 @@ func init() {
 func init() { proto.RegisterFile("entry.proto", fileDescriptor_daa6c5b6c627940f) }
 
 var fileDescriptor_daa6c5b6c627940f = []byte{
-	// 250 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x90, 0xbd, 0x4a, 0x04, 0x31,
-	0x14, 0x85, 0xe7, 0xce, 0xfe, 0x38, 0x73, 0x57, 0x2c, 0x82, 0x68, 0x40, 0x08, 0x61, 0xab, 0x54,
-	0x5b, 0xe8, 0x1b, 0x08, 0x36, 0xa2, 0x22, 0x69, 0x2c, 0x87, 0xab, 0x13, 0x96, 0xc0, 0x6c, 0x32,
-	0x64, 0x63, 0xe1, 0x5b, 0xf8, 0x3a, 0xbe, 0x81, 0xe5, 0x96, 0x96, 0x32, 0xf3, 0x22, 0x32, 0x71,
-	0xc6, 0xce, 0xee, 0x9c, 0xf3, 0xa5, 0xf8, 0x72, 0x71, 0x65, 0x5c, 0x0c, 0x6f, 0x9b, 0x36, 0xf8,
-	0xe8, 0xd7, 0x1f, 0x80, 0xc5, 0x9d, 0xdf, 0xde, 0x0c, 0x13, 0x3b, 0xc3, 0xe5, 0xde, 0xbf, 0x86,
-	0x17, 0xc3, 0x41, 0x82, 0x2a, 0xf5, 0xd8, 0xd8, 0x05, 0x96, 0xd1, 0xee, 0x4c, 0xe5, 0xc8, 0x79,
-	0x9e, 0x4b, 0x50, 0x33, 0x5d, 0x0c, 0xc3, 0x03, 0x39, 0xcf, 0x18, 0xce, 0x1b, 0xeb, 0x0c, 0x9f,
-	0x49, 0x50, 0xc7, 0x3a, 0x65, 0xc6, 0xf1, 0xa8, 0xa5, 0x10, 0x2d, 0x35, 0x7c, 0x2e, 0x41, 0x15,
-	0x7a, 0xaa, 0xec, 0x16, 0x4f, 0xc7, 0x58, 0x35, 0x7e, 0x5b, 0xed, 0x4c, 0xa4, 0x9a, 0x22, 0xf1,
-	0x85, 0x04, 0xb5, 0xba, 0xe4, 0x9b, 0xc7, 0x5f, 0x38, 0x29, 0xdd, 0x8f, 0x5c, 0xb3, 0xf6, 0x0f,
-	0x4c, 0xdb, 0xfa, 0x09, 0xcf, 0xff, 0x79, 0x9e, 0xa4, 0x68, 0x1f, 0xd3, 0x3f, 0x0a, 0x9d, 0x32,
-	0x3b, 0xc1, 0xdc, 0xd6, 0x49, 0xbf, 0xd4, 0xb9, 0xad, 0x07, 0x49, 0x1f, 0x6a, 0xeb, 0xa8, 0x49,
-	0xee, 0x0b, 0x3d, 0xd5, 0x6b, 0xfe, 0xd9, 0x09, 0x38, 0x74, 0x02, 0xbe, 0x3b, 0x01, 0xef, 0xbd,
-	0xc8, 0x0e, 0xbd, 0xc8, 0xbe, 0x7a, 0x91, 0x3d, 0x2f, 0xd3, 0xd5, 0xae, 0x7e, 0x02, 0x00, 0x00,
-	0xff, 0xff, 0xbb, 0x82, 0x62, 0xd5, 0x44, 0x01, 0x00, 0x00,
+	// 293 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x91, 0x4d, 0x4b, 0xc3, 0x30,
+	0x18, 0xc7, 0x97, 0x75, 0xdd, 0xba, 0x67, 0x22, 0x12, 0x86, 0x06, 0x84, 0x50, 0x7a, 0xea, 0xa9,
+	0xe0, 0xfc, 0x04, 0x0a, 0x5e, 0x64, 0x8a, 0xe4, 0xe2, 0xb1, 0x44, 0x1b, 0x4a, 0xb0, 0x4b, 0x4a,
+	0x9a, 0x09, 0xfb, 0x16, 0x7e, 0x2c, 0x8f, 0x3b, 0xea, 0x4d, 0xda, 0x2f, 0x22, 0x4d, 0x53, 0x6f,
+	0xde, 0xfe, 0x2f, 0x3c, 0x0f, 0xcf, 0x2f, 0x81, 0x95, 0x50, 0xd6, 0x1c, 0xb2, 0xda, 0x68, 0xab,
+	0x93, 0x2b, 0x58, 0x6c, 0x75, 0x79, 0x63, 0xad, 0xc1, 0x67, 0x10, 0xbc, 0x89, 0x03, 0x41, 0x31,
+	0x4a, 0x97, 0xac, 0x97, 0x78, 0x0d, 0xe1, 0x3b, 0xaf, 0xf6, 0x82, 0x4c, 0x5d, 0x36, 0x98, 0xe4,
+	0x1b, 0x41, 0xb4, 0xd5, 0xe5, 0x5d, 0xbf, 0x05, 0x9f, 0xc3, 0xbc, 0xd1, 0x7b, 0xf3, 0x2a, 0xfc,
+	0x9c, 0x77, 0xf8, 0x12, 0x96, 0x56, 0xee, 0x44, 0xae, 0xb8, 0xd2, 0x6e, 0x3c, 0x60, 0x51, 0x1f,
+	0x3c, 0x72, 0xa5, 0x31, 0x86, 0x59, 0x25, 0x95, 0x20, 0x41, 0x8c, 0xd2, 0x13, 0xe6, 0x34, 0x26,
+	0xb0, 0xa8, 0xb9, 0xb1, 0x92, 0x57, 0x64, 0x16, 0xa3, 0x34, 0x62, 0xa3, 0xc5, 0xf7, 0xb0, 0xf6,
+	0x32, 0xaf, 0x74, 0x99, 0xef, 0x84, 0xe5, 0x05, 0xb7, 0x9c, 0x84, 0x31, 0x4a, 0x57, 0x1b, 0x92,
+	0x3d, 0x0d, 0xe5, 0x78, 0xd2, 0x83, 0xef, 0x19, 0xae, 0xff, 0x8a, 0x31, 0xc3, 0x14, 0x42, 0x6e,
+	0xad, 0x69, 0xc8, 0x3c, 0x0e, 0xd2, 0xd5, 0x26, 0xca, 0x3c, 0x3c, 0x1b, 0xe2, 0xe4, 0x19, 0x2e,
+	0xfe, 0x59, 0xe7, 0x8e, 0xe6, 0x8d, 0x75, 0x9c, 0x11, 0x73, 0x1a, 0x9f, 0xc2, 0x54, 0x16, 0xfe,
+	0x75, 0xa6, 0xb2, 0xe8, 0x21, 0xb4, 0x29, 0xa4, 0xe2, 0x95, 0x63, 0x0b, 0xd9, 0x68, 0x6f, 0xc9,
+	0x67, 0x4b, 0xd1, 0xb1, 0xa5, 0xe8, 0xa7, 0xa5, 0xe8, 0xa3, 0xa3, 0x93, 0x63, 0x47, 0x27, 0x5f,
+	0x1d, 0x9d, 0xbc, 0xcc, 0xdd, 0x47, 0x5c, 0xff, 0x06, 0x00, 0x00, 0xff, 0xff, 0xde, 0xf1, 0xc7,
+	0x73, 0x97, 0x01, 0x00, 0x00,
+}
+
+func (m *LogAttr) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *LogAttr) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *LogAttr) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Value) > 0 {
+		i -= len(m.Value)
+		copy(dAtA[i:], m.Value)
+		i = encodeVarintEntry(dAtA, i, uint64(len(m.Value)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Key) > 0 {
+		i -= len(m.Key)
+		copy(dAtA[i:], m.Key)
+		i = encodeVarintEntry(dAtA, i, uint64(len(m.Key)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *LogEntry) Marshal() (dAtA []byte, err error) {
@@ -205,6 +306,20 @@ func (m *LogEntry) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.Attrs) > 0 {
+		for iNdEx := len(m.Attrs) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Attrs[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintEntry(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x32
+		}
+	}
 	if m.PartialLogMetadata != nil {
 		{
 			size, err := m.PartialLogMetadata.MarshalToSizedBuffer(dAtA[:i])
@@ -305,6 +420,23 @@ func encodeVarintEntry(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+func (m *LogAttr) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Key)
+	if l > 0 {
+		n += 1 + l + sovEntry(uint64(l))
+	}
+	l = len(m.Value)
+	if l > 0 {
+		n += 1 + l + sovEntry(uint64(l))
+	}
+	return n
+}
+
 func (m *LogEntry) Size() (n int) {
 	if m == nil {
 		return 0
@@ -328,6 +460,12 @@ func (m *LogEntry) Size() (n int) {
 	if m.PartialLogMetadata != nil {
 		l = m.PartialLogMetadata.Size()
 		n += 1 + l + sovEntry(uint64(l))
+	}
+	if len(m.Attrs) > 0 {
+		for _, e := range m.Attrs {
+			l = e.Size()
+			n += 1 + l + sovEntry(uint64(l))
+		}
 	}
 	return n
 }
@@ -356,6 +494,120 @@ func sovEntry(x uint64) (n int) {
 }
 func sozEntry(x uint64) (n int) {
 	return sovEntry(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *LogAttr) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowEntry
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: LogAttr: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: LogAttr: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Key", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEntry
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthEntry
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthEntry
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Key = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Value", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEntry
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthEntry
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthEntry
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Value = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipEntry(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthEntry
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 func (m *LogEntry) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
@@ -524,6 +776,40 @@ func (m *LogEntry) Unmarshal(dAtA []byte) error {
 				m.PartialLogMetadata = &PartialLogEntryMetadata{}
 			}
 			if err := m.PartialLogMetadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Attrs", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEntry
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthEntry
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthEntry
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Attrs = append(m.Attrs, &LogAttr{})
+			if err := m.Attrs[len(m.Attrs)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/daemon/logger/internal/logdriver/entry.proto
+++ b/daemon/logger/internal/logdriver/entry.proto
@@ -1,11 +1,17 @@
 syntax = "proto3";
 
+message LogAttr {
+	string key = 1;
+	string value = 2;
+}
+
 message LogEntry {
 	string source = 1;
 	int64 time_nano = 2;
 	bytes line = 3;
 	bool partial = 4;
 	PartialLogEntryMetadata partial_log_metadata = 5;
+	repeated LogAttr attrs = 6;
 }
 
 message PartialLogEntryMetadata {
@@ -13,4 +19,3 @@ message PartialLogEntryMetadata {
 	string id = 2;
 	int32 ordinal = 3;
 }
-

--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -1,9 +1,11 @@
 package local
 
 import (
+	"cmp"
 	"encoding/binary"
 	"io"
 	"math/bits"
+	"slices"
 	"sync"
 	"time"
 
@@ -38,6 +40,13 @@ var LogOptKeys = map[string]bool{
 	"max-file": true,
 	"max-size": true,
 	"compress": true,
+
+	// Common attributes handled through [logger.Info.ExtraAttributes] and [loggerutils.ParseLogTag].
+	logger.AttrLabels:      true,
+	logger.AttrLabelsRegex: true,
+	logger.AttrEnv:         true,
+	logger.AttrEnvRegex:    true,
+	logger.AttrLogTag:      true,
 }
 
 // ValidateLogOpt looks for log driver specific options.
@@ -52,10 +61,11 @@ func ValidateLogOpt(cfg map[string]string) error {
 
 type driver struct {
 	logfile *loggerutils.LogFile
+	extra   []logdriver.LogAttr
 }
 
 // New creates a new local logger
-// You must provide the `LogPath` in the passed in info argument, this is the file path that logs are written to.
+// You must provide the `LogPath` in the passed-in info argument, this is the file path that logs are written to.
 func New(info logger.Info) (logger.Logger, error) {
 	if info.LogPath == "" {
 		return nil, errdefs.System(errors.New("log path is missing -- this is a bug and should not happen"))
@@ -65,21 +75,46 @@ func New(info logger.Info) (logger.Logger, error) {
 	if err != nil {
 		return nil, errdefs.InvalidParameter(err)
 	}
+	extraAttrs, err := info.ExtraAttributes(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if v, ok := info.Config[logger.AttrLogTag]; ok && v != "" {
+		// no default template. and only use a tag if the user asked for it.
+		if tag, err := loggerutils.ParseLogTag(info, ""); err != nil {
+			return nil, err
+		} else if tag != "" {
+			extraAttrs[logger.AttrLogTag] = tag
+		}
+	}
 
 	lf, err := loggerutils.NewLogFile(info.LogPath, cfg.MaxFileSize, cfg.MaxFileCount, !cfg.DisableCompression, decodeFunc, 0o640, getTailReader)
 	if err != nil {
 		return nil, err
 	}
 
+	attrs := make([]logdriver.LogAttr, 0, len(extraAttrs))
+	for k, v := range extraAttrs {
+		attrs = append(attrs, logdriver.LogAttr{Key: k, Value: v})
+	}
+	slices.SortFunc(attrs, func(a, b logdriver.LogAttr) int {
+		if c := cmp.Compare(a.Key, b.Key); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Value, b.Value)
+	})
+
 	return &driver{
 		logfile: lf,
+		extra:   attrs,
 	}, nil
 }
 
-func marshal(m *logger.Message, buffer *[]byte) error {
+func marshal(m *logger.Message, attrs []logdriver.LogAttr, buffer *[]byte) error {
 	var proto logdriver.LogEntry
 	var md logdriver.PartialLogEntryMetadata
-	messageToProto(m, &proto, &md)
+	messageToProto(m, attrs, &proto, &md)
 	protoSize := proto.Size()
 	writeLen := protoSize + (2 * encodeBinaryLen) // + len(messageDelimiter)
 
@@ -121,7 +156,7 @@ func (d *driver) Log(msg *logger.Message) (err error) {
 	buf := buffersPool.Get().(*[]byte)
 	defer buffersPool.Put(buf)
 
-	if err := marshal(msg, buf); err != nil {
+	if err := marshal(msg, d.extra, buf); err != nil {
 		return errors.Wrap(err, "error marshalling logger.Message")
 	}
 	return d.logfile.WriteLogEntry(msg.Timestamp, *buf)
@@ -131,7 +166,7 @@ func (d *driver) Close() error {
 	return d.logfile.Close()
 }
 
-func messageToProto(msg *logger.Message, proto *logdriver.LogEntry, partial *logdriver.PartialLogEntryMetadata) {
+func messageToProto(msg *logger.Message, extra []logdriver.LogAttr, proto *logdriver.LogEntry, partial *logdriver.PartialLogEntryMetadata) {
 	proto.Source = msg.Source
 	proto.TimeNano = msg.Timestamp.UnixNano()
 	proto.Line = append(proto.Line[:0], msg.Line...)
@@ -144,12 +179,30 @@ func messageToProto(msg *logger.Message, proto *logdriver.LogEntry, partial *log
 	} else {
 		proto.PartialLogMetadata = nil
 	}
+	if len(extra) > 0 {
+		proto.Attrs = make([]*logdriver.LogAttr, len(extra))
+		for i, a := range extra {
+			proto.Attrs[i] = &logdriver.LogAttr{
+				Key:   a.Key,
+				Value: a.Value,
+			}
+		}
+	}
 }
 
 func protoToMessage(proto *logdriver.LogEntry) *logger.Message {
 	msg := &logger.Message{
 		Source:    proto.Source,
 		Timestamp: time.Unix(0, proto.TimeNano).UTC(),
+	}
+	if len(proto.Attrs) > 0 {
+		msg.Attrs = make([]backend.LogAttr, len(proto.Attrs))
+		for i, a := range proto.Attrs {
+			msg.Attrs[i] = backend.LogAttr{
+				Key:   a.Key,
+				Value: a.Value,
+			}
+		}
 	}
 	if proto.Partial {
 		msg.PLogMetaData = &backend.PartialLogMetaData{
@@ -173,4 +226,5 @@ func resetProto(proto *logdriver.LogEntry) {
 		proto.PartialLogMetadata.Ordinal = 0
 	}
 	proto.PartialLogMetadata = nil
+	proto.Attrs = proto.Attrs[:0]
 }

--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -61,7 +61,11 @@ func ValidateLogOpt(cfg map[string]string) error {
 
 type driver struct {
 	logfile *loggerutils.LogFile
-	extra   []logdriver.LogAttr
+
+	// extra contains prebuilt log attributes attached to every log entry.
+	// The slice and its elements must be treated as immutable after initialization,
+	// as they may be shared by multiple marshaled log entries.
+	extra []*logdriver.LogAttr
 }
 
 // New creates a new local logger
@@ -94,11 +98,11 @@ func New(info logger.Info) (logger.Logger, error) {
 		return nil, err
 	}
 
-	attrs := make([]logdriver.LogAttr, 0, len(extraAttrs))
+	attrs := make([]*logdriver.LogAttr, 0, len(extraAttrs))
 	for k, v := range extraAttrs {
-		attrs = append(attrs, logdriver.LogAttr{Key: k, Value: v})
+		attrs = append(attrs, &logdriver.LogAttr{Key: k, Value: v})
 	}
-	slices.SortFunc(attrs, func(a, b logdriver.LogAttr) int {
+	slices.SortFunc(attrs, func(a, b *logdriver.LogAttr) int {
 		if c := cmp.Compare(a.Key, b.Key); c != 0 {
 			return c
 		}
@@ -111,7 +115,7 @@ func New(info logger.Info) (logger.Logger, error) {
 	}, nil
 }
 
-func marshal(m *logger.Message, attrs []logdriver.LogAttr, buffer *[]byte) error {
+func marshal(m *logger.Message, attrs []*logdriver.LogAttr, buffer *[]byte) error {
 	var proto logdriver.LogEntry
 	var md logdriver.PartialLogEntryMetadata
 	messageToProto(m, attrs, &proto, &md)
@@ -166,7 +170,7 @@ func (d *driver) Close() error {
 	return d.logfile.Close()
 }
 
-func messageToProto(msg *logger.Message, extra []logdriver.LogAttr, proto *logdriver.LogEntry, partial *logdriver.PartialLogEntryMetadata) {
+func messageToProto(msg *logger.Message, extra []*logdriver.LogAttr, proto *logdriver.LogEntry, partial *logdriver.PartialLogEntryMetadata) {
 	proto.Source = msg.Source
 	proto.TimeNano = msg.Timestamp.UnixNano()
 	proto.Line = append(proto.Line[:0], msg.Line...)
@@ -179,15 +183,7 @@ func messageToProto(msg *logger.Message, extra []logdriver.LogAttr, proto *logdr
 	} else {
 		proto.PartialLogMetadata = nil
 	}
-	if len(extra) > 0 {
-		proto.Attrs = make([]*logdriver.LogAttr, len(extra))
-		for i, a := range extra {
-			proto.Attrs[i] = &logdriver.LogAttr{
-				Key:   a.Key,
-				Value: a.Value,
-			}
-		}
-	}
+	proto.Attrs = extra
 }
 
 func protoToMessage(proto *logdriver.LogEntry) *logger.Message {

--- a/daemon/logger/local/local_test.go
+++ b/daemon/logger/local/local_test.go
@@ -25,7 +25,16 @@ func TestWriteLog(t *testing.T) {
 	tmpDir := t.TempDir()
 	logPath := filepath.Join(tmpDir, "test.log")
 
-	l, err := New(logger.Info{LogPath: logPath})
+	l, err := New(logger.Info{
+		LogPath: logPath,
+		Config: map[string]string{
+			logger.AttrLabels: "label1",
+			logger.AttrLogTag: "custom-tag",
+		},
+		ContainerLabels: map[string]string{
+			"label1": "value1",
+		},
+	})
 	assert.NilError(t, err)
 	t.Cleanup(func() { assert.NilError(t, l.Close()) })
 
@@ -60,7 +69,11 @@ func TestWriteLog(t *testing.T) {
 
 		var want logdriver.LogEntry
 		var partial logdriver.PartialLogEntryMetadata
-		messageToProto(&messages[i], &want, &partial)
+		extraAttrs := []logdriver.LogAttr{
+			{Key: "label1", Value: "value1"},
+			{Key: "tag", Value: "custom-tag"},
+		}
+		messageToProto(&messages[i], extraAttrs, &want, &partial)
 		assert.Check(t, is.DeepEqual(want, got), "msg %d: expected:\n%+v\ngot:\n%+v", i, want, got)
 
 		if i < len(messages)-1 {

--- a/daemon/logger/local/local_test.go
+++ b/daemon/logger/local/local_test.go
@@ -69,7 +69,7 @@ func TestWriteLog(t *testing.T) {
 
 		var want logdriver.LogEntry
 		var partial logdriver.PartialLogEntryMetadata
-		extraAttrs := []logdriver.LogAttr{
+		extraAttrs := []*logdriver.LogAttr{
 			{Key: "label1", Value: "value1"},
 			{Key: "tag", Value: "custom-tag"},
 		}

--- a/daemon/logger/local/read_test.go
+++ b/daemon/logger/local/read_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 
 	"github.com/moby/moby/v2/daemon/logger"
+	"github.com/moby/moby/v2/daemon/logger/internal/logdriver"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 // TestDecodeIncompleteRecord verifies that Decode returns io.EOF when the
@@ -17,7 +19,8 @@ import (
 func TestDecodeIncompleteRecord(t *testing.T) {
 	buf := make([]byte, 0)
 
-	err := marshal(&logger.Message{Line: []byte("hello")}, &buf)
+	extraAttrs := []logdriver.LogAttr{{Key: "a", Value: "b"}}
+	err := marshal(&logger.Message{Line: []byte("hello")}, extraAttrs, &buf)
 	assert.NilError(t, err)
 
 	tmpDir := t.TempDir()
@@ -50,7 +53,10 @@ func TestDecodeIncompleteRecord(t *testing.T) {
 
 			msg, err := d.Decode()
 			assert.NilError(t, err)
-			assert.Equal(t, string(msg.Line), "hello\n")
+			assert.Check(t, is.Equal(string(msg.Line), "hello\n"))
+			assert.Check(t, is.Len(msg.Attrs, 1))
+			assert.Check(t, is.Equal(msg.Attrs[0].Key, "a"))
+			assert.Check(t, is.Equal(msg.Attrs[0].Value, "b"))
 		})
 	}
 }

--- a/daemon/logger/local/read_test.go
+++ b/daemon/logger/local/read_test.go
@@ -19,7 +19,7 @@ import (
 func TestDecodeIncompleteRecord(t *testing.T) {
 	buf := make([]byte, 0)
 
-	extraAttrs := []logdriver.LogAttr{{Key: "a", Value: "b"}}
+	extraAttrs := []*logdriver.LogAttr{{Key: "a", Value: "b"}}
 	err := marshal(&logger.Message{Line: []byte("hello")}, extraAttrs, &buf)
 	assert.NilError(t, err)
 


### PR DESCRIPTION
depends on:

- [x] https://github.com/moby/moby/pull/52347
- [x] https://github.com/moby/moby/pull/52342
- [x] https://github.com/moby/moby/pull/52344


### add support for custom attributes with the "local" logger

add support for extra attributes in "local" logger

This brings feature-parity with the default json-file logging-driver;

Create a container with some attributes and set the corresponding
log-options;


```bash
docker run -d --name my-container \
    --env=HELLO=world \
    --label=labelA=foo \
    --label=labelB=bar \
    --label=com.docker.compose.project=my-project \
    --label=com.docker.compose.version=1.2.3 \
    --log-driver=local \
    --log-opt env=HELLO \
    --log-opt labels=labelA,labelB \
    --log-opt labels-regex=^com.docker.compose \
    --log-opt "tag={{.ID}}" \
    nginx:alpine
```
Check the logs with `--details`:

```bash
docker logs --details my-container
HELLO=world,com.docker.compose.project=my-project,com.docker.compose.version=1.2.3,labelA=foo,labelB=bar,tag=fff7a761077e /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
HELLO=world,com.docker.compose.project=my-project,com.docker.compose.version=1.2.3,labelA=foo,labelB=bar,tag=fff7a761077e /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
...
```


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
The `local` logging driver now has support for custom attributes, adding support for the `label`, `label-regex`, `env`, `env-regex`, and `tag` log options.
```

**- A picture of a cute animal (not mandatory but encouraged)**

