### PR TITLE
daemon: resolve symlinked device dir entries

### DIFF
--- a/daemon/pkg/oci/devices_linux.go
+++ b/daemon/pkg/oci/devices_linux.go
@@ -21,16 +21,19 @@ func deviceCgroup(d *specs.LinuxDevice, permissions string) specs.LinuxDeviceCgr
 	}
 }
 
-// DevicesFromPath computes a list of devices and device permissions from paths (pathOnHost and pathInContainer) and cgroup permissions.
-func DevicesFromPath(pathOnHost, pathInContainer, cgroupPermissions string) (devs []specs.LinuxDevice, devPermissions []specs.LinuxDeviceCgroup, _ error) {
-	resolvedPathOnHost := pathOnHost
-
-	// check if it is a symbolic link
-	if src, e := os.Lstat(pathOnHost); e == nil && src.Mode()&os.ModeSymlink == os.ModeSymlink {
-		if linkedPathOnHost, e := filepath.EvalSymlinks(pathOnHost); e == nil {
-			resolvedPathOnHost = linkedPathOnHost
+func resolvedDevicePath(path string) string {
+	if src, err := os.Lstat(path); err == nil && src.Mode()&os.ModeSymlink == os.ModeSymlink {
+		if linkedPathOnHost, err := filepath.EvalSymlinks(path); err == nil {
+			return linkedPathOnHost
 		}
 	}
+
+	return path
+}
+
+// DevicesFromPath computes a list of devices and device permissions from paths (pathOnHost and pathInContainer) and cgroup permissions.
+func DevicesFromPath(pathOnHost, pathInContainer, cgroupPermissions string) (devs []specs.LinuxDevice, devPermissions []specs.LinuxDeviceCgroup, _ error) {
+	resolvedPathOnHost := resolvedDevicePath(pathOnHost)
 
 	device, err := coci.DeviceFromPath(resolvedPathOnHost)
 	// if there was no error, return the device
@@ -47,7 +50,7 @@ func DevicesFromPath(pathOnHost, pathInContainer, cgroupPermissions string) (dev
 			// mount the internal devices recursively
 			// TODO check if additional errors should be handled or logged
 			_ = filepath.WalkDir(resolvedPathOnHost, func(dpath string, f os.DirEntry, _ error) error {
-				childDevice, e := coci.DeviceFromPath(dpath)
+				childDevice, e := coci.DeviceFromPath(resolvedDevicePath(dpath))
 				if e != nil {
 					// ignore the device
 					return nil

--- a/daemon/pkg/oci/devices_linux.go
+++ b/daemon/pkg/oci/devices_linux.go
@@ -31,29 +31,19 @@ func isDevicePath(path string) bool {
 }
 
 func resolvedDevicePath(path string) string {
-	// Normalise the path before any filesystem operation so that
-	// user-provided values with ".." components cannot traverse to
-	// unexpected locations.
 	path = filepath.Clean(path)
 	if !filepath.IsAbs(path) {
 		return path
 	}
-	src, err := os.Lstat(path)
-	if err != nil || src.Mode()&os.ModeSymlink != os.ModeSymlink {
-		return path
+	// EvalSymlinks resolves the full symlink chain without opening the file.
+	// We only use the result if it lands under /dev, which prevents
+	// user-controlled symlinks from redirecting to arbitrary host paths
+	// (e.g. /etc/passwd) while still supporting directories like
+	// /dev/disk/by-uuid whose entries are symlinks into /dev.
+	if resolved, err := filepath.EvalSymlinks(path); err == nil && isDevicePath(resolved) {
+		return resolved
 	}
-	linkedPath, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		return path
-	}
-	// Only follow symlinks whose target is a device node under /dev.
-	// This prevents user-controlled symlinks from redirecting to arbitrary
-	// host paths (e.g. /etc/passwd) while still supporting real device
-	// directories such as /dev/disk/by-uuid that contain symlinks into /dev.
-	if !isDevicePath(linkedPath) {
-		return path
-	}
-	return linkedPath
+	return path
 }
 
 // DevicesFromPath computes a list of devices and device permissions from paths (pathOnHost and pathInContainer) and cgroup permissions.

--- a/daemon/pkg/oci/devices_linux.go
+++ b/daemon/pkg/oci/devices_linux.go
@@ -22,13 +22,21 @@ func deviceCgroup(d *specs.LinuxDevice, permissions string) specs.LinuxDeviceCgr
 }
 
 func resolvedDevicePath(path string) string {
-	if src, err := os.Lstat(path); err == nil && src.Mode()&os.ModeSymlink == os.ModeSymlink {
-		if linkedPathOnHost, err := filepath.EvalSymlinks(path); err == nil {
-			return linkedPathOnHost
-		}
+	src, err := os.Lstat(path)
+	if err != nil || src.Mode()&os.ModeSymlink != os.ModeSymlink {
+		return path
 	}
-
-	return path
+	linkedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return path
+	}
+	// Verify the resolved path is a device node to prevent symlink-based
+	// path traversal to non-device files on the host.
+	dst, err := os.Stat(linkedPath)
+	if err != nil || dst.Mode()&(os.ModeDevice|os.ModeCharDevice) == 0 {
+		return path
+	}
+	return linkedPath
 }
 
 // DevicesFromPath computes a list of devices and device permissions from paths (pathOnHost and pathInContainer) and cgroup permissions.

--- a/daemon/pkg/oci/devices_linux.go
+++ b/daemon/pkg/oci/devices_linux.go
@@ -21,7 +21,23 @@ func deviceCgroup(d *specs.LinuxDevice, permissions string) specs.LinuxDeviceCgr
 	}
 }
 
+// devRoot is the canonical path for device files on Linux.
+const devRoot = "/dev"
+
+// isDevicePath reports whether the given (already-cleaned, absolute) path is
+// within the device filesystem root. Only paths under /dev are eligible for
+// symlink resolution to prevent path-traversal via user-controlled values.
+func isDevicePath(path string) bool {
+	return path == devRoot || strings.HasPrefix(path, devRoot+"/")
+}
+
 func resolvedDevicePath(path string) string {
+	// Clean and validate the path before any filesystem operation so that
+	// user-provided values cannot traverse outside the device root.
+	path = filepath.Clean(path)
+	if !isDevicePath(path) {
+		return path
+	}
 	src, err := os.Lstat(path)
 	if err != nil || src.Mode()&os.ModeSymlink != os.ModeSymlink {
 		return path
@@ -30,10 +46,9 @@ func resolvedDevicePath(path string) string {
 	if err != nil {
 		return path
 	}
-	// Verify the resolved path is a device node to prevent symlink-based
-	// path traversal to non-device files on the host.
-	dst, err := os.Stat(linkedPath)
-	if err != nil || dst.Mode()&(os.ModeDevice|os.ModeCharDevice) == 0 {
+	// Reject symlinks that resolve outside /dev to prevent traversal to
+	// arbitrary host paths.
+	if !isDevicePath(linkedPath) {
 		return path
 	}
 	return linkedPath

--- a/daemon/pkg/oci/devices_linux.go
+++ b/daemon/pkg/oci/devices_linux.go
@@ -25,17 +25,17 @@ func deviceCgroup(d *specs.LinuxDevice, permissions string) specs.LinuxDeviceCgr
 const devRoot = "/dev"
 
 // isDevicePath reports whether the given (already-cleaned, absolute) path is
-// within the device filesystem root. Only paths under /dev are eligible for
-// symlink resolution to prevent path-traversal via user-controlled values.
+// within the device filesystem root.
 func isDevicePath(path string) bool {
 	return path == devRoot || strings.HasPrefix(path, devRoot+"/")
 }
 
 func resolvedDevicePath(path string) string {
-	// Clean and validate the path before any filesystem operation so that
-	// user-provided values cannot traverse outside the device root.
+	// Normalise the path before any filesystem operation so that
+	// user-provided values with ".." components cannot traverse to
+	// unexpected locations.
 	path = filepath.Clean(path)
-	if !isDevicePath(path) {
+	if !filepath.IsAbs(path) {
 		return path
 	}
 	src, err := os.Lstat(path)
@@ -46,8 +46,10 @@ func resolvedDevicePath(path string) string {
 	if err != nil {
 		return path
 	}
-	// Reject symlinks that resolve outside /dev to prevent traversal to
-	// arbitrary host paths.
+	// Only follow symlinks whose target is a device node under /dev.
+	// This prevents user-controlled symlinks from redirecting to arbitrary
+	// host paths (e.g. /etc/passwd) while still supporting real device
+	// directories such as /dev/disk/by-uuid that contain symlinks into /dev.
 	if !isDevicePath(linkedPath) {
 		return path
 	}

--- a/daemon/pkg/oci/devices_linux_test.go
+++ b/daemon/pkg/oci/devices_linux_test.go
@@ -1,0 +1,37 @@
+package oci
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	coci "github.com/containerd/containerd/v2/pkg/oci"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestDevicesFromPathResolvesSymlinkedDevicesInDirectories(t *testing.T) {
+	tmpDir := t.TempDir()
+	deviceDir := filepath.Join(tmpDir, "by-uuid")
+	deviceLinkPath := filepath.Join(deviceDir, "linked-device")
+
+	expectedDevice, err := coci.DeviceFromPath("/dev/null")
+	assert.NilError(t, err)
+
+	assert.NilError(t, os.Mkdir(deviceDir, 0o755))
+	assert.NilError(t, os.Symlink("/dev/null", deviceLinkPath))
+
+	devs, permissions, err := DevicesFromPath(deviceDir, "/dev/disk/by-uuid", "rwm")
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(devs, 1))
+	assert.Check(t, is.Len(permissions, 1))
+
+	assert.Equal(t, devs[0].Path, "/dev/disk/by-uuid/linked-device")
+	assert.Equal(t, devs[0].Type, expectedDevice.Type)
+	assert.Equal(t, devs[0].Major, expectedDevice.Major)
+	assert.Equal(t, devs[0].Minor, expectedDevice.Minor)
+	assert.Equal(t, permissions[0].Access, "rwm")
+	assert.Equal(t, permissions[0].Type, expectedDevice.Type)
+	assert.Equal(t, *permissions[0].Major, expectedDevice.Major)
+	assert.Equal(t, *permissions[0].Minor, expectedDevice.Minor)
+}


### PR DESCRIPTION
## Summary
- resolve symlinked children when `DevicesFromPath` walks a directory passed through `--device`
- preserve the original in-container path while probing the resolved device node
- add regression coverage for `/dev/disk/by-uuid`-style symlink directories

## Testing
- `docker run --rm -v /Users/varunhotani/Desktop/moby:/src -w /src golang:1.26.1-bookworm sh -c '/usr/local/go/bin/go test ./daemon/pkg/oci'`

Closes #52341