### PR TITLE
api: align Topology swagger with Segments JSON shape

### DIFF
--- a/api/docs/v1.42.yaml
+++ b/api/docs/v1.42.yaml
@@ -6391,8 +6391,11 @@ definitions:
       details, see documentation for the Topology object in the CSI
       specification.
     type: "object"
-    additionalProperties:
-      type: "string"
+    properties:
+      Segments:
+        type: "object"
+        additionalProperties:
+          type: "string"
 
 paths:
   /containers/json:

--- a/api/docs/v1.43.yaml
+++ b/api/docs/v1.43.yaml
@@ -6424,8 +6424,11 @@ definitions:
       details, see documentation for the Topology object in the CSI
       specification.
     type: "object"
-    additionalProperties:
-      type: "string"
+    properties:
+      Segments:
+        type: "object"
+        additionalProperties:
+          type: "string"
 
 paths:
   /containers/json:

--- a/api/docs/v1.44.yaml
+++ b/api/docs/v1.44.yaml
@@ -6563,8 +6563,11 @@ definitions:
       details, see documentation for the Topology object in the CSI
       specification.
     type: "object"
-    additionalProperties:
-      type: "string"
+    properties:
+      Segments:
+        type: "object"
+        additionalProperties:
+          type: "string"
 
 paths:
   /containers/json:

--- a/api/docs/v1.45.yaml
+++ b/api/docs/v1.45.yaml
@@ -6549,8 +6549,11 @@ definitions:
       details, see documentation for the Topology object in the CSI
       specification.
     type: "object"
-    additionalProperties:
-      type: "string"
+    properties:
+      Segments:
+        type: "object"
+        additionalProperties:
+          type: "string"
 
 paths:
   /containers/json:

--- a/api/docs/v1.46.yaml
+++ b/api/docs/v1.46.yaml
@@ -6660,8 +6660,11 @@ definitions:
       details, see documentation for the Topology object in the CSI
       specification.
     type: "object"
-    additionalProperties:
-      type: "string"
+    properties:
+      Segments:
+        type: "object"
+        additionalProperties:
+          type: "string"
 
 paths:
   /containers/json:

--- a/api/docs/v1.47.yaml
+++ b/api/docs/v1.47.yaml
@@ -6682,8 +6682,11 @@ definitions:
       details, see documentation for the Topology object in the CSI
       specification.
     type: "object"
-    additionalProperties:
-      type: "string"
+    properties:
+      Segments:
+        type: "object"
+        additionalProperties:
+          type: "string"
 
   ImageManifestSummary:
     x-go-name: "ManifestSummary"

--- a/api/docs/v1.48.yaml
+++ b/api/docs/v1.48.yaml
@@ -7745,8 +7745,11 @@ definitions:
       details, see documentation for the Topology object in the CSI
       specification.
     type: "object"
-    additionalProperties:
-      type: "string"
+    properties:
+      Segments:
+        type: "object"
+        additionalProperties:
+          type: "string"
 
   ImageManifestSummary:
     x-go-name: "ManifestSummary"

--- a/api/docs/v1.49.yaml
+++ b/api/docs/v1.49.yaml
@@ -7745,8 +7745,11 @@ definitions:
       details, see documentation for the Topology object in the CSI
       specification.
     type: "object"
-    additionalProperties:
-      type: "string"
+    properties:
+      Segments:
+        type: "object"
+        additionalProperties:
+          type: "string"
 
   ImageManifestSummary:
     x-go-name: "ManifestSummary"

--- a/api/docs/v1.50.yaml
+++ b/api/docs/v1.50.yaml
@@ -7575,8 +7575,11 @@ definitions:
       details, see documentation for the Topology object in the CSI
       specification.
     type: "object"
-    additionalProperties:
-      type: "string"
+    properties:
+      Segments:
+        type: "object"
+        additionalProperties:
+          type: "string"
 
   ImageManifestSummary:
     x-go-name: "ManifestSummary"

--- a/api/docs/v1.51.yaml
+++ b/api/docs/v1.51.yaml
@@ -7596,8 +7596,11 @@ definitions:
       details, see documentation for the Topology object in the CSI
       specification.
     type: "object"
-    additionalProperties:
-      type: "string"
+    properties:
+      Segments:
+        type: "object"
+        additionalProperties:
+          type: "string"
 
   ImageManifestSummary:
     x-go-name: "ManifestSummary"

--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -7886,8 +7886,11 @@ definitions:
       details, see documentation for the Topology object in the CSI
       specification.
     type: "object"
-    additionalProperties:
-      type: "string"
+    properties:
+      Segments:
+        type: "object"
+        additionalProperties:
+          type: "string"
 
   ImageManifestSummary:
     x-go-name: "ManifestSummary"

--- a/api/docs/v1.53.yaml
+++ b/api/docs/v1.53.yaml
@@ -8134,8 +8134,11 @@ definitions:
       details, see documentation for the Topology object in the CSI
       specification.
     type: "object"
-    additionalProperties:
-      type: "string"
+    properties:
+      Segments:
+        type: "object"
+        additionalProperties:
+          type: "string"
 
   ImageManifestSummary:
     x-go-name: "ManifestSummary"

--- a/api/docs/v1.54.yaml
+++ b/api/docs/v1.54.yaml
@@ -8134,8 +8134,11 @@ definitions:
       details, see documentation for the Topology object in the CSI
       specification.
     type: "object"
-    additionalProperties:
-      type: "string"
+    properties:
+      Segments:
+        type: "object"
+        additionalProperties:
+          type: "string"
 
   ImageManifestSummary:
     x-go-name: "ManifestSummary"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8134,8 +8134,11 @@ definitions:
       details, see documentation for the Topology object in the CSI
       specification.
     type: "object"
-    additionalProperties:
-      type: "string"
+    properties:
+      Segments:
+        type: "object"
+        additionalProperties:
+          type: "string"
 
   ImageManifestSummary:
     x-go-name: "ManifestSummary"


### PR DESCRIPTION
- fix: https://github.com/moby/moby/issues/52355

Updated the OpenAPI/Swagger definition for Topology in api/swagger.yaml so it matches the JSON produced by the Go type in api/types/volume/cluster_volume.go (Topology with a Segments field of type map[string]string). Previously the spec described a flat object with string values at the top level, which did not match daemon output (for example under ClusterVolume.Info.AccessibleTopology) and broke clients generated from the spec.

- How I did it

Replaced the Topology schema’s root-level additionalProperties: string with an explicit properties.Segments object whose additionalProperties are strings. Existing $ref: "#/definitions/Topology usages (e.g. AccessibleTopology, accessibility requirements) now resolve to the correct shape without further edits.

- How to verify it

Inspect api/swagger.yaml → definitions → Topology: it should show a Segments property wrapping the map.
Compare with a real GET /volumes/{name} (or equivalent) response for a cluster volume with CSI topology: each topology entry should be an object with a Segments map, matching the updated schema.


- Human readable description for the release notes
 Fix Swagger definition for volume topology so it matches the `Segments` JSON field returned by the API.