### PR TITLE
Dockerfile: update containerd binary to v2.2.3, runhcs v0.14.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,11 +144,11 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # containerd
 FROM base AS containerd-src
 WORKDIR /usr/src/containerd
-# CONTAINERD_VERSION is used to build containerd binaries, and used for the
-# integration tests. The distributed docker .deb and .rpm packages depend on a
-# separate (containerd.io) package, which may be a different version as is
-# specified here.
-ARG CONTAINERD_VERSION=v2.2.2
+# CONTAINERD_VERSION is the version of containerd to use for CI and static binaries.
+# It is used to build containerd binaries, and used for the integration tests.
+# The distributed docker .deb and .rpm packages depend on a separate (containerd.io)
+# package, which may be a different version than specified here.
+ARG CONTAINERD_VERSION=v2.2.3
 ADD https://github.com/containerd/containerd.git?ref=${CONTAINERD_VERSION}&keep-git-dir=1 .
 
 FROM base AS containerd-build

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -169,9 +169,8 @@ ARG GOTESTSUM_VERSION=v1.13.0
 # GOWINRES_VERSION is the version of go-winres to install.
 ARG GOWINRES_VERSION=v0.3.3
 
-# TODO: Update containerd version to match Linux version once 
-# https://github.com/microsoft/hcsshim/issues/2488 is resolved.
-ARG CONTAINERD_VERSION=v2.0.7
+# CONTAINERD_VERSION is the version of containerd to use for CI.
+ARG CONTAINERD_VERSION=v2.2.3
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.


### PR DESCRIPTION
release notes: https://github.com/containerd/containerd/releases/tag/v2.2.3
full diff: https://github.com/containerd/containerd/compare/v2.2.2...v2.2.3

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Update containerd (static binaries only) to [v2.2.3](https://github.com/containerd/containerd/releases/tag/v2.2.3)
```

**- A picture of a cute animal (not mandatory but encouraged)**

