### PR TITLE
daemon/listeners: Support Unix socket on Windows

### DIFF
--- a/daemon/listeners/listeners_windows.go
+++ b/daemon/listeners/listeners_windows.go
@@ -14,6 +14,12 @@ import (
 func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) ([]net.Listener, error) {
 	ls := []net.Listener{}
 
+	// Windows allows a comma-separated list of groups and/or users to be set.
+	var additionalUsersAndGroups []string
+	if socketGroup != "" {
+		additionalUsersAndGroups = strings.Split(socketGroup, ",")
+	}
+
 	switch proto {
 	case "tcp":
 		l, err := sockets.NewTCPSocket(addr, tlsConfig)
@@ -23,11 +29,6 @@ func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) ([]net.Listene
 		ls = append(ls, l)
 
 	case "npipe":
-		// Windows allows a comma-separated list of groups and/or users to be set.
-		var additionalUsersAndGroups []string
-		if socketGroup != "" {
-			additionalUsersAndGroups = strings.Split(socketGroup, ",")
-		}
 		sddl, err := getSecurityDescriptor(additionalUsersAndGroups)
 		if err != nil {
 			return nil, err
@@ -43,8 +44,14 @@ func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) ([]net.Listene
 		}
 		ls = append(ls, l)
 
+	case "unix":
+		l, err := sockets.NewUnixSocket(addr, additionalUsersAndGroups)
+		if err != nil {
+			return nil, err
+		}
+		ls = append(ls, l)
 	default:
-		return nil, fmt.Errorf("invalid protocol format: windows only supports tcp and npipe")
+		return nil, fmt.Errorf("invalid protocol format: windows only supports tcp, unix and npipe")
 	}
 
 	return ls, nil


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/36442

Allow the daemon on Windows to listen on a UNIX socket.

## Testing on a Windows machine

### `dockerd -H unix://C:/docker.sock`

By default, the socket is only accessible by administrator:

```powershell
PS> icacls C:\docker.sock
C:\docker.sock BUILTIN\Administrators:(F)
               NT AUTHORITY\SYSTEM:(F)
               Mandatory Label\High Mandatory Level:(I)(NW)
```


### `dockerd -H unix://C:/docker.sock --group docker-users`

If you pass an extra group, the socket gets the group:

```powershell
PS> icacls C:\docker.sock
C:\docker.sock BUILTIN\Administrators:(F)
               NT AUTHORITY\SYSTEM:(F)
               dockwin\docker-users:(R,W)
               Mandatory Label\High Mandatory Level:(I)(NW)
```

...but actually the user cannot connect (even though it's added to the `docker-users` group).


**Note:** This can be worked around by lowering the integrity level to medium (`icacls C:\docker.sock /setintegritylevel medium` ).
Perhaps we should consider that for the socket when `--group` is passed? 🤔 

### `dockerd -H unix://C:/Users/Paweł/docker.sock --group docker-users`

```powershell
PS> icacls C:/Users/Paweł/docker.sock 
C:/Users/Paweł/docker.sock BUILTIN\Administrators:(F)
               NT AUTHORITY\SYSTEM:(F)
               dockwin\docker-users:(R,W)
```

now this one works, because the socket was created in the user path (not root `C:\`).


```markdown changelog
Windows: The daemon now supports listening on a Unix socket (`-H unix://...`), with optional group-based access control via `--group`.
```
