### PR TITLE
Change default log driver to `local`

### DIFF
--- a/daemon/command/daemon_unix_test.go
+++ b/daemon/command/daemon_unix_test.go
@@ -27,7 +27,7 @@ func TestLoadDaemonCliConfigWithDaemonFlags(t *testing.T) {
 	assert.Check(t, loadedConfig.Debug)
 	assert.Check(t, is.Equal("info", loadedConfig.DaemonLogConfig.LogLevel))
 	assert.Check(t, loadedConfig.EnableSelinuxSupport)
-	assert.Check(t, is.Equal("json-file", loadedConfig.LogConfig.Type))
+	assert.Check(t, is.Equal("local", loadedConfig.LogConfig.Type))
 	assert.Check(t, is.Equal("1k", loadedConfig.LogConfig.Config["max-size"]))
 }
 

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -45,7 +45,7 @@ const (
 	// DisableNetworkBridge is the default value of the option to disable network bridge
 	DisableNetworkBridge = "none"
 	// DefaultLogDriver is the default log-driver.
-	DefaultLogDriver = "json-file"
+	DefaultLogDriver = "local"
 	// DefaultShutdownTimeout is the default shutdown timeout (in seconds) for
 	// the daemon for containers to stop when it is shutting down.
 	DefaultShutdownTimeout = 15

--- a/daemon/config/config_linux_test.go
+++ b/daemon/config/config_linux_test.go
@@ -77,7 +77,7 @@ func TestDaemonConfigurationMerge(t *testing.T) {
 	flags.BoolVarP(&conf.Debug, "debug", "D", false, "")
 	flags.BoolVarP(&conf.AutoRestart, "restart", "r", true, "")
 	flags.Var(opts.NewNamedUlimitOpt("default-ulimits", &conf.Ulimits), "default-ulimit", "")
-	flags.StringVar(&conf.LogConfig.Type, "log-driver", "json-file", "")
+	flags.StringVar(&conf.LogConfig.Type, "log-driver", "local", "")
 	flags.Var(opts.NewNamedMapOpts("log-opts", conf.LogConfig.Config, nil), "log-opt", "")
 	assert.Check(t, flags.Set("restart", "true"))
 	assert.Check(t, flags.Set("log-driver", "syslog"))

--- a/daemon/config/config_windows_test.go
+++ b/daemon/config/config_windows_test.go
@@ -21,7 +21,7 @@ func TestDaemonConfigurationMerge(t *testing.T) {
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	flags.BoolVarP(&conf.Debug, "debug", "D", false, "")
 	flags.BoolVarP(&conf.AutoRestart, "restart", "r", true, "")
-	flags.StringVar(&conf.LogConfig.Type, "log-driver", "json-file", "")
+	flags.StringVar(&conf.LogConfig.Type, "log-driver", "local", "")
 	flags.Var(opts.NewNamedMapOpts("log-opts", conf.LogConfig.Config, nil), "log-opt", "")
 	assert.Check(t, flags.Set("restart", "true"))
 	assert.Check(t, flags.Set("log-driver", "syslog"))

--- a/daemon/logs_test.go
+++ b/daemon/logs_test.go
@@ -4,12 +4,20 @@ import (
 	"testing"
 
 	containertypes "github.com/moby/moby/api/types/container"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestMergeAndVerifyLogConfigNilConfig(t *testing.T) {
-	d := &Daemon{defaultLogConfig: containertypes.LogConfig{Type: "json-file", Config: map[string]string{"max-file": "1"}}}
+	d := &Daemon{defaultLogConfig: containertypes.LogConfig{Type: "local", Config: map[string]string{"max-file": "1"}}}
 	cfg := containertypes.LogConfig{Type: d.defaultLogConfig.Type}
-	if err := d.mergeAndVerifyLogConfig(&cfg); err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, d.mergeAndVerifyLogConfig(&cfg))
+}
+
+func TestMergeAndVerifyLogConfigUsesDefaultDriver(t *testing.T) {
+	d := &Daemon{defaultLogConfig: containertypes.LogConfig{Type: "local"}}
+	cfg := containertypes.LogConfig{}
+
+	assert.NilError(t, d.mergeAndVerifyLogConfig(&cfg))
+	assert.Check(t, is.Equal(cfg.Type, "local"))
 }

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -461,37 +461,16 @@ func (s *DockerDaemonSuite) TestDaemonLoggingDriverDefault(c *testing.T) {
 
 	out, err := s.d.Cmd("run", "--name=test", "busybox", "echo", "testline")
 	assert.NilError(c, err, out)
-	id, err := s.d.GetIDByName("test")
-	assert.NilError(c, err)
 
-	logPath := filepath.Join(s.d.Root, "containers", id, id+"-json.log")
+	// The default log driver is "local". Verify the log output is readable via
+	// "docker logs" and that the log driver type is correctly reported.
+	out, err = s.d.Cmd("logs", "test")
+	assert.NilError(c, err, out)
+	assert.Equal(c, strings.TrimSpace(out), "testline")
 
-	if _, err := os.Stat(logPath); err != nil {
-		c.Fatal(err)
-	}
-	f, err := os.Open(logPath)
-	if err != nil {
-		c.Fatal(err)
-	}
-	defer f.Close()
-
-	var res struct {
-		Log    string    `json:"log"`
-		Stream string    `json:"stream"`
-		Time   time.Time `json:"time"`
-	}
-	if err := json.NewDecoder(f).Decode(&res); err != nil {
-		c.Fatal(err)
-	}
-	if res.Log != "testline\n" {
-		c.Fatalf("Unexpected log line: %q, expected: %q", res.Log, "testline\n")
-	}
-	if res.Stream != "stdout" {
-		c.Fatalf("Unexpected stream: %q, expected: %q", res.Stream, "stdout")
-	}
-	if !time.Now().After(res.Time) {
-		c.Fatalf("Log time %v in future", res.Time)
-	}
+	out, err = s.d.Cmd("inspect", "-f", "{{ .HostConfig.LogConfig.Type }}", "test")
+	assert.NilError(c, err, out)
+	assert.Equal(c, strings.TrimSpace(out), "local")
 }
 
 func (s *DockerDaemonSuite) TestDaemonLoggingDriverDefaultOverride(c *testing.T) {
@@ -504,10 +483,11 @@ func (s *DockerDaemonSuite) TestDaemonLoggingDriverDefaultOverride(c *testing.T)
 	id, err := s.d.GetIDByName("test")
 	assert.NilError(c, err)
 
-	logPath := filepath.Join(s.d.Root, "containers", id, id+"-json.log")
-
+	// The default driver is "local"; verify overriding it with "none" means no
+	// log file is written at the local driver's path.
+	logPath := filepath.Join(s.d.Root, "containers", id, "local-logs", "container.log")
 	if _, err := os.Stat(logPath); err == nil || !os.IsNotExist(err) {
-		c.Fatalf("%s shouldn't exits, error on Stat: %s", logPath, err)
+		c.Fatalf("%s shouldn't exist, error on Stat: %s", logPath, err)
 	}
 }
 
@@ -521,10 +501,14 @@ func (s *DockerDaemonSuite) TestDaemonLoggingDriverNone(c *testing.T) {
 	id, err := s.d.GetIDByName("test")
 	assert.NilError(c, err)
 
-	logPath := filepath.Join(s.d.Root, "containers", id, id+"-json.log")
-
-	if _, err := os.Stat(logPath); err == nil || !os.IsNotExist(err) {
-		c.Fatalf("%s shouldn't exits, error on Stat: %s", logPath, err)
+	// Neither the json-file nor the local driver log paths should be written.
+	for _, logPath := range []string{
+		filepath.Join(s.d.Root, "containers", id, id+"-json.log"),
+		filepath.Join(s.d.Root, "containers", id, "local-logs", "container.log"),
+	} {
+		if _, err := os.Stat(logPath); err == nil || !os.IsNotExist(err) {
+			c.Fatalf("%s shouldn't exist, error on Stat: %s", logPath, err)
+		}
 	}
 }
 

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -900,7 +900,7 @@ func (s *DockerDaemonSuite) TestDaemonWideLogConfig(c *testing.T) {
 
 	out, err = s.d.Cmd("inspect", "-f", "{{ .HostConfig.LogConfig.Type }}", name)
 	assert.NilError(c, err, "Output: %s", out)
-	assert.Equal(c, strings.TrimSpace(out), "json-file")
+	assert.Equal(c, strings.TrimSpace(out), "local")
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartWithPausedContainer(c *testing.T) {

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -266,7 +266,7 @@ func (s *DockerCLIInspectSuite) TestInspectLogConfigNoType(c *testing.T) {
 	err := json.NewDecoder(strings.NewReader(out)).Decode(&logConfig)
 	assert.Assert(c, err == nil, "%v", out)
 
-	assert.Equal(c, logConfig.Type, "json-file")
+	assert.Equal(c, logConfig.Type, "local")
 	assert.Equal(c, logConfig.Config["max-file"], "42", fmt.Sprintf("%v", logConfig))
 }
 

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -336,9 +336,9 @@ unix://[/path/to/socket] to use.
   are not restarted. This option is applicable only for docker daemon running
   on Linux host.
 
-**--log-driver**="**json-file**|**syslog**|**journald**|**gelf**|**fluentd**|**awslogs**|**splunk**|**etwlogs**|**gcplogs**|**none**"
-  Default driver for container logs. Default is **json-file**.
-  **Warning**: **docker logs** command works only for **json-file** logging driver.
+**--log-driver**="**local**|**json-file**|**syslog**|**journald**|**gelf**|**fluentd**|**awslogs**|**splunk**|**etwlogs**|**gcplogs**|**none**"
+  Default driver for container logs. Default is **local**.
+  **Warning**: **docker logs** command works only for logging drivers that implement log reading, such as **local**, **json-file**, and **journald**.
 
 **--log-format**="*text*|*json*"
   Set the format for logs produced by the daemon. Default is "text".


### PR DESCRIPTION
- needs: https://github.com/moby/moby/pull/52348
- closes: https://github.com/docker/container-platform-work/issues/301

Switch the daemon's default container log driver from `json-file` to `local` when no log-driver is configured.

The `local` driver is a better default for most installations because it keeps docker logs support while using a more space-efficient on-disk format and reducing the risk of unbounded log growth filling the disk.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

