### PR TITLE
Retry logging if the ringLogger's wrapped logger fails

### DIFF
--- a/daemon/container/container.go
+++ b/daemon/container/container.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -488,13 +489,20 @@ func (container *Container) StartLogger() (logger.Logger, error) {
 
 	if containertypes.LogMode(cfg.Config["mode"]) == containertypes.LogModeNonBlock {
 		bufferSize := int64(-1)
+		maxRetries := int64(0)
 		if s, exists := cfg.Config["max-buffer-size"]; exists {
 			bufferSize, err = units.RAMInBytes(s)
 			if err != nil {
 				return nil, err
 			}
 		}
-		l = logger.NewRingLogger(l, info, bufferSize)
+		if s, exists := cfg.Config["max-non-blocking-retries"]; exists {
+			maxRetries, err = strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+		}
+		l = logger.NewRingLogger(l, info, bufferSize, maxRetries)
 	}
 
 	if _, ok := l.(logger.LogReader); !ok {

--- a/daemon/logger/copier_test.go
+++ b/daemon/logger/copier_test.go
@@ -228,7 +228,7 @@ func TestCopierWithSized(t *testing.T) {
 	})
 	t.Run("With RingLogger", func(t *testing.T) {
 		testCopierWithSized(t, func(l SizedLogger) SizedLogger {
-			return newRingLogger(l, Info{}, defaultRingMaxSize)
+			return newRingLogger(l, Info{}, defaultRingMaxSize, -1)
 		})
 	})
 }

--- a/daemon/logger/factory.go
+++ b/daemon/logger/factory.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"sync"
 
 	"github.com/docker/go-units"
@@ -148,6 +149,15 @@ func ValidateLogOpts(name string, cfg map[string]string) error {
 		}
 		if _, err := units.RAMInBytes(s); err != nil {
 			return errors.Wrap(err, "error parsing option max-buffer-size")
+		}
+	}
+
+	if s, ok := cfg["max-non-blocking-retries"]; ok {
+		if containertypes.LogMode(cfg["mode"]) != containertypes.LogModeNonBlock {
+			return fmt.Errorf("logger: max-non-blocking-retries option is only supported with 'mode=%s'", containertypes.LogModeNonBlock)
+		}
+		if _, err := strconv.ParseInt(s, 10, 64); err != nil {
+			return errors.Wrap(err, "error parsing option max-non-blocking-retries")
 		}
 	}
 

--- a/daemon/logger/loggerutils/cache/local_cache.go
+++ b/daemon/logger/loggerutils/cache/local_cache.go
@@ -41,13 +41,20 @@ func WithLocalCache(l logger.Logger, info logger.Info) (logger.Logger, error) {
 
 	if container.LogMode(info.Config["mode"]) == container.LogModeUnset || container.LogMode(info.Config["mode"]) == container.LogModeNonBlock {
 		var size int64 = -1
+		var maxRetries int64
 		if s, exists := info.Config["max-buffer-size"]; exists {
 			size, err = units.RAMInBytes(s)
 			if err != nil {
 				return nil, err
 			}
 		}
-		cacher = logger.NewRingLogger(cacher, info, size)
+		if s, exists := info.Config["max-non-blocking-retries"]; exists {
+			maxRetries, err = strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+		}
+		cacher = logger.NewRingLogger(cacher, info, size, maxRetries)
 	}
 
 	return &loggerWithCache{

--- a/daemon/logger/ring.go
+++ b/daemon/logger/ring.go
@@ -12,13 +12,14 @@ const (
 )
 
 // ringLogger is a ring buffer that implements the Logger interface.
-// This is used when lossy logging is OK.
+// maxRetries tunes how many retries are made if the inner logger fails (negative value causes infinite retries).
 type ringLogger struct {
-	buffer    *messageRing
-	l         Logger
-	logInfo   Info
-	closeFlag atomic.Bool
-	wg        sync.WaitGroup
+	buffer     *messageRing
+	l          Logger
+	logInfo    Info
+	closeFlag  atomic.Bool
+	maxRetries int64
+	wg         sync.WaitGroup
 }
 
 var (
@@ -39,11 +40,12 @@ func (r *ringWithReader) ReadLogs(ctx context.Context, cfg ReadConfig) *LogWatch
 	return reader.ReadLogs(ctx, cfg)
 }
 
-func newRingLogger(driver Logger, logInfo Info, maxSize int64) *ringLogger {
+func newRingLogger(driver Logger, logInfo Info, maxSize int64, maxRetries int64) *ringLogger {
 	l := &ringLogger{
-		buffer:  newRing(maxSize),
-		l:       driver,
-		logInfo: logInfo,
+		buffer:     newRing(maxSize),
+		l:          driver,
+		logInfo:    logInfo,
+		maxRetries: maxRetries,
 	}
 	l.wg.Go(l.run)
 	return l
@@ -51,11 +53,11 @@ func newRingLogger(driver Logger, logInfo Info, maxSize int64) *ringLogger {
 
 // NewRingLogger creates a new Logger that is implemented as a RingBuffer wrapping
 // the passed in logger.
-func NewRingLogger(driver Logger, logInfo Info, maxSize int64) Logger {
+func NewRingLogger(driver Logger, logInfo Info, maxSize int64, maxRetries int64) Logger {
 	if maxSize < 0 {
 		maxSize = defaultRingMaxSize
 	}
-	l := newRingLogger(driver, logInfo, maxSize)
+	l := newRingLogger(driver, logInfo, maxSize, maxRetries)
 	if _, ok := driver.(LogReader); ok {
 		return &ringWithReader{l}
 	}
@@ -116,7 +118,7 @@ func (r *ringLogger) Close() error {
 	return r.l.Close()
 }
 
-// run consumes messages from the ring buffer and forwards them to the underling
+// run consumes messages from the ring buffer and forwards them to the underlying
 // logger.
 // This is run in a goroutine when the ringLogger is created
 func (r *ringLogger) run() {
@@ -129,9 +131,16 @@ func (r *ringLogger) run() {
 			// buffer is closed
 			return
 		}
-		if err := r.l.Log(msg); err != nil {
+		retries := int64(0)
+		for {
+			if err = r.l.Log(msg); err == nil {
+				break
+			}
 			logDriverError(r.l.Name(), string(msg.Line), err)
-			PutMessage(msg)
+			if r.maxRetries >= 0 && retries >= r.maxRetries {
+				break
+			}
+			retries++
 		}
 	}
 }

--- a/daemon/logger/ring_test.go
+++ b/daemon/logger/ring_test.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"context"
 	"errors"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -14,18 +15,42 @@ func (l *mockLogger) Log(msg *Message) error {
 	l.c <- msg
 	return nil
 }
-
 func (l *mockLogger) Name() string {
 	return "mock"
 }
-
 func (l *mockLogger) Close() error {
+	close(l.c)
+	return nil
+}
+
+type fallibleLogger struct {
+	c chan *Message
+	// Return these errors (or nils) for each Log call. Returns `nil` continuously once empty.
+	errs []error
+}
+
+func (l *fallibleLogger) Log(msg *Message) error {
+	var err error
+	if len(l.errs) > 0 {
+		err, l.errs = l.errs[0], l.errs[1:]
+	}
+	if err == nil {
+		// Only actually record the message if we didn't get an error ("oh no, the TCP stream broke and we couldn't get the message out")
+		l.c <- msg
+	}
+	return err
+}
+func (l *fallibleLogger) Name() string {
+	return "fallible"
+}
+func (l *fallibleLogger) Close() error {
+	close(l.c)
 	return nil
 }
 
 func TestRingLogger(t *testing.T) {
 	mockLog := &mockLogger{make(chan *Message)} // no buffer on this channel
-	ring := newRingLogger(mockLog, Info{}, 1)
+	ring := newRingLogger(mockLog, Info{}, 1, -1)
 	defer ring.Close()
 
 	// this should never block
@@ -145,6 +170,73 @@ func TestRingDrain(t *testing.T) {
 	}
 }
 
+func TestRingRetries(t *testing.T) {
+	sentMessages := []*Message{
+		{Line: []byte("a")},
+		{Line: []byte("lost")},
+		{Line: []byte("b")},
+	}
+	errs := []error{
+		// Message "a" is fine.
+		nil,
+		// Message "lost" has two consecutive errors so is dropped.
+		errors.New("error #1 for 'lost'"),
+		errors.New("error #2 for 'lost'"),
+		// Message "b" has one error then succeeds.
+		errors.New("error #1 for 'b'"),
+	}
+	expectedMessages := []*Message{
+		{Line: []byte("a")},
+		{Line: []byte("b")},
+	}
+
+	logger := &fallibleLogger{make(chan *Message), errs}
+	// Retry one time per message.
+	ring := NewRingLogger(logger, Info{}, -1, 1)
+
+	for _, msg := range sentMessages {
+		ring.Log(msg)
+	}
+
+	received := []*Message{}
+	for {
+		msg, ok := <-logger.c
+		if !ok {
+			break
+		}
+		received = append(received, msg)
+		if len(received) == len(expectedMessages) {
+			ring.Close()
+		}
+	}
+	if len(expectedMessages) != len(received) {
+		t.Fatalf("received wrong number of messages from ringbuffer: snt %v, received %v", expectedMessages, received)
+	}
+	for i := range len(expectedMessages) {
+		if !slices.Equal(expectedMessages[i].Line, received[i].Line) {
+			t.Fatalf("mismatched message order at index %v: sent %v, received %v", i, expectedMessages, received)
+		}
+	}
+}
+
+func TestRingIndefiniteRetries(t *testing.T) {
+	errs := []error{}
+	for range 100 {
+		errs = append(errs, errors.New("oh no"))
+	}
+	errs = append(errs, nil)
+	logger := &fallibleLogger{make(chan *Message), errs}
+	// Negative maxRetries should cause indefinite retries.
+	ring := NewRingLogger(logger, Info{}, -1, -1)
+	defer ring.Close()
+
+	ring.Log(&Message{Line: []byte("a")})
+	_, ok := <-logger.c
+	if !ok {
+		t.Fatal("logger unexpectedly closed")
+	}
+}
+
 type nopLogger struct{}
 
 func (nopLogger) Name() string       { return "nopLogger" }
@@ -154,7 +246,7 @@ func (nopLogger) Log(*Message) error { return nil }
 func BenchmarkRingLoggerThroughputNoReceiver(b *testing.B) {
 	mockLog := &mockLogger{make(chan *Message)}
 	defer mockLog.Close()
-	l := NewRingLogger(mockLog, Info{}, -1)
+	l := NewRingLogger(mockLog, Info{}, -1, 0)
 	msg := &Message{Line: []byte("hello humans and everyone else!")}
 	b.SetBytes(int64(len(msg.Line)))
 
@@ -166,7 +258,7 @@ func BenchmarkRingLoggerThroughputNoReceiver(b *testing.B) {
 }
 
 func BenchmarkRingLoggerThroughputWithReceiverDelay0(b *testing.B) {
-	l := NewRingLogger(nopLogger{}, Info{}, -1)
+	l := NewRingLogger(nopLogger{}, Info{}, -1, 0)
 	msg := &Message{Line: []byte("hello humans and everyone else!")}
 	b.SetBytes(int64(len(msg.Line)))
 
@@ -199,7 +291,7 @@ func consumeWithDelay(delay time.Duration, c <-chan *Message) (cancel func()) {
 func BenchmarkRingLoggerThroughputConsumeDelay1(b *testing.B) {
 	mockLog := &mockLogger{make(chan *Message)}
 	defer mockLog.Close()
-	l := NewRingLogger(mockLog, Info{}, -1)
+	l := NewRingLogger(mockLog, Info{}, -1, 0)
 	msg := &Message{Line: []byte("hello humans and everyone else!")}
 	b.SetBytes(int64(len(msg.Line)))
 
@@ -216,7 +308,7 @@ func BenchmarkRingLoggerThroughputConsumeDelay1(b *testing.B) {
 func BenchmarkRingLoggerThroughputConsumeDelay10(b *testing.B) {
 	mockLog := &mockLogger{make(chan *Message)}
 	defer mockLog.Close()
-	l := NewRingLogger(mockLog, Info{}, -1)
+	l := NewRingLogger(mockLog, Info{}, -1, 0)
 	msg := &Message{Line: []byte("hello humans and everyone else!")}
 	b.SetBytes(int64(len(msg.Line)))
 
@@ -233,7 +325,7 @@ func BenchmarkRingLoggerThroughputConsumeDelay10(b *testing.B) {
 func BenchmarkRingLoggerThroughputConsumeDelay50(b *testing.B) {
 	mockLog := &mockLogger{make(chan *Message)}
 	defer mockLog.Close()
-	l := NewRingLogger(mockLog, Info{}, -1)
+	l := NewRingLogger(mockLog, Info{}, -1, 0)
 	msg := &Message{Line: []byte("hello humans and everyone else!")}
 	b.SetBytes(int64(len(msg.Line)))
 
@@ -250,7 +342,7 @@ func BenchmarkRingLoggerThroughputConsumeDelay50(b *testing.B) {
 func BenchmarkRingLoggerThroughputConsumeDelay100(b *testing.B) {
 	mockLog := &mockLogger{make(chan *Message)}
 	defer mockLog.Close()
-	l := NewRingLogger(mockLog, Info{}, -1)
+	l := NewRingLogger(mockLog, Info{}, -1, 0)
 	msg := &Message{Line: []byte("hello humans and everyone else!")}
 	b.SetBytes(int64(len(msg.Line)))
 
@@ -267,7 +359,7 @@ func BenchmarkRingLoggerThroughputConsumeDelay100(b *testing.B) {
 func BenchmarkRingLoggerThroughputConsumeDelay300(b *testing.B) {
 	mockLog := &mockLogger{make(chan *Message)}
 	defer mockLog.Close()
-	l := NewRingLogger(mockLog, Info{}, -1)
+	l := NewRingLogger(mockLog, Info{}, -1, 0)
 	msg := &Message{Line: []byte("hello humans and everyone else!")}
 	b.SetBytes(int64(len(msg.Line)))
 
@@ -284,7 +376,7 @@ func BenchmarkRingLoggerThroughputConsumeDelay300(b *testing.B) {
 func BenchmarkRingLoggerThroughputConsumeDelay500(b *testing.B) {
 	mockLog := &mockLogger{make(chan *Message)}
 	defer mockLog.Close()
-	l := NewRingLogger(mockLog, Info{}, -1)
+	l := NewRingLogger(mockLog, Info{}, -1, 0)
 	msg := &Message{Line: []byte("hello humans and everyone else!")}
 	b.SetBytes(int64(len(msg.Line)))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes #52390: make the `ringLogger` impl retry logging, rather than dropping logs after the first failure: see related issue for full writeup of problem.

I've not included a flag to configure this, since as argued in #52390, I think the new semantics are strictly better than the old ones. However, there are some side effects in niche cases:
- memory usage is more likely to increase during logging failures, since the buffer will actually be used in more cases. Any systems affected by the increased memory usage were already vulnerable to it (e.g. if the inner logger started succeeding slowly, filling the buffer), but in practice this might cause some unexpected memory usage.
- any users relying on the buffer draining quickly from the front, during outages that didn't completely fill the buffer, might be affected? But it's hard to say they "depended" on it, since the conditions are very specific.

https://xkcd.com/1172 ¯\\\_(ツ)_/¯

**- How I did it**

loop :)

**- How to verify it**

Regression test included.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
When logging drivers are configured in `non-blocking` mode, retry writing logs from the buffer to the log driver indefinitely, instead of dropping them after the first failed write. This brings the implementation closer to the description in the documentation, and trades off log availability for RAM usage (controlled by the existing `max-buffer-size` option).
```

**- A picture of a cute animal (not mandatory but encouraged)**

![garlic dog](https://images.steamusercontent.com/ugc/1646594242277067195/C4B98ABD8F4889AA39EDB11C8A08DCBC9631B41B/?imw=512&&ima=fit&impolicy=Letterbox&imcolor=%23000000&letterbox=false)