### PR TITLE
daemon/logger/local: marshal: remove redundant resetProto

### DIFF
--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -77,11 +77,8 @@ func New(info logger.Info) (logger.Logger, error) {
 }
 
 func marshal(m *logger.Message, buffer *[]byte) error {
-	proto := logdriver.LogEntry{}
-	md := logdriver.PartialLogEntryMetadata{}
-
-	resetProto(&proto)
-
+	var proto logdriver.LogEntry
+	var md logdriver.PartialLogEntryMetadata
 	messageToProto(m, &proto, &md)
 	protoSize := proto.Size()
 	writeLen := protoSize + (2 * encodeBinaryLen) // + len(messageDelimiter)


### PR DESCRIPTION
This code doesn't reuse the proto, so we can remove the reset here.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

