### PR TITLE
Fix use-after-reset bug related to log message resets

### DIFF
--- a/daemon/logger/copier.go
+++ b/daemon/logger/copier.go
@@ -123,8 +123,9 @@ func (c *Copier) copySrc(name string, src io.Reader) {
 						msg.Timestamp = partialTS
 					}
 
+					line := string(msg.Line)
 					if logErr := c.dst.Log(msg); logErr != nil {
-						logDriverError(c.dst.Name(), string(msg.Line), logErr)
+						logDriverError(c.dst.Name(), line, logErr)
 					}
 				}
 				p += q + 1
@@ -155,8 +156,9 @@ func (c *Copier) copySrc(name string, src io.Reader) {
 					ordinal++
 					hasMorePartial = true
 
+					line := string(msg.Line)
 					if logErr := c.dst.Log(msg); logErr != nil {
-						logDriverError(c.dst.Name(), string(msg.Line), logErr)
+						logDriverError(c.dst.Name(), line, logErr)
 					}
 					p = 0
 					n = 0

--- a/daemon/logger/logger.go
+++ b/daemon/logger/logger.go
@@ -66,6 +66,10 @@ func (m *Message) AsLogMessage() *backend.LogMessage {
 
 // Logger is the interface for docker logging drivers.
 type Logger interface {
+	// It's conventional that loggers will return the message to the message pool
+	// with `PutMessage` inside this function, so the passed message will be reset
+	// and unsafe for use after return due to race conditions. Avoid holding a
+	// reference to the message or its subfields after calling this function.
 	Log(*Message) error
 	Name() string
 	Close() error

--- a/daemon/logger/ring.go
+++ b/daemon/logger/ring.go
@@ -108,8 +108,9 @@ func (r *ringLogger) Close() error {
 			continue
 		}
 
+		line := string(msg.Line)
 		if err := r.l.Log(msg); err != nil {
-			logDriverError(r.l.Name(), string(msg.Line), err)
+			logDriverError(r.l.Name(), line, err)
 			logErr = true
 		}
 	}
@@ -130,8 +131,9 @@ func (r *ringLogger) run() {
 			// buffer is closed
 			return
 		}
+		line := string(msg.Line)
 		if err := r.l.Log(msg); err != nil {
-			logDriverError(r.l.Name(), string(msg.Line), err)
+			logDriverError(r.l.Name(), line, err)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix "use-after-free"-style bug causing daemon logs to emit an empty string instead of the failed log line when the logging driver fails to log the message:
- When messages are returned to the message pool with [`PutMessage`](https://github.com/moby/moby/blob/b570d5de84395226aca4714fc810cafc22eb6929/daemon/logger/ring.go#L107), they're [`reset`](https://github.com/moby/moby/blob/bac3fe5edfaf694442b58b4e824a686960ffe914/daemon/logger/logger.go#L42) (have their `Line` member cleared).
- Any usage of the variable after this point is vulnerable to race conditions: any message that's been put in the pool [may be deallocated at any time](https://pkg.go.dev/sync#Pool), or re-used after a call to `NewMessage` and have its members changed.

There might be more instances of this pattern, but these are the ones I found while working on #52391 and could search for in the codebase. Unfortunately the `NewMessage`/`PutMessage` calls being scattered throughout the drivers makes defending against this quite hard, and verifying that a generic driver handles this correctly is also hard.

I wish we could make e.g. a reference-counted wrapper for messages that automatically returns it to the pool when all references are dropped, so that all these callsites don't need to think about it. But I don't think that's easy to do in Go :(

**- How I did it**

Take a copy of the required fields before resetting the message. This is already done by most "actual logging drivers" like [fluentd](https://github.com/moby/moby/blob/b570d5de84395226aca4714fc810cafc22eb6929/daemon/logger/fluentd/fluentd.go#L109-L121), but not by the "meta logging drivers" changed here.

**- How to verify it**

Minor change - `string(msg.Line)` copies the line into a string, meaning that when the slice is reset with `Line = Line[:0]`, the copy is unaffected.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix daemon log errors showing an empty string, instead of the line trying to be logged, when using nonblocking logging or the `Copier` logging driver.
```

**- A picture of a cute animal (not mandatory but encouraged)**

![giant cat](https://github.com/hnefatl/wallpapers/blob/main/wallpapers/giant_cat.jpg?raw=true)