### PR TITLE
Allow containers using syslog+tcp to start if the syslog server is unavailable

### DIFF
--- a/daemon/logger/syslog/lazy_writer.go
+++ b/daemon/logger/syslog/lazy_writer.go
@@ -1,0 +1,52 @@
+package syslog
+
+import (
+	"errors"
+	"sync"
+
+	syslog "github.com/RackSec/srslog"
+)
+
+// Wraps a `syslog.Writer` delaying connection until `GetOrConnect` is called.
+type lazyWriter struct {
+	connect func() (*syslog.Writer, error)
+
+	mu     *sync.Mutex
+	writer *syslog.Writer
+}
+
+func newLazyWriter(connect func() (*syslog.Writer, error)) lazyWriter {
+	return lazyWriter{
+		connect: connect,
+		mu:      &sync.Mutex{},
+		writer:  nil,
+	}
+}
+
+// Return the connected `Writer` or attempt to connect.
+func (w *lazyWriter) GetOrConnect() (*syslog.Writer, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.writer == nil {
+		var err error
+		w.writer, err = w.connect()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return w.writer, nil
+}
+func (w *lazyWriter) Close() (err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.writer != nil {
+		err = w.writer.Close()
+	}
+
+	w.writer = nil
+	w.connect = func() (*syslog.Writer, error) {
+		return nil, errors.New("LazyWriter is closed")
+	}
+	return err
+}

--- a/daemon/logger/syslog/lazy_writer_test.go
+++ b/daemon/logger/syslog/lazy_writer_test.go
@@ -1,0 +1,50 @@
+package syslog
+
+import (
+	"errors"
+	"testing"
+
+	syslog "github.com/RackSec/srslog"
+)
+
+func TestLazy(t *testing.T) {
+	numErrors := 2
+	l := newLazyWriter(func() (*syslog.Writer, error) {
+		// Pretend to have a few errors then succeed
+		if numErrors > 0 {
+			numErrors--
+			return nil, errors.New("oh no I couldn't connect")
+		}
+		return nil, nil
+	})
+
+	_, err := l.GetOrConnect()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	_, err = l.GetOrConnect()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	_, err = l.GetOrConnect()
+	if err != nil {
+		t.Fatal("expected success")
+	}
+}
+
+func TestClose(t *testing.T) {
+	l := newLazyWriter(func() (*syslog.Writer, error) {
+		// Pretend to always succeed
+		return nil, nil
+	})
+
+	_, err := l.GetOrConnect()
+	if err != nil {
+		t.Fatal("expected success")
+	}
+	l.Close()
+	_, err = l.GetOrConnect()
+	if err == nil {
+		t.Fatal("expected failure after closing")
+	}
+}

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -2,6 +2,7 @@
 package syslog
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	syslog "github.com/RackSec/srslog"
+	cdlog "github.com/containerd/log"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/logger/loggerutils"
@@ -48,7 +50,7 @@ var facilities = map[string]syslog.Priority{
 }
 
 type syslogger struct {
-	writer *syslog.Writer
+	lazyWriter lazyWriter
 }
 
 // rsyslog uses appname part of syslog message to fill in an %syslogtag% template
@@ -92,32 +94,63 @@ func New(info logger.Info) (logger.Logger, error) {
 		return nil, err
 	}
 
+	lazy_connect, err := parseLazyConnect(info.Config["syslog-lazy-connect"])
+	if err != nil {
+		return nil, err
+	}
+	if strings.Contains(proto, "tcp") && !lazy_connect {
+		cdlog.G(context.TODO()).Warn("You've configured syslog over TCP without specifying `syslog-lazy-connect`: if syslog is unavailable when your container attempts to start, it will fail.")
+	}
+
 	syslogFormatter, syslogFramer, err := parseLogFormat(info.Config["syslog-format"], proto)
 	if err != nil {
 		return nil, err
 	}
 
-	var log *syslog.Writer
-	if proto == secureProto {
-		tlsConfig, tlsErr := parseTLSConfig(info.Config)
-		if tlsErr != nil {
-			return nil, tlsErr
-		}
-		log, err = syslog.DialWithTLSConfig(proto, address, facility, tag, tlsConfig)
-	} else {
-		log, err = syslog.Dial(proto, address, facility, tag)
-	}
-
+	timeout, err := parseTimeout(info.Config["syslog-timeout"])
 	if err != nil {
 		return nil, err
 	}
 
-	log.SetFormatter(syslogFormatter)
-	log.SetFramer(syslogFramer)
+	var tlsConfig *tls.Config
+	if proto == secureProto {
+		tlsConfig, err = parseTLSConfig(info.Config)
+		if err != nil {
+			return nil, err
+		}
+	}
+	dialFunc := func(network, addr string) (net.Conn, error) {
+		dialer := &net.Dialer{
+			Timeout: timeout,
+		}
+		if tlsConfig != nil {
+			return tls.DialWithDialer(dialer, network, addr, tlsConfig)
+		} else {
+			return dialer.Dial(network, addr)
+		}
+	}
+	lazyWriter := newLazyWriter(
+		func() (*syslog.Writer, error) {
+			log, err := syslog.DialWithCustomDialer(proto, address, facility, tag, dialFunc)
+			if err != nil {
+				cdlog.G(context.TODO()).Warnf("Failed to connect to syslog: %v", err)
+				return nil, err
+			}
+			log.SetFormatter(syslogFormatter)
+			log.SetFramer(syslogFramer)
+			return log, nil
+		},
+	)
 
-	return &syslogger{
-		writer: log,
-	}, nil
+	if !lazy_connect {
+		// Force a connection attempt, fail to create the logger if the connection fails.
+		_, err = lazyWriter.GetOrConnect()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &syslogger{lazyWriter}, nil
 }
 
 func (s *syslogger) Log(msg *logger.Message) error {
@@ -128,18 +161,61 @@ func (s *syslogger) Log(msg *logger.Message) error {
 	line := string(msg.Line)
 	source := msg.Source
 	logger.PutMessage(msg)
-	if source == "stderr" {
-		return s.writer.Err(line)
+
+	writer, err := s.lazyWriter.GetOrConnect()
+	if err != nil {
+		return err
 	}
-	return s.writer.Info(line)
+	if source == "stderr" {
+		return writer.Err(line)
+	}
+	return writer.Info(line)
 }
 
 func (s *syslogger) Close() error {
-	return s.writer.Close()
+	return s.lazyWriter.Close()
 }
 
 func (s *syslogger) Name() string {
 	return name
+}
+
+// ValidateLogOpt looks for syslog specific log options
+func ValidateLogOpt(cfg map[string]string) error {
+	for key := range cfg {
+		switch key {
+		case logger.AttrEnv, logger.AttrEnvRegex, logger.AttrLabels, logger.AttrLabelsRegex, logger.AttrLogTag:
+			// Common attributes handled through [logger.Info.ExtraAttributes] and [loggerutils.ParseLogTag].
+			continue
+		case "syslog-address":
+		case "syslog-facility":
+		case "syslog-format":
+		case "syslog-lazy-connect":
+		case "syslog-timeout":
+		case "syslog-tls-ca-cert":
+		case "syslog-tls-cert":
+		case "syslog-tls-key":
+		case "syslog-tls-skip-verify":
+		default:
+			return fmt.Errorf("unknown log opt '%s' for syslog log driver", key)
+		}
+	}
+	if _, _, err := parseAddress(cfg["syslog-address"]); err != nil {
+		return err
+	}
+	if _, err := parseFacility(cfg["syslog-facility"]); err != nil {
+		return err
+	}
+	if _, err := parseLazyConnect(cfg["syslog-lazy-connect"]); err != nil {
+		return err
+	}
+	if _, _, err := parseLogFormat(cfg["syslog-format"], ""); err != nil {
+		return err
+	}
+	if _, err := parseTimeout(cfg["syslog-timeout"]); err != nil {
+		return err
+	}
+	return nil
 }
 
 func parseAddress(address string) (string, string, error) {
@@ -174,37 +250,6 @@ func parseAddress(address string) (string, string, error) {
 	return addr.Scheme, host, nil
 }
 
-// ValidateLogOpt looks for syslog specific log options
-// syslog-address, syslog-facility.
-func ValidateLogOpt(cfg map[string]string) error {
-	for key := range cfg {
-		switch key {
-		case logger.AttrEnv, logger.AttrEnvRegex, logger.AttrLabels, logger.AttrLabelsRegex, logger.AttrLogTag:
-			// Common attributes handled through [logger.Info.ExtraAttributes] and [loggerutils.ParseLogTag].
-			continue
-		case "syslog-address":
-		case "syslog-facility":
-		case "syslog-tls-ca-cert":
-		case "syslog-tls-cert":
-		case "syslog-tls-key":
-		case "syslog-tls-skip-verify":
-		case "syslog-format":
-		default:
-			return fmt.Errorf("unknown log opt '%s' for syslog log driver", key)
-		}
-	}
-	if _, _, err := parseAddress(cfg["syslog-address"]); err != nil {
-		return err
-	}
-	if _, err := parseFacility(cfg["syslog-facility"]); err != nil {
-		return err
-	}
-	if _, _, err := parseLogFormat(cfg["syslog-format"], ""); err != nil {
-		return err
-	}
-	return nil
-}
-
 func parseFacility(facility string) (syslog.Priority, error) {
 	if facility == "" {
 		return syslog.LOG_DAEMON, nil
@@ -222,6 +267,14 @@ func parseFacility(facility string) (syslog.Priority, error) {
 	return syslog.Priority(0), errors.New("invalid syslog facility")
 }
 
+func parseTimeout(timeout string) (time.Duration, error) {
+	if timeout == "" {
+		// Default is no timeout (i.e. use OS-defined timeout)
+		return 0, nil
+	}
+	return time.ParseDuration(timeout)
+}
+
 func parseTLSConfig(cfg map[string]string) (*tls.Config, error) {
 	_, skipVerify := cfg["syslog-tls-skip-verify"]
 
@@ -233,6 +286,14 @@ func parseTLSConfig(cfg map[string]string) (*tls.Config, error) {
 	}
 
 	return tlsconfig.Client(opts)
+}
+
+func parseLazyConnect(value string) (bool, error) {
+	if value == "" {
+		// Default if not specified
+		return false, nil
+	}
+	return strconv.ParseBool(value)
 }
 
 func parseLogFormat(logFormat, proto string) (syslog.Formatter, syslog.Framer, error) {

--- a/daemon/logger/syslog/syslog_test.go
+++ b/daemon/logger/syslog/syslog_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	syslog "github.com/RackSec/srslog"
 	"github.com/moby/moby/v2/daemon/logger"
@@ -140,6 +141,24 @@ func TestParseAddressDefaultPort(t *testing.T) {
 	_, port, _ := net.SplitHostPort(address)
 	if port != defaultPort {
 		t.Fatalf("Expected to default to port %s. It used port %s", defaultPort, port)
+	}
+}
+
+func TestParseLazyConnect(t *testing.T) {
+	if value, err := parseLazyConnect("true"); err != nil || !value {
+		t.Fatalf("Expected (true, nil), got (%v, %v)", value, err)
+	}
+	if value, err := parseLazyConnect(""); err != nil || value {
+		t.Fatalf("Expected default (false, nil), got (%v, %v)", value, err)
+	}
+}
+
+func TestParseTimeout(t *testing.T) {
+	if value, err := parseTimeout(""); err != nil || value != 0 {
+		t.Fatalf("Expected (0, nil), got (%v, %v)", value, err)
+	}
+	if value, err := parseTimeout("30s"); err != nil || value != 30*time.Second {
+		t.Fatalf("Expected default (30s, nil), got (%v, %v)", value, err)
 	}
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes #52402: add a new syslog configuration option `syslog-allow-failure-on-startup` (defaults to `false`, i.e. no change in behaviour), which allows the container to continue startup if syslog is unavailable on container start. This avoids containers failing to start if a remote syslog server is unavailable when using TCP+TLS, which is an availability concern for the container's non-logging operations.

I haven't updated docs, since I just saw those are in a [separate repository](https://github.com/docker/docs). If this change is merged, I'll go add docs over there.

**- How I did it**

Unfortunately this is a bit ugly. I originally wanted to add a flag like `syslog-lazy-connect` that just created the syslog client without connecting, only attempting to connect once the first log was emitted. This has the nice behaviour of not blocking the container start _at all_. Unfortunately the [syslog library](https://github.com/RackSec/srslog/tree/master) used by Docker doesn't expose a suitable API for this, and was archived >7 years ago so I doubt I can change the API there.

As a result, we're forced to attempt to connect on container start, and since there's no context passing we can't set a deadline on the connect call (so instead get an OS-dependent timeout). This means container start will be delayed by ~3mins on a generic Linux OS, not great for a high-availability container. But it's better than the alternative of never starting at all.

I'd love to discuss more systemic solutions to this if you have thoughts.

**- How to verify it**

Sadly because we can't set a connection timeout or dependency-inject a fake syslog client, it's hard to write sensible unit tests for this branch. Naively we could just have a test which takes 3mins to run and timeout, but that sucks.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Add `syslog-allow-failure-on-startup` logging driver flag to allow containers to start when a TCP syslog server is unavailable.
```

**- A picture of a cute animal (not mandatory but encouraged)**

![hovercat](https://media1.tenor.com/m/lnbK373D2AkAAAAC/kot-koty.gif)