### PR TITLE
daemon: fix typo "dependant" -> "dependent" in comment

### DIFF
--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -535,7 +535,7 @@ func (c *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 	config, hostConfig, networkingConfig := req.Config, req.HostConfig, req.NetworkingConfig
 
 	// The NetworkMode "default" is used as a way to express a container should
-	// be attached to the OS-dependant default network, in an OS-independent
+	// be attached to the OS-dependent default network, in an OS-independent
 	// way. Doing this conversion as soon as possible ensures we have less
 	// NetworkMode to handle down the path (including in the
 	// backward-compatibility layer we have just below).


### PR DESCRIPTION

**Repo:** moby/moby (⭐ 68000)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-1

## What
Fixes a spelling error in a code comment in `daemon/server/router/container/container_routes.go`. "dependant" is replaced with "dependent", matching the intended adjective meaning ("the OS-dependent default network") and consistent with the adjacent "OS-independent".

## Why
Minor comment hygiene — makes the comment grammatically correct and consistent on the same line. No functional change.

## Testing
Comment-only change, no behavior impact. Nothing to run.

## Risk
Low — comment-only, single word.
