### PR TITLE
Change Conntrack to delete by Both Port And IP

### DIFF
--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -1664,7 +1664,7 @@ func (ep *bridgeEndpoint) trimPortBindings(ctx context.Context, n *bridgeNetwork
 func clearConntrackEntries(nlh nlwrap.Handle, ep *bridgeEndpoint) {
 	var ipv4List []net.IP
 	var ipv6List []net.IP
-	var udpPorts []uint16
+	var udpPorts []types.PortBinding
 
 	if ep.addr != nil {
 		ipv4List = append(ipv4List, ep.addr.IP)
@@ -1674,7 +1674,7 @@ func clearConntrackEntries(nlh nlwrap.Handle, ep *bridgeEndpoint) {
 	}
 	for _, pb := range ep.portMapping {
 		if pb.Proto == types.UDP {
-			udpPorts = append(udpPorts, pb.HostPort)
+			udpPorts = append(udpPorts, pb.PortBinding)
 		}
 	}
 

--- a/daemon/libnetwork/iptables/conntrack.go
+++ b/daemon/libnetwork/iptables/conntrack.go
@@ -57,34 +57,36 @@ func DeleteConntrackEntries(nlh nlwrap.Handle, ipv4List []net.IP, ipv6List []net
 	return nil
 }
 
-func DeleteConntrackEntriesByPort(nlh nlwrap.Handle, proto types.Protocol, ports []uint16) error {
+func DeleteConntrackEntriesByPort(nlh nlwrap.Handle, proto types.Protocol, ports []types.PortBinding) error {
 	if err := checkConntrackProgrammable(nlh); err != nil {
 		return err
 	}
-
 	var totalIPv4FlowPurged uint
 	var totalIPv6FlowPurged uint
-
 	for _, port := range ports {
 		filter := &netlink.ConntrackFilter{}
 		if err := filter.AddProtocol(uint8(proto)); err != nil {
-			log.G(context.TODO()).Warnf("Failed to delete conntrack state for %s port %d: %v", proto.String(), port, err)
+			log.G(context.TODO()).Warnf("Failed to delete conntrack state for %s port %d: %v", proto.String(), port.Port, err)
 			continue
 		}
-		if err := filter.AddPort(netlink.ConntrackOrigDstPort, port); err != nil {
-			log.G(context.TODO()).Warnf("Failed to delete conntrack state for %s port %d: %v", proto.String(), port, err)
+		if err := filter.AddPort(netlink.ConntrackOrigDstPort, port.Port); err != nil {
+			log.G(context.TODO()).Warnf("Failed to delete conntrack state for %s port %d: %v", proto.String(), port.Port, err)
+			continue
+		}
+		if err := filter.AddIP(netlink.ConntrackOrigDstIP, port.HostIP); err != nil {
+			log.G(context.TODO()).Warnf("Failed to delete conntrack state for %s port %d: %v", proto.String(), port.Port, err)
 			continue
 		}
 
 		v4FlowPurged, err := nlh.ConntrackDeleteFilters(netlink.ConntrackTable, syscall.AF_INET, filter)
 		if err != nil {
-			log.G(context.TODO()).Warnf("Failed to delete conntrack state for IPv4 %s port %d: %v", proto.String(), port, err)
+			log.G(context.TODO()).Warnf("Failed to delete conntrack state for IPv4 %s port %d: %v", proto.String(), port.Port, err)
 		}
 		totalIPv4FlowPurged += v4FlowPurged
 
 		v6FlowPurged, err := nlh.ConntrackDeleteFilters(netlink.ConntrackTable, syscall.AF_INET6, filter)
 		if err != nil {
-			log.G(context.TODO()).Warnf("Failed to delete conntrack state for IPv6 %s port %d: %v", proto.String(), port, err)
+			log.G(context.TODO()).Warnf("Failed to delete conntrack state for IPv6 %s port %d: %v", proto.String(), port.Port, err)
 		}
 		totalIPv6FlowPurged += v6FlowPurged
 	}


### PR DESCRIPTION
**- What I did**

Changed DeleteConntrackEntriesByPort to delete by both dest IP And dest Port.
I was running into issues where I was running two diffrent containers with the same port but diffrent IPs. When restarting one container it would delete all the conntrack entires for both containers since it was only deleting by port.

Im not sure if there are any issues open about this, or if this is even the best way to fix this, but It was causing issues for us and seemed like a fairly major issue.

**- How I did it**

Passed the HostIP from portMapping into DeleteConntrackEntriesByPort and added the IPs as a filter by ConntrackOrigDstIP 

**- How to verify it**

Start up a udp listener in one container on one IP, then start up another udp listener in another container on the same port but with a diffrent IP. Restarting one container shouldn't cause the conntrack entires from the other container to get deleted.

**- Human readable description for the release notes**
```markdown changelog
Fix conntrack entries being incorrectly deleted for UDP containers sharing the same port on different IPs when one container is restarted.
```

**- A picture of a cute animal (not mandatory but encouraged)**

Here is one of my pet turtles :)

<img width="310.5" height="552" alt="IMG_9689" src="https://github.com/user-attachments/assets/518263bc-fe78-4432-a9cd-12771e6a2048" />
