### PR TITLE
fix formatting strings for go1.26

### DIFF
--- a/daemon/builder/dockerfile/dispatchers.go
+++ b/daemon/builder/dockerfile/dispatchers.go
@@ -471,11 +471,11 @@ func dispatchHealthcheck(ctx context.Context, d dispatchRequest, c *instructions
 	if runConfig.Healthcheck != nil {
 		oldCmd := runConfig.Healthcheck.Test
 		if len(oldCmd) > 0 && oldCmd[0] != "NONE" {
-			fmt.Fprintf(d.builder.Stdout, "Note: overriding previous HEALTHCHECK: %v\n", oldCmd)
+			fmt.Fprintf(d.builder.Stdout, "Note: overriding previous HEALTHCHECK: %+v\n", oldCmd)
 		}
 	}
 	runConfig.Healthcheck = c.Health
-	return d.builder.commit(ctx, d.state, fmt.Sprintf("HEALTHCHECK %q", runConfig.Healthcheck))
+	return d.builder.commit(ctx, d.state, fmt.Sprintf("HEALTHCHECK %+v", runConfig.Healthcheck))
 }
 
 // ENTRYPOINT /usr/sbin/nginx

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -288,7 +288,7 @@ func TestMerge(t *testing.T) {
 	}
 	for portSpecs := range configUser.ExposedPorts {
 		if portSpecs.Num() != 0 && portSpecs.Num() != 1111 && portSpecs.Num() != 2222 && portSpecs.Num() != 3333 {
-			t.Fatalf("Expected %q or %q or %q or %q, found %s", 0, 1111, 2222, 3333, portSpecs)
+			t.Fatalf("Expected %d or %d or %d or %d, found %d", 0, 1111, 2222, 3333, portSpecs)
 		}
 	}
 }

--- a/daemon/internal/streamformatter/streamformatter.go
+++ b/daemon/internal/streamformatter/streamformatter.go
@@ -94,7 +94,7 @@ type progressOutput struct {
 func (out *progressOutput) WriteProgress(prog progress.Progress) error {
 	var formatted []byte
 	if prog.Message != "" {
-		formatted = out.sf.formatStatus(prog.ID, prog.Message)
+		formatted = out.sf.formatStatus(prog.ID, "%s", prog.Message)
 	} else {
 		jsonProgress := jsonstream.Progress{
 			Current:    prog.Current,

--- a/internal/testutil/daemon/daemon.go
+++ b/internal/testutil/daemon/daemon.go
@@ -811,7 +811,7 @@ out2:
 				d.log.Logf("[%s] tried to interrupt daemon for %d times, now try to kill it", d.id, i)
 				break out2
 			}
-			d.log.Logf("[%d] attempt #%d/5: daemon is still running with pid %d", i, d.cmd.Process.Pid)
+			d.log.Logf("[%s] attempt #%d/5: daemon is still running with pid %d", d.id, i, d.cmd.Process.Pid)
 			if err := d.cmd.Process.Signal(os.Interrupt); err != nil {
 				return errors.Wrapf(err, "[%s] attempt #%d/5 could not send signal", d.id, i)
 			}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/52428
- relates to https://github.com/moby/buildkit/pull/6664


These started producing an error with go1.26;

    daemon/builder/dockerfile/dispatchers.go:478:65: fmt.Sprintf format %q has arg runConfig.Healthcheck of wrong type *github.com/moby/moby/api/types/container.HealthConfig
    daemon/daemon_test.go:291:23: (*testing.common).Fatalf format %q has arg 0 of wrong type int
    daemon/internal/streamformatter/streamformatter.go:97:44: non-constant format string in call to (github.com/moby/moby/v2/daemon/internal/streamformatter.formatProgress).formatStatus
    internal/testutil/daemon/daemon.go:814:128: (github.com/moby/moby/v2/internal/testutil/daemon.LogT).Logf format %d reads arg #3, but call has 2 args

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

