### PR TITLE
libnetwork: keep disabled swarm DNSRR names reserved

### DIFF
--- a/daemon/libnetwork/libnetwork_internal_test.go
+++ b/daemon/libnetwork/libnetwork_internal_test.go
@@ -723,6 +723,58 @@ func TestServiceVIPReuse(t *testing.T) {
 	}
 }
 
+func TestServiceDNSRRDisabledNameStaysReserved(t *testing.T) {
+	skip.If(t, runtime.GOOS == "windows", "test only works on linux")
+
+	defer netnsutils.SetupTestOSContext(t)()
+
+	ctrlr, err := New(context.Background(), config.OptionDataDir(t.TempDir()),
+		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
+	assert.NilError(t, err)
+	defer ctrlr.Stop()
+
+	n, err := ctrlr.NewNetwork(t.Context(), "bridge", "net1", "", nil,
+		NetworkOptionEnableIPv4(true),
+	)
+	assert.NilError(t, err)
+	defer func() {
+		assert.NilError(t, n.Delete())
+	}()
+
+	svcName := "service_test"
+	svcID := "serviceID1"
+	eID := "ep1"
+	containerName := "task1"
+	serviceIP := net.ParseIP("192.168.0.2")
+	serviceAliases := []string{"service-alias"}
+
+	err = ctrlr.addServiceBinding(svcName, svcID, n.ID(), eID, containerName, nil, nil, serviceAliases, nil, serviceIP, "test")
+	assert.NilError(t, err)
+
+	ipList, ok := n.ResolveName(t.Context(), svcName, types.IPv4)
+	assert.Check(t, ok)
+	assert.Check(t, is.Len(ipList, 1))
+	assert.Check(t, is.Equal(ipList[0].String(), serviceIP.String()))
+
+	err = ctrlr.rmServiceBinding(svcName, svcID, n.ID(), eID, containerName, nil, nil, serviceAliases, nil, serviceIP, "test", true, false)
+	assert.NilError(t, err)
+
+	ipList, ok = n.ResolveName(t.Context(), svcName, types.IPv4)
+	assert.Check(t, ok)
+	assert.Check(t, is.Len(ipList, 0))
+
+	ipList, ok = n.ResolveName(t.Context(), "tasks."+svcName, types.IPv4)
+	assert.Check(t, ok)
+	assert.Check(t, is.Len(ipList, 0))
+
+	err = ctrlr.rmServiceBinding(svcName, svcID, n.ID(), eID, containerName, nil, nil, serviceAliases, nil, serviceIP, "test", true, true)
+	assert.NilError(t, err)
+
+	ipList, ok = n.ResolveName(t.Context(), svcName, types.IPv4)
+	assert.Check(t, !ok)
+	assert.Check(t, is.Len(ipList, 0))
+}
+
 func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "test only works on linux")
 

--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -59,10 +59,11 @@ type svcMapEntry struct {
 }
 
 type svcInfo struct {
-	svcMap     setmatrix.SetMatrix[string, svcMapEntry]
-	svcIPv6Map setmatrix.SetMatrix[string, svcMapEntry]
-	ipMap      setmatrix.SetMatrix[string, ipInfo]
-	service    map[string][]servicePorts
+	svcMap      setmatrix.SetMatrix[string, svcMapEntry]
+	svcIPv6Map  setmatrix.SetMatrix[string, svcMapEntry]
+	ipMap       setmatrix.SetMatrix[string, ipInfo]
+	reservedSvc setmatrix.SetMatrix[string, string]
+	service     map[string][]servicePorts
 }
 
 // backing container or host's info
@@ -1360,22 +1361,35 @@ func delIPToName(ipMap *setmatrix.SetMatrix[string, ipInfo], name, serviceID str
 	})
 }
 
+func normalizeSvcName(name string) string {
+	return strings.ToLower(name)
+}
+
 func addNameToIP(svcMap *setmatrix.SetMatrix[string, svcMapEntry], name, serviceID string, epIP net.IP) {
-	// Since DNS name resolution is case-insensitive, Use the lower-case form
-	// of the name as the key into svcMap
-	lowerCaseName := strings.ToLower(name)
-	svcMap.Insert(lowerCaseName, svcMapEntry{
+	svcMap.Insert(normalizeSvcName(name), svcMapEntry{
 		ip:        epIP.String(),
 		serviceID: serviceID,
 	})
 }
 
 func delNameToIP(svcMap *setmatrix.SetMatrix[string, svcMapEntry], name, serviceID string, epIP net.IP) {
-	lowerCaseName := strings.ToLower(name)
-	svcMap.Remove(lowerCaseName, svcMapEntry{
+	svcMap.Remove(normalizeSvcName(name), svcMapEntry{
 		ip:        epIP.String(),
 		serviceID: serviceID,
 	})
+}
+
+func reserveSvcName(svcMap *setmatrix.SetMatrix[string, string], name, recordID string) {
+	svcMap.Insert(normalizeSvcName(name), recordID)
+}
+
+func releaseSvcName(svcMap *setmatrix.SetMatrix[string, string], name, recordID string) {
+	svcMap.Remove(normalizeSvcName(name), recordID)
+}
+
+func hasReservedSvcName(svcMap *setmatrix.SetMatrix[string, string], name string) bool {
+	_, ok := svcMap.Cardinality(normalizeSvcName(name))
+	return ok
 }
 
 // TODO(aker): remove ipMapUpdate param and add a proper method dedicated to update PTR records.
@@ -1448,6 +1462,45 @@ func (n *Network) deleteSvcRecords(eID, name, serviceID string, epIPv4, epIPv6 n
 	if epIPv6 != nil {
 		delNameToIP(&sr.svcIPv6Map, name, serviceID, epIPv6)
 	}
+}
+
+func (n *Network) reserveSvcRecords(name, recordID, method string) {
+	if n.ingress {
+		return
+	}
+	networkID := n.ID()
+	log.G(context.TODO()).Debugf("%s (%.7s).reserveSvcRecords(%s) %s", recordID, networkID, name, method)
+
+	c := n.getController()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	sr, ok := c.svcRecords[networkID]
+	if !ok {
+		sr = &svcInfo{}
+		c.svcRecords[networkID] = sr
+	}
+
+	reserveSvcName(&sr.reservedSvc, name, recordID)
+}
+
+func (n *Network) releaseSvcRecords(name, recordID, method string) {
+	if n.ingress {
+		return
+	}
+	networkID := n.ID()
+	log.G(context.TODO()).Debugf("%s (%.7s).releaseSvcRecords(%s) %s", recordID, networkID, name, method)
+
+	c := n.getController()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	sr, ok := c.svcRecords[networkID]
+	if !ok {
+		return
+	}
+
+	releaseSvcName(&sr.reservedSvc, name, recordID)
 }
 
 func (n *Network) getController() *Controller {
@@ -1935,8 +1988,9 @@ func (n *Network) ResolveName(ctx context.Context, req string, ipType types.IPFa
 	ipSet, ok4 := sr.svcMap.Get(req)
 	ipSet6, ok6 := sr.svcIPv6Map.Get(req)
 	if !ok4 && !ok6 {
-		// No result for v4 or v6, the name doesn't exist.
-		return nil, false
+		// No result for v4 or v6, unless the name is still reserved by service
+		// discovery while there are temporarily no healthy backends.
+		return nil, hasReservedSvcName(&sr.reservedSvc, req)
 	}
 	if ipType == types.IPv6 {
 		ipSet = ipSet6

--- a/daemon/libnetwork/service_common.go
+++ b/daemon/libnetwork/service_common.go
@@ -51,6 +51,15 @@ func (c *Controller) addEndpointNameResolution(svcName, svcID, nID, eID, contain
 		}
 	}
 
+	n.releaseSvcRecords("tasks."+svcName, eID, method)
+	for _, alias := range serviceAliases {
+		n.releaseSvcRecords("tasks."+alias, eID, method)
+	}
+	n.releaseSvcRecords(svcName, eID, method)
+	for _, alias := range serviceAliases {
+		n.releaseSvcRecords(alias, eID, method)
+	}
+
 	return nil
 }
 
@@ -72,7 +81,7 @@ func (c *Controller) addContainerNameResolution(nID, eID, containerName string, 
 	return nil
 }
 
-func (c *Controller) deleteEndpointNameResolution(svcName, svcID, nID, eID, containerName string, vip net.IP, serviceAliases, taskAliases []string, ip net.IP, rmService, multipleEntries bool, method string) error {
+func (c *Controller) deleteEndpointNameResolution(svcName, svcID, nID, eID, containerName string, vip net.IP, serviceAliases, taskAliases []string, ip net.IP, rmService, multipleEntries, fullRemove bool, method string) error {
 	n, err := c.NetworkByID(nID)
 	if err != nil {
 		return err
@@ -89,6 +98,19 @@ func (c *Controller) deleteEndpointNameResolution(svcName, svcID, nID, eID, cont
 	if serviceID == "" {
 		// This is the case of a normal container not part of a service
 		serviceID = eID
+	}
+
+	if !multipleEntries && !fullRemove {
+		n.reserveSvcRecords("tasks."+svcName, eID, method)
+		for _, alias := range serviceAliases {
+			n.reserveSvcRecords("tasks."+alias, eID, method)
+		}
+		if len(vip) == 0 {
+			n.reserveSvcRecords(svcName, eID, method)
+			for _, alias := range serviceAliases {
+				n.reserveSvcRecords(alias, eID, method)
+			}
+		}
 	}
 
 	// Delete the special "tasks.svc_name" backend record.
@@ -112,6 +134,17 @@ func (c *Controller) deleteEndpointNameResolution(svcName, svcID, nID, eID, cont
 		n.deleteSvcRecords(eID, svcName, serviceID, vip, nil, false, method)
 		for _, alias := range serviceAliases {
 			n.deleteSvcRecords(eID, alias, serviceID, vip, nil, false, method)
+		}
+	}
+
+	if fullRemove {
+		n.releaseSvcRecords("tasks."+svcName, eID, method)
+		for _, alias := range serviceAliases {
+			n.releaseSvcRecords("tasks."+alias, eID, method)
+		}
+		n.releaseSvcRecords(svcName, eID, method)
+		for _, alias := range serviceAliases {
+			n.releaseSvcRecords(alias, eID, method)
 		}
 	}
 
@@ -393,7 +426,7 @@ func (c *Controller) rmServiceBinding(svcName, svcID, nID, eID, containerName st
 
 	// Delete the name resolutions
 	if deleteSvcRecords {
-		if err := c.deleteEndpointNameResolution(svcName, svcID, nID, eID, containerName, vip, serviceAliases, taskAliases, ip, rmService, entries > 0, "rmServiceBinding"); err != nil {
+		if err := c.deleteEndpointNameResolution(svcName, svcID, nID, eID, containerName, vip, serviceAliases, taskAliases, ip, rmService, entries > 0, fullRemove, "rmServiceBinding"); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Fixes #52049

## Problem

When all tasks of a DNSRR Swarm service are disabled as unhealthy, libnetwork removes the service name from service discovery. Once that happens, `Network.ResolveName()` reports the name as missing, so the embedded resolver can fall back to the host's external DNS chain.

This already behaves differently for VIP-backed service names because the VIP record stays present; the problematic path is the DNSRR service-name removal when tasks are disabled.

## Root cause

`deleteEndpointNameResolution()` deletes the last DNSRR service record as soon as the endpoint is disabled, and `Network.ResolveName()` only treats names in `svcMap` / `svcIPv6Map` as owned by Swarm. With no remaining records, the name becomes "nonexistent" instead of "temporarily unavailable".

## Fix

Keep disabled service-discovery names reserved until the endpoint is fully removed:

- reserve DNSRR service names, service aliases, and `tasks.*` names while an endpoint is disabled
- clear those reservations when the endpoint is added back or fully removed
- make `ResolveName()` return `ok=true` with no addresses when a name is still reserved but has no healthy backends

That keeps the name inside Swarm DNS and produces an internal empty answer instead of allowing external fallback.

## Tests

Add regression coverage for a DNSRR service that:

- resolves while active
- returns an internal empty result for `service_test` after disable
- returns an internal empty result for `tasks.service_test` after disable
- disappears only after full removal

## Validation

- `GOOS=linux GOARCH=amd64 GOCACHE=/tmp/go-cache go test -c ./daemon/libnetwork`
- attempted to run the focused Linux test in a container, but that environment could not build `daemon/libnetwork` because `libnftables` was unavailable
