### PR TITLE
apparmor: Set abi conditionally

### DIFF
--- a/vendor/github.com/moby/profiles/apparmor/apparmor.go
+++ b/vendor/github.com/moby/profiles/apparmor/apparmor.go
@@ -18,6 +18,8 @@ const profileDirectory = "/etc/apparmor.d"
 
 // profileData holds information about the given profile for generation.
 type profileData struct {
+	// Abi is the ABI version to use, if supported by the host.
+	Abi string
 	// Name is profile name.
 	Name string
 	// DaemonProfile is the profile name of our daemon.
@@ -33,6 +35,11 @@ func (p *profileData) generateDefault(out io.Writer) error {
 	compiled, err := template.New("apparmor_profile").Parse(baseTemplate)
 	if err != nil {
 		return err
+	}
+
+	const abi = "abi/3.0"
+	if macroExists(abi) {
+		p.Abi = abi
 	}
 
 	if macroExists("tunables/global") {

--- a/vendor/github.com/moby/profiles/apparmor/template.go
+++ b/vendor/github.com/moby/profiles/apparmor/template.go
@@ -9,6 +9,8 @@ package apparmor
 
 // baseTemplate defines the default apparmor profile for containers.
 const baseTemplate = `
+{{if .Abi}}abi <{{.Abi}}>,
+{{end}}
 {{range $value := .Imports}}
 {{$value}}
 {{end}}


### PR DESCRIPTION
The "abi" keyword was added for apparmor 3.0
The original change to add this ended up breaking versions < 3.0.
The abi itself is a macro in /etc/apparmor.d so we can check if the
macro exists to determine if we *can* set an abi in the template.

Related: https://github.com/containerd/containerd/pull/13268