### PR TITLE
daemon/logger: refine the Logger contract

### DIFF
--- a/daemon/logger/adapter.go
+++ b/daemon/logger/adapter.go
@@ -33,7 +33,12 @@ type pluginAdapter struct {
 	buf logdriver.LogEntry
 }
 
-func (a *pluginAdapter) Log(msg *Message) error {
+func (a *pluginAdapter) Log(msg *Message) (err error) {
+	defer func() {
+		if err == nil {
+			PutMessage(msg)
+		}
+	}()
 	a.mu.Lock()
 
 	a.buf.Line = msg.Line
@@ -48,12 +53,11 @@ func (a *pluginAdapter) Log(msg *Message) error {
 		}
 	}
 
-	err := a.enc.Encode(&a.buf)
+	err = a.enc.Encode(&a.buf)
 	a.buf.Reset()
 
 	a.mu.Unlock()
 
-	PutMessage(msg)
 	return err
 }
 

--- a/daemon/logger/copier.go
+++ b/daemon/logger/copier.go
@@ -125,6 +125,7 @@ func (c *Copier) copySrc(name string, src io.Reader) {
 
 					if logErr := c.dst.Log(msg); logErr != nil {
 						logDriverError(c.dst.Name(), string(msg.Line), logErr)
+						PutMessage(msg)
 					}
 				}
 				p += q + 1
@@ -157,6 +158,7 @@ func (c *Copier) copySrc(name string, src io.Reader) {
 
 					if logErr := c.dst.Log(msg); logErr != nil {
 						logDriverError(c.dst.Name(), string(msg.Line), logErr)
+						PutMessage(msg)
 					}
 					p = 0
 					n = 0

--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -105,7 +105,13 @@ func New(info logger.Info) (logger.Logger, error) {
 	}, nil
 }
 
-func (f *fluentd) Log(msg *logger.Message) error {
+func (f *fluentd) Log(msg *logger.Message) (err error) {
+	defer func() {
+		if err == nil {
+			logger.PutMessage(msg)
+		}
+	}()
+
 	data := map[string]string{
 		"container_id":   f.containerID,
 		"container_name": f.containerName,
@@ -120,11 +126,9 @@ func (f *fluentd) Log(msg *logger.Message) error {
 		data["partial_last"] = strconv.FormatBool(msg.PLogMetaData.Last)
 	}
 
-	ts := msg.Timestamp
-	logger.PutMessage(msg)
 	// fluent-logger-golang buffers logs from failures and disconnections,
 	// and these are transferred again automatically.
-	return f.writer.PostWithTime(f.tag, ts, data)
+	return f.writer.PostWithTime(f.tag, msg.Timestamp, data)
 }
 
 func (f *fluentd) Close() error {

--- a/daemon/logger/gelf/gelf.go
+++ b/daemon/logger/gelf/gelf.go
@@ -157,7 +157,13 @@ func newGELFUDPWriter(address string, info logger.Info) (gelf.Writer, error) {
 	return gelfWriter, nil
 }
 
-func (s *gelfLogger) Log(msg *logger.Message) error {
+func (s *gelfLogger) Log(msg *logger.Message) (err error) {
+	defer func() {
+		if err == nil {
+			logger.PutMessage(msg)
+		}
+	}()
+
 	if len(msg.Line) == 0 {
 		return nil
 	}
@@ -175,7 +181,6 @@ func (s *gelfLogger) Log(msg *logger.Message) error {
 		Level:    int32(level),
 		RawExtra: s.rawExtra,
 	}
-	logger.PutMessage(msg)
 
 	if err := s.writer.WriteMessage(&m); err != nil {
 		return fmt.Errorf("gelf: cannot send GELF message: %v", err)

--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -144,7 +144,13 @@ func validateLogOpt(cfg map[string]string) error {
 	return nil
 }
 
-func (s *journald) Log(msg *logger.Message) error {
+func (s *journald) Log(msg *logger.Message) (err error) {
+	defer func() {
+		if err == nil {
+			logger.PutMessage(msg)
+		}
+	}()
+
 	vars := map[string]string{}
 	maps.Copy(vars, s.vars)
 	if !msg.Timestamp.IsZero() {
@@ -159,17 +165,13 @@ func (s *journald) Log(msg *logger.Message) error {
 		}
 	}
 
-	line := string(msg.Line)
-	source := msg.Source
-	logger.PutMessage(msg)
-
 	seq := s.ordinal.Add(1)
 	vars[fieldLogOrdinal] = strconv.FormatUint(seq, 10)
 
-	if source == "stderr" {
-		return s.sendToJournal(line, journal.PriErr, vars)
+	if msg.Source == "stderr" {
+		return s.sendToJournal(string(msg.Line), journal.PriErr, vars)
 	}
-	return s.sendToJournal(line, journal.PriInfo, vars)
+	return s.sendToJournal(string(msg.Line), journal.PriInfo, vars)
 }
 
 func (s *journald) Name() string {

--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -106,20 +106,22 @@ func New(info logger.Info) (logger.Logger, error) {
 }
 
 // Log converts logger.Message to jsonlog.JSONLog and serializes it to file.
-func (l *JSONFileLogger) Log(msg *logger.Message) error {
+func (l *JSONFileLogger) Log(msg *logger.Message) (err error) {
+	defer func() {
+		if err == nil {
+			logger.PutMessage(msg)
+		}
+	}()
+
 	buf := buffersPool.Get().(*bytes.Buffer)
 	buf.Reset()
 	defer buffersPool.Put(buf)
 
-	timestamp := msg.Timestamp
-	err := marshalMessage(msg, l.extra, buf)
-	logger.PutMessage(msg)
-
-	if err != nil {
+	if err := marshalMessage(msg, l.extra, buf); err != nil {
 		return err
 	}
 
-	return l.writer.WriteLogEntry(timestamp, buf.Bytes())
+	return l.writer.WriteLogEntry(msg.Timestamp, buf.Bytes())
 }
 
 func marshalMessage(msg *logger.Message, extra json.RawMessage, buf *bytes.Buffer) error {

--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -111,18 +111,20 @@ func (d *driver) Name() string {
 	return Name
 }
 
-func (d *driver) Log(msg *logger.Message) error {
+func (d *driver) Log(msg *logger.Message) (err error) {
+	defer func() {
+		if err == nil {
+			logger.PutMessage(msg)
+		}
+	}()
+
 	buf := buffersPool.Get().(*[]byte)
 	defer buffersPool.Put(buf)
 
-	timestamp := msg.Timestamp
-	err := marshal(msg, buf)
-	logger.PutMessage(msg)
-
-	if err != nil {
+	if err := marshal(msg, buf); err != nil {
 		return errors.Wrap(err, "error marshalling logger.Message")
 	}
-	return d.logfile.WriteLogEntry(timestamp, *buf)
+	return d.logfile.WriteLogEntry(msg.Timestamp, *buf)
 }
 
 func (d *driver) Close() error {

--- a/daemon/logger/logger.go
+++ b/daemon/logger/logger.go
@@ -66,6 +66,8 @@ func (m *Message) AsLogMessage() *backend.LogMessage {
 
 // Logger is the interface for docker logging drivers.
 type Logger interface {
+	// The logger takes ownership of the Message on success. The caller
+	// retains ownership of the Message if an error is returned.
 	Log(*Message) error
 	Name() string
 	Close() error

--- a/daemon/logger/loggerutils/cache/local_cache.go
+++ b/daemon/logger/loggerutils/cache/local_cache.go
@@ -77,10 +77,13 @@ func (l *loggerWithCache) Log(msg *logger.Message) error {
 	dup := logger.NewMessage()
 	dumbCopyMessage(dup, msg)
 
-	if err := l.l.Log(msg); err != nil {
+	// Log the duplicate first so the caller retains ownership of the
+	// original message if either logger returns an error.
+	if err := l.l.Log(dup); err != nil {
+		logger.PutMessage(dup)
 		return err
 	}
-	return l.cache.Log(dup)
+	return l.cache.Log(msg)
 }
 
 func (l *loggerWithCache) Name() string {

--- a/daemon/logger/ring.go
+++ b/daemon/logger/ring.go
@@ -110,6 +110,7 @@ func (r *ringLogger) Close() error {
 
 		if err := r.l.Log(msg); err != nil {
 			logDriverError(r.l.Name(), string(msg.Line), err)
+			PutMessage(msg)
 			logErr = true
 		}
 	}
@@ -132,6 +133,7 @@ func (r *ringLogger) run() {
 		}
 		if err := r.l.Log(msg); err != nil {
 			logDriverError(r.l.Name(), string(msg.Line), err)
+			PutMessage(msg)
 		}
 	}
 }
@@ -174,6 +176,7 @@ func (r *messageRing) Enqueue(m *Message) error {
 	if mSize+r.sizeBytes > r.maxBytes && len(r.queue) > 0 {
 		r.wait.Signal()
 		r.mu.Unlock()
+		PutMessage(m)
 		return nil
 	}
 

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -321,7 +321,13 @@ func New(info logger.Info) (logger.Logger, error) {
 	return loggerWrapper, nil
 }
 
-func (l *splunkLoggerInline) Log(msg *logger.Message) error {
+func (l *splunkLoggerInline) Log(msg *logger.Message) (err error) {
+	defer func() {
+		if err == nil {
+			logger.PutMessage(msg)
+		}
+	}()
+
 	message := l.createSplunkMessage(msg)
 
 	event := *l.nullEvent
@@ -329,11 +335,16 @@ func (l *splunkLoggerInline) Log(msg *logger.Message) error {
 	event.Source = msg.Source
 
 	message.Event = &event
-	logger.PutMessage(msg)
 	return l.queueMessageAsync(message)
 }
 
-func (l *splunkLoggerJSON) Log(msg *logger.Message) error {
+func (l *splunkLoggerJSON) Log(msg *logger.Message) (err error) {
+	defer func() {
+		if err == nil {
+			logger.PutMessage(msg)
+		}
+	}()
+
 	message := l.createSplunkMessage(msg)
 	event := *l.nullEvent
 
@@ -347,11 +358,16 @@ func (l *splunkLoggerJSON) Log(msg *logger.Message) error {
 	event.Source = msg.Source
 
 	message.Event = &event
-	logger.PutMessage(msg)
 	return l.queueMessageAsync(message)
 }
 
-func (l *splunkLoggerRaw) Log(msg *logger.Message) error {
+func (l *splunkLoggerRaw) Log(msg *logger.Message) (err error) {
+	defer func() {
+		if err == nil {
+			logger.PutMessage(msg)
+		}
+	}()
+
 	// empty or whitespace-only messages are not accepted by HEC
 	if strings.TrimSpace(string(msg.Line)) == "" {
 		return nil
@@ -360,7 +376,6 @@ func (l *splunkLoggerRaw) Log(msg *logger.Message) error {
 	message := l.createSplunkMessage(msg)
 
 	message.Event = string(append(l.prefix, msg.Line...))
-	logger.PutMessage(msg)
 	return l.queueMessageAsync(message)
 }
 

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -120,18 +120,20 @@ func New(info logger.Info) (logger.Logger, error) {
 	}, nil
 }
 
-func (s *syslogger) Log(msg *logger.Message) error {
+func (s *syslogger) Log(msg *logger.Message) (err error) {
+	defer func() {
+		if err == nil {
+			logger.PutMessage(msg)
+		}
+	}()
 	if len(msg.Line) == 0 {
 		return nil
 	}
 
-	line := string(msg.Line)
-	source := msg.Source
-	logger.PutMessage(msg)
-	if source == "stderr" {
-		return s.writer.Err(line)
+	if msg.Source == "stderr" {
+		return s.writer.Err(string(msg.Line))
 	}
-	return s.writer.Info(line)
+	return s.writer.Info(string(msg.Line))
 }
 
 func (s *syslogger) Close() error {


### PR DESCRIPTION
- closes #52407 

The pool optimization in the logging infrastructure can be tricky to get correct. Chaos and data races can ensue if a Message is used after it has been returned to the pool, similar to use-after-free bugs in memory-unsafe languages but without the type confusion. Most logging-related code was written assuming that the log driver unconditionally returns the Log()'ed Message to the pool. But some code, particularly the log copier and ring logger, was written as if the log driver did _not_ return the Message to the pool if Log() returned an error. Most log drivers unconditionally return the Message to the pool, making the ring logger and copier implementations subtly incorrect.

Codify the contract to be that ownership of the Message moves to the log driver when Log() returns a nil error, otherwise the caller retains it. This is very convenient for error handling as the fields of the original message can be safely dereferenced instead of having to defensively make copies before calling the driver. Update all the logging infrastructure to adhere to this contract.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix an issue where logging errors appeared as empty strings in the daemon log instead of the message that failed to write.
```

**- A picture of a cute animal (not mandatory but encouraged)**

