### PR TITLE
daemon/logger: requeue messages on log driver error instead of dropping

### DIFF
--- a/daemon/logger/ring.go
+++ b/daemon/logger/ring.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 const (
@@ -99,18 +100,10 @@ func (r *ringLogger) Close() error {
 	r.buffer.Close()
 	r.wg.Wait()
 	// empty out the queue
-	var logErr bool
 	for _, msg := range r.buffer.Drain() {
-		if logErr {
-			// some error logging a previous message, so re-insert to message pool
-			// and assume log driver is hosed
-			PutMessage(msg)
-			continue
-		}
-
 		if err := r.l.Log(msg); err != nil {
 			logDriverError(r.l.Name(), string(msg.Line), err)
-			logErr = true
+			PutMessage(msg)
 		}
 	}
 	return r.l.Close()
@@ -132,6 +125,14 @@ func (r *ringLogger) run() {
 		}
 		if err := r.l.Log(msg); err != nil {
 			logDriverError(r.l.Name(), string(msg.Line), err)
+			// Requeue the message at the front of the buffer so it can be
+			// retried later. Only drop if the buffer is full (requeue fails).
+			if !r.buffer.requeue(msg) {
+				PutMessage(msg)
+			}
+			// Brief sleep to avoid busy-looping if the logger is persistently
+			// failing.
+			time.Sleep(100 * time.Millisecond)
 		}
 	}
 }
@@ -219,6 +220,20 @@ func (r *messageRing) Close() {
 	r.closed = true
 	r.wait.Broadcast()
 	r.mu.Unlock()
+}
+
+// requeue puts a message back at the front of the queue.
+// It returns false if the buffer is closed.
+func (r *messageRing) requeue(m *Message) bool {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return false
+	}
+	r.queue = append([]*Message{m}, r.queue...)
+	r.sizeBytes += int64(len(m.Line))
+	r.mu.Unlock()
+	return true
 }
 
 // Drain drains all messages from the queue.

--- a/daemon/logger/ring_test.go
+++ b/daemon/logger/ring_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 )
@@ -150,6 +151,120 @@ type nopLogger struct{}
 func (nopLogger) Name() string       { return "nopLogger" }
 func (nopLogger) Close() error       { return nil }
 func (nopLogger) Log(*Message) error { return nil }
+
+// flakyLogger fails the first N calls to Log, then succeeds.
+type flakyLogger struct {
+	mu        sync.Mutex
+	failCount int
+	logs      []*Message
+}
+
+func (l *flakyLogger) Name() string { return "flaky" }
+func (l *flakyLogger) Close() error { return nil }
+func (l *flakyLogger) Log(msg *Message) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.failCount > 0 {
+		l.failCount--
+		return errors.New("simulated log failure")
+	}
+	l.logs = append(l.logs, msg)
+	return nil
+}
+
+// TestRingLoggerRetryOnError verifies that messages are not dropped when the
+// underlying logger returns transient errors. They should be requeued and
+// delivered once the logger recovers.
+func TestRingLoggerRetryOnError(t *testing.T) {
+	flaky := &flakyLogger{failCount: 3}
+	ring := newRingLogger(flaky, Info{}, 100)
+	defer ring.Close()
+
+	msg := &Message{Line: []byte("hello")}
+	if err := ring.Log(msg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the consumer to retry and eventually succeed.
+	time.Sleep(500 * time.Millisecond)
+
+	flaky.mu.Lock()
+	if len(flaky.logs) != 1 {
+		t.Fatalf("expected 1 log message, got %d", len(flaky.logs))
+	}
+	if string(flaky.logs[0].Line) != "hello" {
+		t.Fatalf("expected 'hello', got %q", string(flaky.logs[0].Line))
+	}
+	flaky.mu.Unlock()
+}
+
+// TestRingLoggerDoesNotDropOnError verifies that multiple messages are buffered
+// while the logger is failing and all are eventually delivered.
+func TestRingLoggerDoesNotDropOnError(t *testing.T) {
+	flaky := &flakyLogger{failCount: 5}
+	ring := newRingLogger(flaky, Info{}, 1000)
+	defer ring.Close()
+
+	for i := range 3 {
+		if err := ring.Log(&Message{Line: []byte(strconv.Itoa(i))}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Wait for the consumer to work through the retries.
+	time.Sleep(800 * time.Millisecond)
+
+	flaky.mu.Lock()
+	if len(flaky.logs) != 3 {
+		t.Fatalf("expected 3 log messages, got %d", len(flaky.logs))
+	}
+	for i := range 3 {
+		if string(flaky.logs[i].Line) != strconv.Itoa(i) {
+			t.Fatalf("expected message %d to be %q, got %q", i, strconv.Itoa(i), string(flaky.logs[i].Line))
+		}
+	}
+	flaky.mu.Unlock()
+}
+
+// TestRingLoggerRequeuePreservesOrder verifies that message order is preserved
+// when the logger fails intermittently.
+func TestRingLoggerRequeuePreservesOrder(t *testing.T) {
+	flaky := &flakyLogger{failCount: 2}
+	ring := newRingLogger(flaky, Info{}, 1000)
+	defer ring.Close()
+
+	// Queue three messages. The first will fail twice, then succeed.
+	for i := range 3 {
+		if err := ring.Log(&Message{Line: []byte(strconv.Itoa(i))}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Wait for retries to complete.
+	time.Sleep(500 * time.Millisecond)
+
+	flaky.mu.Lock()
+	if len(flaky.logs) != 3 {
+		t.Fatalf("expected 3 log messages, got %d", len(flaky.logs))
+	}
+	for i := range 3 {
+		if string(flaky.logs[i].Line) != strconv.Itoa(i) {
+			t.Fatalf("expected message %d to be %q, got %q", i, strconv.Itoa(i), string(flaky.logs[i].Line))
+		}
+	}
+	flaky.mu.Unlock()
+}
+
+// TestRingLoggerRequeueClosed verifies that requeue fails gracefully when the
+// ring is closed.
+func TestRingLoggerRequeueClosed(t *testing.T) {
+	r := newRing(100)
+	r.Close()
+	msg := &Message{Line: []byte("test")}
+	if r.requeue(msg) {
+		t.Fatal("expected requeue to fail on closed ring")
+	}
+}
 
 func BenchmarkRingLoggerThroughputNoReceiver(b *testing.B) {
 	mockLog := &mockLogger{make(chan *Message)}


### PR DESCRIPTION
**- What I did**

Fixed the ringLogger so that it no longer drops messages when the underlying log driver returns a transient error. Instead, the message is requeued at the front of the ring buffer and retried later. This makes the non-blocking log buffer actually useful during temporary logger outages (slow disk, network hiccup, etc.).

Also updated Close() to try each remaining message individually rather than dropping the entire queue after the first error.

**- How I did it**

* Added a requeue() method to messageRing that prepends a message back to the queue.
* In ringLogger.run(), when Log() returns an error, the message is requeued instead of dropped. A 100ms sleep prevents busy-looping if the logger is persistently failing.
* In ringLogger.Close(), removed the logErr early-exit logic so that a failure on one message does not cause all remaining messages to be discarded.

**- How to verify it**

```bash
go test ./daemon/logger/ -v -run 'TestRingLoggerRetryOnError|TestRingLoggerDoesNotDropOnError|TestRingLoggerRequeuePreservesOrder'
```

Fixes #52390