### PR TITLE
integration/container: migrate TestAPIStatsStoppedContainerInGoroutin…

### DIFF
--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/moby/moby/api/types/container"
-	"github.com/moby/moby/api/types/system"
 	"github.com/moby/moby/v2/integration-cli/cli"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/request"
@@ -62,41 +61,6 @@ func (s *DockerAPISuite) TestAPIStatsNoStreamGetCpu(c *testing.T) {
 	}
 
 	assert.Assert(c, cpuPercent != 0.0, "docker stats with no-stream get cpu usage failed: was %v", cpuPercent)
-}
-
-func (s *DockerAPISuite) TestAPIStatsStoppedContainerInGoroutines(c *testing.T) {
-	out := cli.DockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo 1").Stdout()
-	id := strings.TrimSpace(out)
-
-	getGoRoutines := func() int {
-		_, body, err := request.Get(testutil.GetContext(c), "/info")
-		assert.NilError(c, err)
-		info := system.Info{}
-		err = json.NewDecoder(body).Decode(&info)
-		assert.NilError(c, err)
-		_ = body.Close()
-		return info.NGoroutines
-	}
-
-	// When the HTTP connection is closed, the number of goroutines should not increase.
-	routines := getGoRoutines()
-	_, body, err := request.Get(testutil.GetContext(c), "/containers/"+id+"/stats")
-	assert.NilError(c, err)
-	_ = body.Close()
-
-	t := time.After(30 * time.Second)
-	for {
-		select {
-		case <-t:
-			assert.Assert(c, getGoRoutines() <= routines)
-			return
-		default:
-			if n := getGoRoutines(); n <= routines {
-				return
-			}
-			time.Sleep(200 * time.Millisecond)
-		}
-	}
 }
 
 func (s *DockerAPISuite) TestAPIStatsNetworkStats(c *testing.T) {

--- a/integration/container/stats_test.go
+++ b/integration/container/stats_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"reflect"
 	"testing"
+	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
 	containertypes "github.com/moby/moby/api/types/container"
@@ -91,5 +92,40 @@ func TestStatsContainerNotFound(t *testing.T) {
 			assert.ErrorType(t, err, cerrdefs.IsNotFound)
 			assert.ErrorContains(t, err, "no-such-container")
 		})
+	}
+}
+
+func TestStatsStoppedContainerInGoroutines(t *testing.T) {
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	// Run a container that exits immediately
+	cID := container.Run(ctx, t, apiClient, container.WithCmd("/bin/sh", "-c", "echo 1"))
+
+	getGoRoutines := func() int {
+		info, err := apiClient.Info(ctx, client.InfoOptions{})
+		assert.NilError(t, err)
+		return info.Info.NGoroutines
+	}
+
+	routines := getGoRoutines()
+	res, err := apiClient.ContainerStats(ctx, cID, client.ContainerStatsOptions{})
+
+	// Immediately close the HTTP connection by closing the body
+	assert.NilError(t, err)
+	_ = res.Body.Close()
+
+	interval := time.After(30 * time.Second)
+	for {
+		select {
+		case <-interval:
+			assert.Assert(t, getGoRoutines() <= routines)
+			return
+		default:
+			if n := getGoRoutines(); n <= routines {
+				return
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
 	}
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/13966

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Migrated the test `TestAPIStatsStoppedContainerInGoroutines` to `integration/` from the `integration-cli/` suite in reference to this [epic 50159](https://github.com/moby/moby/issues/50159).

**- How I did it**
Using test on integration-cli/docker_api_stats_test.go and slightly tweaking it to use the go-client instead of the direct CLI.

**- How to verify it**
Run the following command to run the test:
```
TESTDIRS='./integration/container/' TESTFLAGS='-test.run TestStatsStoppedContainerInGoroutines' make test-integration
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
![Manatee bonk window](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeG10M205bWk2dnd3Mm83YWsxY3ZqNGlzaWxqZ2NuY3UxczNmbXhrcyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/toe6vBrtWgKvKW7Ehz/giphy.gif)


