### PR TITLE
vendor: github.com/moby/profiles/seccomp v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/moby/patternmatcher v0.6.1
 	github.com/moby/policy-helpers v0.0.0-20260324161837-b7c0b994300b
 	github.com/moby/profiles/apparmor v0.1.0
-	github.com/moby/profiles/seccomp v0.1.0
+	github.com/moby/profiles/seccomp v0.2.0
 	github.com/moby/pubsub v1.0.0
 	github.com/moby/swarmkit/v2 v2.1.2
 	github.com/moby/sys/atomicwriter v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/moby/policy-helpers v0.0.0-20260324161837-b7c0b994300b h1:lvBBM2ACrsG
 github.com/moby/policy-helpers v0.0.0-20260324161837-b7c0b994300b/go.mod h1:Cbc1brDwYl1K294MmZB+6WhQR9Tr24hfhgSGND4UlL0=
 github.com/moby/profiles/apparmor v0.1.0 h1:dMUt6fqdOeU9tfKjntPN9hBY1C5tJtsUWZNiIuHK8QM=
 github.com/moby/profiles/apparmor v0.1.0/go.mod h1:2iRxPw+MrPuDvmb5lAEAeLB1kcOt7AzZeW3paBs2TQY=
-github.com/moby/profiles/seccomp v0.1.0 h1:kVf1lc5ytNB1XPxEdZUVF+oPpbBYJHR50eEvPt/9k8A=
-github.com/moby/profiles/seccomp v0.1.0/go.mod h1:Kqk57vxH6/wuOc5bmqRiSXJ6iEz8Pvo3LQRkv0ytFWs=
+github.com/moby/profiles/seccomp v0.2.0 h1:JCLyeOwIcPn83QBZlPD/UAsZfQkbwvUfWD7n0wB6B0E=
+github.com/moby/profiles/seccomp v0.2.0/go.mod h1:8m3qkkWZXrRsMqlUUN2zyccnYmBf3EAdQYPMVJ3NBhk=
 github.com/moby/pubsub v1.0.0 h1:jkp/imWsmJz2f6LyFsk7EkVeN2HxR/HTTOY8kHrsxfA=
 github.com/moby/pubsub v1.0.0/go.mod h1:bXSO+3h5MNXXCaEG+6/NlAIk7MMZbySZlnB+cUQhKKc=
 github.com/moby/swarmkit/v2 v2.1.2 h1:1WDZAI6HVYNKdCG4zlXnTAPyLsLwuhRGWlHoOUf5Z6I=

--- a/vendor/github.com/moby/profiles/seccomp/default.json
+++ b/vendor/github.com/moby/profiles/seccomp/default.json
@@ -52,6 +52,10 @@
 		{
 			"architecture": "SCMP_ARCH_RISCV64",
 			"subArchitectures": null
+		},
+		{
+			"architecture": "SCMP_ARCH_LOONGARCH64",
+			"subArchitectures": null
 		}
 	],
 	"syscalls": [

--- a/vendor/github.com/moby/profiles/seccomp/default_linux.go
+++ b/vendor/github.com/moby/profiles/seccomp/default_linux.go
@@ -1,3 +1,6 @@
+// Copyright The Moby Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package seccomp
 
 import (
@@ -37,6 +40,10 @@ func arches() []Architecture {
 		},
 		{
 			Arch:      specs.ArchRISCV64,
+			SubArches: nil,
+		},
+		{
+			Arch:      specs.ArchLOONGARCH64,
 			SubArches: nil,
 		},
 	}

--- a/vendor/github.com/moby/profiles/seccomp/kernel_linux.go
+++ b/vendor/github.com/moby/profiles/seccomp/kernel_linux.go
@@ -1,3 +1,6 @@
+// Copyright The Moby Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package seccomp
 
 import (

--- a/vendor/github.com/moby/profiles/seccomp/seccomp.go
+++ b/vendor/github.com/moby/profiles/seccomp/seccomp.go
@@ -1,3 +1,6 @@
+// Copyright The Moby Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package seccomp
 
 import (
@@ -93,7 +96,7 @@ func (k *KernelVersion) UnmarshalJSON(version []byte) error {
 
 	// make sure we have a string
 	if err = json.Unmarshal(version, &ver); err != nil {
-		return fmt.Errorf(`invalid kernel version: %s, expected "<kernel>.<major>": %v`, string(version), err)
+		return fmt.Errorf(`invalid kernel version: %s, expected "<kernel>.<major>": %w`, string(version), err)
 	}
 	if ver == "" {
 		return nil
@@ -103,10 +106,10 @@ func (k *KernelVersion) UnmarshalJSON(version []byte) error {
 		return fmt.Errorf(`invalid kernel version: %s, expected "<kernel>.<major>"`, string(version))
 	}
 	if k.Kernel, err = strconv.ParseUint(parts[0], 10, 8); err != nil {
-		return fmt.Errorf(`invalid kernel version: %s, expected "<kernel>.<major>": %v`, string(version), err)
+		return fmt.Errorf(`invalid kernel version: %s, expected "<kernel>.<major>": %w`, string(version), err)
 	}
 	if k.Major, err = strconv.ParseUint(parts[1], 10, 8); err != nil {
-		return fmt.Errorf(`invalid kernel version: %s, expected "<kernel>.<major>": %v`, string(version), err)
+		return fmt.Errorf(`invalid kernel version: %s, expected "<kernel>.<major>": %w`, string(version), err)
 	}
 	if k.Kernel == 0 && k.Major == 0 {
 		return fmt.Errorf(`invalid kernel version: %s, expected "<kernel>.<major>": version cannot be 0.0`, string(version))

--- a/vendor/github.com/moby/profiles/seccomp/seccomp_linux.go
+++ b/vendor/github.com/moby/profiles/seccomp/seccomp_linux.go
@@ -1,3 +1,6 @@
+// Copyright The Moby Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:generate go run -tags 'seccomp' generate.go
 
 package seccomp
@@ -7,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"slices"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -20,7 +24,7 @@ func GetDefaultProfile(rs *specs.Spec) (*specs.LinuxSeccomp, error) {
 func LoadProfile(body string, rs *specs.Spec) (*specs.LinuxSeccomp, error) {
 	var config Seccomp
 	if err := json.Unmarshal([]byte(body), &config); err != nil {
-		return nil, fmt.Errorf("Decoding seccomp profile failed: %v", err)
+		return nil, fmt.Errorf("Decoding seccomp profile failed: %w", err)
 	}
 	return setupSeccomp(&config, rs)
 }
@@ -31,6 +35,7 @@ var nativeToSeccomp = map[string]specs.Arch{
 	"amd64":       specs.ArchX86_64,
 	"arm":         specs.ArchARM,
 	"arm64":       specs.ArchAARCH64,
+	"loong64":     specs.ArchLOONGARCH64,
 	"mips64":      specs.ArchMIPS64,
 	"mips64n32":   specs.ArchMIPS64N32,
 	"mipsel64":    specs.ArchMIPSEL64,
@@ -50,6 +55,7 @@ var goToNative = map[string]string{
 	"amd64":       "amd64",
 	"arm":         "arm",
 	"arm64":       "arm64",
+	"loong64":     "loongarch64",
 	"mips64":      "mips64",
 	"mips64p32":   "mips64n32",
 	"mips64le":    "mipsel64",
@@ -61,17 +67,6 @@ var goToNative = map[string]string{
 	"riscv64":     "riscv64",
 	"s390":        "s390",
 	"s390x":       "s390x",
-}
-
-// inSlice tests whether a string is contained in a slice of strings or not.
-// Comparison is case sensitive
-func inSlice(slice []string, s string) bool {
-	for _, ss := range slice {
-		if s == ss {
-			return true
-		}
-	}
-	return false
 }
 
 func setupSeccomp(config *Seccomp, rs *specs.Spec) (*specs.LinuxSeccomp, error) {
@@ -121,13 +116,13 @@ Loop:
 		}
 		if call.Excludes != nil {
 			if len(call.Excludes.Arches) > 0 {
-				if inSlice(call.Excludes.Arches, arch) {
+				if slices.Contains(call.Excludes.Arches, arch) {
 					continue Loop
 				}
 			}
 			if len(call.Excludes.Caps) > 0 {
 				for _, c := range call.Excludes.Caps {
-					if inSlice(rs.Process.Capabilities.Bounding, c) {
+					if slices.Contains(rs.Process.Capabilities.Bounding, c) {
 						continue Loop
 					}
 				}
@@ -142,13 +137,13 @@ Loop:
 		}
 		if call.Includes != nil {
 			if len(call.Includes.Arches) > 0 {
-				if !inSlice(call.Includes.Arches, arch) {
+				if !slices.Contains(call.Includes.Arches, arch) {
 					continue Loop
 				}
 			}
 			if len(call.Includes.Caps) > 0 {
 				for _, c := range call.Includes.Caps {
-					if !inSlice(rs.Process.Capabilities.Bounding, c) {
+					if !slices.Contains(rs.Process.Capabilities.Bounding, c) {
 						continue Loop
 					}
 				}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1216,7 +1216,7 @@ github.com/moby/policy-helpers/types
 # github.com/moby/profiles/apparmor v0.1.0
 ## explicit; go 1.23.0
 github.com/moby/profiles/apparmor
-# github.com/moby/profiles/seccomp v0.1.0
+# github.com/moby/profiles/seccomp v0.2.0
 ## explicit; go 1.23.0
 github.com/moby/profiles/seccomp
 # github.com/moby/pubsub v1.0.0


### PR DESCRIPTION
- Apply copyright and licenses headers to source code.
- feat(seccomp): Add support for LoongArch64 architecture.
- seccomp: fix linting issues (errorlint).
- seccomp: remove inSlice in favor of slices.Contains.
- ci: enable GitHub actions and linting.
- ci: pin actions by sha.

full diff: https://github.com/moby/profiles/compare/seccomp/v0.1.0...seccomp/v0.2.0

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

