### PR TITLE
integration: reduce `skip.If(t, testEnv.IsRootless)`

### DIFF
--- a/integration/container/daemon_linux_test.go
+++ b/integration/container/daemon_linux_test.go
@@ -136,7 +136,6 @@ func TestDaemonRestartIpcMode(t *testing.T) {
 func TestDaemonHostGatewayIP(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
-	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
 	t.Parallel()
 
 	ctx := testutil.StartSpan(baseContext, t)

--- a/integration/container/links_linux_test.go
+++ b/integration/container/links_linux_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestLinksEtcHostsContentMatch(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
-	skip.If(t, testEnv.IsRootless, "rootless mode has different view of /etc/hosts")
 
 	hosts, err := os.ReadFile("/etc/hosts")
 	skip.If(t, os.IsNotExist(err))

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -105,7 +105,7 @@ func TestHostnameDnsResolution(t *testing.T) {
 
 func TestUnprivilegedPortsAndPing(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
-	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support setting net.ipv4.ping_group_range and net.ipv4.ip_unprivileged_port_start")
+	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support setting net.ipv4.ping_group_range")
 
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()

--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -195,8 +195,6 @@ func TestImageImportBadSrc(t *testing.T) {
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 
-	skip.If(t, testEnv.IsRootless, "rootless daemon cannot access the test's HTTP server in the host's netns")
-
 	server := httptest.NewServer(nil)
 	defer server.Close()
 

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -121,7 +121,6 @@ func createTestImage(ctx context.Context, t testing.TB, store content.Store) oci
 func TestImagePullStoredDigestForOtherRepo(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "We don't run a test registry on Windows")
-	skip.If(t, testEnv.IsRootless, "Rootless has a different view of localhost (needed for test registry access)")
 	ctx := setupTest(t)
 
 	reg := registry.NewV2(t, registry.WithStdout(os.Stdout), registry.WithStderr(os.Stderr))

--- a/integration/network/network_linux_test.go
+++ b/integration/network/network_linux_test.go
@@ -29,7 +29,6 @@ import (
 func TestRunContainerWithBridgeNone(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot start daemon on remote test run")
 	skip.If(t, testEnv.IsUserNamespace)
-	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
 
 	ctx := testutil.StartSpan(baseContext, t)
 

--- a/integration/plugin/authz/main_test.go
+++ b/integration/plugin/authz/main_test.go
@@ -71,7 +71,6 @@ func TestMain(m *testing.M) {
 func setupTest(t *testing.T) context.Context {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
-	skip.If(t, testEnv.IsRootless, "rootless mode has different view of localhost")
 
 	ctx := testutil.StartSpan(baseContext, t)
 	environment.ProtectAll(ctx, t, testEnv)

--- a/integration/plugin/common/plugin_test.go
+++ b/integration/plugin/common/plugin_test.go
@@ -98,7 +98,6 @@ func TestPluginInvalidJSON(t *testing.T) {
 func TestPluginInstall(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
-	skip.If(t, testEnv.IsRootless, "rootless mode has different view of localhost")
 
 	ctx := testutil.StartSpan(baseContext, t)
 	apiclient := testEnv.APIClient()
@@ -330,7 +329,6 @@ func TestPluginsWithRuntimes(t *testing.T) {
 func TestPluginBackCompatMediaTypes(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
-	skip.If(t, testEnv.IsRootless, "Rootless has a different view of localhost (needed for test registry access)")
 
 	ctx := setupTest(t)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Run more tests for rootless.

Follow-up to:
- https://github.com/moby/moby/pull/47103

**- How I did it**

Reduced `skip.If(t, testEnv.IsRootless)`.

**- How to verify it**

See if the CI passes.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

