### PR TITLE
integration: Try to fix flaky TestNslookupWindows

### DIFF
--- a/integration/networking/resolvconf_test.go
+++ b/integration/networking/resolvconf_test.go
@@ -200,7 +200,7 @@ func TestNslookupWindows(t *testing.T) {
 	ctx := setupTest(t)
 	c := testEnv.APIClient()
 
-	attachCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	res := container.RunAttach(attachCtx, t, c,
 		container.WithCmd("nslookup", "docker.com"),


### PR DESCRIPTION
The 5-second context timeout may be insufficient for Windows container start-up.

Increase to 15 seconds, consistent with other Windows networking tests in the same package.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

