### PR TITLE
vendor: github.com/vbatts/tar-split v0.12.3

### DIFF
--- a/daemon/internal/layer/layer_store.go
+++ b/daemon/internal/layer/layer_store.go
@@ -228,18 +228,23 @@ func (ls *layerStore) applyTar(tx *fileMetadataTransaction, ts io.Reader, parent
 
 	// we're passing nil here for the file putter, because the ApplyDiff will
 	// handle the extraction of the archive
-	rdr, err := asm.NewInputTarStream(tr, metaPacker, nil)
+	rdr, done, err := asm.NewInputTarStreamWithDone(tr, metaPacker, nil)
 	if err != nil {
 		return err
 	}
 
-	applySize, err := ls.driver.ApplyDiff(layer.cacheID, parent, rdr)
-	// discard trailing data but ensure metadata is picked up to reconstruct stream
-	// unconditionally call io.Copy here before checking err to ensure the resources
-	// allocated by NewInputTarStream above are always released
-	io.Copy(io.Discard, rdr) // ignore error as reader may be closed
-	if err != nil {
-		return err
+	applySize, applyErr := ls.driver.ApplyDiff(layer.cacheID, parent, rdr)
+
+	// Discard trailing data but ensure metadata is picked up to reconstruct
+	// stream unconditionally call io.Copy here before checking applyErr to
+	// ensure the goroutine behind NewInputTarStreamWithDone finishes.
+	_, _ = io.Copy(io.Discard, rdr) // ignore error as reader may be closed
+
+	if doneErr := <-done; applyErr == nil {
+		applyErr = doneErr
+	}
+	if applyErr != nil {
+		return applyErr
 	}
 
 	layer.size = applySize

--- a/daemon/internal/layer/migration.go
+++ b/daemon/internal/layer/migration.go
@@ -32,11 +32,14 @@ func (ls *layerStore) ChecksumForGraphID(id, parent, newTarDataPath string) (dif
 
 	packerCounter := &packSizeCounter{metaPacker, &size}
 
-	archive, err := asm.NewInputTarStream(rawArchive, packerCounter, nil)
+	archive, done, err := asm.NewInputTarStreamWithDone(rawArchive, packerCounter, nil)
 	if err != nil {
 		return "", 0, err
 	}
 	dgst, err := digest.FromReader(archive)
+	if doneErr := <-done; err == nil {
+		err = doneErr
+	}
 	if err != nil {
 		return "", 0, err
 	}

--- a/daemon/internal/layer/migration.go
+++ b/daemon/internal/layer/migration.go
@@ -36,6 +36,8 @@ func (ls *layerStore) ChecksumForGraphID(id, parent, newTarDataPath string) (dif
 	if err != nil {
 		return "", 0, err
 	}
+	defer archive.Close()
+
 	dgst, err := digest.FromReader(archive)
 	if doneErr := <-done; err == nil {
 		err = doneErr

--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/tonistiigi/go-archvariant v1.0.0
-	github.com/vbatts/tar-split v0.12.2
+	github.com/vbatts/tar-split v0.12.3
 	github.com/vishvananda/netlink v1.3.1
 	github.com/vishvananda/netns v0.0.5
 	go.etcd.io/bbolt v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -803,8 +803,8 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
-github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
+github.com/vbatts/tar-split v0.12.3 h1:Cd46rkGXI3Td4yrVNwU8ripbxFaQbmesqhjBUUYAJSw=
+github.com/vbatts/tar-split v0.12.3/go.mod h1:sQOc6OlqGCr7HkGx/IDBeKiTIvqhmj8KffNhEXG4Nq0=
 github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=
 github.com/vishvananda/netlink v1.3.1/go.mod h1:ARtKouGSTGchR8aMwmkzC0qiNPrrWO5JS/XMVl45+b4=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=

--- a/vendor/github.com/vbatts/tar-split/archive/tar/format.go
+++ b/vendor/github.com/vbatts/tar-split/archive/tar/format.go
@@ -147,6 +147,12 @@ const (
 	// Max length of a special file (PAX header, GNU long name or link).
 	// This matches the limit used by libarchive.
 	maxSpecialFileSize = 1 << 20
+
+	// Maximum number of sparse file entries.
+	// We should never actually hit this limit
+	// (every sparse encoding will first be limited by maxSpecialFileSize),
+	// but this adds an additional layer of defense.
+	maxSparseFileEntries = 1 << 20
 )
 
 // blockPadding computes the number of bytes needed to pad offset up to the

--- a/vendor/github.com/vbatts/tar-split/archive/tar/reader.go
+++ b/vendor/github.com/vbatts/tar-split/archive/tar/reader.go
@@ -537,7 +537,8 @@ func (tr *Reader) readOldGNUSparseMap(hdr *Header, blk *block) (sparseDatas, err
 	}
 	s := blk.GNU().Sparse()
 	spd := make(sparseDatas, 0, s.MaxEntries())
-	for {
+	totalSize := len(s)
+	for totalSize < maxSpecialFileSize {
 		for i := 0; i < s.MaxEntries(); i++ {
 			// This termination condition is identical to GNU and BSD tar.
 			if s.Entry(i).Offset()[0] == 0x00 {
@@ -548,7 +549,11 @@ func (tr *Reader) readOldGNUSparseMap(hdr *Header, blk *block) (sparseDatas, err
 			if p.err != nil {
 				return nil, p.err
 			}
-			spd = append(spd, sparseEntry{Offset: offset, Length: length})
+			var err error
+			spd, err = appendSparseEntry(spd, sparseEntry{Offset: offset, Length: length})
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		if s.IsExtended()[0] > 0 {
@@ -560,10 +565,12 @@ func (tr *Reader) readOldGNUSparseMap(hdr *Header, blk *block) (sparseDatas, err
 				tr.rawBytes.Write(blk[:])
 			}
 			s = blk.Sparse()
+			totalSize += len(s)
 			continue
 		}
 		return spd, nil // Done
 	}
+	return nil, errSparseTooLong
 }
 
 // readGNUSparseMap1x0 reads the sparse map as stored in GNU's PAX sparse format
@@ -636,7 +643,10 @@ func readGNUSparseMap1x0(r io.Reader) (sparseDatas, error) {
 		if err1 != nil || err2 != nil {
 			return nil, ErrHeader
 		}
-		spd = append(spd, sparseEntry{Offset: offset, Length: length})
+		spd, err = appendSparseEntry(spd, sparseEntry{Offset: offset, Length: length})
+		if err != nil {
+			return nil, err
+		}
 	}
 	return spd, nil
 }
@@ -670,10 +680,20 @@ func readGNUSparseMap0x1(paxHdrs map[string]string) (sparseDatas, error) {
 		if err1 != nil || err2 != nil {
 			return nil, ErrHeader
 		}
-		spd = append(spd, sparseEntry{Offset: offset, Length: length})
+		spd, err = appendSparseEntry(spd, sparseEntry{Offset: offset, Length: length})
+		if err != nil {
+			return nil, err
+		}
 		sparseMap = sparseMap[2:]
 	}
 	return spd, nil
+}
+
+func appendSparseEntry(spd sparseDatas, ent sparseEntry) (sparseDatas, error) {
+	if len(spd) >= maxSparseFileEntries {
+		return nil, errSparseTooLong
+	}
+	return append(spd, ent), nil
 }
 
 // Read reads from the current file in the tar archive.

--- a/vendor/github.com/vbatts/tar-split/tar/asm/disassemble.go
+++ b/vendor/github.com/vbatts/tar-split/tar/asm/disassemble.go
@@ -1,23 +1,168 @@
 package asm
 
 import (
+	"errors"
 	"io"
 
 	"github.com/vbatts/tar-split/archive/tar"
 	"github.com/vbatts/tar-split/tar/storage"
 )
 
-// NewInputTarStream wraps the Reader stream of a tar archive and provides a
-// Reader stream of the same.
+// runInputTarStreamGoroutine is the goroutine entrypoint.
 //
-// In the middle it will pack the segments and file metadata to storage.Packer
-// `p`.
+// It centralizes the goroutine protocol so the core parsing logic can be
+// written as ordinary Go code that just "returns an error".
 //
-// The the storage.FilePutter is where payload of files in the stream are
-// stashed. If this stashing is not needed, you can provide a nil
-// storage.FilePutter. Since the checksumming is still needed, then a default
-// of NewDiscardFilePutter will be used internally
-func NewInputTarStream(r io.Reader, p storage.Packer, fp storage.FilePutter) (io.Reader, error) {
+// Protocol guarantees:
+//   - pW is always closed exactly once (CloseWithError(nil) == Close()).
+//   - if done != nil, exactly one value is sent (nil on success, non-nil on failure).
+//   - panics are converted into a non-nil error (and the panic is rethrown).
+func runInputTarStreamGoroutine(outputRdr io.Reader, pW *io.PipeWriter, p storage.Packer, fp storage.FilePutter, done chan<- error) {
+	// Default to a non-nil error so a panic can't accidentally look like success.
+	err := errors.New("panic in runInputTarStream")
+	defer func() {
+		// CloseWithError(nil) is equivalent to Close().
+		pW.CloseWithError(err)
+
+		if done != nil {
+			done <- err
+		}
+
+		// Preserve panic semantics while still ensuring the protocol above runs.
+		if r := recover(); r != nil {
+			panic(r)
+		}
+	}()
+
+	err = runInputTarStream(outputRdr, p, fp)
+}
+
+// runInputTarStream drives tar-split parsing.
+//
+// It reads a tar stream from outputRdr and records tar-split metadata into the
+// provided storage.Packer.
+//
+// Abort behavior: if the consumer closes the read end early, the tee reader will
+// stop producing bytes (due to pipe write failure) and tar parsing will return
+// an error. We propagate that error so the goroutine terminates promptly rather
+// than draining the input stream for no benefit.
+func runInputTarStream(outputRdr io.Reader, p storage.Packer, fp storage.FilePutter) error {
+	tr := tar.NewReader(outputRdr)
+	tr.RawAccounting = true
+
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			if err != io.EOF {
+				return err
+			}
+			// Even when EOF is reached, there is often 1024 null bytes at the end
+			// of an archive. Collect them too.
+			if b := tr.RawBytes(); len(b) > 0 {
+				if _, err := p.AddEntry(storage.Entry{
+					Type:    storage.SegmentType,
+					Payload: b,
+				}); err != nil {
+					return err
+				}
+			}
+			break // Not return: we still need to drain any additional padding.
+		}
+		if hdr == nil {
+			break // Not return: we still need to drain any additional padding.
+		}
+
+		if b := tr.RawBytes(); len(b) > 0 {
+			if _, err := p.AddEntry(storage.Entry{
+				Type:    storage.SegmentType,
+				Payload: b,
+			}); err != nil {
+				return err
+			}
+		}
+
+		var csum []byte
+		if hdr.Size > 0 {
+			_, csum, err = fp.Put(hdr.Name, tr)
+			if err != nil {
+				return err
+			}
+		}
+
+		entry := storage.Entry{
+			Type:    storage.FileType,
+			Size:    hdr.Size,
+			Payload: csum,
+		}
+		// For proper marshalling of non-utf8 characters
+		entry.SetName(hdr.Name)
+
+		// File entries added, regardless of size
+		if _, err := p.AddEntry(entry); err != nil {
+			return err
+		}
+
+		if b := tr.RawBytes(); len(b) > 0 {
+			if _, err := p.AddEntry(storage.Entry{
+				Type:    storage.SegmentType,
+				Payload: b,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+
+	// It is allowable, and not uncommon that there is further padding on
+	// the end of an archive, apart from the expected 1024 null bytes. We
+	// do this in chunks rather than in one go to avoid cases where a
+	// maliciously crafted tar file tries to trick us into reading many GBs
+	// into memory.
+	const paddingChunkSize = 1024 * 1024
+	var paddingChunk [paddingChunkSize]byte
+	for {
+		n, err := outputRdr.Read(paddingChunk[:])
+		if n != 0 {
+			if _, aerr := p.AddEntry(storage.Entry{
+				Type:    storage.SegmentType,
+				Payload: paddingChunk[:n],
+			}); aerr != nil {
+				return aerr
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// newInputTarStreamCommon sets up the shared plumbing for NewInputTarStream and
+// NewInputTarStreamWithDone.
+//
+// It constructs an io.Pipe and an io.TeeReader such that:
+//
+//   - The caller reads tar bytes from the returned *io.PipeReader.
+//   - The background goroutine simultaneously reads the same stream from the
+//     TeeReader to perform tar-split parsing and metadata packing.
+//
+// Abort and synchronization semantics:
+//
+//   - Closing the returned PipeReader causes the TeeReader to fail its write to
+//     the pipe, which in turn causes the background goroutine to exit promptly.
+//   - If withDone is true, a done channel is returned that receives exactly one
+//     error value (nil on success) once the background goroutine has fully
+//     terminated. This allows callers to safely wait until the input reader `r`
+//     is no longer in use.
+func newInputTarStreamCommon(
+	r io.Reader,
+	p storage.Packer,
+	fp storage.FilePutter,
+	done chan<- error,
+) (pr *io.PipeReader) {
 	// What to do here... folks will want their own access to the Reader that is
 	// their tar archive stream, but we'll need that same stream to use our
 	// forked 'archive/tar'.
@@ -34,123 +179,59 @@ func NewInputTarStream(r io.Reader, p storage.Packer, fp storage.FilePutter) (io
 	// only read what the outputRdr Read's. Since Tar archives have padding on
 	// the end, we want to be the one reading the padding, even if the user's
 	// `archive/tar` doesn't care.
-	pR, pW := io.Pipe()
-	outputRdr := io.TeeReader(r, pW)
+	pr, pw := io.Pipe()
 
-	// we need a putter that will generate the crc64 sums of file payloads
 	if fp == nil {
 		fp = storage.NewDiscardFilePutter()
 	}
 
-	go func() {
-		tr := tar.NewReader(outputRdr)
-		tr.RawAccounting = true
-		for {
-			hdr, err := tr.Next()
-			if err != nil {
-				if err != io.EOF {
-					pW.CloseWithError(err)
-					return
-				}
-				// even when an EOF is reached, there is often 1024 null bytes on
-				// the end of an archive. Collect them too.
-				if b := tr.RawBytes(); len(b) > 0 {
-					_, err := p.AddEntry(storage.Entry{
-						Type:    storage.SegmentType,
-						Payload: b,
-					})
-					if err != nil {
-						pW.CloseWithError(err)
-						return
-					}
-				}
-				break // not return. We need the end of the reader.
-			}
-			if hdr == nil {
-				break // not return. We need the end of the reader.
-			}
+	outputRdr := io.TeeReader(r, pw)
+	go runInputTarStreamGoroutine(outputRdr, pw, p, fp, done)
 
-			if b := tr.RawBytes(); len(b) > 0 {
-				_, err := p.AddEntry(storage.Entry{
-					Type:    storage.SegmentType,
-					Payload: b,
-				})
-				if err != nil {
-					pW.CloseWithError(err)
-					return
-				}
-			}
+	return pr
+}
 
-			var csum []byte
-			if hdr.Size > 0 {
-				var err error
-				_, csum, err = fp.Put(hdr.Name, tr)
-				if err != nil {
-					pW.CloseWithError(err)
-					return
-				}
-			}
+// NewInputTarStream wraps the Reader stream of a tar archive and provides a
+// Reader stream of the same.
+//
+// In the middle it will pack the segments and file metadata to storage.Packer
+// `p`.
+//
+// The storage.FilePutter is where payload of files in the stream are
+// stashed. If this stashing is not needed, you can provide a nil
+// storage.FilePutter. Since the checksumming is still needed, then a default
+// of NewDiscardFilePutter will be used internally
+//
+// If callers need to be able to abort early and/or wait for goroutine termination,
+// prefer NewInputTarStreamWithDone.
+//
+// Deprecated: This leaves a goroutine around if the consumer aborts without consuming
+// the whole stream, and does not allow the caller to know when r is safe to deallocate
+// or when p has written everything. Use NewInputTarStreamWithDone instead.
+func NewInputTarStream(r io.Reader, p storage.Packer, fp storage.FilePutter) (io.Reader, error) {
+	pr := newInputTarStreamCommon(r, p, fp, nil)
+	return pr, nil
+}
 
-			entry := storage.Entry{
-				Type:    storage.FileType,
-				Size:    hdr.Size,
-				Payload: csum,
-			}
-			// For proper marshalling of non-utf8 characters
-			entry.SetName(hdr.Name)
-
-			// File entries added, regardless of size
-			_, err = p.AddEntry(entry)
-			if err != nil {
-				pW.CloseWithError(err)
-				return
-			}
-
-			if b := tr.RawBytes(); len(b) > 0 {
-				_, err = p.AddEntry(storage.Entry{
-					Type:    storage.SegmentType,
-					Payload: b,
-				})
-				if err != nil {
-					pW.CloseWithError(err)
-					return
-				}
-			}
-		}
-
-		// It is allowable, and not uncommon that there is further padding on
-		// the end of an archive, apart from the expected 1024 null bytes. We
-		// do this in chunks rather than in one go to avoid cases where a
-		// maliciously crafted tar file tries to trick us into reading many GBs
-		// into memory.
-		const paddingChunkSize = 1024 * 1024
-		var paddingChunk [paddingChunkSize]byte
-		for {
-			var isEOF bool
-			n, err := outputRdr.Read(paddingChunk[:])
-			if err != nil {
-				if err != io.EOF {
-					pW.CloseWithError(err)
-					return
-				}
-				isEOF = true
-			}
-			if n != 0 {
-				_, err = p.AddEntry(storage.Entry{
-					Type:    storage.SegmentType,
-					Payload: paddingChunk[:n],
-				})
-				if err != nil {
-					pW.CloseWithError(err)
-					return
-				}
-			}
-			if isEOF {
-				break
-			}
-		}
-		pW.Close()
-	}()
-
-	return pR, nil
+// NewInputTarStreamWithDone wraps the Reader stream of a tar archive and provides a
+// Reader stream of the same.
+//
+// In the middle it will pack the segments and file metadata to storage.Packer `p`.
+//
+// It also returns a done channel that will receive exactly one error value
+// (nil on success) when the internal goroutine has fully completed parsing
+// the tar stream (including the final paddingChunk draining loop) and has
+// finished writing all entries to `p`.
+//
+// The returned reader is an io.ReadCloser so callers can stop early; closing it
+// aborts the pipe so the internal goroutine can terminate promptly (rather than
+// hanging on a blocked pipe write).
+//
+// The caller is expected to consume the returned reader fully until EOF
+// (not just the tar EOF marker); closing the returned reader earlier will
+// cause the done channel to return a failure.
+func NewInputTarStreamWithDone(r io.Reader, p storage.Packer, fp storage.FilePutter) (io.ReadCloser, <-chan error, error) {
+	done := make(chan error, 1)
+	pr := newInputTarStreamCommon(r, p, fp, done)
+	return pr, done, nil
 }

--- a/vendor/github.com/vbatts/tar-split/tar/asm/iterate.go
+++ b/vendor/github.com/vbatts/tar-split/tar/asm/iterate.go
@@ -11,7 +11,7 @@ import (
 
 // IterateHeaders calls handler for each tar header provided by Unpacker
 func IterateHeaders(unpacker storage.Unpacker, handler func(hdr *tar.Header) error) error {
-	// We assume about NewInputTarStream:
+	// We assume about NewInputTarStreamWithDone:
 	// - There is a separate SegmentType entry for every tar header, but only one SegmentType entry for the full header incl. any extensions
 	// - (There is a FileType entry for every tar header, we ignore it)
 	// - Trailing padding of a file, if any, is included in the next SegmentType entry

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1595,8 +1595,8 @@ github.com/transparency-dev/merkle
 github.com/transparency-dev/merkle/compact
 github.com/transparency-dev/merkle/proof
 github.com/transparency-dev/merkle/rfc6962
-# github.com/vbatts/tar-split v0.12.2
-## explicit; go 1.17
+# github.com/vbatts/tar-split v0.12.3
+## explicit; go 1.22.0
 github.com/vbatts/tar-split/archive/tar
 github.com/vbatts/tar-split/tar/asm
 github.com/vbatts/tar-split/tar/storage


### PR DESCRIPTION
- replace: https://github.com/moby/moby/pull/52466

### vendor: github.com/vbatts/tar-split v0.12.3

Most important changes are:
* tar/asm: add NewInputTarStreamWithDone + tests - [https://github.com/vbatts/tar-split/pull/86](https://redirect.github.com/vbatts/tar-split/pull/86)
* Port fix for CVE-2026-32288 - [https://github.com/vbatts/tar-split/pull/88](https://redirect.github.com/vbatts/tar-split/pull/88)

**Full Changelog**: <https://github.com/vbatts/tar-split/compare/v0.12.2...v0.12.3>


### layer: Migrate off deprecated NewInputTarStream

  The deprecated asm.NewInputTarStream leaves a goroutine hanging if the consumer doesn't fully drain the stream, and provides no signal for when the internal parsing goroutine has completed.

  Switch to asm.NewInputTarStreamWithDone which returns a done channel, allowing us to detect goroutine completion and surface any errors from the internal tar parsing.


```markdown changelog
CVE-2026-32288: Fix a denial of service where pulling a maliciously crafted image could cause the daemon to allocate unbounded memory when processing sparse tar archives. [GHSA-x4jj-h2v8-hqqv](https://github.com/advisories/GHSA-x4jj-h2v8-hqqv)
```