### PR TITLE
Fix flaky `Swarm is encrypted and needs to be unlocked` error

### DIFF
--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -36,7 +36,7 @@ type nodeRunner struct {
 
 	repeatedRun     bool
 	cancelReconnect func()
-	stopping        bool
+	stopped         bool
 	cluster         *Cluster // only for accessing config helpers, never call any methods. TODO: change to config struct
 }
 
@@ -310,7 +310,7 @@ func (n *nodeRunner) handleNodeExit(node *swarmnode.Node) {
 // Stop stops the current swarm node if it is running.
 func (n *nodeRunner) Stop() error {
 	n.mu.Lock()
-	n.stopping = true
+	n.stopped = true
 	if n.cancelReconnect != nil { // between restarts
 		n.cancelReconnect()
 		n.cancelReconnect = nil
@@ -363,7 +363,7 @@ func (n *nodeRunner) State() nodeState {
 }
 
 func (n *nodeRunner) enableReconnectWatcher() {
-	if n.stopping {
+	if n.stopped {
 		return
 	}
 	n.reconnectDelay *= 2
@@ -381,7 +381,7 @@ func (n *nodeRunner) enableReconnectWatcher() {
 		}
 		n.mu.Lock()
 		defer n.mu.Unlock()
-		if n.stopping {
+		if n.stopped {
 			return
 		}
 

--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -310,6 +310,7 @@ func (n *nodeRunner) handleNodeExit(node *swarmnode.Node) {
 // Stop stops the current swarm node if it is running.
 func (n *nodeRunner) Stop() error {
 	n.mu.Lock()
+	n.stopping = true
 	if n.cancelReconnect != nil { // between restarts
 		n.cancelReconnect()
 		n.cancelReconnect = nil
@@ -323,7 +324,6 @@ func (n *nodeRunner) Stop() error {
 		n.mu.Unlock()
 		return nil
 	}
-	n.stopping = true
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	n.mu.Unlock()

--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -324,16 +324,18 @@ func (n *nodeRunner) Stop() error {
 		n.mu.Unlock()
 		return nil
 	}
+	swarmNode := n.swarmNode
+	done := n.done
 	n.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	if err := n.swarmNode.Stop(ctx); err != nil && !strings.Contains(err.Error(), "context canceled") {
+	if err := swarmNode.Stop(ctx); err != nil && !strings.Contains(err.Error(), "context canceled") {
 		return err
 	}
 	n.cluster.SendClusterEvent(lncluster.EventNodeLeave)
-	<-n.done
+	<-done
 	return nil
 }
 

--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -324,9 +324,11 @@ func (n *nodeRunner) Stop() error {
 		n.mu.Unlock()
 		return nil
 	}
+	n.mu.Unlock()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	n.mu.Unlock()
+
 	if err := n.swarmNode.Stop(ctx); err != nil && !strings.Contains(err.Error(), "context canceled") {
 		return err
 	}


### PR DESCRIPTION
### daemon/cluster: Alway set stopping flag on Stop

  Move `n.stopping=true` to the top of Stop(), before the nil check, so the reconnect goroutine always sees the correct state.

  When a swarm is locked, the node exits and handleNodeExit sets
  `swarmNode=nil` and starts a reconnect watcher goroutine. If Stop() is called while `swarmNode==nil`, it takes an early return without setting
  `stopping=true`.

  When the reconnect timer later fires, the goroutine sees
  `stopping==false` and calls n.start(), spawning an orphaned swarm node that writes encrypted state to disk.

  The next swarm init then fails with a 503 "Swarm is encrypted and needs to be unlocked" error - the flaky failure often seen in docker-py CI.



### daemon/cluster: Rename nodeRunner.stopping to stopped

  The past tense better conveys that this is a terminal state ("don't restart") rather than an in-progress action.



### daemon/cluster: Move context creation outside of critical section

  No need to keep it inside the section


```markdown changelog
Fix a bug where leaving an autolock-enabled swarm could leave orphaned state, causing subsequent swarm init to fail with "Swarm is encrypted and needs to be unlocked".
```