### PR TITLE
daemon: connectToNetwork: keep Networks on failure

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -744,6 +744,17 @@ func (daemon *Daemon) connectToNetwork(ctx context.Context, cfg *config.Config, 
 		}
 	}
 
+	// Snapshot Networks so a failure anywhere in the rest of this function
+	// rolls it back to its pre-call state. Without this, a failed start (e.g.
+	// published port already in use) would leave Networks empty and the next
+	// start would silently "succeed" with no networking configured.
+	origNetworks := maps.Clone(ctr.NetworkSettings.Networks)
+	defer func() {
+		if retErr != nil {
+			ctr.NetworkSettings.Networks = origNetworks
+		}
+	}()
+
 	if err := daemon.updateNetworkConfig(ctr, n, endpointConfig.EndpointSettings); err != nil {
 		return err
 	}
@@ -772,11 +783,6 @@ func (daemon *Daemon) connectToNetwork(ctx context.Context, cfg *config.Config, 
 
 	delete(ctr.NetworkSettings.Networks, n.ID())
 	ctr.NetworkSettings.Networks[nwName] = endpointConfig
-	defer func() {
-		if retErr != nil {
-			delete(ctr.NetworkSettings.Networks, nwName)
-		}
-	}()
 
 	if nwName == network.DefaultNetwork {
 		// Legacy links must be prepared before the Endpoint.Join, because the network

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -537,6 +537,18 @@ func TestPublishedPortAlreadyInUse(t *testing.T) {
 	inspect, err := apiClient.ContainerInspect(ctx, ctr2, client.ContainerInspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(inspect.Container.State.Status, containertypes.StateCreated))
+
+	_, err = apiClient.ContainerStart(ctx, ctr2, client.ContainerStartOptions{})
+	assert.Assert(t, is.ErrorContains(err, "failed to set up container networking"))
+
+	inspect, err = apiClient.ContainerInspect(ctx, ctr2, client.ContainerInspectOptions{})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(inspect.Container.State.Status, containertypes.StateCreated))
+	assert.Assert(t, is.Len(inspect.Container.HostConfig.PortBindings[mappedPort], 1))
+	assert.Check(t, is.Equal(inspect.Container.HostConfig.PortBindings[mappedPort][0].HostPort, "8000"))
+	// The bridge entry must survive the failed start, otherwise the next start
+	// would silently succeed with no networking attached.
+	assert.Assert(t, is.Contains(inspect.Container.NetworkSettings.Networks, "bridge"))
 }
 
 // TestAllPortMappingsAreReturned check that dual-stack ports mapped through


### PR DESCRIPTION
Closes #51758

When `connectToNetwork` fails (e.g. `ep.Join` hits a "port already allocated"), the deferred rollback unconditionally deleted the entry it had just written under `nwName`. For the start-time path that entry was the original `Networks["bridge"]` put there by `docker create` — not something this function introduced — so deleting it wiped the container's network config.

With `Networks` empty, the next `docker start` ranges over an empty map in `allocateNetwork`, returns `nil`, and the container "starts" with no networking attached. `HostConfig.PortBindings` is preserved but never applied, and the conflicting port goes silently unbound.

Snapshot `Networks[n.ID()]` and `Networks[nwName]` before any mutation in the function, and on `retErr` restore each to its pre-call state. Pre-existing entries (created at `docker create` time) get restored; entries this function itself added (e.g. on a failed `docker network connect` to a new network) get deleted.

Extend `TestPublishedPortAlreadyInUse` to check that a second `ContainerStart` against the same port conflict also errors and that `NetworkSettings.Networks` still contains the bridge entry.

---

### What I did

Fixed a bug where `docker start` on a "Created" container with a conflicting published port would error on the first attempt but **silently succeed with no networking** on subsequent attempts. The container would end up running with `NetworkSettings.Networks: {}` and `Ports: {}` — appearing "Up" in `docker ps` but completely detached from any network.

### How I did it

In [`daemon/container_operations.go`](https://github.com/moby/moby/blob/master/daemon/container_operations.go) → `connectToNetwork`:

- The deferred rollback used to be `delete(Networks, nwName)`. That's correct only if this function was the one that *put* the entry there. On the start-time path it wasn't — `docker create` had already populated `Networks["bridge"]`, so the unconditional delete was wiping the user's config.
- Replaced it with a snapshot/restore pattern: capture `Networks[n.ID()]` and `Networks[nwName]` before any mutation, and on `retErr` either restore the original or delete (depending on whether the key existed pre-call).

Also extended `TestPublishedPortAlreadyInUse` with assertions for the second-start case and for the bridge entry surviving in `NetworkSettings.Networks`.

### How to verify it

**Integration test:**
```bash
  TEST_FILTER=TestPublishedPortAlreadyInUse make test-integration

```

<img width="1080" height="1080" alt="cato" src="https://github.com/user-attachments/assets/38cef224-3c6f-4da9-8183-e13e786de6fa" />
