### PR TITLE
daemon/containerd: include shared content blobs in image SharedSize

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -208,6 +208,9 @@ func (i *ImageService) Images(ctx context.Context, opts imagebackend.ListOptions
 				}
 				usage, err := snapshotter.Usage(ctx, d.String())
 				if err != nil {
+					if cerrdefs.IsNotFound(err) {
+						return 0, nil
+					}
 					return 0, err
 				}
 				sizeCache[d] = usage.Size

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -59,6 +59,12 @@ func (r byCreated) Len() int           { return len(r) }
 func (r byCreated) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
 func (r byCreated) Less(i, j int) bool { return r[i].Created < r[j].Created }
 
+// sharedSizeData groups chainIDs and content descriptors for a single image.
+type sharedSizeData struct {
+	chainIDs []digest.Digest
+	content  []ocispec.Descriptor
+}
+
 // Images returns a filtered list of images.
 //
 // TODO(thaJeztah): verify behavior of `RepoDigests` and `RepoTags` for images without (untagged) or multiple tags; see https://github.com/moby/moby/issues/43861
@@ -76,21 +82,6 @@ func (i *ImageService) Images(ctx context.Context, opts imagebackend.ListOptions
 	imgs, err := i.images.List(ctx)
 	if err != nil {
 		return nil, err
-	}
-
-	// TODO(thaJeztah): do we need to take multiple snapshotters into account? See https://github.com/moby/moby/issues/45273
-	snapshotter := i.snapshotterService(i.snapshotter)
-	sizeCache := make(map[digest.Digest]int64)
-	snapshotSizeFn := func(d digest.Digest) (int64, error) {
-		if s, ok := sizeCache[d]; ok {
-			return s, nil
-		}
-		usage, err := snapshotter.Usage(ctx, d.String())
-		if err != nil {
-			return 0, err
-		}
-		sizeCache[d] = usage.Size
-		return usage.Size, nil
 	}
 
 	uniqueImages := map[digest.Digest]c8dimages.Image{}
@@ -151,13 +142,15 @@ func (i *ImageService) Images(ctx context.Context, opts imagebackend.ListOptions
 	eg.SetLimit(runtime.NumCPU() * 2)
 
 	var (
-		summaries = make([]imagetypes.Summary, 0, len(imgs))
-		root      []*[]digest.Digest
-		layers    map[digest.Digest]int
+		summaries  = make([]imagetypes.Summary, 0, len(imgs))
+		sharedData []sharedSizeData
+		layers     map[digest.Digest]int
+		blobs      map[digest.Digest]int
 	)
 	if opts.SharedSize {
-		root = make([]*[]digest.Digest, 0, len(imgs))
+		sharedData = make([]sharedSizeData, 0, len(imgs))
 		layers = make(map[digest.Digest]int)
+		blobs = make(map[digest.Digest]int)
 	}
 
 	for _, img := range uniqueImages {
@@ -178,9 +171,21 @@ func (i *ImageService) Images(ctx context.Context, opts imagebackend.ListOptions
 			summaries = append(summaries, *image)
 
 			if opts.SharedSize {
-				root = append(root, &multiSummary.AllChainIDs)
+				sharedData = append(sharedData, sharedSizeData{
+					chainIDs: multiSummary.AllChainIDs,
+					content:  multiSummary.content,
+				})
 				for _, id := range multiSummary.AllChainIDs {
 					layers[id] = layers[id] + 1
+				}
+
+				seen := map[digest.Digest]struct{}{}
+				for _, desc := range multiSummary.content {
+					if _, ok := seen[desc.Digest]; ok {
+						continue
+					}
+					seen[desc.Digest] = struct{}{}
+					blobs[desc.Digest]++
 				}
 			}
 			resultsMut.Unlock()
@@ -193,8 +198,21 @@ func (i *ImageService) Images(ctx context.Context, opts imagebackend.ListOptions
 	}
 
 	if opts.SharedSize {
-		for n, chainIDs := range root {
-			sharedSize, err := computeSharedSize(*chainIDs, layers, snapshotSizeFn)
+		// TODO(thaJeztah): do we need to take multiple snapshotters into account? See https://github.com/moby/moby/issues/45273
+		snapshotter := i.snapshotterService(i.snapshotter)
+		sizeCache := make(map[digest.Digest]int64)
+		for n, data := range sharedData {
+			sharedSize, err := computeSharedSize(data, layers, blobs, func(d digest.Digest) (int64, error) {
+				if s, ok := sizeCache[d]; ok {
+					return s, nil
+				}
+				usage, err := snapshotter.Usage(ctx, d.String())
+				if err != nil {
+					return 0, err
+				}
+				sizeCache[d] = usage.Size
+				return usage.Size, nil
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -230,6 +248,8 @@ type multiPlatformSummary struct {
 	BestPlatform ocispec.Platform
 
 	manifestIdentityRefs map[digest.Digest]manifestIdentityRef
+
+	content []ocispec.Descriptor
 }
 
 type manifestIdentityRef struct {
@@ -268,6 +288,7 @@ func (i *ImageService) multiPlatformSummary(ctx context.Context, img c8dimages.I
 		var contentSize int64
 		if err := i.walkPresentChildren(ctx, target, func(ctx context.Context, desc ocispec.Descriptor) error {
 			contentSize += desc.Size
+			summary.content = append(summary.content, desc)
 			return nil
 		}); err == nil {
 			mfstSummary.Size.Content = contentSize
@@ -782,9 +803,9 @@ func setupLabelFilter(ctx context.Context, store content.Store, fltrs filters.Ar
 	}, nil
 }
 
-func computeSharedSize(chainIDs []digest.Digest, layers map[digest.Digest]int, sizeFn func(d digest.Digest) (int64, error)) (int64, error) {
+func computeSharedSize(data sharedSizeData, layers map[digest.Digest]int, blobs map[digest.Digest]int, sizeFn func(d digest.Digest) (int64, error)) (int64, error) {
 	var sharedSize int64
-	for _, chainID := range chainIDs {
+	for _, chainID := range data.chainIDs {
 		if layers[chainID] == 1 {
 			continue
 		}
@@ -799,6 +820,21 @@ func computeSharedSize(chainIDs []digest.Digest, layers map[digest.Digest]int, s
 		}
 		sharedSize += size
 	}
+
+	seen := map[digest.Digest]struct{}{}
+	for _, desc := range data.content {
+		if blobs[desc.Digest] == 1 {
+			continue
+		}
+
+		if _, ok := seen[desc.Digest]; ok {
+			continue
+		}
+
+		seen[desc.Digest] = struct{}{}
+		sharedSize += desc.Size
+	}
+
 	return sharedSize, nil
 }
 

--- a/daemon/containerd/image_list_test.go
+++ b/daemon/containerd/image_list_test.go
@@ -456,3 +456,52 @@ func TestImageList(t *testing.T) {
 		})
 	}
 }
+
+func TestComputeSharedSizeIncludesSharedContentBlobs(t *testing.T) {
+	sharedChainID := digest.FromString("shared-chain")
+	uniqueChainID := digest.FromString("unique-chain")
+
+	sharedBlob := ocispec.Descriptor{
+		Digest: digest.FromString("shared-blob"),
+		Size:   20,
+	}
+	uniqueBlob := ocispec.Descriptor{
+		Digest: digest.FromString("unique-blob"),
+		Size:   30,
+	}
+
+	sizeFn := func(d digest.Digest) (int64, error) {
+		switch d {
+		case sharedChainID:
+			return 100, nil
+		case uniqueChainID:
+			return 200, nil
+		default:
+			t.Fatalf("unexpected chainID: %s", d)
+			return 0, nil
+		}
+	}
+
+	sharedSize, err := computeSharedSize(
+		sharedSizeData{
+			chainIDs: []digest.Digest{sharedChainID, uniqueChainID},
+			content: []ocispec.Descriptor{
+				sharedBlob,
+				sharedBlob, // duplicate reference within the same image should not double count.
+				uniqueBlob,
+			},
+		},
+		map[digest.Digest]int{
+			sharedChainID: 2,
+			uniqueChainID: 1,
+		},
+		map[digest.Digest]int{
+			sharedBlob.Digest: 2,
+			uniqueBlob.Digest: 1,
+		},
+		sizeFn,
+	)
+
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(sharedSize, int64(120)))
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #52476 

**- What I did**

Fixed incorrect `UNIQUE SIZE` / `SHARED SIZE` reporting in `docker system df -v`.

The current implementation only accounts for snapshot layers (`chainIDs`) when computing `SharedSize`, but image `Size` also includes content blobs. Hence content blobs shared across images are incorrectly attributed to `UNIQUE SIZE`.

This change extends the calculation to include shared content blobs, ensuring that `SHARED SIZE` reflects all shared data correctly.

**- How I did it**

Updated the logic in `daemon/containerd/image_list.go` to:

- Track content descriptors (OCI blobs) referenced by each image
- Count blob usage across images
- Include blobs referenced by multiple images in `SharedSize`
- Ensure de-duplication using digest-based tracking to avoid double counting

The calculation now accounts for both:
- snapshot layers (`chainIDs`)
- content blobs (descriptors)

when determining shared vs unique size.

**- How to verify it**

1. Build two images sharing a common base (eg `node:22`):

```bash
npm init -y
npm i express@4.19.2 --save-exact

mkdir -p src

cat <<'EOF' > src/index.js
const express = require('express');
const app = express();
const port = process.env.PORT;
app.get('/', (req, res) => {
  res.send('Hello from node');
});
app.listen(port, () => {
  console.log(`Example app listening at http://localhost:${port}`);
});
EOF

cat <<'EOF' > Dockerfile
FROM node:22
WORKDIR /app
COPY package*.json ./
RUN npm ci
ENV PORT=3000
COPY src/index.js index.js
CMD ["node", "index.js"]
EOF

docker pull node:22
docker build -t express_app:v0.0.1 .
docker system df -v
```
2. Results
Before fix:
```bash
REPOSITORY    TAG       IMAGE ID       CREATED                  SIZE      SHARED SIZE   UNIQUE SIZE   CONTAINERS
express_app   v0.0.1    ff6863dac927   Less than a second ago   1.64GB    1.216GB       421.3MB       0
node          22        9059d9d7db98   7 days ago               1.64GB    1.216GB       424.4MB       0
```
where `express_app` `UNIQUE SIZE` ~ hundreds of MB (incorrect) and Shared content blobs are misattributed.

After fix:
```bash
REPOSITORY    TAG       IMAGE ID       CREATED         SIZE      SHARED SIZE   UNIQUE SIZE   CONTAINERS
express_app   v0.0.1    ff6863dac927   3 minutes ago   1.64GB    1.624GB       13.12MB       0
node          22        9059d9d7db98   7 days ago      1.64GB    1.624GB       16.18MB       0
```
`express_app` `UNIQUE SIZE` ~ 13.12MB (correct, matches actual added layers) and now `SHARED SIZE` correctly includes shared content blobs

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix incorrect SHARED SIZE and UNIQUE SIZE reporting in `docker system df -v` by including shared content blobs in size calculation.
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="774" height="1161" alt="image" src="https://github.com/user-attachments/assets/980537aa-e067-4700-b86d-18e873e73722" />
