### PR TITLE
docker-proxy: Fix dropping UDP datagrams after backend becomes reachable

### DIFF
--- a/cmd/docker-proxy/udp_proxy_linux.go
+++ b/cmd/docker-proxy/udp_proxy_linux.go
@@ -199,6 +199,13 @@ func (proxy *UDPProxy) Run() {
 		for i := 0; i != read; {
 			written, err := cte.conn.Write(readBuf[i:read])
 			if err != nil {
+				if opErr, ok := err.(*net.OpError); ok && errors.Is(opErr.Err, syscall.ECONNREFUSED) {
+					// A previous write to the backend may have resulted in an
+					// ICMP port-unreachable. The kernel queues this as an error
+					// on the socket, which is returned on the next Write. Retry
+					// so the current datagram is not silently dropped.
+					continue
+				}
 				log.Printf("Can't proxy a datagram to udp/%s: %s\n", proxy.backendAddr, err)
 				break
 			}


### PR DESCRIPTION
Note: This caused TestUDPWriteError flakiness.

### docker-proxy: Retry UDP write on ECONNREFUSED from stale ICMP errors

  When the proxy forwards a UDP datagram to a backend that isn't listening, the kernel queues an ICMP port-unreachable error on the connected socket. This error is returned on the *next* Write() call, not the one that triggered it. As a result, a subsequent write carrying new data silently fails and the datagram is never sent to the backend.

  The replyLoop already handles this for reads (goto again on ECONNREFUSED). Apply the same treatment to writes in Run() and retry the write when the error is ECONNREFUSED.


```markdown changelog
Fix the userland proxy silently dropping UDP datagrams when a previous write to an unavailable backend left a stale ECONNREFUSED error on the socket
```