### PR TITLE
gha/windows: Fix flaky Docker info

### DIFF
--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -72,6 +72,18 @@ jobs:
       -
         name: Docker info
         run: |
+          $tries = 30
+          Write-Host "Waiting for Docker daemon..."
+          while ($true) {
+            $ErrorActionPreference = "SilentlyContinue"
+            docker version | Out-Null
+            $ok = ($LastExitCode -eq 0)
+            $ErrorActionPreference = "Stop"
+            if ($ok) { break }
+            $tries--
+            if ($tries -le 0) { throw "Docker daemon did not become ready" }
+            Start-Sleep -Seconds 2
+          }
           docker info
       -
         name: Build base image
@@ -141,6 +153,18 @@ jobs:
       -
         name: Docker info
         run: |
+          $tries = 30
+          Write-Host "Waiting for Docker daemon..."
+          while ($true) {
+            $ErrorActionPreference = "SilentlyContinue"
+            docker version | Out-Null
+            $ok = ($LastExitCode -eq 0)
+            $ErrorActionPreference = "Stop"
+            if ($ok) { break }
+            $tries--
+            if ($tries -le 0) { throw "Docker daemon did not become ready" }
+            Start-Sleep -Seconds 2
+          }
           docker info
       -
         name: Build base image


### PR DESCRIPTION
The daemon may need a bit more time to start, probe the daemon first via `docker version` and then run docker info.


Fixes flaky failures like: https://github.com/moby/moby/actions/runs/25103994873/job/73560437346