### PR TITLE
gha/ci: Store slim test-results-* artifacts

### DIFF
--- a/.github/workflows/.test-unit.yml
+++ b/.github/workflows/.test-unit.yml
@@ -91,6 +91,14 @@ jobs:
           name: test-reports-unit--${{ matrix.mode }}
           path: /tmp/reports/*
           retention-days: 1
+      -
+        name: Upload test results (gotestsum JSON)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-unit--${{ matrix.mode }}
+          path: /tmp/reports/**/*go-test-report*.json
+          retention-days: 7
 
   unit-report:
     runs-on: ubuntu-24.04

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -269,6 +269,14 @@ jobs:
           name: test-reports-integration-${{ inputs.storage }}-${{ env.TESTREPORTS_NAME }}
           path: /tmp/reports/*
           retention-days: 1
+      -
+        name: Upload test results (gotestsum JSON)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-integration-${{ inputs.storage }}-${{ env.TESTREPORTS_NAME }}
+          path: /tmp/reports/**/*go-test-report*.json
+          retention-days: 7
 
   integration-report:
     runs-on: ubuntu-24.04
@@ -489,6 +497,14 @@ jobs:
           name: test-reports-integration-cli-${{ inputs.storage }}-${{ matrix.mode }}-${{ env.TESTREPORTS_NAME }}
           path: /tmp/reports/*
           retention-days: 1
+      -
+        name: Upload test results (gotestsum JSON)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-integration-cli-${{ inputs.storage }}-${{ matrix.mode }}-${{ env.TESTREPORTS_NAME }}
+          path: /tmp/reports/**/*go-test-report*.json
+          retention-days: 7
 
   integration-cli-report:
     runs-on: ubuntu-24.04

--- a/.github/workflows/.vm.yml
+++ b/.github/workflows/.vm.yml
@@ -179,6 +179,14 @@ jobs:
           name: test-reports-integration-${{ env.TESTREPORTS_NAME }}
           path: /tmp/reports/*
           retention-days: 1
+      -
+        name: Upload test results (gotestsum JSON)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-integration-${{ env.TESTREPORTS_NAME }}
+          path: /tmp/reports/**/*go-test-report*.json
+          retention-days: 7
 
   integration-report:
     runs-on: ubuntu-24.04

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -198,6 +198,14 @@ jobs:
           name: ${{ inputs.os }}-${{ inputs.storage }}-unit-reports
           path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*
           retention-days: 1
+      -
+        name: Upload test results (gotestsum JSON)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-unit-${{ inputs.os }}-${{ inputs.storage }}
+          path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\**\*go-test-report*.json
+          retention-days: 7
 
   unit-test-report:
     runs-on: ubuntu-24.04
@@ -529,6 +537,14 @@ jobs:
           name: ${{ inputs.os }}-${{ inputs.storage }}-integration-reports-${{ matrix.runtime }}-${{ env.TESTREPORTS_NAME }}
           path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\*
           retention-days: 1
+      -
+        name: Upload test results (gotestsum JSON)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-integration-${{ inputs.os }}-${{ inputs.storage }}-${{ matrix.runtime }}-${{ env.TESTREPORTS_NAME }}
+          path: ${{ env.GOPATH }}\src\github.com\docker\docker\bundles\**\*go-test-report*.json
+          retention-days: 7
 
   integration-test-report:
     runs-on: ubuntu-24.04

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -145,6 +145,14 @@ jobs:
           name: test-reports-unit-arm64-graphdriver
           path: /tmp/reports/*
           retention-days: 1
+      -
+        name: Upload test results (gotestsum JSON)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-unit-arm64-graphdriver
+          path: /tmp/reports/**/*go-test-report*.json
+          retention-days: 7
 
   test-unit-report:
     runs-on: ubuntu-24.04
@@ -252,6 +260,14 @@ jobs:
           name: test-reports-integration-arm64-graphdriver
           path: /tmp/reports/*
           retention-days: 1
+      -
+        name: Upload test results (gotestsum JSON)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-integration-arm64-graphdriver
+          path: /tmp/reports/**/*go-test-report*.json
+          retention-days: 7
 
   test-integration-report:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
- prepare for: https://github.com/moby/moby/issues/52567

Upload the `*-go-test-report.json` files emitted by gotestsum as a separate artifact with 7-day retention.
The artifact contains only the per-event JSON stream (one Action/Package/Test record per line); no logs, no otel traces, no profiles.

The plan is to mine these for automatically identifying flaky tests.

Doing that requires looking at more than one day of history, which isn't feasible with the existing test-reports-* artifacts because they bundle the gotestsum JSON together with daemon logs, otel traces, and profiles, totalling ~500 MB compressed across ~40 artifacts on a typical master run (the JSON itself is under 0.5% of that). Those artifacts therefore have to stay at retention-days: 1 to keep storage usage sane.

The existing test-reports-* artifacts are left untouched.