### PR TITLE
builder-next: Stop using libnetwork-setkey reexec for BuildKit networking

### DIFF
--- a/daemon/internal/builder-next/executor.go
+++ b/daemon/internal/builder-next/executor.go
@@ -61,7 +61,6 @@ func (iface *lnInterface) init(c *libnetwork.Controller, n *libnetwork.Network) 
 	sbx, err := c.NewSandbox(
 		context.TODO(),
 		id,
-		libnetwork.OptionUseExternalKey(),
 		libnetwork.OptionHostsPath(filepath.Join(iface.provider.Root, id, "hosts")),
 		libnetwork.OptionResolvConfPath(filepath.Join(iface.provider.Root, id, "resolv.conf")),
 	)

--- a/daemon/internal/builder-next/executor_linux.go
+++ b/daemon/internal/builder-next/executor_linux.go
@@ -2,9 +2,9 @@ package buildkit
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/containerd/log"
 	"github.com/moby/buildkit/executor"
@@ -12,7 +12,6 @@ import (
 	"github.com/moby/buildkit/executor/runcexecutor"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/network"
-	"github.com/moby/moby/v2/daemon/internal/stringid"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -81,13 +80,30 @@ func (iface *lnInterface) Set(s *specs.Spec) error {
 		log.G(context.TODO()).WithError(iface.err).Error("failed to set networking spec")
 		return iface.err
 	}
-	shortNetCtlrID := stringid.TruncateID(iface.provider.Controller.ID())
-	// attach netns to bridge within the container namespace, using reexec in a prestart hook
-	s.Hooks = &specs.Hooks{
-		Prestart: []specs.Hook{{
-			Path: filepath.Join("/proc", strconv.Itoa(os.Getpid()), "exe"),
-			Args: []string{"libnetwork-setkey", "-exec-root=" + iface.provider.Config().ExecRoot, iface.sbx.ContainerID(), shortNetCtlrID},
-		}},
+	nsPath, ok := iface.sbx.NetnsPath()
+	if !ok {
+		return fmt.Errorf("buildkit sandbox %s has no network namespace", iface.sbx.ContainerID())
 	}
+	// Tell runc to join the daemon-owned netns instead of creating a new one.
+	// This replaces the previous approach of using a "libnetwork-setkey" reexec
+	// prestart hook that bind-mounted /proc/<pid>/ns/net after container creation.
+	return setLinuxNamespace(s, specs.LinuxNamespace{
+		Type: specs.NetworkNamespace,
+		Path: nsPath,
+	})
+}
+
+// setLinuxNamespace sets or replaces a namespace entry in the OCI spec.
+func setLinuxNamespace(s *specs.Spec, ns specs.LinuxNamespace) error {
+	for i, n := range s.Linux.Namespaces {
+		if n.Type == ns.Type {
+			if n.Path != "" {
+				return fmt.Errorf("network namespace already set to %s", n.Path)
+			}
+			s.Linux.Namespaces[i] = ns
+			return nil
+		}
+	}
+	s.Linux.Namespaces = append(s.Linux.Namespaces, ns)
 	return nil
 }


### PR DESCRIPTION
- related to: https://github.com/moby/moby/issues/52488

BuildKit's bridge network provider used OptionUseExternalKey to defer netns creation, then wired up a "libnetwork-setkey" reexec binary as an OCI prestart hook.

When runc created the container, the hook would dial the controller's external key listener to call SetKey, which bind-mounted `/proc/<pid>/ns/net` onto a persistent path.

Switch to the simpler approach: the daemon creates the network namespace upfront (by not passing OptionUseExternalKey), then passes its path to runc via the OCI spec's NetworkNamespace entry. runc joins the existing netns instead of creating a new one. This is the same pattern used by BuildKit's CNI network provider.

This eliminates the prestart hook, the reexec binary invocation, and the unix socket protocol from the BuildKit build path, removing a layer of indirection.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

