### PR TITLE
gha/windows: Retry busybox image build on transient registry failures

### DIFF
--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -440,10 +440,23 @@ jobs:
       -
         name: Building contrib/busybox
         run: |
-          & "${{ env.BIN_OUT }}\docker" build -t busybox `
-            --build-arg WINDOWS_BASE_IMAGE `
-            --build-arg WINDOWS_BASE_IMAGE_TAG `
-            .\contrib\busybox\
+          $maxRetries = 5
+          for ($i = 1; $i -le $maxRetries; $i++) {
+            & "${{ env.BIN_OUT }}\docker" build -t busybox `
+              --build-arg WINDOWS_BASE_IMAGE `
+              --build-arg WINDOWS_BASE_IMAGE_TAG `
+              .\contrib\busybox\
+            if ($LASTEXITCODE -eq 0) {
+              break
+            }
+            if ($i -eq $maxRetries) {
+              Write-Error "Failed to build contrib/busybox after $maxRetries attempts"
+              exit 1
+            }
+            $delay = 15 * $i
+            Write-Warning "Build attempt $i failed (exit code: $LASTEXITCODE). Retrying in $delay seconds..."
+            Start-Sleep -Seconds $delay
+          }
         env:
           DOCKER_HOST: npipe:////./pipe/docker_engine
       -


### PR DESCRIPTION
Pulling mcr.microsoft.com/windows/servercore in the "Building contrib/busybox" step intermittently fails with "pull access denied" due to transient CDN or rate-limiting issues on the Microsoft container registry.

Wrap the docker build invocation in a retry loop (up to 5 attempts with 15-second delays) so that a single transient pull failure does not fail the whole workflow run.
