### PR TITLE
gha/windows: Diagnose and recover from stopped Docker service

### DIFF
--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -76,10 +76,20 @@ jobs:
           Write-Host "Waiting for Docker daemon..."
           while ($true) {
             $ErrorActionPreference = "SilentlyContinue"
-            docker version | Out-Null
+            docker version 2>&1 | Out-Null
             $ok = ($LastExitCode -eq 0)
             $ErrorActionPreference = "Stop"
             if ($ok) { break }
+            # Check if Docker service exists and try to start it if stopped
+            $svc = Get-Service docker -ErrorAction SilentlyContinue
+            if ($svc) {
+              if ($svc.Status -ne 'Running') {
+                Write-Host "Docker service status: $($svc.Status) - attempting to start..."
+                Start-Service docker -ErrorAction SilentlyContinue
+              }
+            } else {
+              Write-Host "Docker service not found!"
+            }
             $tries--
             if ($tries -le 0) { throw "Docker daemon did not become ready" }
             Start-Sleep -Seconds 2
@@ -157,10 +167,20 @@ jobs:
           Write-Host "Waiting for Docker daemon..."
           while ($true) {
             $ErrorActionPreference = "SilentlyContinue"
-            docker version | Out-Null
+            docker version 2>&1 | Out-Null
             $ok = ($LastExitCode -eq 0)
             $ErrorActionPreference = "Stop"
             if ($ok) { break }
+            # Check if Docker service exists and try to start it if stopped
+            $svc = Get-Service docker -ErrorAction SilentlyContinue
+            if ($svc) {
+              if ($svc.Status -ne 'Running') {
+                Write-Host "Docker service status: $($svc.Status) - attempting to start..."
+                Start-Service docker -ErrorAction SilentlyContinue
+              }
+            } else {
+              Write-Host "Docker service not found!"
+            }
             $tries--
             if ($tries -le 0) { throw "Docker daemon did not become ready" }
             Start-Sleep -Seconds 2


### PR DESCRIPTION
- related to: https://github.com/moby/moby/issues/52568

Looks like https://github.com/moby/moby/pull/52487  didn't help - the dockerd isn't up even after a minute.

https://github.com/moby/moby/actions/runs/25177849622/job/73815129133?pr=52491


Add service status diagnostics and attempt to start the Docker service on each retry if it exists but is not running. Also redirect stderr to null so `docker version` error messages don't flood the log.
