### PR TITLE
seccomp: Block AF_ALG sockets in default profile (CVE-2026-31431)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/moby/patternmatcher v0.6.1
 	github.com/moby/policy-helpers v0.0.0-20260324161837-b7c0b994300b
 	github.com/moby/profiles/apparmor v0.2.0
-	github.com/moby/profiles/seccomp v0.2.0
+	github.com/moby/profiles/seccomp v0.2.1
 	github.com/moby/pubsub v1.0.0
 	github.com/moby/swarmkit/v2 v2.1.2
 	github.com/moby/sys/atomicwriter v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/moby/patternmatcher v0.6.1
 	github.com/moby/policy-helpers v0.0.0-20260324161837-b7c0b994300b
 	github.com/moby/profiles/apparmor v0.2.0
-	github.com/moby/profiles/seccomp v0.2.1
+	github.com/moby/profiles/seccomp v0.2.2
 	github.com/moby/pubsub v1.0.0
 	github.com/moby/swarmkit/v2 v2.1.2
 	github.com/moby/sys/atomicwriter v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/moby/policy-helpers v0.0.0-20260324161837-b7c0b994300b h1:lvBBM2ACrsG
 github.com/moby/policy-helpers v0.0.0-20260324161837-b7c0b994300b/go.mod h1:Cbc1brDwYl1K294MmZB+6WhQR9Tr24hfhgSGND4UlL0=
 github.com/moby/profiles/apparmor v0.2.0 h1:QqmRNCkf8Bq7YA8rY+bwfC1VNhrkCXGveqdLbrjuOfs=
 github.com/moby/profiles/apparmor v0.2.0/go.mod h1:DtaWKVB992B38PG5i6VZU6w71JQatA6qtkaQGiqUsoc=
-github.com/moby/profiles/seccomp v0.2.1 h1:IlgbbUlIkalddnatSMPurLs63cfLiVILdx3ykMousH0=
-github.com/moby/profiles/seccomp v0.2.1/go.mod h1:8m3qkkWZXrRsMqlUUN2zyccnYmBf3EAdQYPMVJ3NBhk=
+github.com/moby/profiles/seccomp v0.2.2 h1:T1AiR9bmVoP6NHic7hXvlp/JNZuMwGC484axRwmPUyQ=
+github.com/moby/profiles/seccomp v0.2.2/go.mod h1:8m3qkkWZXrRsMqlUUN2zyccnYmBf3EAdQYPMVJ3NBhk=
 github.com/moby/pubsub v1.0.0 h1:jkp/imWsmJz2f6LyFsk7EkVeN2HxR/HTTOY8kHrsxfA=
 github.com/moby/pubsub v1.0.0/go.mod h1:bXSO+3h5MNXXCaEG+6/NlAIk7MMZbySZlnB+cUQhKKc=
 github.com/moby/swarmkit/v2 v2.1.2 h1:1WDZAI6HVYNKdCG4zlXnTAPyLsLwuhRGWlHoOUf5Z6I=

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/moby/policy-helpers v0.0.0-20260324161837-b7c0b994300b h1:lvBBM2ACrsG
 github.com/moby/policy-helpers v0.0.0-20260324161837-b7c0b994300b/go.mod h1:Cbc1brDwYl1K294MmZB+6WhQR9Tr24hfhgSGND4UlL0=
 github.com/moby/profiles/apparmor v0.2.0 h1:QqmRNCkf8Bq7YA8rY+bwfC1VNhrkCXGveqdLbrjuOfs=
 github.com/moby/profiles/apparmor v0.2.0/go.mod h1:DtaWKVB992B38PG5i6VZU6w71JQatA6qtkaQGiqUsoc=
-github.com/moby/profiles/seccomp v0.2.0 h1:JCLyeOwIcPn83QBZlPD/UAsZfQkbwvUfWD7n0wB6B0E=
-github.com/moby/profiles/seccomp v0.2.0/go.mod h1:8m3qkkWZXrRsMqlUUN2zyccnYmBf3EAdQYPMVJ3NBhk=
+github.com/moby/profiles/seccomp v0.2.1 h1:IlgbbUlIkalddnatSMPurLs63cfLiVILdx3ykMousH0=
+github.com/moby/profiles/seccomp v0.2.1/go.mod h1:8m3qkkWZXrRsMqlUUN2zyccnYmBf3EAdQYPMVJ3NBhk=
 github.com/moby/pubsub v1.0.0 h1:jkp/imWsmJz2f6LyFsk7EkVeN2HxR/HTTOY8kHrsxfA=
 github.com/moby/pubsub v1.0.0/go.mod h1:bXSO+3h5MNXXCaEG+6/NlAIk7MMZbySZlnB+cUQhKKc=
 github.com/moby/swarmkit/v2 v2.1.2 h1:1WDZAI6HVYNKdCG4zlXnTAPyLsLwuhRGWlHoOUf5Z6I=

--- a/integration/container/exec_afalg_linux_test.go
+++ b/integration/container/exec_afalg_linux_test.go
@@ -19,13 +19,15 @@ var (
 
 	//go:embed testdata/af_vsock.c
 	afVSOCKSource string
+
+	//go:embed testdata/af_alg_socketcall.c
+	afALGSocketcallSource string
 )
 
 // compileAndExecSocketDenied writes a C source file into the container,
 // compiles it with the given compiler command, runs the binary as uid 1000,
-// and asserts that socket creation fails with a permission or
-// address-family error (not EFAULT or other unrelated failures).
-func compileAndExecSocketDenied(ctx context.Context, t *testing.T, apiClient client.APIClient, cID string, name string, src string, cc []string) {
+// and asserts that socket creation fails with the expected error.
+func compileAndExecSocketDenied(ctx context.Context, t *testing.T, apiClient client.APIClient, cID string, name string, src string, cc []string, expectedErr string) {
 	t.Helper()
 
 	binPath := "/tmp/" + name
@@ -50,12 +52,7 @@ func compileAndExecSocketDenied(ctx context.Context, t *testing.T, apiClient cli
 
 	out := strings.ToLower(res.Combined())
 	assert.Check(t, is.Contains(out, "socket"), "expected socket-related error message")
-
-	// Seccomp blocks return either EPERM ("operation not permitted") or
-	// EAFNOSUPPORT ("address family not supported"). Make sure the failure
-	// is from seccomp, not from a bogus pointer (EFAULT) or other issue.
-	permErr := strings.Contains(out, "not permitted") || strings.Contains(out, "not supported")
-	assert.Check(t, permErr, "expected EPERM or EAFNOSUPPORT, got: %s", res.Combined())
+	assert.Check(t, is.Contains(out, expectedErr), "expected %s, got: %s", expectedErr, res.Combined())
 }
 
 // TestExecSocketDenied verifies that AF_ALG and AF_VSOCK sockets cannot be
@@ -77,10 +74,39 @@ func TestExecSocketDenied(t *testing.T) {
 
 	gcc := []string{"gcc"}
 
+	arch := testEnv.DaemonInfo.Architecture
+	isAmd64 := arch == "amd64" || arch == "x86_64"
+
 	t.Run("AF_ALG", func(t *testing.T) {
-		compileAndExecSocketDenied(ctx, t, apiClient, cID, "AF_ALG", afALGSource, gcc)
+		compileAndExecSocketDenied(ctx, t, apiClient, cID, "AF_ALG", afALGSource, gcc, "not permitted")
 	})
 	t.Run("AF_VSOCK", func(t *testing.T) {
-		compileAndExecSocketDenied(ctx, t, apiClient, cID, "AF_VSOCK", afVSOCKSource, gcc)
+		compileAndExecSocketDenied(ctx, t, apiClient, cID, "AF_VSOCK", afVSOCKSource, gcc, "not permitted")
+	})
+
+	// Test AF_ALG via the socketcall(2) multiplexer using int $0x80 to
+	// invoke the ia32 compat syscall path from a native 64-bit binary.
+	// MAP_32BIT is used to place the args array below 4 GB, since the
+	// ia32 compat path truncates all registers to 32 bits.
+	t.Run("AF_ALG_socketcall_int80", func(t *testing.T) {
+		skip.If(t, !isAmd64, "int $0x80 ia32 compat only available on amd64")
+
+		compileAndExecSocketDenied(ctx, t, apiClient, cID, "AF_ALG_socketcall_int80", afALGSocketcallSource, gcc, "not implemented")
+	})
+
+	// Test AF_ALG with a real i386 binary cross-compiled from amd64. glibc
+	// on i386 routes socket() through the socketcall(2) multiplexer, which
+	// is a different seccomp path than the native socket(2) syscall.
+	t.Run("AF_ALG_socketcall_i386", func(t *testing.T) {
+		skip.If(t, !isAmd64, "i386 cross-compilation only available on amd64")
+
+		res := container.ExecT(ctx, t, apiClient, cID, []string{
+			"sh", "-c", "apt-get install -y --no-install-recommends gcc-i686-linux-gnu libc6-dev-i386-cross linux-libc-dev-i386-cross",
+		})
+		res.AssertSuccess(t)
+
+		compileAndExecSocketDenied(ctx, t, apiClient, cID, "AF_ALG_socketcall_i386", afALGSource,
+			[]string{"i686-linux-gnu-gcc", "-static"}, "not implemented",
+		)
 	})
 }

--- a/integration/container/exec_afalg_linux_test.go
+++ b/integration/container/exec_afalg_linux_test.go
@@ -1,0 +1,86 @@
+package container
+
+import (
+	"context"
+	_ "embed"
+	"strings"
+	"testing"
+
+	"github.com/moby/moby/client"
+	"github.com/moby/moby/v2/integration/internal/container"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
+)
+
+var (
+	//go:embed testdata/af_alg.c
+	afALGSource string
+
+	//go:embed testdata/af_vsock.c
+	afVSOCKSource string
+)
+
+// compileAndExecSocketDenied writes a C source file into the container,
+// compiles it with the given compiler command, runs the binary as uid 1000,
+// and asserts that socket creation fails with a permission or
+// address-family error (not EFAULT or other unrelated failures).
+func compileAndExecSocketDenied(ctx context.Context, t *testing.T, apiClient client.APIClient, cID string, name string, src string, cc []string) {
+	t.Helper()
+
+	binPath := "/tmp/" + name
+	srcPath := binPath + ".c"
+
+	res := container.ExecT(ctx, t, apiClient, cID, []string{
+		"sh", "-c", "cat > " + srcPath + " << 'CEOF'\n" + src + "\nCEOF",
+	})
+	res.AssertSuccess(t)
+
+	compileCmd := append(cc, srcPath, "-o", binPath)
+	res = container.ExecT(ctx, t, apiClient, cID, compileCmd)
+	res.AssertSuccess(t)
+
+	res, err := container.Exec(ctx, apiClient, cID, []string{binPath},
+		func(ec *client.ExecCreateOptions) {
+			ec.User = "1000"
+		},
+	)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(res.ExitCode, 1), "expected %s socket program to fail", name)
+
+	out := strings.ToLower(res.Combined())
+	assert.Check(t, is.Contains(out, "socket"), "expected socket-related error message")
+
+	// Seccomp blocks return either EPERM ("operation not permitted") or
+	// EAFNOSUPPORT ("address family not supported"). Make sure the failure
+	// is from seccomp, not from a bogus pointer (EFAULT) or other issue.
+	permErr := strings.Contains(out, "not permitted") || strings.Contains(out, "not supported")
+	assert.Check(t, permErr, "expected EPERM or EAFNOSUPPORT, got: %s", res.Combined())
+}
+
+// TestExecSocketDenied verifies that AF_ALG and AF_VSOCK sockets cannot be
+// created inside a container. These address families are blocked by the
+// default seccomp profile.
+func TestExecSocketDenied(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	cID := container.Run(ctx, t, apiClient, container.WithImage("debian:trixie-slim"), container.WithCmd("sleep", "infinity"))
+
+	// Install build dependencies as root.
+	res := container.ExecT(ctx, t, apiClient, cID, []string{
+		"sh", "-c", "apt-get update && apt-get install -y --no-install-recommends gcc libc-dev linux-libc-dev",
+	})
+	res.AssertSuccess(t)
+
+	gcc := []string{"gcc"}
+
+	t.Run("AF_ALG", func(t *testing.T) {
+		compileAndExecSocketDenied(ctx, t, apiClient, cID, "AF_ALG", afALGSource, gcc)
+	})
+	t.Run("AF_VSOCK", func(t *testing.T) {
+		compileAndExecSocketDenied(ctx, t, apiClient, cID, "AF_VSOCK", afVSOCKSource, gcc)
+	})
+}

--- a/integration/container/testdata/af_alg.c
+++ b/integration/container/testdata/af_alg.c
@@ -1,0 +1,45 @@
+#include <sys/socket.h>
+#include <linux/if_alg.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdio.h>
+
+int main() {
+    int sockfd, opfd;
+    struct sockaddr_alg sa = {
+        .salg_family = AF_ALG,
+        .salg_type = "hash",
+        .salg_name = "sha1"
+    };
+
+    sockfd = socket(AF_ALG, SOCK_SEQPACKET, 0);
+    if (sockfd < 0) {
+        perror("socket");
+        return 1;
+    }
+
+    if (bind(sockfd, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
+        perror("bind");
+        close(sockfd);
+        return 1;
+    }
+
+    opfd = accept(sockfd, NULL, 0);
+    if (opfd < 0) {
+        perror("accept");
+        close(sockfd);
+        return 1;
+    }
+
+    char data[] = "hello world";
+    write(opfd, data, strlen(data));
+
+    char hash[20];
+    read(opfd, hash, sizeof(hash));
+
+    printf("SHA1 hash computed\n");
+
+    close(opfd);
+    close(sockfd);
+    return 0;
+}

--- a/integration/container/testdata/af_alg_socketcall.c
+++ b/integration/container/testdata/af_alg_socketcall.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <errno.h>
+#include <sys/mman.h>
+
+#define SYS_SOCKETCALL_I386 102
+#define SYS_SOCKET 1
+#define AF_ALG 38
+#define SOCK_SEQPACKET 5
+
+int main() {
+    /*
+     * The int $0x80 ia32 compat path truncates all registers to 32 bits.
+     * The args pointer must live below 4 GB, so allocate it with MAP_32BIT.
+     */
+    unsigned int *args = mmap(NULL, 4096,
+        PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT,
+        -1, 0);
+    if (args == MAP_FAILED) {
+        perror("mmap");
+        return 2;
+    }
+    args[0] = AF_ALG;
+    args[1] = SOCK_SEQPACKET;
+    args[2] = 0;
+
+    int ret;
+    asm volatile (
+        "int $0x80"
+        : "=a"(ret)
+        : "a"(SYS_SOCKETCALL_I386), "b"(SYS_SOCKET), "c"(args)
+        : "memory"
+    );
+
+    if (ret < 0) {
+        errno = -ret;
+        perror("socket");
+        return 1;
+    }
+
+    printf("AF_ALG socket created via socketcall\n");
+    return 0;
+}

--- a/integration/container/testdata/af_vsock.c
+++ b/integration/container/testdata/af_vsock.c
@@ -1,0 +1,16 @@
+#include <sys/socket.h>
+#include <linux/vm_sockets.h>
+#include <unistd.h>
+#include <stdio.h>
+
+int main() {
+    int sockfd = socket(AF_VSOCK, SOCK_STREAM, 0);
+    if (sockfd < 0) {
+        perror("socket");
+        return 1;
+    }
+
+    printf("AF_VSOCK socket created\n");
+    close(sockfd);
+    return 0;
+}

--- a/vendor/github.com/moby/profiles/seccomp/default.json
+++ b/vendor/github.com/moby/profiles/seccomp/default.json
@@ -371,7 +371,6 @@
 				"signalfd4",
 				"sigprocmask",
 				"sigreturn",
-				"socketcall",
 				"socketpair",
 				"splice",
 				"stat",
@@ -435,6 +434,13 @@
 			"includes": {
 				"minKernel": "4.8"
 			}
+		},
+		{
+			"names": [
+				"socketcall"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"errnoRet": 38
 		},
 		{
 			"names": [

--- a/vendor/github.com/moby/profiles/seccomp/default.json
+++ b/vendor/github.com/moby/profiles/seccomp/default.json
@@ -444,8 +444,34 @@
 			"args": [
 				{
 					"index": 0,
+					"value": 38,
+					"op": "SCMP_CMP_LT"
+				}
+			]
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 39,
+					"op": "SCMP_CMP_EQ"
+				}
+			]
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
 					"value": 40,
-					"op": "SCMP_CMP_NE"
+					"op": "SCMP_CMP_GT"
 				}
 			]
 		},

--- a/vendor/github.com/moby/profiles/seccomp/default_linux.go
+++ b/vendor/github.com/moby/profiles/seccomp/default_linux.go
@@ -8,6 +8,14 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// The socket rules in DefaultProfile rely on AF_ALG and AF_VSOCK being
+// exactly two apart (38 and 40), with a single family (39) between them.
+var (
+	_ [38]byte = [unix.AF_ALG]byte{}
+	_ [40]byte = [unix.AF_VSOCK]byte{}
+	_ [1]byte  = [unix.AF_VSOCK - unix.AF_ALG - 1]byte{}
+)
+
 func arches() []Architecture {
 	return []Architecture{
 		{
@@ -434,6 +442,38 @@ func DefaultProfile() *Seccomp {
 				MinKernel: &KernelVersion{4, 8},
 			},
 		},
+		// Allow socket(2) for all address families except AF_VSOCK and AF_ALG.
+		// NOTE: on 32-bit x86, socket() goes through socketcall(2) which is
+		// allowed unconditionally above, so AF_VSOCK/AF_ALG is still reachable
+		// via the socketcall-based socket() path. These arg filters only apply
+		// to the direct socket syscall, and do not protect 32-bit x86 unless
+		// socketcall(2) is also addressed.
+		{
+			LinuxSyscall: specs.LinuxSyscall{
+				Names:  []string{"socket"},
+				Action: specs.ActAllow,
+				Args: []specs.LinuxSeccompArg{
+					{
+						Index: 0,
+						Value: unix.AF_ALG,
+						Op:    specs.OpLessThan,
+					},
+				},
+			},
+		},
+		{
+			LinuxSyscall: specs.LinuxSyscall{
+				Names:  []string{"socket"},
+				Action: specs.ActAllow,
+				Args: []specs.LinuxSeccompArg{
+					{
+						Index: 0,
+						Value: unix.AF_ALG + 1,
+						Op:    specs.OpEqualTo,
+					},
+				},
+			},
+		},
 		{
 			LinuxSyscall: specs.LinuxSyscall{
 				Names:  []string{"socket"},
@@ -442,7 +482,7 @@ func DefaultProfile() *Seccomp {
 					{
 						Index: 0,
 						Value: unix.AF_VSOCK,
-						Op:    specs.OpNotEqual,
+						Op:    specs.OpGreaterThan,
 					},
 				},
 			},

--- a/vendor/github.com/moby/profiles/seccomp/default_linux.go
+++ b/vendor/github.com/moby/profiles/seccomp/default_linux.go
@@ -374,7 +374,6 @@ func DefaultProfile() *Seccomp {
 					"signalfd4",
 					"sigprocmask",
 					"sigreturn",
-					"socketcall",
 					"socketpair",
 					"splice",
 					"stat",
@@ -442,12 +441,27 @@ func DefaultProfile() *Seccomp {
 				MinKernel: &KernelVersion{4, 8},
 			},
 		},
+		// socketcall(2) is explicitly denied to prevent bypassing the socket
+		// address family filters above on architectures where socketcall is
+		// supported (i386, s390, MIPS o32).
+		// Seccomp cannot inspect socketcall's pointer argument, so allowing it
+		// would let an attacker open AF_ALG sockets via socketcall(SYS_SOCKET,
+		// ...). Since Linux 4.3 all affected architectures provide direct
+		// socket syscalls, so modern userspace is not impacted.
+		//
+		// ENOSYS (not EPERM) is used because the errno must differ from
+		// DefaultErrnoRet; otherwise both runc and libseccomp treat the rule
+		// as identical to the default action and silently omit it from the
+		// generated BPF, which lets libseccomp's auto-generated
+		// socketcall(SYS_SOCKET) -> ALLOW path survive unchallenged.
+		{
+			LinuxSyscall: specs.LinuxSyscall{
+				Names:    []string{"socketcall"},
+				Action:   specs.ActErrno,
+				ErrnoRet: &nosys,
+			},
+		},
 		// Allow socket(2) for all address families except AF_VSOCK and AF_ALG.
-		// NOTE: on 32-bit x86, socket() goes through socketcall(2) which is
-		// allowed unconditionally above, so AF_VSOCK/AF_ALG is still reachable
-		// via the socketcall-based socket() path. These arg filters only apply
-		// to the direct socket syscall, and do not protect 32-bit x86 unless
-		// socketcall(2) is also addressed.
 		{
 			LinuxSyscall: specs.LinuxSyscall{
 				Names:  []string{"socket"},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1219,7 +1219,7 @@ github.com/moby/policy-helpers/types
 # github.com/moby/profiles/apparmor v0.2.0
 ## explicit; go 1.23.0
 github.com/moby/profiles/apparmor
-# github.com/moby/profiles/seccomp v0.2.0
+# github.com/moby/profiles/seccomp v0.2.1
 ## explicit; go 1.23.0
 github.com/moby/profiles/seccomp
 # github.com/moby/pubsub v1.0.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1219,7 +1219,7 @@ github.com/moby/policy-helpers/types
 # github.com/moby/profiles/apparmor v0.2.0
 ## explicit; go 1.23.0
 github.com/moby/profiles/apparmor
-# github.com/moby/profiles/seccomp v0.2.1
+# github.com/moby/profiles/seccomp v0.2.2
 ## explicit; go 1.23.0
 github.com/moby/profiles/seccomp
 # github.com/moby/pubsub v1.0.0


### PR DESCRIPTION
CVE-2026-31431 ("Copy Fail") is a logic flaw in the kernel's `algif_aead` module that allows any unprivileged user with access to `AF_ALG` sockets to perform a controlled 4-byte page-cache write, leading to reliable local privilege escalation. The exploit is a 732-byte Python script that works on every Linux distribution shipped since 2017.

Inside a container, this allows escalation to root within the container by corrupting setuid binaries in the page cache. Since the page cache is shared across the host, corruption of shared image-layer files is also visible to other containers using the same layers on the same node.

- https://copy.fail
- https://xint.io/blog/copy-fail-linux-distributions

## Seccomp profile changes

The previous default seccomp profile allowed `AF_ALG` sockets (only `AF_VSOCK` was denied). This update denies both `AF_ALG` (38) and `AF_VSOCK` (40) by allowing socket creation only for address families outside that range:

- `arg0 < 38` (AF_ALG) → allow
- `arg0 == 39` (the single family between them) → allow
- `arg0 > 40` (AF_VSOCK) → allow
- everything else (38 and 40) → falls through to default ERRNO

The previous socket rule used a single `arg0 != AF_VSOCK` condition. Naively adding a second `OpNotEqual` for AF_ALG does not work: seccomp evaluates multiple argument conditions within a single rule as a logical AND, so `arg0 != 38 AND arg0 != 40` requires two comparisons against the same argument index, which libseccomp does not support reliably in one rule. Splitting into separate deny-action rules also fails because any matching allow rule takes precedence in seccomp's first-match-wins evaluation.

See https://github.com/moby/profiles/pull/20 for more details.

Additionally, `socketcall(2)` is now explicitly denied to prevent bypassing the socket address family filters on architectures with the legacy socketcall multiplexer. See https://github.com/moby/profiles/releases/tag/seccomp%2Fv0.2.2 for details.

## Integration tests

Adds `TestExecSocketDenied` which compiles and runs small C programs inside a container to verify that:

- `AF_ALG` socket creation is denied
- `AF_VSOCK` socket creation is denied
- `AF_ALG` via `socketcall(2)` (using `int $0x80` from amd64) is denied
- `AF_ALG` via a cross-compiled static i386 binary is denied

## Changelog

```markdown changelog
CVE-2026-31431: Block `AF_ALG` sockets and the `socketcall(2)` multiplexer in the default seccomp profile to prevent in-container privilege escalation via the kernel crypto API ("Copy Fail").
```



Big thanks to @tianon for helping me figure out why the initial socketcall block didn't work: https://github.com/moby/profiles/releases/tag/seccomp%2Fv0.2.2 ❤️ 