### PR TITLE
daemon/server/router: handle write errors in container attach

### DIFF
--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -1098,17 +1098,24 @@ func (c *containerRouter) postContainersAttach(ctx context.Context, w http.Respo
 		}
 
 		// set raw mode
-		conn.Write([]byte{})
+		if _, err := conn.Write([]byte{}); err != nil {
+			conn.Close()
+			return nil, nil, nil, err
+		}
 
 		if upgrade {
 			if multiplexed && versions.GreaterThanOrEqualTo(httputils.VersionFromContext(ctx), "1.42") {
 				contentType = types.MediaTypeMultiplexedStream
 			}
-			// FIXME(thaJeztah): we should not ignore errors here; see https://github.com/moby/moby/pull/48359#discussion_r1725562802
-			fmt.Fprintf(conn, "HTTP/1.1 101 UPGRADED\r\nContent-Type: %v\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\n", contentType)
+			if _, err := fmt.Fprintf(conn, "HTTP/1.1 101 UPGRADED\r\nContent-Type: %v\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\n", contentType); err != nil {
+				conn.Close()
+				return nil, nil, nil, err
+			}
 		} else {
-			// FIXME(thaJeztah): we should not ignore errors here; see https://github.com/moby/moby/pull/48359#discussion_r1725562802
-			fmt.Fprint(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/vnd.docker.raw-stream\r\n\r\n")
+			if _, err := fmt.Fprint(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/vnd.docker.raw-stream\r\n\r\n"); err != nil {
+				conn.Close()
+				return nil, nil, nil, err
+			}
 		}
 
 		go notifyClosed(ctx, conn, cancel)


### PR DESCRIPTION
**- What I did**

Fixed error handling in container attach endpoint. Previously, write errors to the hijacked connection were being ignored (marked with FIXME comments from #48359).

**- How I did it**

Added proper error handling for write operations in the `setupStreams` function:
- Check errors from `conn.Write()` when setting raw mode
- Check errors from `fmt.Fprintf()` when writing HTTP 101 UPGRADED response
- Check errors from `fmt.Fprint()` when writing HTTP 200 OK response

On write error, the connection is now closed and an error is returned to prevent wasting cycles on a reset connection.

**- How to verify it**

Run existing container attach tests to verify functionality is preserved:
```bash
make test-integration TESTDIRS=integration/container
```

**- Human readable description for the release notes**

```markdown changelog

```

**- Related issue**

Addresses FIXME comments from https://github.com/moby/moby/pull/48359#discussion_r1725562802