### PR TITLE
cmd/docker-proxy: remove redundant error-type asserts

### DIFF
--- a/cmd/docker-proxy/udp_proxy_linux.go
+++ b/cmd/docker-proxy/udp_proxy_linux.go
@@ -121,7 +121,7 @@ func (proxy *UDPProxy) replyLoop(cte *connTrackEntry, serverAddr net.IP, clientA
 	again:
 		read, err := cte.conn.Read(readBuf)
 		if err != nil {
-			if err, ok := err.(*net.OpError); ok && errors.Is(err.Err, syscall.ECONNREFUSED) {
+			if errors.Is(err, syscall.ECONNREFUSED) {
 				// This will happen if the last write failed
 				// (e.g: nothing is actually listening on the
 				// proxied port on the container), ignore it
@@ -199,7 +199,7 @@ func (proxy *UDPProxy) Run() {
 		for i := 0; i != read; {
 			written, err := cte.conn.Write(readBuf[i:read])
 			if err != nil {
-				if opErr, ok := err.(*net.OpError); ok && errors.Is(opErr.Err, syscall.ECONNREFUSED) {
+				if errors.Is(err, syscall.ECONNREFUSED) {
 					// A previous write to the backend may have resulted in an
 					// ICMP port-unreachable. The kernel queues this as an error
 					// on the socket, which is returned on the next Write. Retry


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/52483#discussion_r3170008041

errors.Is unwraps recursively, so there's no need to assert the error-type for these.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

