### PR TITLE
distribution: scope auth credentials to target registry, not mirrors

### DIFF
--- a/daemon/containerd/resolver.go
+++ b/daemon/containerd/resolver.go
@@ -39,6 +39,7 @@ func hostsWrapper(hostsFn docker.RegistryHosts, optAuthConfig *registrytypes.Aut
 	}
 
 	authorizer := authorizerFromAuthConfig(*optAuthConfig, ref)
+	targetHost := resolveAuthHost(*optAuthConfig, ref)
 
 	return func(n string) ([]docker.RegistryHost, error) {
 		hosts, err := hostsFn(n)
@@ -47,13 +48,23 @@ func hostsWrapper(hostsFn docker.RegistryHosts, optAuthConfig *registrytypes.Aut
 		}
 
 		for i := range hosts {
-			hosts[i].Authorizer = authorizer
+			// Only apply the request's auth credentials to the host
+			// they are scoped to (the target registry). Mirror hosts
+			// keep their existing Authorizer (e.g. from hosts.toml)
+			// so that per-mirror credentials are not clobbered and
+			// upstream registry credentials are not leaked to mirrors.
+			if hosts[i].Host == targetHost {
+				hosts[i].Authorizer = authorizer
+			}
 		}
 		return hosts, nil
 	}
 }
 
-func authorizerFromAuthConfig(authConfig registrytypes.AuthConfig, ref reference.Named) docker.Authorizer {
+// resolveAuthHost returns the normalized hostname that authConfig
+// credentials are scoped to. This is used to match credentials to
+// the correct registry endpoint and avoid sending them to mirrors.
+func resolveAuthHost(authConfig registrytypes.AuthConfig, ref reference.Named) string {
 	cfgHost := registry.ConvertToHostname(authConfig.ServerAddress)
 	if cfgHost == "" {
 		cfgHost = reference.Domain(ref)
@@ -61,6 +72,11 @@ func authorizerFromAuthConfig(authConfig registrytypes.AuthConfig, ref reference
 	if cfgHost == registry.IndexHostname || cfgHost == registry.IndexName {
 		cfgHost = registry.DefaultRegistryHost
 	}
+	return cfgHost
+}
+
+func authorizerFromAuthConfig(authConfig registrytypes.AuthConfig, ref reference.Named) docker.Authorizer {
+	cfgHost := resolveAuthHost(authConfig, ref)
 
 	if authConfig.RegistryToken != "" {
 		return &bearerAuthorizer{

--- a/daemon/containerd/resolver_test.go
+++ b/daemon/containerd/resolver_test.go
@@ -1,0 +1,199 @@
+package containerd
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/distribution/reference"
+	registrytypes "github.com/moby/moby/api/types/registry"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestResolveAuthHost(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		auth     registrytypes.AuthConfig
+		ref      string
+		expected string
+	}{
+		{
+			name:     "docker hub via index URL",
+			auth:     registrytypes.AuthConfig{ServerAddress: "https://index.docker.io/v1/"},
+			ref:      "docker.io/library/nginx",
+			expected: "registry-1.docker.io",
+		},
+		{
+			name:     "docker hub via index hostname",
+			auth:     registrytypes.AuthConfig{ServerAddress: "index.docker.io"},
+			ref:      "docker.io/library/nginx",
+			expected: "registry-1.docker.io",
+		},
+		{
+			name:     "docker hub via docker.io",
+			auth:     registrytypes.AuthConfig{ServerAddress: "docker.io"},
+			ref:      "docker.io/library/nginx",
+			expected: "registry-1.docker.io",
+		},
+		{
+			name:     "empty server address defaults to ref domain",
+			auth:     registrytypes.AuthConfig{},
+			ref:      "docker.io/library/nginx",
+			expected: "registry-1.docker.io",
+		},
+		{
+			name:     "private registry",
+			auth:     registrytypes.AuthConfig{ServerAddress: "ghcr.io"},
+			ref:      "ghcr.io/org/image",
+			expected: "ghcr.io",
+		},
+		{
+			name:     "private registry with port",
+			auth:     registrytypes.AuthConfig{ServerAddress: "registry.example.com:5000"},
+			ref:      "registry.example.com:5000/myimage",
+			expected: "registry.example.com:5000",
+		},
+		{
+			name:     "private registry via https URL",
+			auth:     registrytypes.AuthConfig{ServerAddress: "https://registry.example.com:5000"},
+			ref:      "registry.example.com:5000/myimage",
+			expected: "registry.example.com:5000",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ref, err := reference.ParseNormalizedNamed(tc.ref)
+			assert.NilError(t, err)
+			got := resolveAuthHost(tc.auth, ref)
+			assert.Check(t, is.Equal(got, tc.expected))
+		})
+	}
+}
+
+// stubAuthorizer is a test Authorizer that records whether it was used.
+type stubAuthorizer struct {
+	name string
+}
+
+func (a *stubAuthorizer) Authorize(_ context.Context, _ *http.Request) error { return nil }
+func (a *stubAuthorizer) AddResponses(_ context.Context, _ []*http.Response) error {
+	return nil
+}
+
+func TestHostsWrapper_OnlyAppliesToTargetHost(t *testing.T) {
+	mirrorAuth := &stubAuthorizer{name: "mirror-auth"}
+	primaryAuth := &stubAuthorizer{name: "primary-auth"}
+
+	hostsFn := func(n string) ([]docker.RegistryHost, error) {
+		return []docker.RegistryHost{
+			{Host: "mirror.example.com", Authorizer: mirrorAuth},
+			{Host: "registry-1.docker.io", Authorizer: primaryAuth},
+		}, nil
+	}
+
+	ref, err := reference.ParseNormalizedNamed("docker.io/library/nginx")
+	assert.NilError(t, err)
+
+	auth := &registrytypes.AuthConfig{
+		Username:      "user",
+		Password:      "pass",
+		ServerAddress: "https://index.docker.io/v1/",
+	}
+
+	wrapped := hostsWrapper(hostsFn, auth, ref)
+	hosts, err := wrapped("docker.io")
+	assert.NilError(t, err)
+	assert.Assert(t, is.Len(hosts, 2))
+
+	// Mirror host should keep its original authorizer.
+	assert.Check(t, hosts[0].Host == "mirror.example.com")
+	assert.Check(t, hosts[0].Authorizer == mirrorAuth,
+		"mirror authorizer was replaced; expected it to be preserved")
+
+	// Primary host should get the new authorizer from authConfig.
+	assert.Check(t, hosts[1].Host == "registry-1.docker.io")
+	assert.Check(t, hosts[1].Authorizer != primaryAuth,
+		"primary authorizer was not replaced; expected it to be updated with authConfig credentials")
+}
+
+func TestHostsWrapper_NilAuthConfig(t *testing.T) {
+	called := false
+	hostsFn := func(n string) ([]docker.RegistryHost, error) {
+		called = true
+		return []docker.RegistryHost{{Host: "registry-1.docker.io"}}, nil
+	}
+
+	ref, err := reference.ParseNormalizedNamed("docker.io/library/nginx")
+	assert.NilError(t, err)
+
+	wrapped := hostsWrapper(hostsFn, nil, ref)
+
+	// When authConfig is nil, hostsWrapper should return hostsFn unchanged.
+	hosts, err := wrapped("docker.io")
+	assert.NilError(t, err)
+	assert.Assert(t, called)
+	assert.Assert(t, is.Len(hosts, 1))
+}
+
+func TestHostsWrapper_PreservesMirrorAuthorizer(t *testing.T) {
+	// Simulates a hosts.toml-configured mirror that has its own Authorizer
+	// with static Authorization header (e.g., [header] Authorization = "Basic ...").
+	mirrorAuth := &stubAuthorizer{name: "hosts-toml-mirror"}
+
+	hostsFn := func(n string) ([]docker.RegistryHost, error) {
+		return []docker.RegistryHost{
+			{Host: "nexus.corp.example.com", Authorizer: mirrorAuth},
+			{Host: "registry-1.docker.io", Authorizer: nil},
+		}, nil
+	}
+
+	ref, err := reference.ParseNormalizedNamed("docker.io/library/alpine")
+	assert.NilError(t, err)
+
+	auth := &registrytypes.AuthConfig{
+		Username:      "hubuser",
+		Password:      "hubpass",
+		ServerAddress: "https://index.docker.io/v1/",
+	}
+
+	wrapped := hostsWrapper(hostsFn, auth, ref)
+	hosts, err := wrapped("docker.io")
+	assert.NilError(t, err)
+
+	// Mirror's authorizer from hosts.toml must be preserved.
+	assert.Check(t, hosts[0].Host == "nexus.corp.example.com")
+	assert.Check(t, hosts[0].Authorizer == mirrorAuth,
+		"hosts.toml mirror authorizer was replaced; credentials would be lost")
+
+	// Primary gets the authConfig-based authorizer.
+	assert.Check(t, hosts[1].Host == "registry-1.docker.io")
+	assert.Check(t, hosts[1].Authorizer != nil,
+		"primary host should have an authorizer set from authConfig")
+}
+
+func TestHostsWrapper_PrivateRegistry(t *testing.T) {
+	// For non-docker.io registries, there are no mirrors. The single host
+	// should get the authConfig authorizer applied.
+	hostsFn := func(n string) ([]docker.RegistryHost, error) {
+		return []docker.RegistryHost{
+			{Host: "ghcr.io"},
+		}, nil
+	}
+
+	ref, err := reference.ParseNormalizedNamed("ghcr.io/org/myimage")
+	assert.NilError(t, err)
+
+	auth := &registrytypes.AuthConfig{
+		Username:      "ghuser",
+		Password:      "ghtoken",
+		ServerAddress: "ghcr.io",
+	}
+
+	wrapped := hostsWrapper(hostsFn, auth, ref)
+	hosts, err := wrapped("ghcr.io")
+	assert.NilError(t, err)
+	assert.Assert(t, is.Len(hosts, 1))
+	assert.Check(t, hosts[0].Authorizer != nil,
+		"private registry host should get authConfig authorizer")
+}

--- a/daemon/hosts_test.go
+++ b/daemon/hosts_test.go
@@ -97,6 +97,31 @@ func TestMirrorsToHosts(t *testing.T) {
 	}
 }
 
+func TestMirrorsToHosts_DistinctHostFields(t *testing.T) {
+	// Verifies that mirror hosts have distinct Host fields from the primary,
+	// which is critical for hostsWrapper to apply credentials correctly.
+	primaryHost := "registry-1.docker.io"
+	allCaps := docker.HostCapabilityPull | docker.HostCapabilityResolve | docker.HostCapabilityPush | docker.HostCapabilityReferrers
+	dHost := testRegistryHost("https", primaryHost, "/v2", allCaps)
+
+	mirrors := []string{
+		"https://nexus.example.com:5000",
+		"https://harbor.corp.internal",
+	}
+
+	hosts := mirrorsToRegistryHosts(mirrors, dHost)
+	assert.Assert(t, is.Len(hosts, 3)) // 2 mirrors + 1 primary
+
+	// Each mirror must have a Host value different from the primary.
+	for i, h := range hosts[:len(hosts)-1] {
+		assert.Check(t, h.Host != primaryHost,
+			"mirror %d has same Host as primary (%s); hostsWrapper cannot distinguish them", i, primaryHost)
+	}
+
+	// The last entry must be the primary.
+	assert.Check(t, is.Equal(hosts[len(hosts)-1].Host, primaryHost))
+}
+
 func testRegistryHost(scheme, host, path string, caps docker.HostCapabilities) docker.RegistryHost {
 	return docker.RegistryHost{
 		Host:         host,

--- a/daemon/internal/distribution/registry.go
+++ b/daemon/internal/distribution/registry.go
@@ -107,10 +107,17 @@ func newRepository(
 		}
 	}
 
-	if authConfig.RegistryToken != "" {
-		modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, &passThruTokenHandler{token: authConfig.RegistryToken}))
+	// Do not send upstream registry credentials to mirror endpoints
+	// to prevent credential leakage (see moby/moby#42022).
+	effectiveAuth := authConfig
+	if endpoint.Mirror && authConfig != nil {
+		effectiveAuth = &registrytypes.AuthConfig{}
+	}
+
+	if effectiveAuth.RegistryToken != "" {
+		modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, &passThruTokenHandler{token: effectiveAuth.RegistryToken}))
 	} else {
-		creds := registry.NewStaticCredentialStore(authConfig)
+		creds := registry.NewStaticCredentialStore(effectiveAuth)
 		tokenHandler := auth.NewTokenHandlerWithOptions(auth.TokenHandlerOptions{
 			Transport:   authTransport,
 			Credentials: creds,

--- a/daemon/internal/distribution/registry_unit_test.go
+++ b/daemon/internal/distribution/registry_unit_test.go
@@ -74,6 +74,32 @@ func TestTokenPassThru(t *testing.T) {
 	assert.Check(t, handler.gotToken, "Failed to receive registry token")
 }
 
+func TestMirrorEndpointNoCredentialLeak(t *testing.T) {
+	handler := &tokenPassThruHandler{shouldSend401: func(url string) bool { return url == "/v2/" }}
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	uri, err := url.Parse(ts.URL)
+	assert.NilError(t, err)
+
+	repoName, err := reference.ParseNormalizedNamed("testremotename")
+	assert.NilError(t, err)
+
+	// Create an endpoint marked as a mirror with upstream registry credentials.
+	_, err = newRepository(context.Background(), repoName, registrypkg.APIEndpoint{
+		URL:    uri,
+		Mirror: true,
+	}, http.Header{}, &registry.AuthConfig{
+		RegistryToken: secretRegistryToken,
+	}, "pull")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Check(t, handler.reached, "Handler not reached")
+	assert.Check(t, !handler.gotToken, "Mirror endpoint should not receive upstream registry credentials")
+}
+
 func TestTokenPassThruDifferentHost(t *testing.T) {
 	handler := new(tokenPassThruHandler)
 	ts := httptest.NewServer(handler)


### PR DESCRIPTION
## What

Scope pull-request auth credentials to the target registry only, preventing them from being sent to registry mirrors on both the containerd and legacy distribution code paths.

## Why

Two long-standing issues exist around mirror authentication:

1. **Credential leak to mirrors ([#42022](https://github.com/moby/moby/issues/42022))**: In the legacy distribution path, `StaticCredentialStore.Basic` ignores the URL parameter entirely, so upstream registry credentials (e.g. Docker Hub tokens) are unconditionally sent to every mirror endpoint.

2. **Mirror auth broken ([#30880](https://github.com/moby/moby/issues/30880))**: In the containerd path, `hostsWrapper` unconditionally overwrites every host's `Authorizer`, clobbering any per-mirror credentials configured via `hosts.toml`. While `authorizerFromAuthConfig` has a host-mismatch guard that returns empty credentials for non-matching hosts, this means mirrors effectively receive no usable auth at all.

## How

### Containerd path (`daemon/containerd/resolver.go`)

- Extract `resolveAuthHost` from `authorizerFromAuthConfig` so `hostsWrapper` can reuse the same hostname normalization logic.
- In `hostsWrapper`, only apply the pull request's `Authorizer` to hosts whose `Host` field matches the target registry. Mirror hosts keep their existing `Authorizer` (e.g. from `hosts.toml` / `ConfigureHosts`).

### Legacy distribution path (`daemon/internal/distribution/registry.go`)

- When `endpoint.Mirror` is `true`, use an empty `AuthConfig` instead of the upstream registry's credentials.

### Tests

- `daemon/containerd/resolver_test.go` (new): 5 test functions covering `resolveAuthHost` normalization and `hostsWrapper` scoping behavior (mirror authorizer preserved, target host updated, nil authConfig passthrough, private registry handling).
- `daemon/internal/distribution/registry_unit_test.go` (new): Verifies mirror endpoints receive empty auth.
- `daemon/hosts_test.go` (extended): Verifies mirror `Host` fields are distinct from the primary, which is an invariant `hostsWrapper` depends on.

## Scope

This is intentionally a minimal, focused fix for the credential scoping issue. Follow-up work for credential-helper fallback for `docker login <mirror-host>` and extended `daemon.json` per-mirror configuration are planned as separate PRs.

Fixes #30880
Ref #42022