### PR TITLE
daemon: Always reload AppArmor profile at daemon startup

### DIFF
--- a/daemon/apparmor_default.go
+++ b/daemon/apparmor_default.go
@@ -28,7 +28,33 @@ func DefaultApparmorProfile() string {
 	return ""
 }
 
-func ensureDefaultAppArmorProfile() error {
+func loadDefaultAppArmorProfileIfMissing() error {
+	if !defaultAppArmorProfileSupported() {
+		return nil
+	}
+
+	loaded, err := aaprofile.IsLoaded(defaultAppArmorProfile)
+	if err != nil {
+		return fmt.Errorf("Could not check if %s AppArmor profile was loaded: %s", defaultAppArmorProfile, err)
+	}
+	if loaded {
+		return nil
+	}
+
+	return installDefaultAppArmorProfile()
+}
+
+func installDefaultAppArmorProfile() error {
+	if defaultAppArmorProfileSupported() {
+		if err := aaprofile.InstallDefault(defaultAppArmorProfile); err != nil {
+			return fmt.Errorf("AppArmor enabled on system but the %s profile could not be loaded: %s", defaultAppArmorProfile, err)
+		}
+	}
+
+	return nil
+}
+
+func defaultAppArmorProfileSupported() bool {
 	hostSupports := apparmor.HostSupports()
 	if hostSupports {
 		if detachedNetNS, _ := rootless.DetachedNetNS(); detachedNetNS != "" {
@@ -37,22 +63,6 @@ func ensureDefaultAppArmorProfile() error {
 			hostSupports = false
 		}
 	}
-	if hostSupports {
-		loaded, err := aaprofile.IsLoaded(defaultAppArmorProfile)
-		if err != nil {
-			return fmt.Errorf("Could not check if %s AppArmor profile was loaded: %s", defaultAppArmorProfile, err)
-		}
 
-		// Nothing to do.
-		if loaded {
-			return nil
-		}
-
-		// Load the profile.
-		if err := aaprofile.InstallDefault(defaultAppArmorProfile); err != nil {
-			return fmt.Errorf("AppArmor enabled on system but the %s profile could not be loaded: %s", defaultAppArmorProfile, err)
-		}
-	}
-
-	return nil
+	return hostSupports
 }

--- a/daemon/apparmor_default_unsupported.go
+++ b/daemon/apparmor_default_unsupported.go
@@ -2,11 +2,15 @@
 
 package daemon
 
-func ensureDefaultAppArmorProfile() error {
+func loadDefaultAppArmorProfileIfMissing() error {
 	return nil
 }
 
 // DefaultApparmorProfile returns an empty string.
 func DefaultApparmorProfile() string {
 	return ""
+}
+
+func installDefaultAppArmorProfile() error {
+	return nil
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -966,9 +966,10 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		log.G(ctx).Warnf("Failed to configure golang's threads limit: %v", err)
 	}
 
-	// ensureDefaultAppArmorProfile does nothing if apparmor is disabled
-	if err := ensureDefaultAppArmorProfile(); err != nil {
-		log.G(ctx).WithError(err).Error("Failed to ensure default apparmor profile is loaded")
+	// Always install the default AppArmor profile at startup to pick up
+	// any changes to the profile template from a daemon upgrade.
+	if err := installDefaultAppArmorProfile(); err != nil {
+		log.G(ctx).WithError(err).Error("Failed to load default apparmor profile")
 	}
 
 	daemonRepo := filepath.Join(cfgStore.Root, "containers")

--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -83,9 +83,9 @@ func (daemon *Daemon) execSetPlatformOpt(ctx context.Context, daemonCfg *config.
 			// profiles inadvertently. Since we cannot store our profile in
 			// /etc/apparmor.d, nor can we practically add other ways of
 			// telling the system to keep our profile loaded, in order to make
-			// sure that we keep the default profile enabled we dynamically
-			// reload it if necessary.
-			if err := ensureDefaultAppArmorProfile(); err != nil {
+			// sure that we keep the default profile enabled we load it again
+			// if it is missing.
+			if err := loadDefaultAppArmorProfileIfMissing(); err != nil {
 				return err
 			}
 		}

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -145,9 +145,9 @@ func WithApparmor(c *container.Container) coci.SpecOpts {
 				// profiles inadvertently. Since we cannot store our profile in
 				// /etc/apparmor.d, nor can we practically add other ways of
 				// telling the system to keep our profile loaded, in order to make
-				// sure that we keep the default profile enabled we dynamically
-				// reload it if necessary.
-				if err := ensureDefaultAppArmorProfile(); err != nil {
+				// sure that we keep the default profile enabled we load it again
+				// if it is missing.
+				if err := loadDefaultAppArmorProfileIfMissing(); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
The daemon upgrades do not restart the kernel, so after a daemon upgrade the old "docker-default" AppArmor profile remains loaded in the kernel.

The previous code checked IsLoaded and skipped installation if the profile already existed, which meant that profile template updates (e.g., from a moby/profiles dependency bump) were never applied until the next kernel restart.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix the default AppArmor profile not being updated on daemon restart, requiring a system reboot to pick up profile changes from daemon upgrades.
```

**- A picture of a cute animal (not mandatory but encouraged)**

