### PR TITLE
daemon/libnetwork: waitForLocalDNSServer: rm error-type assert

### DIFF
--- a/daemon/libnetwork/resolver_test.go
+++ b/daemon/libnetwork/resolver_test.go
@@ -124,15 +124,12 @@ func waitForLocalDNSServer(t *testing.T) {
 		tconn, err := net.DialTimeout("tcp", "127.0.0.1:53", 10*time.Second)
 		retries = retries + 1
 		if err != nil {
-			if oerr, ok := err.(*net.OpError); ok {
+			if errors.Is(err, syscall.ECONNREFUSED) {
 				// server is probably initializing
-				if errors.Is(oerr.Err, syscall.ECONNREFUSED) {
-					continue
-				}
-			} else {
-				// something is wrong: we should stop for analysis
-				t.Fatal(err)
+				continue
 			}
+			// something is wrong: we should stop for analysis
+			t.Fatal(err)
 		}
 		if tconn != nil {
 			tconn.Close()


### PR DESCRIPTION
- similar to https://github.com/moby/moby/pull/52531


Similar to 943f46c425c0916296f5478d0aa3de6c660c9bbd; slight change in behavior, because previously, other errors would not be retried, but also didn't mark the check as failed.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

