### PR TITLE
Switch to AppArmor/SELinux based `socketcall` block

### DIFF
--- a/contrib/selinux/docker-af-alg-deny.cil
+++ b/contrib/selinux/docker-af-alg-deny.cil
@@ -1,0 +1,12 @@
+;; Block AF_ALG sockets in container domains to mitigate CVE-2026-31431.
+;; AF_ALG exposes the kernel crypto API which has no legitimate use in containers and enables trivial privilege escalation
+;; on unpatched kernels.
+;;
+;; This rule targets container_domain (container_t, spc_t, etc.) and
+;; does not affect the container runtime (container_runtime_t) or host
+;; processes.
+;;
+;; Requires SELinux userspace >= 3.6 for CIL deny support.
+;; Requires container-selinux for the container_domain attribute.
+
+(deny container_domain self (alg_socket (create)))

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/moby/patternmatcher v0.6.1
 	github.com/moby/policy-helpers v0.0.0-20260324161837-b7c0b994300b
 	github.com/moby/profiles/apparmor v0.2.1
-	github.com/moby/profiles/seccomp v0.2.2
+	github.com/moby/profiles/seccomp v0.2.3
 	github.com/moby/pubsub v1.0.0
 	github.com/moby/swarmkit/v2 v2.1.2
 	github.com/moby/sys/atomicwriter v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/moby/moby/client v0.4.1
 	github.com/moby/patternmatcher v0.6.1
 	github.com/moby/policy-helpers v0.0.0-20260324161837-b7c0b994300b
-	github.com/moby/profiles/apparmor v0.2.0
+	github.com/moby/profiles/apparmor v0.2.1
 	github.com/moby/profiles/seccomp v0.2.2
 	github.com/moby/pubsub v1.0.0
 	github.com/moby/swarmkit/v2 v2.1.2

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/moby/policy-helpers v0.0.0-20260324161837-b7c0b994300b h1:lvBBM2ACrsG
 github.com/moby/policy-helpers v0.0.0-20260324161837-b7c0b994300b/go.mod h1:Cbc1brDwYl1K294MmZB+6WhQR9Tr24hfhgSGND4UlL0=
 github.com/moby/profiles/apparmor v0.2.1 h1:LAUrERjl2trYlInOppli35RQJPIfR3KMWQYeNFTd4+s=
 github.com/moby/profiles/apparmor v0.2.1/go.mod h1:DtaWKVB992B38PG5i6VZU6w71JQatA6qtkaQGiqUsoc=
-github.com/moby/profiles/seccomp v0.2.2 h1:T1AiR9bmVoP6NHic7hXvlp/JNZuMwGC484axRwmPUyQ=
-github.com/moby/profiles/seccomp v0.2.2/go.mod h1:8m3qkkWZXrRsMqlUUN2zyccnYmBf3EAdQYPMVJ3NBhk=
+github.com/moby/profiles/seccomp v0.2.3 h1:nrHNSiECQQvq4WjgceCUgJXIXUJBIswVQ133k4Do2mA=
+github.com/moby/profiles/seccomp v0.2.3/go.mod h1:8m3qkkWZXrRsMqlUUN2zyccnYmBf3EAdQYPMVJ3NBhk=
 github.com/moby/pubsub v1.0.0 h1:jkp/imWsmJz2f6LyFsk7EkVeN2HxR/HTTOY8kHrsxfA=
 github.com/moby/pubsub v1.0.0/go.mod h1:bXSO+3h5MNXXCaEG+6/NlAIk7MMZbySZlnB+cUQhKKc=
 github.com/moby/swarmkit/v2 v2.1.2 h1:1WDZAI6HVYNKdCG4zlXnTAPyLsLwuhRGWlHoOUf5Z6I=

--- a/go.sum
+++ b/go.sum
@@ -565,8 +565,8 @@ github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x
 github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/policy-helpers v0.0.0-20260324161837-b7c0b994300b h1:lvBBM2ACrsG5/O1G1caEwlh0XeqA89IQK3xq0Sh/5NI=
 github.com/moby/policy-helpers v0.0.0-20260324161837-b7c0b994300b/go.mod h1:Cbc1brDwYl1K294MmZB+6WhQR9Tr24hfhgSGND4UlL0=
-github.com/moby/profiles/apparmor v0.2.0 h1:QqmRNCkf8Bq7YA8rY+bwfC1VNhrkCXGveqdLbrjuOfs=
-github.com/moby/profiles/apparmor v0.2.0/go.mod h1:DtaWKVB992B38PG5i6VZU6w71JQatA6qtkaQGiqUsoc=
+github.com/moby/profiles/apparmor v0.2.1 h1:LAUrERjl2trYlInOppli35RQJPIfR3KMWQYeNFTd4+s=
+github.com/moby/profiles/apparmor v0.2.1/go.mod h1:DtaWKVB992B38PG5i6VZU6w71JQatA6qtkaQGiqUsoc=
 github.com/moby/profiles/seccomp v0.2.2 h1:T1AiR9bmVoP6NHic7hXvlp/JNZuMwGC484axRwmPUyQ=
 github.com/moby/profiles/seccomp v0.2.2/go.mod h1:8m3qkkWZXrRsMqlUUN2zyccnYmBf3EAdQYPMVJ3NBhk=
 github.com/moby/pubsub v1.0.0 h1:jkp/imWsmJz2f6LyFsk7EkVeN2HxR/HTTOY8kHrsxfA=

--- a/integration/container/exec_afalg_linux_test.go
+++ b/integration/container/exec_afalg_linux_test.go
@@ -20,14 +20,14 @@ var (
 	//go:embed testdata/af_vsock.c
 	afVSOCKSource string
 
-	//go:embed testdata/af_alg_socketcall.c
-	afALGSocketcallSource string
+	//go:embed testdata/socketcall.c
+	socketcallSource string
 )
 
 // compileAndExecSocketDenied writes a C source file into the container,
 // compiles it with the given compiler command, runs the binary as uid 1000,
-// and asserts that socket creation fails with the expected error.
-func compileAndExecSocketDenied(ctx context.Context, t *testing.T, apiClient client.APIClient, cID string, name string, src string, cc []string, expectedErr string) {
+// and asserts that socket creation fails.
+func compileAndExecSocketDenied(ctx context.Context, t *testing.T, apiClient client.APIClient, cID string, name string, src string, cc []string) {
 	t.Helper()
 
 	binPath := "/tmp/" + name
@@ -56,8 +56,9 @@ func compileAndExecSocketDenied(ctx context.Context, t *testing.T, apiClient cli
 }
 
 // TestExecSocketDenied verifies that AF_ALG and AF_VSOCK sockets cannot be
-// created inside a container. These address families are blocked by the
-// default seccomp profile.
+// created inside a container. AF_ALG is blocked by the default seccomp profile
+// (via socket arg filtering) and by the default AppArmor profile (via
+// "deny network alg"). AF_VSOCK is blocked by seccomp only.
 func TestExecSocketDenied(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 
@@ -78,19 +79,67 @@ func TestExecSocketDenied(t *testing.T) {
 	isAmd64 := arch == "amd64" || arch == "x86_64"
 
 	t.Run("AF_ALG", func(t *testing.T) {
-		compileAndExecSocketDenied(ctx, t, apiClient, cID, "AF_ALG", afALGSource, gcc, "not permitted")
+		compileAndExecSocketDenied(ctx, t, apiClient, cID, "AF_ALG", afALGSource, gcc)
 	})
 	t.Run("AF_VSOCK", func(t *testing.T) {
-		compileAndExecSocketDenied(ctx, t, apiClient, cID, "AF_VSOCK", afVSOCKSource, gcc, "not permitted")
+		compileAndExecSocketDenied(ctx, t, apiClient, cID, "AF_VSOCK", afVSOCKSource, gcc)
 	})
 
-	// Test AF_ALG via the socketcall(2) multiplexer using int $0x80 to
-	// invoke the ia32 compat syscall path from a native 64-bit binary.
-	// MAP_32BIT is used to place the args array below 4 GB, since the
-	// ia32 compat path truncates all registers to 32 bits.
-	t.Run("AF_ALG_socketcall_int80", func(t *testing.T) {
+	// Test socketcall(2) via int $0x80 to invoke the ia32 compat syscall
+	// path from a native 64-bit binary. MAP_32BIT is used to place the
+	// args array below 4 GB since the ia32 compat path truncates all
+	// registers to 32 bits.
+	//
+	// The socketcall binary is compiled with -DSOCK_FAMILY and -DSOCK_TYPE
+	// to set the address family and socket type at compile time.
+	t.Run("socketcall_int80", func(t *testing.T) {
 		skip.If(t, !isAmd64, "int $0x80 ia32 compat only available on amd64")
 
-		compileAndExecSocketDenied(ctx, t, apiClient, cID, "AF_ALG_socketcall_int80", afALGSocketcallSource, gcc, "not implemented")
+		srcPath := "/tmp/socketcall.c"
+		res := container.ExecT(ctx, t, apiClient, cID, []string{
+			"sh", "-c", "cat > " + srcPath + " << 'CEOF'\n" + socketcallSource + "\nCEOF",
+		})
+		res.AssertSuccess(t)
+
+		// AF_ALG (38) via socketcall must be denied by AppArmor's
+		// "deny network alg" rule, which catches it at the kernel
+		// socket layer even though seccomp cannot filter socketcall args.
+		t.Run("AF_ALG", func(t *testing.T) {
+			binPath := "/tmp/socketcall_af_alg"
+			res := container.ExecT(ctx, t, apiClient, cID, append(gcc,
+				"-DSOCK_FAMILY=AF_ALG", "-DSOCK_TYPE=SOCK_SEQPACKET",
+				"-include", "linux/if_alg.h",
+				srcPath, "-o", binPath,
+			))
+			res.AssertSuccess(t)
+
+			res, err := container.Exec(ctx, apiClient, cID, []string{binPath},
+				func(ec *client.ExecCreateOptions) {
+					ec.User = "1000"
+				},
+			)
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(res.ExitCode, 1), "expected AF_ALG socketcall to fail, got: %s", res.Combined())
+			assert.Check(t, is.Contains(strings.ToLower(res.Combined()), "permission denied"))
+		})
+
+		// AF_INET via socketcall must still work to ensure the deny
+		// rule is targeted and does not break legitimate usage.
+		t.Run("AF_INET", func(t *testing.T) {
+			binPath := "/tmp/socketcall_af_inet"
+			res := container.ExecT(ctx, t, apiClient, cID, append(gcc,
+				"-DSOCK_FAMILY=AF_INET", "-DSOCK_TYPE=SOCK_STREAM",
+				srcPath, "-o", binPath,
+			))
+			res.AssertSuccess(t)
+
+			res, err := container.Exec(ctx, apiClient, cID, []string{binPath},
+				func(ec *client.ExecCreateOptions) {
+					ec.User = "1000"
+				},
+			)
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(res.ExitCode, 0), "expected AF_INET socketcall to succeed, got: %s", res.Combined())
+		})
 	})
 }

--- a/integration/container/exec_afalg_linux_test.go
+++ b/integration/container/exec_afalg_linux_test.go
@@ -53,7 +53,10 @@ func compileAndExecSocketDenied(ctx context.Context, t *testing.T, apiClient cli
 
 	out := strings.ToLower(res.Combined())
 	assert.Check(t, is.Contains(out, "socket"), "expected socket-related error message")
-	assert.Check(t, is.Contains(out, expectedErr), "expected %s, got: %s", expectedErr, res.Combined())
+	// Seccomp returns EPERM ("not permitted"), AppArmor returns EACCES
+	// ("permission denied"). Accept either.
+	denied := strings.Contains(out, "not permitted") || strings.Contains(out, "permission denied")
+	assert.Check(t, denied, "expected EPERM or EACCES, got: %s", res.Combined())
 }
 
 // TestExecSocketDenied verifies that AF_ALG and AF_VSOCK sockets cannot be

--- a/integration/container/exec_afalg_linux_test.go
+++ b/integration/container/exec_afalg_linux_test.go
@@ -3,6 +3,7 @@ package container
 import (
 	"context"
 	_ "embed"
+	"slices"
 	"strings"
 	"testing"
 
@@ -94,6 +95,12 @@ func TestExecSocketDenied(t *testing.T) {
 	// to set the address family and socket type at compile time.
 	t.Run("socketcall_int80", func(t *testing.T) {
 		skip.If(t, !isAmd64, "int $0x80 ia32 compat only available on amd64")
+		// Seccomp cannot filter socketcall arguments (the address family
+		// is behind a userspace pointer). Only an LSM (AppArmor or
+		// SELinux) can deny AF_ALG via the security_socket_create hook.
+		hasLSM := slices.Contains(testEnv.DaemonInfo.SecurityOptions, "name=apparmor") ||
+			slices.Contains(testEnv.DaemonInfo.SecurityOptions, "name=selinux")
+		skip.If(t, !hasLSM, "socketcall filtering requires AppArmor or SELinux")
 
 		srcPath := "/tmp/socketcall.c"
 		res := container.ExecT(ctx, t, apiClient, cID, []string{
@@ -101,9 +108,10 @@ func TestExecSocketDenied(t *testing.T) {
 		})
 		res.AssertSuccess(t)
 
-		// AF_ALG (38) via socketcall must be denied by AppArmor's
-		// "deny network alg" rule, which catches it at the kernel
-		// socket layer even though seccomp cannot filter socketcall args.
+		// AF_ALG (38) via socketcall must be denied by the LSM
+		// (AppArmor's "deny network alg" or SELinux's alg_socket deny),
+		// which catches it at the security_socket_create hook even
+		// though seccomp cannot filter socketcall args.
 		t.Run("AF_ALG", func(t *testing.T) {
 			binPath := "/tmp/socketcall_af_alg"
 			res := container.ExecT(ctx, t, apiClient, cID, append(gcc,

--- a/integration/container/testdata/socketcall.c
+++ b/integration/container/testdata/socketcall.c
@@ -1,11 +1,18 @@
 #include <stdio.h>
 #include <errno.h>
+#include <unistd.h>
+#include <sys/socket.h>
 #include <sys/mman.h>
 
 #define SYS_SOCKETCALL_I386 102
 #define SYS_SOCKET 1
-#define AF_ALG 38
-#define SOCK_SEQPACKET 5
+
+#ifndef SOCK_FAMILY
+#error "define SOCK_FAMILY via -DSOCK_FAMILY=..."
+#endif
+#ifndef SOCK_TYPE
+#error "define SOCK_TYPE via -DSOCK_TYPE=..."
+#endif
 
 int main() {
     /*
@@ -20,8 +27,8 @@ int main() {
         perror("mmap");
         return 2;
     }
-    args[0] = AF_ALG;
-    args[1] = SOCK_SEQPACKET;
+    args[0] = SOCK_FAMILY;
+    args[1] = SOCK_TYPE;
     args[2] = 0;
 
     int ret;
@@ -38,6 +45,7 @@ int main() {
         return 1;
     }
 
-    printf("AF_ALG socket created via socketcall\n");
+    printf("socket(%d, %d, 0) via socketcall succeeded\n", SOCK_FAMILY, SOCK_TYPE);
+    close(ret);
     return 0;
 }

--- a/vendor/github.com/moby/profiles/apparmor/template.go
+++ b/vendor/github.com/moby/profiles/apparmor/template.go
@@ -32,6 +32,8 @@ profile "{{.Name}}" flags=(attach_disconnected,mediate_deleted) {
 {{- end}}{{if .InnerImports}}
 {{end}}
   network,
+  # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
+  deny network alg,
   capability,
   file,
   umount,

--- a/vendor/github.com/moby/profiles/seccomp/default.json
+++ b/vendor/github.com/moby/profiles/seccomp/default.json
@@ -371,6 +371,7 @@
 				"signalfd4",
 				"sigprocmask",
 				"sigreturn",
+				"socketcall",
 				"socketpair",
 				"splice",
 				"stat",
@@ -434,13 +435,6 @@
 			"includes": {
 				"minKernel": "4.8"
 			}
-		},
-		{
-			"names": [
-				"socketcall"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"errnoRet": 38
 		},
 		{
 			"names": [

--- a/vendor/github.com/moby/profiles/seccomp/default_linux.go
+++ b/vendor/github.com/moby/profiles/seccomp/default_linux.go
@@ -374,6 +374,7 @@ func DefaultProfile() *Seccomp {
 					"signalfd4",
 					"sigprocmask",
 					"sigreturn",
+					"socketcall",
 					"socketpair",
 					"splice",
 					"stat",
@@ -441,27 +442,12 @@ func DefaultProfile() *Seccomp {
 				MinKernel: &KernelVersion{4, 8},
 			},
 		},
-		// socketcall(2) is explicitly denied to prevent bypassing the socket
-		// address family filters above on architectures where socketcall is
-		// supported (i386, s390, MIPS o32).
-		// Seccomp cannot inspect socketcall's pointer argument, so allowing it
-		// would let an attacker open AF_ALG sockets via socketcall(SYS_SOCKET,
-		// ...). Since Linux 4.3 all affected architectures provide direct
-		// socket syscalls, so modern userspace is not impacted.
-		//
-		// ENOSYS (not EPERM) is used because the errno must differ from
-		// DefaultErrnoRet; otherwise both runc and libseccomp treat the rule
-		// as identical to the default action and silently omit it from the
-		// generated BPF, which lets libseccomp's auto-generated
-		// socketcall(SYS_SOCKET) -> ALLOW path survive unchallenged.
-		{
-			LinuxSyscall: specs.LinuxSyscall{
-				Names:    []string{"socketcall"},
-				Action:   specs.ActErrno,
-				ErrnoRet: &nosys,
-			},
-		},
 		// Allow socket(2) for all address families except AF_VSOCK and AF_ALG.
+		// NOTE: on 32-bit x86, socket() goes through socketcall(2) which is
+		// allowed unconditionally above, so AF_VSOCK/AF_ALG is still reachable
+		// via the socketcall-based socket() path. These arg filters only apply
+		// to the direct socket syscall, and do not protect 32-bit x86 unless
+		// socketcall(2) is also addressed.
 		{
 			LinuxSyscall: specs.LinuxSyscall{
 				Names:  []string{"socket"},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1216,7 +1216,7 @@ github.com/moby/policy-helpers/image
 github.com/moby/policy-helpers/roots
 github.com/moby/policy-helpers/roots/dhi
 github.com/moby/policy-helpers/types
-# github.com/moby/profiles/apparmor v0.2.0
+# github.com/moby/profiles/apparmor v0.2.1
 ## explicit; go 1.23.0
 github.com/moby/profiles/apparmor
 # github.com/moby/profiles/seccomp v0.2.2

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1219,7 +1219,7 @@ github.com/moby/policy-helpers/types
 # github.com/moby/profiles/apparmor v0.2.1
 ## explicit; go 1.23.0
 github.com/moby/profiles/apparmor
-# github.com/moby/profiles/seccomp v0.2.2
+# github.com/moby/profiles/seccomp v0.2.3
 ## explicit; go 1.23.0
 github.com/moby/profiles/seccomp
 # github.com/moby/pubsub v1.0.0


### PR DESCRIPTION
Seccomp cannot filter socketcall(2) arguments because the address family is behind a userspace pointer that BPF cannot dereference. Only an LSM (AppArmor or SELinux) can deny AF_ALG via the security_socket_create hook in the socketcall path.

```markdown changelog
CVE-2026-31431: Replace the socketcall(2) seccomp deny that broke 32-bit programs with targeted AppArmor (deny network alg) and SELinux (alg_socket) rules that block AF_ALG at the LSM layer, covering both socket(2) and socketcall(2) paths without disrupting legitimate 32-bit workloads.
```