### PR TITLE
test-docker-py: Pin Python base to 3.12-bookworm

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -67,6 +67,10 @@ PY_TEST_OPTIONS="${PY_TEST_OPTIONS} --deselect=tests/integration/api_container_t
 			[ -n "${TESTDEBUG}" ] && set -x
 			[ -z "${TESTDEBUG}" ] && build_opts="--quiet"
 			[ -f /.dockerenv ] || build_opts="${build_opts} --network=host"
+
+			# TODO(vvoland): Fix upstream - move off legacy gpg keyring
+			build_opts="${build_opts} --build-arg PYTHON_VERSION=3.12-bookworm"
+
 			# shellcheck disable=SC2086
 			exec docker build ${build_opts} -t "${docker_py_image}" -f tests/Dockerfile "https://github.com/docker/docker-py.git#${DOCKER_PY_COMMIT}"
 		)


### PR DESCRIPTION
The docker-py upstream tests/Dockerfile uses `FROM python:3.12` by default.

That tag is a floating reference and was recently republished onto Debian Trixie, which ships a newer GnuPG that fails to import the legacy gpg keyring fixture.

The result is that test-docker-py fails on:

  `RUN gpg2 --import gpg-keys/secret`

before any actual test runs, even though nothing in moby has changed.

Pin PYTHON_VERSION=3.12-bookworm via --build-arg so the image build is not sensitive to upstream Python tag refreshes.
