### PR TITLE
daemon: separate reserving SELinux label from loading

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -25,7 +25,6 @@ import (
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/sys/signal"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/pkg/errors"
 )
 
@@ -77,8 +76,6 @@ func (daemon *Daemon) load(id string) (*container.Container, error) {
 	if err := ctr.FromDisk(); err != nil {
 		return nil, err
 	}
-	selinux.ReserveLabel(ctr.ProcessLabel)
-
 	if ctr.ID != id {
 		return ctr, fmt.Errorf("Container %s is stored at %s", ctr.ID, id)
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -40,6 +40,7 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/nri"
 	"github.com/moby/sys/user"
 	"github.com/moby/sys/userns"
+	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -244,6 +245,9 @@ func (daemon *Daemon) loadContainers(ctx context.Context) (map[string]map[string
 			if err != nil {
 				log.G(ctx).WithFields(log.Fields{"error": err, "container": id}).Error("Failed to load container")
 				return
+			}
+			if c.ProcessLabel != "" {
+				selinux.ReserveLabel(c.ProcessLabel)
 			}
 
 			mapLock.Lock()

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -165,7 +165,9 @@ func (daemon *Daemon) cleanupContainer(ctr *container.Container, config backend.
 	}
 
 	linkNames := daemon.linkIndex.delete(ctr)
-	selinux.ReleaseLabel(ctr.ProcessLabel)
+	if ctr.ProcessLabel != "" {
+		selinux.ReleaseLabel(ctr.ProcessLabel)
+	}
 	daemon.containers.Delete(ctr.ID)
 	daemon.containersReplica.Delete(ctr)
 	if err := daemon.removeMountPoints(ctr, config.RemoveVolume); err != nil {


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/52556#discussion_r3200594983


Separate loading the container from reserving MCS labels; the old logic would attempt to reserve the label, but could fail after reserving.

Move this code separate, as it's a separate concern; also gate both reserving and releasing the label on whether a label is configured instead of depending on the selinux module treating an empty label as a no-op.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

