### PR TITLE
Some improvements to getInspectData(), create()

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -227,22 +227,6 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 
 	ctr.ImageManifest = imgManifest
 
-	// Set RWLayer for container after mount labels have been set
-	rwLayer, err := daemon.imageService.CreateLayer(ctr, setupInitLayer(daemon.idMapping.RootPair()))
-	if err != nil {
-		return nil, errdefs.System(err)
-	}
-	ctr.RWLayer = rwLayer
-
-	cuid := os.Getuid()
-	_, gid := daemon.IdentityMapping().RootPair()
-	if err := user.MkdirAndChown(ctr.Root, 0o710, cuid, gid); err != nil {
-		return nil, err
-	}
-	if err := user.MkdirAndChown(ctr.CheckpointDir(), 0o700, cuid, os.Getegid()); err != nil {
-		return nil, err
-	}
-
 	if err := daemon.registerLinks(ctr); err != nil {
 		return nil, err
 	}
@@ -268,6 +252,23 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 	if err := daemon.registerMountPoints(ctr, opts.params.DefaultReadOnlyNonRecursive); err != nil {
 		return nil, err
 	}
+
+	// Set RWLayer for container after mount labels have been set
+	rwLayer, err := daemon.imageService.CreateLayer(ctr, setupInitLayer(daemon.idMapping.RootPair()))
+	if err != nil {
+		return nil, errdefs.System(err)
+	}
+	ctr.RWLayer = rwLayer
+
+	cuid := os.Getuid()
+	_, gid := daemon.IdentityMapping().RootPair()
+	if err := user.MkdirAndChown(ctr.Root, 0o710, cuid, gid); err != nil {
+		return nil, err
+	}
+	if err := user.MkdirAndChown(ctr.CheckpointDir(), 0o700, cuid, os.Getegid()); err != nil {
+		return nil, err
+	}
+
 	if err := daemon.createContainerVolumesOS(ctx, ctr, opts.params.Config); err != nil {
 		return nil, err
 	}

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -25,38 +25,12 @@ func (daemon *Daemon) ContainerInspect(ctx context.Context, name string, options
 	if err != nil {
 		return nil, nil, err
 	}
-
-	ctr.Lock()
-
-	base, desiredMACAddress, err := daemon.getInspectData(&daemon.config().Config, ctr)
+	base, desiredMACAddress, err := daemon.containerInspect(&daemon.config().Config, ctr)
 	if err != nil {
-		ctr.Unlock()
-		return nil, nil, err
+		return base, desiredMACAddress, err
 	}
-
-	// TODO(thaJeztah): do we need a deep copy here? Otherwise we could use maps.Clone (see https://github.com/moby/moby/commit/7917a36cc787ada58987320e67cc6d96858f3b55)
-	ports := make(networktypes.PortMap, len(ctr.NetworkSettings.Ports))
-	maps.Copy(ports, ctr.NetworkSettings.Ports)
-
-	apiNetworks := make(map[string]*networktypes.EndpointSettings)
-	for nwName, epConf := range ctr.NetworkSettings.Networks {
-		if epConf.EndpointSettings != nil {
-			// We must make a copy of this pointer object otherwise it can race with other operations
-			apiNetworks[nwName] = epConf.EndpointSettings.Copy()
-		}
-	}
-
-	networkSettings := &containertypes.NetworkSettings{
-		SandboxID:  ctr.NetworkSettings.SandboxID,
-		SandboxKey: ctr.NetworkSettings.SandboxKey,
-		Ports:      ports,
-		Networks:   apiNetworks,
-	}
-
-	mountPoints := ctr.GetMountPoints()
 
 	// Don’t hold container lock for size calculation (see https://github.com/moby/moby/issues/31158)
-	ctr.Unlock()
 	if options.Size {
 		sizeRw, sizeRootFs, err := daemon.imageService.GetContainerLayerSize(ctx, base.ID)
 		if err != nil {
@@ -65,19 +39,38 @@ func (daemon *Daemon) ContainerInspect(ctx context.Context, name string, options
 		base.SizeRw = &sizeRw
 		base.SizeRootFs = &sizeRootFs
 	}
+	return base, desiredMACAddress, nil
+}
 
-	imageManifest := ctr.ImageManifest
-	if imageManifest != nil && imageManifest.Platform == nil {
-		// Copy the image manifest to avoid mutating the original
-		c := *imageManifest
-		imageManifest = &c
+func (daemon *Daemon) containerInspect(daemonCfg *config.Config, ctr *container.Container) (_ *containertypes.InspectResponse, desiredMACAddress networktypes.HardwareAddr, _ error) {
+	ctr.Lock()
+	defer ctr.Unlock()
 
-		imageManifest.Platform = &ctr.ImagePlatform
+	base, desiredMACAddress, err := daemon.getInspectData(daemonCfg, ctr)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	base.Mounts = mountPoints
-	base.NetworkSettings = networkSettings
-	base.ImageManifestDescriptor = imageManifest
+	if !daemon.UsesSnapshotter() {
+		if ctr.RWLayer == nil {
+			if ctr.State.Dead {
+				return base, desiredMACAddress, nil
+			}
+			return nil, nil, errdefs.System(errors.New("RWLayer of container " + ctr.ID + " is unexpectedly nil"))
+		}
+
+		graphDriverData, err := ctr.RWLayer.Metadata()
+		if err != nil {
+			if ctr.State.Dead {
+				// container is marked as Dead, and its graphDriver metadata may
+				// have been removed; we can ignore errors.
+				return base, desiredMACAddress, nil
+			}
+			return nil, nil, errdefs.System(err)
+		}
+
+		base.GraphDriver.Data = graphDriverData
+	}
 
 	return base, desiredMACAddress, nil
 }
@@ -154,6 +147,37 @@ func (daemon *Daemon) getInspectData(daemonCfg *config.Config, ctr *container.Co
 		Config:          ctr.Config,
 	}
 
+	// TODO(thaJeztah): do we need a deep copy here? Otherwise we could use maps.Clone (see https://github.com/moby/moby/commit/7917a36cc787ada58987320e67cc6d96858f3b55)
+	ports := make(networktypes.PortMap, len(ctr.NetworkSettings.Ports))
+	maps.Copy(ports, ctr.NetworkSettings.Ports)
+
+	apiNetworks := make(map[string]*networktypes.EndpointSettings)
+	for nwName, epConf := range ctr.NetworkSettings.Networks {
+		if epConf.EndpointSettings != nil {
+			// We must make a copy of this pointer object otherwise it can race with other operations
+			apiNetworks[nwName] = epConf.EndpointSettings.Copy()
+		}
+	}
+
+	inspectResponse.NetworkSettings = &containertypes.NetworkSettings{
+		SandboxID:  ctr.NetworkSettings.SandboxID,
+		SandboxKey: ctr.NetworkSettings.SandboxKey,
+		Ports:      ports,
+		Networks:   apiNetworks,
+	}
+	inspectResponse.Mounts = ctr.GetMountPoints()
+
+	imageManifest := ctr.ImageManifest
+	if imageManifest != nil && imageManifest.Platform == nil {
+		// Copy the image manifest to avoid mutating the original
+		c := *imageManifest
+		imageManifest = &c
+
+		imageManifest.Platform = &ctr.ImagePlatform
+	}
+
+	inspectResponse.ImageManifestDescriptor = imageManifest
+
 	if daemon.UsesSnapshotter() {
 		inspectResponse.Storage = &storage.Storage{
 			RootFS: &storage.RootFSStorage{
@@ -162,32 +186,11 @@ func (daemon *Daemon) getInspectData(daemonCfg *config.Config, ctr *container.Co
 				},
 			},
 		}
-
-		// Additional information only applies to graphDrivers, so we're done.
-		return inspectResponse, macAddress, nil
-	}
-
-	inspectResponse.GraphDriver = &storage.DriverData{
-		Name: ctr.Driver,
-	}
-	if ctr.RWLayer == nil {
-		if ctr.State.Dead {
-			return inspectResponse, macAddress, nil
+	} else {
+		inspectResponse.GraphDriver = &storage.DriverData{
+			Name: ctr.Driver,
 		}
-		return nil, nil, errdefs.System(errors.New("RWLayer of container " + ctr.ID + " is unexpectedly nil"))
 	}
-
-	graphDriverData, err := ctr.RWLayer.Metadata()
-	if err != nil {
-		if ctr.State.Dead {
-			// container is marked as Dead, and its graphDriver metadata may
-			// have been removed; we can ignore errors.
-			return inspectResponse, macAddress, nil
-		}
-		return nil, nil, errdefs.System(err)
-	}
-
-	inspectResponse.GraphDriver.Data = graphDriverData
 	return inspectResponse, macAddress, nil
 }
 

--- a/daemon/inspect_test.go
+++ b/daemon/inspect_test.go
@@ -5,16 +5,37 @@ import (
 
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/v2/daemon/container"
+	"github.com/moby/moby/v2/daemon/network"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestGetInspectData(t *testing.T) {
 	c := &container.Container{
-		ID:           "inspect-me",
-		HostConfig:   &containertypes.HostConfig{},
-		State:        &container.State{},
-		ExecCommands: container.NewExecStore(),
+		ID:              "inspect-me",
+		NetworkSettings: &network.Settings{},
+		HostConfig:      &containertypes.HostConfig{},
+		State:           &container.State{},
+		ExecCommands:    container.NewExecStore(),
+	}
+
+	d := &Daemon{
+		linkIndex: newLinkIndex(),
+	}
+	cfg := &configStore{}
+	d.configStore.Store(cfg)
+
+	_, _, err := d.getInspectData(&cfg.Config, c)
+	assert.Check(t, err)
+}
+
+func TestContainerInspect(t *testing.T) {
+	c := &container.Container{
+		ID:              "inspect-me",
+		NetworkSettings: &network.Settings{},
+		HostConfig:      &containertypes.HostConfig{},
+		State:           &container.State{},
+		ExecCommands:    container.NewExecStore(),
 	}
 
 	d := &Daemon{
@@ -26,10 +47,10 @@ func TestGetInspectData(t *testing.T) {
 	cfg := &configStore{}
 	d.configStore.Store(cfg)
 
-	_, _, err := d.getInspectData(&cfg.Config, c)
+	_, _, err := d.containerInspect(&cfg.Config, c)
 	assert.Check(t, is.ErrorContains(err, "RWLayer of container inspect-me is unexpectedly nil"))
 
 	c.State.Dead = true
-	_, _, err = d.getInspectData(&cfg.Config, c)
+	_, _, err = d.containerInspect(&cfg.Config, c)
 	assert.Check(t, err)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

### daemon: make getInspectData() reusable

Move the bulk of the code to inspect a container into
`(*Daemon).getInspectData()` so other daemon code can inspect a
`*container.Container` (e.g. while holding its lock) and get almost the
same result as `(*Daemon).ContainerInspect()` of a container in the store.
The RWLayer metadata and size calculation are omitted so a container can
be inspected successfully when `ctr.RWLayer == nil && !ctr.Dead`.


### daemon: init container rootfs at end of create

Build up the full container config and do all the bookkeeping that can be done before initializing the container's RWLayer, rootfs and mounts so the comparatively expensive filesystem operations do not need to be performed then reverted if the container creation fails due to a problem with the container configuration.

### daemon: log event after reload is committed

The NRI integration performs the heavy lifting of stopping the old instance and initializing the new one in a daemon-reload commit callback. Container create operations may hang if racing NRI initialization. (This is a bug in the NRI integration or module.) The TestNRIReload integration test waits for the daemon reload event before creating a container. A daemon reload event is logged before the reload transaction is committed, setting the test up to consistently race creating containers concurrently with the NRI reload.

Move logging the daemon event to after the reload transaction is committed so subscribers will not be informed prematurely that the reload has completed.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

