### PR TITLE
daemon: add "time-namespaces" feature-flag to disable time-namespaces

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1623,7 +1623,20 @@ func getSysInfo(cfg *config.Config) *sysinfo.SysInfo {
 			siOpts = append(siOpts, sysinfo.WithCgroup2GroupPath("/user.slice/user-"+euid+".slice"))
 		}
 	}
-	return sysinfo.New(siOpts...)
+	si := sysinfo.New(siOpts...)
+
+	// The "time-namespaces" feature-flag is a (temporary) escape-hatch to disable
+	// the use of time-namespaces for containers. This allows users to return to the
+	// previous default, which unconditionally used the host's time-namespace.
+	//
+	// We can consider removing this flag if there's no regressions; see https://github.com/moby/moby/pull/52326#issuecomment-4401495854
+	if enabled, ok := cfg.Features["time-namespaces"]; ok && !enabled {
+		if si.TimeNamespaces {
+			si.TimeNamespaces = false
+			log.G(context.TODO()).Info("time-namespaces disabled through feature-override")
+		}
+	}
+	return si
 }
 
 func recursiveUnmount(target string) error {


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/52326

Add a (temporary) escape-hatch to disable the use of time-namespaces for containers. This allows users to return to the previous default, which unconditionally used the host's time-namespace.

With this patch:

    dockerd --feature time-namespaces=false
    ..
    INFO[2026-05-07T21:48:40.840255929Z] time-namespaces disabled through feature-override


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Add "time-namespaces" feature flag to disable time-namespaces.
```

**- A picture of a cute animal (not mandatory but encouraged)**

