### PR TITLE
daemon: preserve CDI additional GIDs

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -1015,6 +1015,8 @@ func (daemon *Daemon) createSpec(ctx context.Context, daemonCfg *configStore, c 
 		withCgroups(daemon, &daemonCfg.Config, c),
 		WithResources(c),
 		WithSysctls(c),
+		// Set the user before CDI device injection, which may append supplementary groups.
+		WithUser(c),
 		WithDevices(daemon, c),
 		withRlimits(daemon, &daemonCfg.Config, c),
 		WithNamespaces(daemon, c),
@@ -1025,7 +1027,6 @@ func (daemon *Daemon) createSpec(ctx context.Context, daemonCfg *configStore, c 
 		WithSelinux(c),
 		WithOOMScore(&c.HostConfig.OomScoreAdj),
 		coci.WithAnnotations(c.HostConfig.Annotations),
-		WithUser(c),
 	)
 
 	if c.NoNewPrivileges {

--- a/daemon/oci_linux_test.go
+++ b/daemon/oci_linux_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -74,6 +75,45 @@ type fakeImageService struct {
 
 func (i *fakeImageService) StorageDriver() string {
 	return "overlay"
+}
+
+func TestCreateSpecPreservesCDIAdditionalGIDs(t *testing.T) {
+	cdiDir := t.TempDir()
+	err := os.WriteFile(filepath.Join(cdiDir, "test-device.yaml"), []byte(`
+cdiVersion: "0.7.0"
+kind: "example.com/device"
+devices:
+- name: foo
+  containerEdits:
+    additionalGids:
+    - 1234
+`), 0o644)
+	assert.NilError(t, err)
+
+	origDeviceDrivers := maps.Clone(deviceDrivers)
+	t.Cleanup(func() {
+		deviceDrivers = origDeviceDrivers
+	})
+	RegisterCDIDriver(cdiDir)
+
+	c := &container.Container{
+		Config: &containertypes.Config{},
+		HostConfig: &containertypes.HostConfig{
+			Resources: containertypes.Resources{
+				DeviceRequests: []containertypes.DeviceRequest{
+					{
+						Driver:    "cdi",
+						DeviceIDs: []string{"example.com/device=foo"},
+					},
+				},
+			},
+		},
+	}
+	d := setupFakeDaemon(t, c)
+
+	s, err := d.createSpec(t.Context(), &configStore{}, c, nil)
+	assert.NilError(t, err)
+	assert.Assert(t, slices.Contains(s.Process.User.AdditionalGids, uint32(1234)), "CDI additional GID not present in OCI spec")
 }
 
 // TestTmpfsDevShmNoDupMount checks that a user-specified /dev/shm tmpfs


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Ensured that the addition of the user to the OCI spec runs before CDI injection. This is required to allow additional (non-root) group IDs to be added to the OCI spec if required for device nodes, for example. One case where this is applicable is on certain NVIDIA systems where device nodes have `660` permisions and are owned by `root:video`:
```
$ ls -al /dev/nvmap
crw-rw---- 1 root video 10, 124 Aug 26  2025 /dev/nvmap
```

This injection is equivalent with running `docker` with `--group-add`.

**- How I did it**

Reordered the functional modifers of the OCI spec so that `WithUsers` is called before `WithDevices` (which triggers CDI device injection).

**- How to verify it**

Create the following CDI spec at `/var/run/cdi/additional-gid-test.yaml`:
```
cdiVersion: "0.7.0"
kind: "example.com/device"
devices:
- name: foo
  containerEdits:
    additionalGids:
    - 1234
```
(also specified in the tests).

Running id in a container requesting the device should show the additional group:
```
$ docker run --rm -ti --device=example.com/device=foo alpine id
uid=0(root) gid=0(root) groups=0(root),0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video),1234
```
(this is equivalent to running `--group-add`:
```
$ docker run --rm -ti --group-add 1234 alpine id
uid=0(root) gid=0(root) groups=0(root),0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video),1234
```

(remove the created file).

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix support for CDI specifications that request additional group IDs.
```

**- A picture of a cute animal (not mandatory but encouraged)**

