### PR TITLE
daemon: fix healthcheck empty-cmd panic

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -68,6 +68,9 @@ type cmdProbe struct {
 func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container) (*containertypes.HealthcheckResult, error) {
 	startTime := time.Now()
 	cmd := cntr.Config.Healthcheck.Test[1:]
+	if len(cmd) == 0 {
+		return nil, fmt.Errorf("healthcheck for container %s has no command", cntr.ID)
+	}
 	if p.shell {
 		cmd = append(getShell(cntr), cmd...)
 	}

--- a/daemon/health_test.go
+++ b/daemon/health_test.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -150,5 +152,24 @@ func TestHealthStates(t *testing.T) {
 	expect(eventtypes.ActionHealthStatusHealthy)
 	if c.State.Health.Health.FailingStreak != 0 {
 		t.Errorf("Expecting FailingStreak=0, but got %d\n", c.State.Health.Health.FailingStreak)
+	}
+}
+
+func TestCmdProbeEmptyCommand(t *testing.T) {
+	c := &container.Container{
+		ID: "container_id",
+		Config: &containertypes.Config{
+			Healthcheck: &containertypes.HealthConfig{
+				Test: []string{"CMD"},
+			},
+		},
+	}
+	p := &cmdProbe{shell: false}
+	_, err := p.run(context.Background(), nil, c)
+	if err == nil {
+		t.Fatal("expected error for empty healthcheck command, got nil")
+	}
+	if !strings.Contains(err.Error(), "has no command") {
+		t.Fatalf("expected 'has no command' error, got: %v", err)
 	}
 }


### PR DESCRIPTION
- taken from https://github.com/moby/moby/pull/52450
- fixes / addresses https://github.com/moby/moby/issues/52330

If Healthcheck.Test was ["CMD"] (only the probe type with no command), cmdProbe.run would panic with an index-out-of-range accessing cmd[0]. Add an explicit length check and return a descriptive error instead.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

