### PR TITLE
gha: Fix test-integration-flaky

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -93,6 +93,9 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Full history needed to diff against target branch and detect new tests (test-integration-flaky).
+          fetch-depth: 0
       -
         name: Set up runner
         uses: ./.github/actions/setup-runner

--- a/hack/make/test-integration-flaky
+++ b/hack/make/test-integration-flaky
@@ -4,9 +4,11 @@ set -e -o pipefail
 source hack/validate/.validate
 
 run_integration_flaky() {
+	diff=$(
+		validate_diff --diff-filter=ACMR --unified=0 -- 'integration/*_test.go'
+	)
 	new_tests=$(
-		validate_diff --diff-filter=ACMR --unified=0 -- 'integration/*_test.go' \
-			| grep -E '^(\+func Test)(.*)(\*testing\.T\))' || true
+		printf '%s\n' "$diff" | grep -E '^(\+func Test)(.*)(\*testing\.T\))' || true
 	)
 
 	if [ -z "$new_tests" ]; then


### PR DESCRIPTION
### gha: Fix test-integration-flaky

  Use fetch-depth: 0 for the full git history.

  The test-integration-flaky job stress-tests new integration tests by diffing the PR against the target branch with 'git diff A...B'.

  The default checkout does a shallow clone, so the diff fails and the job silently exits without running the stress loop:

  ```
  ---> Making bundle: test-integration-flaky (in bundles/test-integration-flaky) fatal: 50b02f40b9d7d6dcd4ec6e64e91bb3ae412db8b0...7438c15e36c2de47dfadb2cb8fc143679180893d: no merge base No new tests added to integration.
  ```



### hack: Fix test-integration-flaky

  Split the diff from the grep in the bundle so a failed diff is no longer swallowed and misreported as "no new tests".