### PR TITLE
Fix flakiness with NRI integration tests

### DIFF
--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -131,8 +131,9 @@ func (daemon *Daemon) Reload(conf *config.Config) error {
 	}
 
 	daemon.configStore.Store(newCfg)
+	err = txn.Commit()
 	daemon.LogDaemonEventWithAttributes(events.ActionReload, attributes)
-	return txn.Commit()
+	return err
 }
 
 func marshalAttributeSlice(v []string) string {

--- a/integration/daemon/nri/plugin.go
+++ b/integration/daemon/nri/plugin.go
@@ -37,9 +37,10 @@ type builtinPluginConfig struct {
 }
 
 type builtinPlugin struct {
-	stub   stub.Stub
-	logG   func(context.Context) *log.Entry
-	config builtinPluginConfig
+	stub         stub.Stub
+	logG         func(context.Context) *log.Entry
+	config       builtinPluginConfig
+	synchronized chan struct{}
 }
 
 // startBuiltinPlugin turns the test binary into an NRI plugin, or fails the test.
@@ -49,7 +50,8 @@ func startBuiltinPlugin(ctx context.Context, t *testing.T, cfg builtinPluginConf
 		logG: func(ctx context.Context) *log.Entry {
 			return log.G(ctx).WithField("nri-plugin", cfg.pluginIdx+"-"+cfg.pluginName)
 		},
-		config: cfg,
+		config:       cfg,
+		synchronized: make(chan struct{}),
 	}
 	stub, err := stub.New(p,
 		stub.WithOnClose(p.onClose),
@@ -61,6 +63,11 @@ func startBuiltinPlugin(ctx context.Context, t *testing.T, cfg builtinPluginConf
 	p.stub = stub
 	err = p.stub.Start(ctx)
 	assert.Assert(t, err)
+	select {
+	case <-p.synchronized:
+	case <-ctx.Done():
+		t.Fatalf("%v", ctx.Err())
+	}
 	return p.stub.Stop
 }
 
@@ -76,6 +83,11 @@ func (p *builtinPlugin) Configure(ctx context.Context, config, runtime, version 
 func (p *builtinPlugin) Synchronize(ctx context.Context, pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
 	p.logG(ctx).Infof("Synchronized state with the runtime (%d pods, %d containers)...",
 		len(pods), len(containers))
+	select {
+	case <-p.synchronized:
+	default:
+		close(p.synchronized)
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

I have observed flakiness in the NRI tests after rearranging `(*daemon.Daemon).create()` such that the NRI settings-adjustment happens before the RWLayer and container rootfs are set up. Setting up the container filesystem must be delaying the call into NRI just enough to allow the tests to pass consistently.

**- What I did**
I fixed the logical races that affected the NRI integration tests.

**- How I did it**

Config-reload defers starting the new NRI instance until the transaction is commmitted. However, the config-reloaded daemon event is published before the transaction is committed. This results in the NRI reload tests racing with the startup of the new NRI instance since they wait for the daemon event before attempting to create containers. Modify the daemon to only publish the reloaded event once all the commit callbacks have completed, which is more correct behaviour in general.

Other NRI tests utilize an external (to the daemon under test) plugin as part of the test harness. They wait until the plugin has started up before proceeding. Plugin registration is asynchronous so the tests flake out if the test creates a container before the external plugin has been fully registered with the NRI instance. Change `startBuiltinPlugin` to block until the plugin has been synchronized with NRI at least once, which signifies that the plugin is registered.

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Daemon reload events now signify that the daemon reload has fully completed.
```

**- A picture of a cute animal (not mandatory but encouraged)**

