### PR TITLE
hack: preserve pseudo-version hashes in buildkit-ref

### DIFF
--- a/hack/buildkit-ref
+++ b/hack/buildkit-ref
@@ -13,8 +13,8 @@ buildkit_repo=$(go list -mod=mod -u -m -f '{{if .Replace}}{{.Replace.Path}}{{els
 buildkit_repo=${buildkit_repo#github.com/}
 
 if [[ "${buildkit_ref}" == *-*-* ]]; then
-	# if pseudo-version, figure out just the uncommon sha (https://github.com/golang/go/issues/34745)
-	buildkit_ref=$(awk -F"-" '{print $NF}' <<< "$buildkit_ref" | awk 'BEGIN{FIELDWIDTHS="7"} {print $1}')
+	# if pseudo-version, figure out just the commit sha
+	buildkit_ref=$(awk -F"-" '{print $NF}' <<< "$buildkit_ref")
 	# use github api to return full sha to be able to use it as ref
 	buildkit_ref=$(curl -s "https://api.github.com/repos/${buildkit_repo}/commits/${buildkit_ref}" | jq -r .sha)
 fi


### PR DESCRIPTION
relates to https://github.com/moby/moby/actions/runs/25656953594/job/75308053817#step:7:4

The script now keeps the full commit suffix from the pseudo-version before asking the GitHub API for the full commit SHA.

The previous logic truncated the pseudo-version hash to seven characters, which can fail to resolve through GitHub and caused `BUILDKIT_REF` to become `null`.

This was tested in https://github.com/moby/moby/pull/52593/changes#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R303 with a `go.mod` replacement for `github.com/moby/buildkit` pointing at `github.com/crazy-max/buildkit v0.7.1-0.20260508130014-1795e480b0d9`, and `./hack/buildkit-ref` returned the expected full commit SHA.