### PR TITLE
Test build with userns-remap and revert setkey reexec removal

### DIFF
--- a/daemon/internal/builder-next/executor.go
+++ b/daemon/internal/builder-next/executor.go
@@ -61,6 +61,7 @@ func (iface *lnInterface) init(c *libnetwork.Controller, n *libnetwork.Network) 
 	sbx, err := c.NewSandbox(
 		context.TODO(),
 		id,
+		libnetwork.OptionUseExternalKey(),
 		libnetwork.OptionHostsPath(filepath.Join(iface.provider.Root, id, "hosts")),
 		libnetwork.OptionResolvConfPath(filepath.Join(iface.provider.Root, id, "resolv.conf")),
 	)

--- a/daemon/internal/builder-next/executor_linux.go
+++ b/daemon/internal/builder-next/executor_linux.go
@@ -2,9 +2,9 @@ package buildkit
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/containerd/log"
 	"github.com/moby/buildkit/executor"
@@ -12,6 +12,7 @@ import (
 	"github.com/moby/buildkit/executor/runcexecutor"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/network"
+	"github.com/moby/moby/v2/daemon/internal/stringid"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -80,30 +81,13 @@ func (iface *lnInterface) Set(s *specs.Spec) error {
 		log.G(context.TODO()).WithError(iface.err).Error("failed to set networking spec")
 		return iface.err
 	}
-	nsPath, ok := iface.sbx.NetnsPath()
-	if !ok {
-		return fmt.Errorf("buildkit sandbox %s has no network namespace", iface.sbx.ContainerID())
+	shortNetCtlrID := stringid.TruncateID(iface.provider.Controller.ID())
+	// attach netns to bridge within the container namespace, using reexec in a prestart hook
+	s.Hooks = &specs.Hooks{
+		Prestart: []specs.Hook{{
+			Path: filepath.Join("/proc", strconv.Itoa(os.Getpid()), "exe"),
+			Args: []string{"libnetwork-setkey", "-exec-root=" + iface.provider.Config().ExecRoot, iface.sbx.ContainerID(), shortNetCtlrID},
+		}},
 	}
-	// Tell runc to join the daemon-owned netns instead of creating a new one.
-	// This replaces the previous approach of using a "libnetwork-setkey" reexec
-	// prestart hook that bind-mounted /proc/<pid>/ns/net after container creation.
-	return setLinuxNamespace(s, specs.LinuxNamespace{
-		Type: specs.NetworkNamespace,
-		Path: nsPath,
-	})
-}
-
-// setLinuxNamespace sets or replaces a namespace entry in the OCI spec.
-func setLinuxNamespace(s *specs.Spec, ns specs.LinuxNamespace) error {
-	for i, n := range s.Linux.Namespaces {
-		if n.Type == ns.Type {
-			if n.Path != "" {
-				return fmt.Errorf("network namespace already set to %s", n.Path)
-			}
-			s.Linux.Namespaces[i] = ns
-			return nil
-		}
-	}
-	s.Linux.Namespaces = append(s.Linux.Namespaces, ns)
 	return nil
 }

--- a/integration/build/build_userns_linux_test.go
+++ b/integration/build/build_userns_linux_test.go
@@ -10,8 +10,10 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/pkg/stdcopy"
+	buildtypes "github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/jsonmessage"
+	"github.com/moby/moby/v2/integration/internal/build"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/daemon"
@@ -129,4 +131,39 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	if strings.TrimSpace(actualStdout.String()) != "/bin/sleep cap_net_bind_service=eip" {
 		t.Fatalf("run produced invalid output: %q, expected %q", actualStdout.String(), "/bin/sleep cap_net_bind_service=eip")
 	}
+}
+
+func TestBuildUserNamespaceRemap(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRootless())
+	skip.If(t, testEnv.UsingSnapshotter(), "TODO: Broken with containerd")
+
+	ctx := testutil.StartSpan(baseContext, t)
+
+	d := daemon.New(t, daemon.WithUserNsRemap("default"))
+	d.Start(t)
+	defer func() {
+		d.Stop(t)
+		d.Cleanup(t)
+	}()
+
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
+
+	_, err := apiClient.Info(ctx, client.InfoOptions{})
+	assert.NilError(t, err)
+
+	err = load.FrozenImagesLinux(ctx, apiClient, "busybox:latest")
+	assert.NilError(t, err)
+
+	const dockerfile = `FROM busybox
+RUN echo "hello world"
+`
+
+	source := fakecontext.New(t, "", fakecontext.WithDockerfile(dockerfile))
+	defer source.Close()
+
+	assert.Check(t, build.Do(ctx, t, apiClient, source, client.ImageBuildOptions{
+		Version: buildtypes.BuilderBuildKit,
+	}) != "")
 }

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -294,8 +294,8 @@ func TestExecUser(t *testing.T) {
 		container.WithTty(true),
 		container.WithUser("1:1"),
 	}
-	withoutEtcGroups := container.WithImage(build.Do(ctx, t, apiClient, fakecontext.New(t, "", fakecontext.WithDockerfile("FROM busybox\nRUN rm /etc/group"))))
-	withoutEtcPasswd := container.WithImage(build.Do(ctx, t, apiClient, fakecontext.New(t, "", fakecontext.WithDockerfile("FROM busybox\nRUN rm /etc/passwd"))))
+	withoutEtcGroups := container.WithImage(build.Do(ctx, t, apiClient, fakecontext.New(t, "", fakecontext.WithDockerfile("FROM busybox\nRUN rm /etc/group")), client.ImageBuildOptions{}))
+	withoutEtcPasswd := container.WithImage(build.Do(ctx, t, apiClient, fakecontext.New(t, "", fakecontext.WithDockerfile("FROM busybox\nRUN rm /etc/passwd")), client.ImageBuildOptions{}))
 
 	withUser := func(user string) func(options *client.ExecCreateOptions) {
 		return func(options *client.ExecCreateOptions) { options.User = user }

--- a/integration/image/history_test.go
+++ b/integration/image/history_test.go
@@ -22,7 +22,7 @@ func TestAPIImagesHistory(t *testing.T) {
 
 	dockerfile := "FROM busybox\nENV FOO bar"
 
-	imgID := build.Do(ctx, t, apiClient, fakecontext.New(t, t.TempDir(), fakecontext.WithDockerfile(dockerfile)))
+	imgID := build.Do(ctx, t, apiClient, fakecontext.New(t, t.TempDir(), fakecontext.WithDockerfile(dockerfile)), client.ImageBuildOptions{})
 
 	res, err := apiClient.ImageHistory(ctx, imgID)
 	assert.NilError(t, err)

--- a/integration/image/remove_test.go
+++ b/integration/image/remove_test.go
@@ -191,7 +191,7 @@ func TestAPIImagesDelete(t *testing.T) {
 ENV FOO=bar`))
 	defer buildCtx.Close()
 
-	imgID := build.Do(ctx, t, apiClient, buildCtx)
+	imgID := build.Do(ctx, t, apiClient, buildCtx, client.ImageBuildOptions{})
 
 	// Cleanup always runs
 	defer func() {

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -489,7 +489,7 @@ func TestSaveDirectoryPermissions(t *testing.T) {
 RUN adduser -D user && mkdir -p /opt/a/b && chown -R user:user /opt/a
 RUN touch /opt/a/b/c && chown user:user /opt/a/b/c`
 
-	imgID := build.Do(ctx, t, apiClient, fakecontext.New(t, t.TempDir(), fakecontext.WithDockerfile(dockerfile)))
+	imgID := build.Do(ctx, t, apiClient, fakecontext.New(t, t.TempDir(), fakecontext.WithDockerfile(dockerfile)), client.ImageBuildOptions{})
 
 	rdr, err := apiClient.ImageSave(ctx, []string{imgID})
 	assert.NilError(t, err)

--- a/integration/internal/build/build.go
+++ b/integration/internal/build/build.go
@@ -17,9 +17,10 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-// Do builds an image from the given context and returns the image ID.
-func Do(ctx context.Context, t *testing.T, apiClient client.APIClient, buildCtx *fakecontext.Fake) string {
-	resp, err := apiClient.ImageBuild(ctx, buildCtx.AsTarReader(t), client.ImageBuildOptions{})
+// Do builds an image from the given context with the supplied options
+// and returns the image ID.
+func Do(ctx context.Context, t *testing.T, apiClient client.APIClient, buildCtx *fakecontext.Fake, options client.ImageBuildOptions) string {
+	resp, err := apiClient.ImageBuild(ctx, buildCtx.AsTarReader(t), options)
 	assert.NilError(t, err)
 	if resp.Body != nil {
 		defer resp.Body.Close()

--- a/integration/internal/build/build.go
+++ b/integration/internal/build/build.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/moby/client/pkg/jsonmessage"
 	"github.com/moby/moby/v2/internal/testutil/fakecontext"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 // Do builds an image from the given context with the supplied options
@@ -53,6 +54,10 @@ func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 		jsonmessage.Display(jm, buf, false, 0)
 		if buf.Len() == 0 {
 			continue
+		}
+
+		if jm.Error != nil {
+			assert.Assert(t, is.Equal(jm.Error, ""))
 		}
 
 		t.Log(buf.String())

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -2272,7 +2272,7 @@ func TestPublishAllWithNilPortBindings(t *testing.T) {
 	c := testEnv.APIClient()
 
 	imgWithExpose := container.WithImage(build.Do(ctx, t, c,
-		fakecontext.New(t, "", fakecontext.WithDockerfile("FROM busybox\nEXPOSE 80/tcp\n"))))
+		fakecontext.New(t, "", fakecontext.WithDockerfile("FROM busybox\nEXPOSE 80/tcp\n")), client.ImageBuildOptions{}))
 
 	_ = container.Run(ctx, t, c,
 		container.WithAutoRemove,

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -338,7 +338,7 @@ func TestVolumePruneAnonFromImage(t *testing.T) {
 	dockerfile := `FROM busybox
 VOLUME ` + volDest
 
-	img := build.Do(ctx, t, apiClient, fakecontext.New(t, "", fakecontext.WithDockerfile(dockerfile)))
+	img := build.Do(ctx, t, apiClient, fakecontext.New(t, "", fakecontext.WithDockerfile(dockerfile)), client.ImageBuildOptions{})
 
 	id := container.Create(ctx, t, apiClient, container.WithImage(img))
 	defer apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{})


### PR DESCRIPTION
- revert: https://github.com/moby/moby/pull/52490


Verify building with userns-remap enabled works.
Unfortunately the test fails because of #52490 so it needs to be reverted.