### PR TITLE
ci: check-labels: re-read labels when triggered

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -6,6 +6,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 on:
   pull_request:
@@ -16,18 +17,25 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     steps:
-      - name: Missing `area/` label
-        if: always() && contains(join(github.event.pull_request.labels.*.name, ','), 'impact/') && !contains(join(github.event.pull_request.labels.*.name, ','), 'area/')
+      - name: Validate labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          echo "::error::Every PR with an 'impact/*' label should also have an 'area/*' label"
-          exit 1
-      - name: Missing `kind/` label
-        if: always() && contains(join(github.event.pull_request.labels.*.name, ','), 'impact/') && !contains(join(github.event.pull_request.labels.*.name, ','), 'kind/')
-        run: |
-          echo "::error::Every PR with an 'impact/*' label should also have a 'kind/*' label"
-          exit 1
-      - name: OK
-        run: exit 0
+          labels="$(gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name')"
+          
+          echo "$labels" | grep -q '^impact/' || exit 0
+          
+          echo "$labels" | grep -q '^area/' || {
+            echo "::error::Every PR with an 'impact/*' label should also have an 'area/*' label"
+            exit 1
+          }
+          
+          echo "$labels" | grep -q '^kind/' || {
+            echo "::error::Every PR with an 'impact/*' label should also have a 'kind/*' label"
+            exit 1
+          }
 
   check-changelog:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/52589#issuecomment-4421462017


The check was failing if labels were set after the initial PR was created, and re-running would not refresh the current labels (which are based on the original event that triggered it).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

