### PR TITLE
c8d/resolver: Use per-host HTTP client for auth requests

### DIFF
--- a/daemon/containerd/resolver.go
+++ b/daemon/containerd/resolver.go
@@ -38,8 +38,6 @@ func hostsWrapper(hostsFn docker.RegistryHosts, optAuthConfig *registrytypes.Aut
 		return hostsFn
 	}
 
-	authorizer := authorizerFromAuthConfig(*optAuthConfig, ref)
-
 	return func(n string) ([]docker.RegistryHost, error) {
 		hosts, err := hostsFn(n)
 		if err != nil {
@@ -47,13 +45,13 @@ func hostsWrapper(hostsFn docker.RegistryHosts, optAuthConfig *registrytypes.Aut
 		}
 
 		for i := range hosts {
-			hosts[i].Authorizer = authorizer
+			hosts[i].Authorizer = authorizerFromAuthConfig(*optAuthConfig, ref, hosts[i].Client)
 		}
 		return hosts, nil
 	}
 }
 
-func authorizerFromAuthConfig(authConfig registrytypes.AuthConfig, ref reference.Named) docker.Authorizer {
+func authorizerFromAuthConfig(authConfig registrytypes.AuthConfig, ref reference.Named, client *http.Client) docker.Authorizer {
 	cfgHost := registry.ConvertToHostname(authConfig.ServerAddress)
 	if cfgHost == "" {
 		cfgHost = reference.Domain(ref)
@@ -69,19 +67,25 @@ func authorizerFromAuthConfig(authConfig registrytypes.AuthConfig, ref reference
 		}
 	}
 
-	return docker.NewDockerAuthorizer(docker.WithAuthCreds(func(host string) (string, string, error) {
-		if cfgHost != host {
-			log.G(context.TODO()).WithFields(log.Fields{
-				"host":    host,
-				"cfgHost": cfgHost,
-			}).Warn("Host doesn't match")
-			return "", "", nil
-		}
-		if authConfig.IdentityToken != "" {
-			return "", authConfig.IdentityToken, nil
-		}
-		return authConfig.Username, authConfig.Password, nil
-	}))
+	opts := []docker.AuthorizerOpt{
+		docker.WithAuthCreds(func(host string) (string, string, error) {
+			if cfgHost != host {
+				log.G(context.TODO()).WithFields(log.Fields{
+					"host":    host,
+					"cfgHost": cfgHost,
+				}).Warn("Host doesn't match")
+				return "", "", nil
+			}
+			if authConfig.IdentityToken != "" {
+				return "", authConfig.IdentityToken, nil
+			}
+			return authConfig.Username, authConfig.Password, nil
+		}),
+	}
+	if client != nil {
+		opts = append(opts, docker.WithAuthClient(client))
+	}
+	return docker.NewDockerAuthorizer(opts...)
 }
 
 type bearerAuthorizer struct {


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/52361
- fixes: https://github.com/docker/desktop-feedback/issues/155
- fixes: https://github.com/moby/moby/issues/51771

When using the containerd image store, each registry host entry carries its own HTTP client configured with the host-specific TLS settings (custom CAs from /etc/docker/certs.d, insecure-registries, etc.).

hostsWrapper replaces the Authorizer on every host entry so that explicit auth credentials are used for token/OAuth requests. Previously it created a single authorizer before iterating the hosts, without supplying any HTTP client.

The result was that token endpoint requests bypassed custom CAs and insecure-registry settings.

```markdown changelog
containerd integration: Fix auth token requests ignoring per-host TLS settings (custom CAs, insecure-registries).
```