### PR TITLE
hack: authenticate BuildKit ref resolution

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -105,8 +105,10 @@ jobs:
           cache: false
       -
         name: BuildKit ref
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          echo "$(./hack/buildkit-ref)" >> $GITHUB_ENV
+          ./hack/buildkit-ref >> "$GITHUB_ENV"
         working-directory: moby
       -
         name: Checkout BuildKit ${{ env.BUILDKIT_REF }}
@@ -328,8 +330,10 @@ jobs:
 
       - name: BuildKit ref
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          echo "$(./hack/buildkit-ref)" >> $GITHUB_ENV
+          ./hack/buildkit-ref >> "$GITHUB_ENV"
         working-directory: moby
 
       - name: Checkout BuildKit ${{ env.BUILDKIT_REF }}

--- a/hack/buildkit-ref
+++ b/hack/buildkit-ref
@@ -5,7 +5,34 @@
 # The output of this script may be valid shell script, but is intended for use with
 # GitHub Actions' $GITHUB_ENV.
 
+set -euo pipefail
+
 buildkit_pkg=github.com/moby/buildkit
+
+resolve_github_commit_sha() {
+	local repo=$1
+	local ref=$2
+	local resolved
+
+	if command -v gh > /dev/null 2>&1; then
+		if resolved=$(gh api "repos/${repo}/commits/${ref}" --jq '.sha // empty' 2> /dev/null) && [[ -n "$resolved" ]]; then
+			echo "$resolved"
+			return 0
+		fi
+	fi
+
+	local curl_args=(-fsSL)
+	if [[ -n "${GH_TOKEN:-}" ]]; then
+		curl_args+=(-H "Authorization: Bearer ${GH_TOKEN}")
+	fi
+
+	if resolved=$(curl "${curl_args[@]}" "https://api.github.com/repos/${repo}/commits/${ref}" | jq -er '.sha // empty'); then
+		echo "$resolved"
+		return 0
+	fi
+
+	return 1
+}
 
 # get buildkit version from go.mod
 buildkit_ref=$(go list -mod=mod -u -m -f '{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}' "$buildkit_pkg")
@@ -14,9 +41,12 @@ buildkit_repo=${buildkit_repo#github.com/}
 
 if [[ "${buildkit_ref}" == *-*-* ]]; then
 	# if pseudo-version, figure out just the commit sha
-	buildkit_ref=$(awk -F"-" '{print $NF}' <<< "$buildkit_ref")
-	# use github api to return full sha to be able to use it as ref
-	buildkit_ref=$(curl -s "https://api.github.com/repos/${buildkit_repo}/commits/${buildkit_ref}" | jq -r .sha)
+	commit_ref=$(awk -F"-" '{print $NF}' <<< "$buildkit_ref")
+	# resolve through GitHub to get the full sha for use as a ref.
+	if ! buildkit_ref=$(resolve_github_commit_sha "$buildkit_repo" "$commit_ref"); then
+		echo "failed to resolve BuildKit commit ${buildkit_repo}@${commit_ref}" >&2
+		exit 1
+	fi
 fi
 
 cat << EOF


### PR DESCRIPTION
relates to https://github.com/moby/moby/actions/runs/25790520561/job/75756592188?pr=52613#step:7:83

Makes BuildKit pseudo-version ref resolution prefer `gh api` and fall back to `curl` with `GH_TOKEN` authentication when available.

The `hack/buildkit-ref` script now fails if GitHub does not return a usable commit SHA, so API errors can no longer become `BUILDKIT_REF=null`. The BuildKit workflow now passes `GH_TOKEN` to the script and appends script output directly to `$GITHUB_ENV` so failures propagate.

The previous `curl | jq -r .sha` path treated missing SHA fields as the literal value `null`, which could happen on GitHub API errors or unauthenticated rate limiting. Using the GitHub CLI first and authenticating the curl fallback makes the lookup less flaky and makes failures explicit.