### PR TITLE
daemon/config: set userland-proxy default value in config.New

### DIFF
--- a/daemon/command/config_unix.go
+++ b/daemon/command/config_unix.go
@@ -36,7 +36,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.IPVar(&conf.BridgeConfig.DefaultGatewayIPv6, "default-gateway-v6", nil, "Default gateway IPv6 address for the default bridge network")
 	flags.BoolVar(&conf.BridgeConfig.InterContainerCommunication, "icc", true, "Enable inter-container communication for the default bridge network")
 	flags.IPVar(&conf.BridgeConfig.DefaultIP, "ip", net.IPv4zero, "Host IP for port publishing from the default bridge network")
-	flags.BoolVar(&conf.BridgeConfig.EnableUserlandProxy, "userland-proxy", true, "Use userland proxy for loopback traffic")
+	flags.BoolVar(&conf.BridgeConfig.EnableUserlandProxy, "userland-proxy", conf.BridgeConfig.EnableUserlandProxy, "Use userland proxy for loopback traffic")
 	flags.StringVar(&conf.BridgeConfig.UserlandProxyPath, "userland-proxy-path", conf.BridgeConfig.UserlandProxyPath, "Path to the userland proxy binary")
 	flags.BoolVar(&conf.BridgeConfig.AllowDirectRouting, "allow-direct-routing", false, "Allow remote access to published ports on container IP addresses")
 	flags.StringVar(&conf.BridgeConfig.BridgeAcceptFwMark, "bridge-accept-fwmark", "", "In bridge networks, accept packets with this firewall mark/mask")

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -155,6 +155,7 @@ func setPlatformDefaults(cfg *Config) error {
 	}
 
 	var err error
+	cfg.BridgeConfig.EnableUserlandProxy = true
 	cfg.BridgeConfig.UserlandProxyPath, err = lookupBinPath(userlandProxyBinary)
 	if err != nil {
 		// Log, but don't error here. This allows running a daemon with


### PR DESCRIPTION
- similar to https://github.com/moby/moby/pull/52609

Set the default as part of the default config, instead of depending on the default value set in the command-line flags. We should probably consider doing the same for most (all) other defaults that are not a zero-value.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

