### PR TITLE
dockerversion: touch-up GoDoc, un-export UAStringKey, and add WithUpstreamUserAgent

### DIFF
--- a/daemon/server/server.go
+++ b/daemon/server/server.go
@@ -61,7 +61,7 @@ func (s *Server) makeHTTPHandler(route router.Route) http.HandlerFunc {
 		// use intermediate variable to prevent "should not use basic type
 		// string as key in context.WithValue" golint errors
 		ua := r.Header.Get("User-Agent")
-		ctx := baggage.ContextWithBaggage(context.WithValue(r.Context(), dockerversion.UAStringKey{}, ua), otelutil.MustNewBaggage(
+		ctx := baggage.ContextWithBaggage(dockerversion.WithUpstreamUserAgent(r.Context(), ua), otelutil.MustNewBaggage(
 			otelutil.MustNewMemberRaw(otelutil.TriggerKey, "api"),
 		))
 

--- a/dockerversion/useragent.go
+++ b/dockerversion/useragent.go
@@ -88,13 +88,16 @@ func getUpstreamUserAgent(ctx context.Context) string {
 	return "UpstreamClient(" + escapeStr(upstreamUA) + ")"
 }
 
-// escapeStr escapes and sanitizes s for use in a User-Agent comment.
+// escapeStr escapes and sanitizes s for use in a User-Agent comment ([RFC9110]).
+//
+// [RFC9110]: https://www.rfc-editor.org/rfc/rfc9110#section-10.1.5
 func escapeStr(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
 
 	for i := range len(s) {
 		switch c := s[i]; c {
+		// TODO(thaJeztah): remove redundant escaping semicolons; see https://github.com/moby/moby/pull/52356#discussion_r3234266285
 		case '(', ')', ';', '\\':
 			b.WriteByte('\\')
 			b.WriteByte(c)

--- a/dockerversion/useragent.go
+++ b/dockerversion/useragent.go
@@ -13,10 +13,17 @@ import (
 // UAStringKey is used as key type for user-agent string in net/context struct
 type UAStringKey struct{}
 
-// DockerUserAgent is the User-Agent the Docker client uses to identify itself.
-// In accordance with RFC 7231 (5.5.3) is of the form:
+// DockerUserAgent is the User-Agent used by the daemon.
 //
-//	[docker client's UA] UpstreamClient([upstream client's UA])
+// It consists of the daemon's User-Agent, optional version metadata, and
+// an optional upstream client comment:
+//
+//	[daemon user agent] [extra] [UpstreamClient(<upstream-user-agent>)]
+//
+// "UpstreamClient" is a Docker-defined convention. The upstream value is
+// sanitized before inclusion. See [RFC9110], section 10.1.5.
+//
+// [RFC9110]: https://www.rfc-editor.org/rfc/rfc9110#section-10.1.5
 func DockerUserAgent(ctx context.Context, extraVersions ...useragent.VersionInfo) string {
 	ua := useragent.AppendVersions(getDaemonUserAgent(), extraVersions...)
 	if upstreamUA := getUpstreamUserAgent(ctx); upstreamUA != "" {

--- a/dockerversion/useragent.go
+++ b/dockerversion/useragent.go
@@ -10,8 +10,17 @@ import (
 	"github.com/moby/moby/v2/pkg/useragent"
 )
 
-// UAStringKey is used as key type for user-agent string in net/context struct
-type UAStringKey struct{}
+// uaStringKey is used as key type for user-agent string in net/context struct
+type uaStringKey struct{}
+
+// WithUpstreamUserAgent returns a new context carrying the upstream client's
+// User-Agent string.
+func WithUpstreamUserAgent(ctx context.Context, ua string) context.Context {
+	if ua == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, uaStringKey{}, ua)
+}
 
 // DockerUserAgent is the User-Agent used by the daemon.
 //
@@ -71,7 +80,7 @@ func getDaemonUserAgent() string {
 //
 // It returns an empty string if no user-agent is present in the context.
 func getUpstreamUserAgent(ctx context.Context) string {
-	upstreamUA, ok := ctx.Value(UAStringKey{}).(string)
+	upstreamUA, ok := ctx.Value(uaStringKey{}).(string)
 	if !ok || upstreamUA == "" {
 		return ""
 	}

--- a/dockerversion/useragent_test.go
+++ b/dockerversion/useragent_test.go
@@ -32,12 +32,12 @@ func TestDockerUserAgent(t *testing.T) {
 		},
 		{
 			doc:      "daemon user-agent with upstream",
-			ctx:      context.WithValue(t.Context(), UAStringKey{}, "Magic-Client/1.2.3 (linux)"),
+			ctx:      WithUpstreamUserAgent(t.Context(), "Magic-Client/1.2.3 (linux)"),
 			expected: getDaemonUserAgent() + ` UpstreamClient(Magic-Client/1.2.3 \(linux\))`,
 		},
 		{
 			doc: "daemon user-agent with upstream and custom metadata",
-			ctx: context.WithValue(t.Context(), UAStringKey{}, "Magic-Client/1.2.3 (linux)"),
+			ctx: WithUpstreamUserAgent(t.Context(), "Magic-Client/1.2.3 (linux)"),
 			metadata: []useragent.VersionInfo{
 				{Name: "hello", Version: "world"},
 				{Name: "foo", Version: "bar"},
@@ -46,12 +46,12 @@ func TestDockerUserAgent(t *testing.T) {
 		},
 		{
 			doc:      "daemon user-agent with upstream special chars",
-			ctx:      context.WithValue(t.Context(), UAStringKey{}, `Magic-Client/1.2.3 (linux); \ test`),
+			ctx:      WithUpstreamUserAgent(t.Context(), `Magic-Client/1.2.3 (linux); \ test`),
 			expected: getDaemonUserAgent() + ` UpstreamClient(Magic-Client/1.2.3 \(linux\)\; \\ test)`,
 		},
 		{
 			doc:      "daemon user-agent with upstream control chars",
-			ctx:      context.WithValue(t.Context(), UAStringKey{}, "Magic-Client/1.2.3\r\nInjected: evil"),
+			ctx:      WithUpstreamUserAgent(t.Context(), "Magic-Client/1.2.3\r\nInjected: evil"),
 			expected: getDaemonUserAgent() + ` UpstreamClient(Magic-Client/1.2.3Injected: evil)`,
 		},
 	}


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/52356


### dockerversion: DockerUserAgent: touch-up GoDoc

Update link to RFC9110 (obsoletes RFC7231), and outline the convention used.


### dockerversion: un-export UAStringKey, add WithUpstreamUserAgent

Add a WithUpstreamUserAgent utility instead of exporting the context-key used.




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

