### PR TITLE
daemon/command: test fixes and improvements

### DIFF
--- a/daemon/command/daemon_test.go
+++ b/daemon/command/daemon_test.go
@@ -28,7 +28,7 @@ func defaultOptions(t *testing.T, configFile string) *daemonOptions {
 	return opts
 }
 
-func TestLoadDaemonCliConfigWithoutOverriding(t *testing.T) {
+func TestLoadDaemonConfigWithoutOverriding(t *testing.T) {
 	opts := defaultOptions(t, "")
 	opts.Debug = true
 
@@ -40,7 +40,7 @@ func TestLoadDaemonCliConfigWithoutOverriding(t *testing.T) {
 	}
 }
 
-func TestLoadDaemonCliConfigWithTLS(t *testing.T) {
+func TestLoadDaemonConfigWithTLS(t *testing.T) {
 	opts := defaultOptions(t, "")
 	opts.TLSOptions.CAFile = "/tmp/ca.pem"
 	opts.TLS = true
@@ -51,7 +51,7 @@ func TestLoadDaemonCliConfigWithTLS(t *testing.T) {
 	assert.Check(t, is.Equal("/tmp/ca.pem", loadedConfig.TLSOptions.CAFile))
 }
 
-func TestLoadDaemonCliConfigWithConflicts(t *testing.T) {
+func TestLoadDaemonConfigWithConflicts(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{"labels": ["l3=foo"]}`))
 	configFile := tempFile.Path()
 
@@ -66,7 +66,7 @@ func TestLoadDaemonCliConfigWithConflicts(t *testing.T) {
 	assert.Check(t, is.ErrorContains(err, "as a flag and in the configuration file: labels"))
 }
 
-func TestLoadDaemonCliWithConflictingNodeGenericResources(t *testing.T) {
+func TestLoadDaemonConfigWithConflictingNodeGenericResources(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{"node-generic-resources": ["foo=bar", "bar=baz"]}`))
 	configFile := tempFile.Path()
 
@@ -81,7 +81,7 @@ func TestLoadDaemonCliWithConflictingNodeGenericResources(t *testing.T) {
 	assert.Check(t, is.ErrorContains(err, "as a flag and in the configuration file: node-generic-resources"))
 }
 
-func TestLoadDaemonCliWithConflictingLabels(t *testing.T) {
+func TestLoadDaemonConfigWithConflictingLabels(t *testing.T) {
 	opts := defaultOptions(t, "")
 	flags := opts.flags
 
@@ -92,7 +92,7 @@ func TestLoadDaemonCliWithConflictingLabels(t *testing.T) {
 	assert.Check(t, is.Error(err, "conflict labels for foo=baz and foo=bar"))
 }
 
-func TestLoadDaemonCliWithDuplicateLabels(t *testing.T) {
+func TestLoadDaemonConfigWithDuplicateLabels(t *testing.T) {
 	opts := defaultOptions(t, "")
 	flags := opts.flags
 
@@ -103,7 +103,7 @@ func TestLoadDaemonCliWithDuplicateLabels(t *testing.T) {
 	assert.Check(t, err)
 }
 
-func TestLoadDaemonCliConfigWithTLSVerify(t *testing.T) {
+func TestLoadDaemonConfigWithTLSVerify(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{"tlsverify": true}`))
 
 	opts := defaultOptions(t, tempFile.Path())
@@ -115,7 +115,7 @@ func TestLoadDaemonCliConfigWithTLSVerify(t *testing.T) {
 	assert.Check(t, is.Equal(*loadedConfig.TLS, true))
 }
 
-func TestLoadDaemonCliConfigWithExplicitTLSVerifyFalse(t *testing.T) {
+func TestLoadDaemonConfigWithExplicitTLSVerifyFalse(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{"tlsverify": false}`))
 
 	opts := defaultOptions(t, tempFile.Path())
@@ -127,7 +127,7 @@ func TestLoadDaemonCliConfigWithExplicitTLSVerifyFalse(t *testing.T) {
 	assert.Check(t, *loadedConfig.TLS)
 }
 
-func TestLoadDaemonCliConfigWithoutTLSVerify(t *testing.T) {
+func TestLoadDaemonConfigWithoutTLSVerify(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{}`))
 
 	opts := defaultOptions(t, tempFile.Path())
@@ -139,7 +139,7 @@ func TestLoadDaemonCliConfigWithoutTLSVerify(t *testing.T) {
 	assert.Check(t, is.Nil(loadedConfig.TLS))
 }
 
-func TestLoadDaemonCliConfigWithLogLevel(t *testing.T) {
+func TestLoadDaemonConfigWithLogLevel(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{"log-level": "warn"}`))
 
 	opts := defaultOptions(t, tempFile.Path())
@@ -149,7 +149,7 @@ func TestLoadDaemonCliConfigWithLogLevel(t *testing.T) {
 	assert.Check(t, is.Equal("warn", loadedConfig.LogLevel))
 }
 
-func TestLoadDaemonCliConfigWithLogFormat(t *testing.T) {
+func TestLoadDaemonConfigWithLogFormat(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{"log-format": "json"}`))
 	defer tempFile.Remove()
 
@@ -160,7 +160,7 @@ func TestLoadDaemonCliConfigWithLogFormat(t *testing.T) {
 	assert.Check(t, is.Equal(log.JSONFormat, loadedConfig.DaemonLogConfig.LogFormat))
 }
 
-func TestLoadDaemonCliConfigWithInvalidLogFormat(t *testing.T) {
+func TestLoadDaemonConfigWithInvalidLogFormat(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{"log-format": "foo"}`))
 	defer tempFile.Remove()
 

--- a/daemon/command/daemon_test.go
+++ b/daemon/command/daemon_test.go
@@ -17,6 +17,13 @@ import (
 func defaultOptions(t *testing.T, configFile string) *daemonOptions {
 	cfg, err := config.New()
 	assert.NilError(t, err)
+
+	// Disable userland-proxy to prevent unit-tests from failing if the "docker-proxy"
+	// binary was not built, which would leave the "UserlandProxyPath" field empty,
+	// resulting in failures, e.g.:
+	//
+	// 	invalid userland-proxy-path: userland-proxy is enabled, but userland-proxy-path is not set
+	cfg.EnableUserlandProxy = false
 	opts := newDaemonOptions(cfg)
 	opts.flags = &pflag.FlagSet{}
 	opts.installFlags(opts.flags)

--- a/daemon/command/daemon_test.go
+++ b/daemon/command/daemon_test.go
@@ -34,7 +34,6 @@ func TestLoadDaemonConfigWithoutOverriding(t *testing.T) {
 
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
-	assert.Assert(t, loadedConfig != nil)
 	if !loadedConfig.Debug {
 		t.Fatalf("expected debug to be copied from the common flags, got false")
 	}
@@ -47,7 +46,6 @@ func TestLoadDaemonConfigWithTLS(t *testing.T) {
 
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
-	assert.Assert(t, loadedConfig != nil)
 	assert.Check(t, is.Equal("/tmp/ca.pem", loadedConfig.TLSOptions.CAFile))
 }
 
@@ -111,7 +109,6 @@ func TestLoadDaemonConfigWithTLSVerify(t *testing.T) {
 
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
-	assert.Assert(t, loadedConfig != nil)
 	assert.Check(t, is.Equal(*loadedConfig.TLS, true))
 }
 
@@ -123,7 +120,6 @@ func TestLoadDaemonConfigWithExplicitTLSVerifyFalse(t *testing.T) {
 
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
-	assert.Assert(t, loadedConfig != nil)
 	assert.Check(t, *loadedConfig.TLS)
 }
 
@@ -135,7 +131,6 @@ func TestLoadDaemonConfigWithoutTLSVerify(t *testing.T) {
 
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
-	assert.Assert(t, loadedConfig != nil)
 	assert.Check(t, is.Nil(loadedConfig.TLS))
 }
 
@@ -145,7 +140,6 @@ func TestLoadDaemonConfigWithLogLevel(t *testing.T) {
 	opts := defaultOptions(t, tempFile.Path())
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
-	assert.Assert(t, loadedConfig != nil)
 	assert.Check(t, is.Equal("warn", loadedConfig.LogLevel))
 }
 
@@ -156,7 +150,6 @@ func TestLoadDaemonConfigWithLogFormat(t *testing.T) {
 	opts := defaultOptions(t, tempFile.Path())
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
-	assert.Assert(t, loadedConfig != nil)
 	assert.Check(t, is.Equal(log.JSONFormat, loadedConfig.DaemonLogConfig.LogFormat))
 }
 
@@ -176,7 +169,6 @@ func TestLoadDaemonConfigWithEmbeddedOptions(t *testing.T) {
 	opts := defaultOptions(t, tempFile.Path())
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
-	assert.Assert(t, loadedConfig != nil)
 	assert.Check(t, is.Equal("/etc/certs/ca.pem", loadedConfig.TLSOptions.CAFile))
 	assert.Check(t, is.Equal("syslog", loadedConfig.LogConfig.Type))
 }
@@ -191,7 +183,6 @@ func TestLoadDaemonConfigWithRegistryOptions(t *testing.T) {
 	opts := defaultOptions(t, tempFile.Path())
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
-	assert.Assert(t, loadedConfig != nil)
 
 	assert.Check(t, is.Len(loadedConfig.Mirrors, 1))
 	assert.Check(t, is.Len(loadedConfig.InsecureRegistries, 1))

--- a/daemon/command/daemon_unix_test.go
+++ b/daemon/command/daemon_unix_test.go
@@ -11,7 +11,7 @@ import (
 	"gotest.tools/v3/fs"
 )
 
-func TestLoadDaemonCliConfigWithDaemonFlags(t *testing.T) {
+func TestLoadDaemonConfigWithDaemonFlags(t *testing.T) {
 	content := `{"log-opts": {"max-size": "1k"}}`
 	tempFile := fs.NewFile(t, "config", fs.WithContent(content))
 

--- a/daemon/command/daemon_unix_test.go
+++ b/daemon/command/daemon_unix_test.go
@@ -17,17 +17,17 @@ func TestLoadDaemonConfigWithDaemonFlags(t *testing.T) {
 
 	opts := defaultOptions(t, tempFile.Path())
 	opts.Debug = true
-	opts.daemonConfig.DaemonLogConfig.LogLevel = "info"
+	opts.daemonConfig.DaemonLogConfig.LogLevel = "warn"
 	assert.Check(t, opts.flags.Set("selinux-enabled", "true"))
 
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
 
-	assert.Check(t, loadedConfig.Debug)
-	assert.Check(t, is.Equal("info", loadedConfig.DaemonLogConfig.LogLevel))
-	assert.Check(t, loadedConfig.EnableSelinuxSupport)
-	assert.Check(t, is.Equal("json-file", loadedConfig.LogConfig.Type))
-	assert.Check(t, is.Equal("1k", loadedConfig.LogConfig.Config["max-size"]))
+	assert.Check(t, is.Equal(loadedConfig.Debug, true))
+	assert.Check(t, is.Equal(loadedConfig.DaemonLogConfig.LogLevel, "warn"))
+	assert.Check(t, is.Equal(loadedConfig.EnableSelinuxSupport, true))
+	assert.Check(t, is.Equal(loadedConfig.LogConfig.Type, "json-file"))
+	assert.Check(t, is.Equal(loadedConfig.LogConfig.Config["max-size"], "1k"))
 }
 
 func TestLoadDaemonConfigWithNetwork(t *testing.T) {

--- a/daemon/command/daemon_unix_test.go
+++ b/daemon/command/daemon_unix_test.go
@@ -22,7 +22,6 @@ func TestLoadDaemonConfigWithDaemonFlags(t *testing.T) {
 
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
-	assert.Assert(t, loadedConfig != nil)
 
 	assert.Check(t, loadedConfig.Debug)
 	assert.Check(t, is.Equal("info", loadedConfig.DaemonLogConfig.LogLevel))
@@ -38,7 +37,6 @@ func TestLoadDaemonConfigWithNetwork(t *testing.T) {
 	opts := defaultOptions(t, tempFile.Path())
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
-	assert.Assert(t, loadedConfig != nil)
 
 	assert.Check(t, is.Equal(loadedConfig.IP, "127.0.0.2/8"))
 	assert.Check(t, is.Equal(loadedConfig.IP6, "fd98:e5f2:e637::1/64"))
@@ -52,7 +50,7 @@ func TestLoadDaemonConfigWithMapOptions(t *testing.T) {
 	opts := defaultOptions(t, tempFile.Path())
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
-	assert.Assert(t, loadedConfig != nil)
+
 	assert.Check(t, loadedConfig.LogConfig.Config != nil)
 	assert.Check(t, is.Equal("test", loadedConfig.LogConfig.Config["tag"]))
 }
@@ -64,7 +62,6 @@ func TestLoadDaemonConfigWithTrueDefaultValues(t *testing.T) {
 	opts := defaultOptions(t, tempFile.Path())
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
-	assert.Assert(t, loadedConfig != nil)
 
 	assert.Check(t, !loadedConfig.EnableUserlandProxy)
 
@@ -82,7 +79,6 @@ func TestLoadDaemonConfigWithTrueDefaultValuesLeaveDefaults(t *testing.T) {
 	opts := defaultOptions(t, tempFile.Path())
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
-	assert.Assert(t, loadedConfig != nil)
 
 	assert.Check(t, loadedConfig.EnableUserlandProxy)
 }

--- a/daemon/command/daemon_unix_test.go
+++ b/daemon/command/daemon_unix_test.go
@@ -56,21 +56,20 @@ func TestLoadDaemonConfigWithMapOptions(t *testing.T) {
 }
 
 func TestLoadDaemonConfigWithTrueDefaultValues(t *testing.T) {
-	content := `{ "userland-proxy": false }`
+	content := `{ "icc": false }`
 	tempFile := fs.NewFile(t, "config", fs.WithContent(content))
 
 	opts := defaultOptions(t, tempFile.Path())
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
 
-	assert.Check(t, !loadedConfig.EnableUserlandProxy)
+	assert.Check(t, is.Equal(loadedConfig.InterContainerCommunication, false))
 
 	// make sure reloading doesn't generate configuration
 	// conflicts after normalizing boolean values.
-	reload := func(reloadedConfig *config.Config) {
-		assert.Check(t, !reloadedConfig.EnableUserlandProxy)
-	}
-	assert.Check(t, config.Reload(opts.configFile, opts.flags, reload))
+	assert.Check(t, config.Reload(opts.configFile, opts.flags, func(reloadedConfig *config.Config) {
+		assert.Check(t, is.Equal(reloadedConfig.InterContainerCommunication, false))
+	}))
 }
 
 func TestLoadDaemonConfigWithTrueDefaultValuesLeaveDefaults(t *testing.T) {
@@ -80,5 +79,5 @@ func TestLoadDaemonConfigWithTrueDefaultValuesLeaveDefaults(t *testing.T) {
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
 
-	assert.Check(t, loadedConfig.EnableUserlandProxy)
+	assert.Check(t, is.Equal(loadedConfig.InterContainerCommunication, true))
 }


### PR DESCRIPTION
### daemon/command: rename daemon config tests to have common prefix

### daemon/command: rm redundant nil-asserts

loadDaemonCliConfig should never return nil, nil; if it would, then it's fine
for these tests to panic. Adding the nil-assert tripped up my IDE (Goland), as
it doesn't consider the assert to be a hard-fail, so it kept flagging the asserts
following it for "potentially nil".


### daemon/command: fix unix-tests if userland-proxy binary is not present

Parts of the daemon-config validation depend on the userland-proxy ("docker-proxy")
binary to be present. While this generally works in CI, it would cause unit-tests
to fail, e.g.:

    go test -v -run TestLoadDaemonConfig
    === RUN   TestLoadDaemonConfigWithoutOverriding
        daemon_test.go:36: assertion failed: error is not nil: invalid userland-proxy-path: userland-proxy is enabled, but userland-proxy-path is not set

Disable the userland-proxy in the default config used in tests, and replace some
uses of the userland-proxy config with the "icc" option (also enabled by default).


### daemon/command: TestLoadDaemonConfigWithDaemonFlags: minor cleanup

- Use "warn" for the expected log-level, because "info" is the default
- Use consistent order for "expected" and "actual" values in asserts
- Explicitly check for boolean values (mostly for consistency with
  other asserts).



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

