### PR TITLE
integration-cli: Deflake TestBuildEmitsEvents

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6216,10 +6216,10 @@ func (s *DockerCLIBuildSuite) TestBuildEmitsEvents(t *testing.T) {
 				skip.If(t, builder.buildkit && DaemonIsWindows() && !containerdSnapshotterEnabled(),
 					"Buildkit is not supported on Windows with graphdrivers")
 
-				time.Sleep(time.Second)
-				before := time.Now()
+				since := daemonUnixTime(t)
 
-				args := []string{"build"}
+				iidFile := filepath.Join(t.TempDir(), "iid")
+				args := []string{"build", "--iidfile", iidFile}
 				args = append(args, tc.args...)
 
 				b := cli.Docker(cli.Args(args...),
@@ -6229,12 +6229,18 @@ func (s *DockerCLIBuildSuite) TestBuildEmitsEvents(t *testing.T) {
 				)
 				assert.NilError(t, b.Compare(icmd.Success), b.Combined())
 
+				imageID, err := os.ReadFile(iidFile)
+				assert.NilError(t, err)
+
+				until := daemonUnixTime(t)
+
 				cmd := cli.Docker(
 					cli.Args("events",
 						"--filter", "type=image",
-						"--since", before.Format(time.RFC3339),
+						"--filter", "image="+strings.TrimSpace(string(imageID)),
+						"--since", since,
+						"--until", until,
 					),
-					cli.WithTimeout(time.Millisecond*300),
 					cli.WithEnvironmentVariables("DOCKER_API_VERSION=v1.46"), // FIXME(thaJeztah): integration-cli runs docker CLI 25.0; we're "upgrading" the API version to a version it doesn't support here ;)
 				)
 


### PR DESCRIPTION
The test queried `docker events` without `--until` and relied on a 300ms timeout to collect output.

On slow CI, events may not stream back within that window, resulting in empty stdout and assertion failures.

Use `--since`/`--until` with nanosecond-precision daemon timestamps (via daemonUnixTime) instead, matching the pattern used by the adjacent TestBuildTagEvent and other event tests in the suite.
