### PR TITLE
The 28.x is unmaintained

### DIFF
--- a/project/BRANCHES-AND-TAGS.md
+++ b/project/BRANCHES-AND-TAGS.md
@@ -35,7 +35,7 @@ Currently (and previously) maintained release branches are documented in the tab
 | Branch Name                 | Sponsoring Maintainer(s)                       | Contribution Status   | Expected End of Maintenance | Known Distributors                        |
 |-----------------------------|------------------------------------------------|-----------------------|-----------------------------|-------------------------------------------|
 | docker-29.x                 | The Moby Project [MAINTAINERS](../MAINTAINERS) | Maintained            | After docker-30.x           | [Docker, Inc.][docker], [Microsoft][msft] |
-| docker-28.x                 | @cpuguy83                                      | Maintained            | TBD                         | [Microsoft][msft]                         |
+| docker-28.x                 |                                                | Unmaintained          |                             |                                           |
 | 27.x                        |                                                | Unmaintained          |                             |                                           |
 | 26.1                        |                                                | Unmaintained          |                             |                                           |
 | 26.0                        |                                                | Unmaintained          |                             |                                           |


### PR DESCRIPTION
We brought back older API compat (well, a bunch of it) to 29, there is no need to keep 28 around and its not actually being maintained.