### PR TITLE
daemon: fix AppArmor support check for detached-netns

### DIFF
--- a/daemon/apparmor_default.go
+++ b/daemon/apparmor_default.go
@@ -5,7 +5,6 @@ package daemon
 import (
 	"fmt"
 
-	"github.com/containerd/containerd/v2/pkg/apparmor"
 	"github.com/moby/moby/v2/daemon/internal/rootless"
 	aaprofile "github.com/moby/profiles/apparmor"
 )
@@ -18,11 +17,7 @@ const (
 
 // DefaultApparmorProfile returns the name of the default apparmor profile
 func DefaultApparmorProfile() string {
-	if apparmor.HostSupports() {
-		if detachedNetNS, _ := rootless.DetachedNetNS(); detachedNetNS != "" {
-			// AppArmor is inaccessible with detached-netns because sysfs is netns-scoped.
-			return ""
-		}
+	if appArmorSupported() {
 		return defaultAppArmorProfile
 	}
 	return ""
@@ -55,7 +50,7 @@ func installDefaultAppArmorProfile() error {
 }
 
 func defaultAppArmorProfileSupported() bool {
-	hostSupports := apparmor.HostSupports()
+	hostSupports := appArmorSupported()
 	if hostSupports {
 		if detachedNetNS, _ := rootless.DetachedNetNS(); detachedNetNS != "" {
 			// "open /sys/kernel/security/apparmor/profiles: permission denied"

--- a/daemon/apparmor_linux.go
+++ b/daemon/apparmor_linux.go
@@ -1,0 +1,16 @@
+package daemon
+
+import (
+	"github.com/containerd/containerd/v2/pkg/apparmor"
+	"github.com/moby/moby/v2/daemon/internal/rootless"
+)
+
+// appArmorSupported returns true if AppArmor is supported and accessible on the host.
+func appArmorSupported() bool {
+	if detachedNetNS, _ := rootless.DetachedNetNS(); detachedNetNS != "" {
+		// AppArmor is inaccessible with detached-netns because sysfs is netns-scoped.
+		// https://github.com/moby/moby/issues/52626
+		return false
+	}
+	return apparmor.HostSupports()
+}

--- a/daemon/apparmor_unsupported.go
+++ b/daemon/apparmor_unsupported.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package daemon
+
+// appArmorSupported returns true if AppArmor is supported and accessible on the host.
+func appArmorSupported() bool {
+	return false
+}

--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	containerd "github.com/containerd/containerd/v2/client"
-	"github.com/containerd/containerd/v2/pkg/apparmor"
 	coci "github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/daemon/container"
@@ -66,7 +65,7 @@ func (daemon *Daemon) execSetPlatformOpt(ctx context.Context, daemonCfg *config.
 		}
 	}
 
-	if apparmor.HostSupports() {
+	if appArmorSupported() {
 		var appArmorProfile string
 		if ec.Container.AppArmorProfile != "" {
 			appArmorProfile = ec.Container.AppArmorProfile

--- a/daemon/exec_linux_test.go
+++ b/daemon/exec_linux_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/containerd/containerd/v2/pkg/apparmor"
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestExecSetPlatformOptAppArmor(t *testing.T) {
-	appArmorEnabled := apparmor.HostSupports()
+	appArmorEnabled := appArmorSupported()
 
 	tests := []struct {
 		doc             string

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -12,13 +12,11 @@ import (
 
 	cdcgroups "github.com/containerd/cgroups/v3"
 	"github.com/containerd/containerd/v2/core/containers"
-	"github.com/containerd/containerd/v2/pkg/apparmor"
 	coci "github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/log"
 	containertypes "github.com/moby/moby/api/types/container"
 	dconfig "github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/daemon/container"
-	"github.com/moby/moby/v2/daemon/internal/rootless"
 	"github.com/moby/moby/v2/daemon/internal/rootless/mountopts"
 	"github.com/moby/moby/v2/daemon/internal/rootless/specconv"
 	"github.com/moby/moby/v2/daemon/pkg/oci"
@@ -126,11 +124,7 @@ func WithSelinux(c *container.Container) coci.SpecOpts {
 // WithApparmor sets the apparmor profile
 func WithApparmor(c *container.Container) coci.SpecOpts {
 	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
-		if apparmor.HostSupports() {
-			// AppArmor is inaccessible with detached-netns because sysfs is netns-scoped.
-			if detachedNetNS, _ := rootless.DetachedNetNS(); detachedNetNS != "" {
-				return nil
-			}
+		if appArmorSupported() {
 			var appArmorProfile string
 			if c.AppArmorProfile != "" {
 				appArmorProfile = c.AppArmorProfile


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixes #52626

**- How I did it**
Consolidated the code to check AppArmor availability to `daemon/apparmor_linux.go:appArmorSupported()`.
The function returns `false` when `detach-netns` is enabled.

**- How to verify it**
```
dockerd-rootless-setuptool.sh install
docker run -d --name foo busybox sleep infinity
docker exec -it foo sh
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

