### PR TITLE
integration/service: Migrated TestAPISwarmInit to /integration

### DIFF
--- a/integration/service/swarm_test.go
+++ b/integration/service/swarm_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	swarmTypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/swarm"
 	"github.com/moby/moby/v2/internal/testutil/daemon"
@@ -33,4 +34,59 @@ func TestSwarmCAHash(t *testing.T) {
 		RemoteAddrs: []string{d1.SwarmListenAddr()},
 	})
 	assert.ErrorContains(t, err, "remote CA does not match fingerprint")
+}
+
+func TestSwarmInit(t *testing.T) {
+	skip.If(t, strings.HasPrefix(testEnv.FirewallBackendDriver(), "nftables"), "swarm cannot be used with nftables")
+	ctx := setupTest(t)
+
+	d1 := swarm.NewSwarm(ctx, t, testEnv)
+	defer d1.Stop(t)
+
+	// TODO: Should still find a better way to verify that components are running than /info
+	info := d1.SwarmInfo(ctx, t)
+	assert.Equal(t, info.ControlAvailable, true)
+	assert.Equal(t, info.LocalNodeState, swarmTypes.LocalNodeStateActive)
+	assert.Equal(t, info.Cluster.RootRotationInProgress, false)
+
+	d2 := daemon.New(t)
+	d2.StartAndSwarmJoin(ctx, t, d1, false)
+	defer d2.Stop(t)
+
+	info = d2.SwarmInfo(ctx, t)
+	assert.Equal(t, info.ControlAvailable, false)
+	assert.Equal(t, info.LocalNodeState, swarmTypes.LocalNodeStateActive)
+
+	// Leaving swarm cluster
+	assert.NilError(t, d2.SwarmLeave(ctx, t, false))
+
+	info = d2.SwarmInfo(ctx, t)
+	assert.Equal(t, info.ControlAvailable, false)
+	assert.Equal(t, info.LocalNodeState, swarmTypes.LocalNodeStateInactive)
+
+	// Rejoining cluster
+	d2.SwarmJoin(ctx, t, swarmTypes.JoinRequest{
+		ListenAddr:  d1.SwarmListenAddr(),
+		JoinToken:   d1.JoinTokens(t).Worker,
+		RemoteAddrs: []string{d1.SwarmListenAddr()},
+	})
+
+	info = d2.SwarmInfo(ctx, t)
+	assert.Equal(t, info.ControlAvailable, false)
+	assert.Equal(t, info.LocalNodeState, swarmTypes.LocalNodeStateActive)
+
+	// Restarting and restoring states
+	d1.Stop(t)
+	d2.Stop(t)
+
+	d1.StartNode(t)
+	d2.StartNode(t)
+
+	info = d1.SwarmInfo(ctx, t)
+	assert.Equal(t, info.ControlAvailable, true)
+	assert.Equal(t, info.LocalNodeState, swarmTypes.LocalNodeStateActive)
+
+	info = d2.SwarmInfo(ctx, t)
+	assert.Equal(t, info.ControlAvailable, false)
+	assert.Equal(t, info.LocalNodeState, swarmTypes.LocalNodeStateActive)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Migrated test `TestAPISwarmInit` from the `integration-cli/` to the `integration/` suite. It still uses `Swarm.Info` to verify connectivity.

**- How to verify it**
You can run the following command:
```
TESTDIRS='./integration/service/' TESTFLAGS='-test.run TestSwarmInit' make test-integration
```

**- A picture of a cute animal (not mandatory but encouraged)**

![manatee](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExZGp5MjN3ZzVkNGR0dHZjMWR5bmMxYWdrbG5uc3pqaGZtMHNuMWU4ZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/JyuNpotfCzSXS/giphy.gif)