### PR TITLE
daemon/logger/awslogs: add CloudWatch entity support

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -2,12 +2,14 @@
 package awslogs
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 	"unicode/utf8"
@@ -26,6 +28,7 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/lazyregexp"
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/logger/loggerutils"
+	"github.com/moby/moby/v2/daemon/logger/templates"
 	"github.com/moby/moby/v2/dockerversion"
 	"github.com/pkg/errors"
 )
@@ -45,9 +48,18 @@ const (
 	forceFlushIntervalKey  = "awslogs-force-flush-interval-seconds"
 	maxBufferedEventsKey   = "awslogs-max-buffered-events"
 	logFormatKey           = "awslogs-format"
+	entityServiceNameKey   = "awslogs-entity-service-name"
+	entityEnvironmentKey   = "awslogs-entity-environment"
+	entityAttributesKey    = "awslogs-entity-attributes"
 
 	defaultForceFlushInterval = 5 * time.Second
 	defaultMaxBufferedEvents  = 4096
+
+	// See: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_Entity.html
+	entityTypeService   = "Service"
+	maxEntityAttributes = 10
+	maxAttributeKey     = 256
+	maxEntityValue      = 512
 
 	// See: http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
 	perEventBytes          = 26
@@ -75,6 +87,7 @@ type logStream struct {
 	logCreateStream    bool
 	forceFlushInterval time.Duration
 	multilinePattern   *regexp.Regexp
+	entity             *types.Entity
 	client             api
 
 	messages *loggerutils.MessageQueue
@@ -91,6 +104,7 @@ type logStreamConfig struct {
 	forceFlushInterval time.Duration
 	maxBufferedEvents  int
 	multilinePattern   *regexp.Regexp
+	entity             *types.Entity
 }
 
 var _ logger.SizedLogger = &logStream{}
@@ -125,7 +139,8 @@ type eventBatch struct {
 // New creates an awslogs logger using the configuration passed in on the
 // context.  Supported context configuration variables are awslogs-region,
 // awslogs-endpoint, awslogs-group, awslogs-stream, awslogs-create-group,
-// awslogs-multiline-pattern and awslogs-datetime-format.
+// awslogs-multiline-pattern, awslogs-datetime-format, awslogs-entity-service-name,
+// awslogs-entity-environment and awslogs-entity-attributes.
 // When available, configuration is also taken from environment variables
 // AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, the shared credentials
 // file (~/.aws/credentials), and the EC2 Instance Metadata Service.
@@ -148,6 +163,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		logCreateStream:    containerStreamConfig.logCreateStream,
 		forceFlushInterval: containerStreamConfig.forceFlushInterval,
 		multilinePattern:   containerStreamConfig.multilinePattern,
+		entity:             containerStreamConfig.entity,
 		client:             client,
 		messages:           loggerutils.NewMessageQueue(containerStreamConfig.maxBufferedEvents),
 	}
@@ -235,6 +251,11 @@ func newStreamConfig(info logger.Info) (*logStreamConfig, error) {
 		return nil, err
 	}
 
+	entity, err := parseEntity(info)
+	if err != nil {
+		return nil, err
+	}
+
 	containerStreamConfig := &logStreamConfig{
 		logStreamName:      logStreamName,
 		logGroupName:       logGroupName,
@@ -243,9 +264,117 @@ func newStreamConfig(info logger.Info) (*logStreamConfig, error) {
 		forceFlushInterval: forceFlushInterval,
 		maxBufferedEvents:  maxBufferedEvents,
 		multilinePattern:   multilinePattern,
+		entity:             entity,
 	}
 
 	return containerStreamConfig, nil
+}
+
+// parseEntity builds a CloudWatch Entity from the awslogs-entity-* log options.
+// It returns a nil entity when none of the entity options are set.
+// The service name and environment values support the same Go-template
+// placeholders as the awslogs-stream and tag options (for example {{.Name}}).
+func parseEntity(info logger.Info) (*types.Entity, error) {
+	serviceNameTmpl := info.Config[entityServiceNameKey]
+	environmentTmpl := info.Config[entityEnvironmentKey]
+	attributesRaw := info.Config[entityAttributesKey]
+
+	if serviceNameTmpl == "" && environmentTmpl == "" && attributesRaw == "" {
+		return nil, nil
+	}
+	if serviceNameTmpl == "" || environmentTmpl == "" {
+		return nil, fmt.Errorf("log opts '%s' and '%s' must both be specified to set a CloudWatch entity", entityServiceNameKey, entityEnvironmentKey)
+	}
+
+	serviceName, err := expandEntityTemplate(info, entityServiceNameKey, serviceNameTmpl)
+	if err != nil {
+		return nil, err
+	}
+	environment, err := expandEntityTemplate(info, entityEnvironmentKey, environmentTmpl)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateKeyAttributeValue(entityServiceNameKey, serviceName); err != nil {
+		return nil, err
+	}
+	if err := validateKeyAttributeValue(entityEnvironmentKey, environment); err != nil {
+		return nil, err
+	}
+
+	attributes, err := parseEntityAttributes(attributesRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.Entity{
+		KeyAttributes: map[string]string{
+			"Type":        entityTypeService,
+			"Name":        serviceName,
+			"Environment": environment,
+		},
+		Attributes: attributes,
+	}, nil
+}
+
+// validateKeyAttributeValue checks a resolved entity KeyAttribute value against
+// the CloudWatch Entity limits.
+func validateKeyAttributeValue(optKey, val string) error {
+	if val == "" {
+		return fmt.Errorf("log opt '%s' resolved to an empty value", optKey)
+	}
+	if len(val) > maxEntityValue {
+		return fmt.Errorf("log opt '%s' value exceeds the CloudWatch limit of %d characters", optKey, maxEntityValue)
+	}
+	return nil
+}
+
+// expandEntityTemplate runs an entity log-opt value through the container-aware
+// template engine, the same one used by ParseLogTag.
+func expandEntityTemplate(info logger.Info, optKey, tmplText string) (string, error) {
+	tmpl, err := templates.NewParse(optKey, tmplText)
+	if err != nil {
+		return "", errors.Wrapf(err, "awslogs could not parse log opt %q", optKey)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, &info); err != nil {
+		return "", errors.Wrapf(err, "awslogs could not expand log opt %q", optKey)
+	}
+	return buf.String(), nil
+}
+
+// parseEntityAttributes parses a comma-separated key=value list into a map,
+// enforcing the CloudWatch Entity attribute limits. Empty entries (for example
+// from a trailing comma) are ignored.
+func parseEntityAttributes(raw string) (map[string]string, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	attributes := map[string]string{}
+	for _, pair := range strings.Split(raw, ",") {
+		if strings.TrimSpace(pair) == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(pair, "=")
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if !ok || k == "" || v == "" {
+			return nil, fmt.Errorf("log opt '%s' must be a comma-separated list of key=value pairs", entityAttributesKey)
+		}
+		if _, exists := attributes[k]; exists {
+			return nil, fmt.Errorf("log opt '%s' has a duplicate key %q", entityAttributesKey, k)
+		}
+		if len(k) > maxAttributeKey || len(v) > maxEntityValue {
+			return nil, fmt.Errorf("log opt '%s' entry %q exceeds CloudWatch limits (key <= %d chars, value <= %d chars)", entityAttributesKey, k, maxAttributeKey, maxEntityValue)
+		}
+		attributes[k] = v
+	}
+	if len(attributes) == 0 {
+		return nil, nil
+	}
+	if len(attributes) > maxEntityAttributes {
+		return nil, fmt.Errorf("log opt '%s' supports at most %d attributes", entityAttributesKey, maxEntityAttributes)
+	}
+	return attributes, nil
 }
 
 // formatSequences matches each strftime format sequence.
@@ -705,6 +834,7 @@ func (l *logStream) putLogEvents(events []types.InputLogEvent, sequenceToken *st
 		SequenceToken: sequenceToken,
 		LogGroupName:  aws.String(l.logGroupName),
 		LogStreamName: aws.String(l.logStreamName),
+		Entity:        l.entity,
 	}
 	resp, err := l.client.PutLogEvents(context.TODO(), input)
 	if err != nil {
@@ -719,12 +849,22 @@ func (l *logStream) putLogEvents(events []types.InputLogEvent, sequenceToken *st
 		}
 		return nil, err
 	}
+	if resp.RejectedEntityInfo != nil {
+		// The log events are still accepted when only the entity is rejected,
+		// so this is logged as a warning rather than returned as an error.
+		log.G(context.TODO()).WithFields(log.Fields{
+			"errorType":     resp.RejectedEntityInfo.ErrorType,
+			"logGroupName":  l.logGroupName,
+			"logStreamName": l.logStreamName,
+		}).Warn("CloudWatch rejected the entity metadata")
+	}
 	return resp.NextSequenceToken, nil
 }
 
 // ValidateLogOpt looks for awslogs-specific log options awslogs-region, awslogs-endpoint
 // awslogs-group, awslogs-stream, awslogs-create-group, awslogs-create-stream, awslogs-datetime-format,
-// awslogs-multiline-pattern
+// awslogs-multiline-pattern, awslogs-entity-service-name, awslogs-entity-environment and
+// awslogs-entity-attributes
 func ValidateLogOpt(cfg map[string]string) error {
 	for key := range cfg {
 		switch key {
@@ -742,6 +882,9 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case forceFlushIntervalKey:
 		case maxBufferedEventsKey:
 		case logFormatKey:
+		case entityServiceNameKey:
+		case entityEnvironmentKey:
+		case entityAttributesKey:
 		default:
 			return fmt.Errorf("unknown log opt '%s' for %s log driver", key, name)
 		}
@@ -783,6 +926,16 @@ func ValidateLogOpt(cfg map[string]string) error {
 		if datetimeFormatKeyExists || multilinePatternKeyExists {
 			return fmt.Errorf("you cannot configure log opt '%s' or '%s' when log opt '%s' is set to '%s'", datetimeFormatKey, multilinePatternKey, logFormatKey, jsonEmfLogFormat)
 		}
+	}
+
+	serviceNameSet := cfg[entityServiceNameKey] != ""
+	environmentSet := cfg[entityEnvironmentKey] != ""
+	attributesSet := cfg[entityAttributesKey] != ""
+	if (serviceNameSet || environmentSet || attributesSet) && (!serviceNameSet || !environmentSet) {
+		return fmt.Errorf("log opts '%s' and '%s' must be configured together", entityServiceNameKey, entityEnvironmentKey)
+	}
+	if _, err := parseEntityAttributes(cfg[entityAttributesKey]); err != nil {
+		return err
 	}
 
 	return nil

--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -859,13 +859,14 @@ func (l *logStream) putLogEvents(events []types.InputLogEvent, sequenceToken *st
 		return nil, err
 	}
 	if resp.RejectedEntityInfo != nil {
-		// The log events are still accepted when only the entity is rejected,
-		// so this is logged as a warning rather than returned as an error.
 		log.G(context.TODO()).WithFields(log.Fields{
 			"errorType":     resp.RejectedEntityInfo.ErrorType,
 			"logGroupName":  l.logGroupName,
 			"logStreamName": l.logStreamName,
 		}).Warn("CloudWatch rejected the entity metadata")
+		// Entity configuration is immutable for the stream, so do not keep
+		// sending metadata that the service has already rejected.
+		l.entity = nil
 	}
 	return resp.NextSequenceToken, nil
 }

--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -4,6 +4,7 @@ package awslogs
 import (
 	"bytes"
 	"context"
+	"encoding/csv"
 	"fmt"
 	"os"
 	"regexp"
@@ -343,14 +344,22 @@ func expandEntityTemplate(info logger.Info, optKey, tmplText string) (string, er
 }
 
 // parseEntityAttributes parses a comma-separated key=value list into a map,
-// enforcing the CloudWatch Entity attribute limits. Empty entries (for example
-// from a trailing comma) are ignored.
+// enforcing the CloudWatch Entity attribute limits. Quoting a complete pair
+// preserves commas in its value. Empty entries, such as a trailing comma, are
+// ignored.
 func parseEntityAttributes(raw string) (map[string]string, error) {
 	if raw == "" {
 		return nil, nil
 	}
+	reader := csv.NewReader(strings.NewReader(raw))
+	reader.TrimLeadingSpace = true
+	records, err := reader.ReadAll()
+	if err != nil || len(records) != 1 {
+		return nil, fmt.Errorf("log opt '%s' must be a comma-separated CSV list of key=value pairs", entityAttributesKey)
+	}
+
 	attributes := map[string]string{}
-	for _, pair := range strings.Split(raw, ",") {
+	for _, pair := range records[0] {
 		if strings.TrimSpace(pair) == "" {
 			continue
 		}

--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -323,7 +323,7 @@ func validateKeyAttributeValue(optKey, val string) error {
 	if val == "" {
 		return fmt.Errorf("log opt '%s' resolved to an empty value", optKey)
 	}
-	if len(val) > maxEntityValue {
+	if utf8.RuneCountInString(val) > maxEntityValue {
 		return fmt.Errorf("log opt '%s' value exceeds the CloudWatch limit of %d characters", optKey, maxEntityValue)
 	}
 	return nil
@@ -372,7 +372,7 @@ func parseEntityAttributes(raw string) (map[string]string, error) {
 		if _, exists := attributes[k]; exists {
 			return nil, fmt.Errorf("log opt '%s' has a duplicate key %q", entityAttributesKey, k)
 		}
-		if len(k) > maxAttributeKey || len(v) > maxEntityValue {
+		if utf8.RuneCountInString(k) > maxAttributeKey || utf8.RuneCountInString(v) > maxEntityValue {
 			return nil, fmt.Errorf("log opt '%s' entry %q exceeds CloudWatch limits (key <= %d chars, value <= %d chars)", entityAttributesKey, k, maxAttributeKey, maxEntityValue)
 		}
 		attributes[k] = v

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -1672,6 +1672,289 @@ func BenchmarkUnwrapEvents(b *testing.B) {
 	}
 }
 
+func TestNewStreamConfigEntity(t *testing.T) {
+	tests := []struct {
+		testName      string
+		containerName string
+		config        map[string]string
+		shouldErr     bool
+		wantNil       bool
+		wantKeyAttr   map[string]string
+		wantAttr      map[string]string
+	}{
+		{
+			testName: "no entity options",
+			config:   map[string]string{logGroupKey: groupName},
+			wantNil:  true,
+		},
+		{
+			testName: "service name and environment",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: "my-service",
+				entityEnvironmentKey: "prod",
+			},
+			wantKeyAttr: map[string]string{"Type": "Service", "Name": "my-service", "Environment": "prod"},
+		},
+		{
+			testName:      "templated service name",
+			containerName: "/test-container",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: "{{.Name}}",
+				entityEnvironmentKey: "prod",
+			},
+			wantKeyAttr: map[string]string{"Type": "Service", "Name": "test-container", "Environment": "prod"},
+		},
+		{
+			testName: "with attributes",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: "my-service",
+				entityEnvironmentKey: "prod",
+				entityAttributesKey:  "PlatformType=Generic, Host=worker-7 ,K8s.Cluster=foo=bar",
+			},
+			wantKeyAttr: map[string]string{"Type": "Service", "Name": "my-service", "Environment": "prod"},
+			wantAttr:    map[string]string{"PlatformType": "Generic", "Host": "worker-7", "K8s.Cluster": "foo=bar"},
+		},
+		{
+			testName: "trailing comma in attributes is tolerated",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: "my-service",
+				entityEnvironmentKey: "prod",
+				entityAttributesKey:  "Host=worker-7,",
+			},
+			wantKeyAttr: map[string]string{"Type": "Service", "Name": "my-service", "Environment": "prod"},
+			wantAttr:    map[string]string{"Host": "worker-7"},
+		},
+		{
+			testName: "service name without environment",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: "my-service",
+			},
+			shouldErr: true,
+		},
+		{
+			testName: "malformed attribute pair",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: "my-service",
+				entityEnvironmentKey: "prod",
+				entityAttributesKey:  "PlatformType",
+			},
+			shouldErr: true,
+		},
+		{
+			testName: "invalid template field in service name",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: "{{.Nope}}",
+				entityEnvironmentKey: "prod",
+			},
+			shouldErr: true,
+		},
+		{
+			testName: "invalid template field in environment",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: "my-service",
+				entityEnvironmentKey: "{{.Nope}}",
+			},
+			shouldErr: true,
+		},
+		{
+			testName: "malformed template syntax",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: "{{.Name",
+				entityEnvironmentKey: "prod",
+			},
+			shouldErr: true,
+		},
+		{
+			testName: "service name resolves to empty value",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: "{{.Name}}",
+				entityEnvironmentKey: "prod",
+			},
+			// containerName is left empty, so {{.Name}} resolves to ""
+			shouldErr: true,
+		},
+		{
+			testName: "service name exceeds length limit",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: strings.Repeat("x", maxEntityValue+1),
+				entityEnvironmentKey: "prod",
+			},
+			shouldErr: true,
+		},
+		{
+			testName: "environment exceeds length limit",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: "my-service",
+				entityEnvironmentKey: strings.Repeat("x", maxEntityValue+1),
+			},
+			shouldErr: true,
+		},
+		{
+			testName: "blank-only attributes resolve to no attributes",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: "my-service",
+				entityEnvironmentKey: "prod",
+				entityAttributesKey:  ", ,",
+			},
+			wantKeyAttr: map[string]string{"Type": "Service", "Name": "my-service", "Environment": "prod"},
+			wantAttr:    nil,
+		},
+		{
+			testName: "duplicate attribute key",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: "my-service",
+				entityEnvironmentKey: "prod",
+				entityAttributesKey:  "Host=a,Host=b",
+			},
+			shouldErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			info := logger.Info{
+				ContainerName: tc.containerName,
+				Config:        tc.config,
+			}
+			streamConfig, err := newStreamConfig(info)
+			if tc.shouldErr {
+				assert.Check(t, err != nil, "Expected an error")
+				return
+			}
+			assert.NilError(t, err)
+			if tc.wantNil {
+				assert.Check(t, is.Nil(streamConfig.entity))
+				return
+			}
+			assert.Assert(t, streamConfig.entity != nil)
+			assert.DeepEqual(t, tc.wantKeyAttr, streamConfig.entity.KeyAttributes)
+			assert.DeepEqual(t, tc.wantAttr, streamConfig.entity.Attributes)
+		})
+	}
+}
+
+func TestValidateLogOptEntity(t *testing.T) {
+	tests := []struct {
+		testName  string
+		config    map[string]string
+		shouldErr bool
+	}{
+		{
+			testName: "both key attributes set",
+			config:   map[string]string{logGroupKey: groupName, entityServiceNameKey: "svc", entityEnvironmentKey: "prod"},
+		},
+		{
+			testName:  "only service name set",
+			config:    map[string]string{logGroupKey: groupName, entityServiceNameKey: "svc"},
+			shouldErr: true,
+		},
+		{
+			testName:  "only environment set",
+			config:    map[string]string{logGroupKey: groupName, entityEnvironmentKey: "prod"},
+			shouldErr: true,
+		},
+		{
+			testName: "valid attributes",
+			config:   map[string]string{logGroupKey: groupName, entityServiceNameKey: "svc", entityEnvironmentKey: "prod", entityAttributesKey: "a=1,b=2"},
+		},
+		{
+			testName:  "malformed attributes",
+			config:    map[string]string{logGroupKey: groupName, entityServiceNameKey: "svc", entityEnvironmentKey: "prod", entityAttributesKey: "a"},
+			shouldErr: true,
+		},
+		{
+			testName:  "too many attributes",
+			config:    map[string]string{logGroupKey: groupName, entityServiceNameKey: "svc", entityEnvironmentKey: "prod", entityAttributesKey: "a=1,b=2,c=3,d=4,e=5,f=6,g=7,h=8,i=9,j=10,k=11"},
+			shouldErr: true,
+		},
+		{
+			testName:  "attribute value too long",
+			config:    map[string]string{logGroupKey: groupName, entityServiceNameKey: "svc", entityEnvironmentKey: "prod", entityAttributesKey: "a=" + strings.Repeat("x", maxEntityValue+1)},
+			shouldErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			err := ValidateLogOpt(tc.config)
+			if tc.shouldErr {
+				assert.Check(t, err != nil, "Expected an error")
+			} else {
+				assert.NilError(t, err)
+			}
+		})
+	}
+}
+
+func TestPublishBatchEntity(t *testing.T) {
+	mockClient := &mockClient{}
+	entity := &types.Entity{
+		KeyAttributes: map[string]string{"Type": "Service", "Name": "my-service", "Environment": "prod"},
+		Attributes:    map[string]string{"PlatformType": "Generic"},
+	}
+	stream := &logStream{
+		client:        mockClient,
+		logGroupName:  groupName,
+		logStreamName: streamName,
+		sequenceToken: aws.String(sequenceToken),
+		entity:        entity,
+	}
+	var input *cloudwatchlogs.PutLogEventsInput
+	mockClient.putLogEventsFunc = func(ctx context.Context, i *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
+		input = i
+		return &cloudwatchlogs.PutLogEventsOutput{NextSequenceToken: aws.String(nextSequenceToken)}, nil
+	}
+	events := []wrappedEvent{
+		{inputLogEvent: types.InputLogEvent{Message: aws.String(logline)}},
+	}
+
+	stream.publishBatch(testEventBatch(events))
+	assert.Assert(t, input != nil)
+	assert.Assert(t, input.Entity != nil)
+	assert.DeepEqual(t, entity.KeyAttributes, input.Entity.KeyAttributes)
+	assert.DeepEqual(t, entity.Attributes, input.Entity.Attributes)
+}
+
+func TestPublishBatchEntityRejected(t *testing.T) {
+	mockClient := &mockClient{}
+	stream := &logStream{
+		client:        mockClient,
+		logGroupName:  groupName,
+		logStreamName: streamName,
+		sequenceToken: aws.String(sequenceToken),
+		entity: &types.Entity{
+			KeyAttributes: map[string]string{"Type": "Service", "Name": "my-service", "Environment": "prod"},
+		},
+	}
+	mockClient.putLogEventsFunc = func(ctx context.Context, i *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
+		return &cloudwatchlogs.PutLogEventsOutput{
+			NextSequenceToken:  aws.String(nextSequenceToken),
+			RejectedEntityInfo: &types.RejectedEntityInfo{ErrorType: types.EntityRejectionErrorTypeInvalidEntity},
+		}, nil
+	}
+	events := []wrappedEvent{
+		{inputLogEvent: types.InputLogEvent{Message: aws.String(logline)}},
+	}
+
+	// A rejected entity must not block the log events from being accepted.
+	stream.publishBatch(testEventBatch(events))
+	assert.Equal(t, nextSequenceToken, aws.ToString(stream.sequenceToken), "sequenceToken")
+}
+
 func TestNewAWSLogsClientCredentialEndpointDetect(t *testing.T) {
 	// required for the cloudwatchlogs client
 	t.Setenv("AWS_REGION", "us-west-2")

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -1972,19 +1972,27 @@ func TestPublishBatchEntityRejected(t *testing.T) {
 			KeyAttributes: map[string]string{"Type": "Service", "Name": "my-service", "Environment": "prod"},
 		},
 	}
+	var inputs []*cloudwatchlogs.PutLogEventsInput
 	mockClient.putLogEventsFunc = func(ctx context.Context, i *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
-		return &cloudwatchlogs.PutLogEventsOutput{
-			NextSequenceToken:  aws.String(nextSequenceToken),
-			RejectedEntityInfo: &types.RejectedEntityInfo{ErrorType: types.EntityRejectionErrorTypeInvalidEntity},
-		}, nil
+		inputs = append(inputs, i)
+		output := &cloudwatchlogs.PutLogEventsOutput{NextSequenceToken: aws.String(nextSequenceToken)}
+		if i.Entity != nil {
+			output.RejectedEntityInfo = &types.RejectedEntityInfo{ErrorType: types.EntityRejectionErrorTypeInvalidEntity}
+		}
+		return output, nil
 	}
 	events := []wrappedEvent{
 		{inputLogEvent: types.InputLogEvent{Message: aws.String(logline)}},
 	}
 
-	// A rejected entity must not block the log events from being accepted.
-	stream.publishBatch(testEventBatch(events))
+	batch := testEventBatch(events)
+	stream.publishBatch(batch)
+	stream.publishBatch(batch)
+
 	assert.Equal(t, nextSequenceToken, aws.ToString(stream.sequenceToken), "sequenceToken")
+	assert.Equal(t, len(inputs), 2)
+	assert.Assert(t, inputs[0].Entity != nil)
+	assert.Check(t, is.Nil(inputs[1].Entity))
 }
 
 func TestNewAWSLogsClientCredentialEndpointDetect(t *testing.T) {

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -1718,6 +1718,20 @@ func TestNewStreamConfigEntity(t *testing.T) {
 			wantAttr:    map[string]string{"PlatformType": "Generic", "Host": "worker-7", "K8s.Cluster": "foo=bar"},
 		},
 		{
+			testName: "attributes containing commas",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: "my-service",
+				entityEnvironmentKey: "prod",
+				entityAttributesKey:  `"Telemetry.SDK=opentelemetry,1.32.0-aws-SNAPSHOT,java,Auto","Telemetry.Source=ClientSpan, JMX"`,
+			},
+			wantKeyAttr: map[string]string{"Type": "Service", "Name": "my-service", "Environment": "prod"},
+			wantAttr: map[string]string{
+				"Telemetry.SDK":    "opentelemetry,1.32.0-aws-SNAPSHOT,java,Auto",
+				"Telemetry.Source": "ClientSpan, JMX",
+			},
+		},
+		{
 			testName: "trailing comma in attributes is tolerated",
 			config: map[string]string{
 				logGroupKey:          groupName,

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -1732,6 +1732,15 @@ func TestNewStreamConfigEntity(t *testing.T) {
 			},
 		},
 		{
+			testName: "multi-byte service name within character limit",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: strings.Repeat("界", maxEntityValue),
+				entityEnvironmentKey: "prod",
+			},
+			wantKeyAttr: map[string]string{"Type": "Service", "Name": strings.Repeat("界", maxEntityValue), "Environment": "prod"},
+		},
+		{
 			testName: "trailing comma in attributes is tolerated",
 			config: map[string]string{
 				logGroupKey:          groupName,
@@ -1899,6 +1908,15 @@ func TestValidateLogOptEntity(t *testing.T) {
 			testName:  "attribute value too long",
 			config:    map[string]string{logGroupKey: groupName, entityServiceNameKey: "svc", entityEnvironmentKey: "prod", entityAttributesKey: "a=" + strings.Repeat("x", maxEntityValue+1)},
 			shouldErr: true,
+		},
+		{
+			testName: "multi-byte attribute key and value within character limits",
+			config: map[string]string{
+				logGroupKey:          groupName,
+				entityServiceNameKey: "svc",
+				entityEnvironmentKey: "prod",
+				entityAttributesKey:  strings.Repeat("界", maxAttributeKey) + "=" + strings.Repeat("界", maxEntityValue),
+			},
 		},
 	}
 


### PR DESCRIPTION
closes #52622

**Added**

  - awslogs-entity-service-name: the entity's Name key attribute
  - awslogs-entity-environment:  the entity's Environment key attribute
  - awslogs-entity-attributes:   a comma-separated key=value list of
                                 non-identifying entity attributes

The entity type is fixed to "Service", matching how the CloudWatch agent
attributes log telemetry. Service name and environment support
Go-template placeholders as awslogs-stream (for example {{.Name}}). When no
entity option is set, no Entity is sent.

A rejected entity (RejectedEntityInfo in the response) is logged as a warning
rather than treated as an error, since the log events are still accepted.

**- What I did**

Added support for the CloudWatch `Entity` field to the `awslogs` logging
driver. The driver now lets users attach entity metadata to log events so that
CloudWatch can associate container logs with a service in the "Explore related"
feature. Previously the `Entity` field of `PutLogEvents` was never populated.

**- How I did it**

- `parseEntity` builds a `types.Entity` from the new log options and stores it
  on the `logStream`; it's attached to every `PutLogEvents` request.
- Service name and environment go through the existing template engine
  (`templates.NewParse`, as used by `awslogs-stream`), so `{{.Name}}`-style
  placeholders resolve per container.
- `awslogs-entity-attributes` is parsed as a `key=value` list, enforcing the
  CloudWatch limits (max 10; key/value lengths).
- `ValidateLogOpt` rejects a half-configured entity (service name and
  environment must be set together).
- `RejectedEntityInfo` in a response is logged as a warning — the log events
  are still accepted, so it isn't an error.
- No entity option set → no `Entity` sent; existing behavior unchanged.


**- How to verify it**
`go test -v -run Entity ./daemon/logger/awslogs/`


```markdown changelog
Add support for attaching service names, environments, and custom CloudWatch entity attributes to logs from the `awslogs` logging driver.
```
