### PR TITLE
fix: return 400 for invalid t and shmsize query params

### DIFF
--- a/daemon/server/router/build/build_routes.go
+++ b/daemon/server/router/build/build_routes.go
@@ -92,7 +92,7 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*buildbackend.B
 	if s := r.Form.Get("shmsize"); s != "" {
 		shmSize, err := strconv.ParseInt(s, 10, 64)
 		if err != nil {
-			return nil, err
+			return nil, invalidParam{err}
 		}
 		options.ShmSize = shmSize
 	}

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -335,7 +335,7 @@ func (c *containerRouter) postContainersRestart(ctx context.Context, w http.Resp
 	if tmpSeconds := r.Form.Get("t"); tmpSeconds != "" {
 		valSeconds, err := strconv.Atoi(tmpSeconds)
 		if err != nil {
-			return err
+			return errdefs.InvalidParameter(err)
 		}
 		options.Timeout = &valSeconds
 	}


### PR DESCRIPTION
## Description

Two API handlers parse integer query parameters but return a bare error
on parse failure, resulting in a 500 response instead of the correct 400.

**`postContainersRestart`** (`container_routes.go`):
The `t=<seconds>` parameter is parsed with `strconv.Atoi` and on failure
returns `err` directly. The adjacent `postContainersStop` handler already
wraps the same parse error with `errdefs.InvalidParameter(err)`. This
brings restart in line with stop.

**`newImageBuildOptions`** (`build_routes.go`):
The `shmsize=<bytes>` parameter is parsed with `strconv.ParseInt` and on
failure returns `err` directly. Every other parse error in the same
function wraps the error with `invalidParam{}`. This extends that
consistency to shmsize.

## How to test

```bash
# restart with non-integer t
curl -s -o /dev/null -w "%{http_code}" -X POST \
  "http://localhost:2375/v1.47/containers/<id>/restart?t=notanint"
# expect: 400

# build with non-integer shmsize
curl -s -o /dev/null -w "%{http_code}" -X POST \
  "http://localhost:2375/v1.47/build?shmsize=notanint" \
  --data-binary @/dev/null
# expect: 400
```