### PR TITLE
libnet/iptables: don't filter on unspecified IP to delete conntrack

### DIFF
--- a/daemon/libnetwork/iptables/conntrack.go
+++ b/daemon/libnetwork/iptables/conntrack.go
@@ -98,14 +98,20 @@ func DeleteConntrackEntriesByPort(nlh nlwrap.Handle, proto types.Protocol, ports
 			}).Warn("Failed to delete conntrack state for port")
 			continue
 		}
-		if err := filter.AddIP(netlink.ConntrackOrigDstIP, port.HostIP); err != nil {
-			log.G(context.TODO()).WithFields(log.Fields{
-				"error":  err,
-				"hostIP": port.HostIP.String(),
-				"proto":  port.Proto.String(),
-				"port":   port.Port,
-			}).Warn("Failed to delete conntrack state for port")
-			continue
+		// Only filter by destination IP when the host IP is specified. When
+		// HostIP is 0.0.0.0 or ::, the binding applies to all interfaces, but
+		// conntrack entries record the actual interface IP, so filtering by the
+		// unspecified address would never match.
+		if !port.HostIP.IsUnspecified() {
+			if err := filter.AddIP(netlink.ConntrackOrigDstIP, port.HostIP); err != nil {
+				log.G(context.TODO()).WithFields(log.Fields{
+					"error":  err,
+					"hostIP": port.HostIP.String(),
+					"proto":  port.Proto.String(),
+					"port":   port.Port,
+				}).Warn("Failed to delete conntrack state for port")
+				continue
+			}
 		}
 
 		v4FlowPurged, err := nlh.ConntrackDeleteFilters(netlink.ConntrackTable, syscall.AF_INET, filter)


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/52423#issuecomment-4466939530 
- relates to https://github.com/akvorado/akvorado/issues/2431


Fixes: a836506d193b "Change Conntrack to delete by Both Port And IP"

**- Human readable description for the release notes**
```markdown changelog
Fix UDP conntrack entries not being deleted when not bound to a specific IP address.
```
