### PR TITLE
daemon: throttle libcontainerd event resubscribe

### DIFF
--- a/daemon/internal/libcontainerd/remote/client.go
+++ b/daemon/internal/libcontainerd/remote/client.go
@@ -19,6 +19,7 @@ import (
 	runcoptions "github.com/containerd/containerd/api/types/runc/options"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/content"
+	c8devents "github.com/containerd/containerd/v2/core/events"
 	c8dimages "github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/pkg/archive"
 	"github.com/containerd/containerd/v2/pkg/cio"
@@ -595,6 +596,37 @@ func (c *client) waitServe(ctx context.Context) bool {
 }
 
 func (c *client) processEventStream(ctx context.Context, ns string) {
+	c.processEventStreamWithRestart(ctx, ns, eventStreamRestartDelay, func(ctx context.Context, filter string) (<-chan *c8devents.Envelope, <-chan error) {
+		return c.client.EventService().Subscribe(ctx, filter)
+	}, c.waitServe)
+}
+
+const eventStreamRestartDelay = 100 * time.Millisecond
+
+type eventStreamSubscribeFunc func(context.Context, string) (<-chan *c8devents.Envelope, <-chan error)
+type eventStreamReadyFunc func(context.Context) bool
+
+func (c *client) processEventStreamWithRestart(ctx context.Context, ns string, delay time.Duration, subscribe eventStreamSubscribeFunc, waitReady eventStreamReadyFunc) {
+	for c.processEventStreamOnce(ctx, ns, subscribe, waitReady) {
+		if !waitEventStreamRestart(ctx, delay) {
+			return
+		}
+	}
+}
+
+func waitEventStreamRestart(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func (c *client) processEventStreamOnce(ctx context.Context, ns string, subscribe eventStreamSubscribeFunc, waitReady eventStreamReadyFunc) bool {
 	// Create a new context specifically for this subscription.
 	// The context must be cancelled to cancel the subscription.
 	// In cases where we have to restart event stream processing,
@@ -604,7 +636,7 @@ func (c *client) processEventStream(ctx context.Context, ns string) {
 
 	// Filter on both namespace *and* topic. To create an "and" filter,
 	// this must be a single, comma-separated string
-	eventStream, errC := c.client.EventService().Subscribe(subCtx, "namespace=="+ns+",topic~=|^/tasks/|")
+	eventStream, errC := subscribe(subCtx, "namespace=="+ns+",topic~=|^/tasks/|")
 
 	c.logger.Debug("processing event stream")
 
@@ -616,14 +648,13 @@ func (c *client) processEventStream(ctx context.Context, ns string) {
 				if !ok || errStatus.Code() != codes.Canceled {
 					c.logger.WithError(err).Error("Failed to get event")
 					c.logger.Info("Waiting for containerd to be ready to restart event processing")
-					if c.waitServe(ctx) {
-						go c.processEventStream(ctx, ns)
-						return
+					if waitReady(ctx) {
+						return true
 					}
 				}
 				c.logger.WithError(ctx.Err()).Info("stopping event stream following graceful shutdown")
 			}
-			return
+			return false
 		case ev := <-eventStream:
 			if ev.Event == nil {
 				c.logger.WithField("event", ev).Warn("invalid event")

--- a/daemon/internal/libcontainerd/remote/client_test.go
+++ b/daemon/internal/libcontainerd/remote/client_test.go
@@ -1,0 +1,60 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	c8devents "github.com/containerd/containerd/v2/core/events"
+	"github.com/containerd/log"
+)
+
+func TestProcessEventStreamRestartBacksOffBetweenSubscriptions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const delay = 30 * time.Millisecond
+	var starts []time.Time
+
+	subscribe := func(context.Context, string) (<-chan *c8devents.Envelope, <-chan error) {
+		starts = append(starts, time.Now())
+		events := make(chan *c8devents.Envelope)
+		errs := make(chan error, 1)
+		errs <- errors.New("subscription lost")
+		return events, errs
+	}
+
+	waitReady := func(ctx context.Context) bool {
+		if len(starts) >= 3 {
+			cancel()
+			return false
+		}
+		return ctx.Err() == nil
+	}
+
+	c := &client{logger: log.G(ctx)}
+	c.processEventStreamWithRestart(ctx, "moby", delay, subscribe, waitReady)
+
+	if len(starts) != 3 {
+		t.Fatalf("expected 3 subscription attempts, got %d", len(starts))
+	}
+	for i := 1; i < len(starts); i++ {
+		if elapsed := starts[i].Sub(starts[i-1]); elapsed < delay {
+			t.Fatalf("subscription attempt %d restarted after %s, expected at least %s", i+1, elapsed, delay)
+		}
+	}
+}
+
+func TestWaitEventStreamRestartStopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	if waitEventStreamRestart(ctx, time.Hour) {
+		t.Fatal("expected canceled context to stop restart wait")
+	}
+	if elapsed := time.Since(start); elapsed >= time.Second {
+		t.Fatalf("canceled restart wait took %s", elapsed)
+	}
+}


### PR DESCRIPTION
If the containerd event subscription returns an error, the daemon waits for
containerd to report that it is serving again and then immediately starts a
replacement event stream subscription. If containerd reports readiness while
the subscription path is still failing, that can resubscribe in a tight loop
against the containerd socket.

Keep the restart path in one loop and wait briefly before opening the next
subscription. The shutdown path still returns immediately when the parent
context is canceled.

This refresh also adds a regression test for the full restart path so the PR no
longer only tests the standalone timer helper.

Validation:
- `gofmt -w daemon/internal/libcontainerd/remote/client.go daemon/internal/libcontainerd/remote/client_test.go`
- `git diff --check -- daemon/internal/libcontainerd/remote/client.go daemon/internal/libcontainerd/remote/client_test.go`
- `HOME=/home/kom/tmp/moby-test-home GOCACHE=/home/kom/tmp/moby-test-gocache GOPATH=/home/kom/tmp/moby-test-gopath GOFLAGS=-mod=mod go test ./daemon/internal/libcontainerd/remote -run 'Test(ProcessEventStreamRestartBacksOffBetweenSubscriptions|WaitEventStreamRestartStopsOnCancel)' -count=1`
- `HOME=/home/kom/tmp/moby-test-home GOCACHE=/home/kom/tmp/moby-test-gocache GOPATH=/home/kom/tmp/moby-test-gopath GOFLAGS=-mod=mod go test ./daemon/internal/libcontainerd/remote -count=1`
