### PR TITLE
libnet: add firewalld_zone option for bridge networks

### DIFF
--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -97,6 +97,7 @@ type networkConfiguration struct {
 	HostIPv4              net.IP
 	HostIPv6              net.IP
 	ContainerIfacePrefix  string
+	FirewalldZone         string
 	// Internal fields set after ipam data parsing
 	AddressIPv4        *net.IPNet
 	AddressIPv6        *net.IPNet
@@ -397,6 +398,8 @@ func (ncfg *networkConfiguration) fromLabels(labels map[string]string) error {
 			}
 		case netlabel.ContainerIfacePrefix:
 			ncfg.ContainerIfacePrefix = value
+		case FirewalldZone:
+			ncfg.FirewalldZone = value
 		case netlabel.HostIPv4:
 			if ncfg.HostIPv4 = net.ParseIP(value); ncfg.HostIPv4 == nil {
 				return parseErr(label, value, "nil ip")
@@ -451,12 +454,12 @@ func (n *bridgeNetwork) newFirewallerNetwork(ctx context.Context) (_ firewaller.
 		return nil, err
 	}
 
-	if err := iptables.AddInterfaceFirewalld(n.config.BridgeName); err != nil {
+	if err := iptables.AddInterfaceFirewalld(n.config.BridgeName, n.config.FirewalldZone); err != nil {
 		return nil, err
 	}
 	defer func() {
 		if retErr != nil {
-			if err := iptables.DelInterfaceFirewalld(n.config.BridgeName); err != nil {
+			if err := iptables.DelInterfaceFirewalld(n.config.BridgeName, n.config.FirewalldZone); err != nil {
 				log.G(ctx).WithError(err).Errorf("failed to delete network level rules following error")
 			}
 		}
@@ -1014,7 +1017,7 @@ func (d *driver) deleteNetwork(nid string) error {
 			log.G(context.TODO()).WithError(err).Warnf("Failed to clean iptables rules for bridge network")
 		}
 	}
-	if err := iptables.DelInterfaceFirewalld(n.config.BridgeName); err != nil {
+	if err := iptables.DelInterfaceFirewalld(n.config.BridgeName, n.config.FirewalldZone); err != nil {
 		log.G(context.TODO()).WithError(err).Warnf("Failed to clean firewalld rules for bridge network")
 	}
 
@@ -1764,7 +1767,7 @@ func (d *driver) handleFirewalldReloadNw(nid string) {
 	// with the gateway.
 	nw.reapplyPerPortIptables()
 
-	if err := iptables.AddInterfaceFirewalld(nw.config.BridgeName); err != nil {
+	if err := iptables.AddInterfaceFirewalld(nw.config.BridgeName, nw.config.FirewalldZone); err != nil {
 		log.G(context.Background()).WithFields(log.Fields{
 			"error":  err,
 			"nid":    nw.id,

--- a/daemon/libnetwork/drivers/bridge/bridge_store.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_store.go
@@ -160,6 +160,7 @@ func (ncfg *networkConfiguration) MarshalJSON() ([]byte, error) {
 	nMap["DefaultGatewayIPv6"] = ncfg.DefaultGatewayIPv6.String()
 	nMap["ContainerIfacePrefix"] = ncfg.ContainerIfacePrefix
 	nMap["BridgeIfaceCreator"] = ncfg.BridgeIfaceCreator
+	nMap["FirewalldZone"] = ncfg.FirewalldZone
 
 	if ncfg.AddressIPv4 != nil {
 		nMap["AddressIPv4"] = ncfg.AddressIPv4.String()
@@ -241,6 +242,10 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 
 	if v, ok := nMap["BridgeIfaceCreator"]; ok {
 		ncfg.BridgeIfaceCreator = ifaceCreator(v.(float64))
+	}
+
+	if v, ok := nMap["FirewalldZone"]; ok {
+		ncfg.FirewalldZone = v.(string)
 	}
 
 	return nil

--- a/daemon/libnetwork/drivers/bridge/labels.go
+++ b/daemon/libnetwork/drivers/bridge/labels.go
@@ -27,4 +27,9 @@ const (
 	// TrustedHostInterfaces can be used to supply a list of host interfaces that are
 	// allowed direct access to published ports on a container's address.
 	TrustedHostInterfaces = "com.docker.network.bridge.trusted_host_interfaces"
+
+	// FirewalldZone sets the firewalld zone for the bridge interface. When firewalld
+	// is running, this overrides the default "docker" zone for this network's bridge
+	// interface.
+	FirewalldZone = "com.docker.network.bridge.firewalld_zone"
 )

--- a/daemon/libnetwork/iptables/firewalld.go
+++ b/daemon/libnetwork/iptables/firewalld.go
@@ -309,52 +309,60 @@ func setupDockerForwardingPolicy() (bool, error) {
 	return true, nil
 }
 
-// AddInterfaceFirewalld adds the interface to the trusted zone. It is a
-// no-op if firewalld is not running.
-func AddInterfaceFirewalld(intf string) error {
+// AddInterfaceFirewalld adds the interface to the given firewalld zone. If zone
+// is empty, the default "docker" zone is used. It is a no-op if firewalld is
+// not running.
+func AddInterfaceFirewalld(intf, zone string) error {
 	if !firewalldRunning {
 		return nil
+	}
+	if zone == "" {
+		zone = dockerZone
 	}
 
 	var intfs []string
 	// Check if interface is already added to the zone
-	if err := connection.sysObj.Call(dbusInterface+".zone.getInterfaces", 0, dockerZone).Store(&intfs); err != nil {
+	if err := connection.sysObj.Call(dbusInterface+".zone.getInterfaces", 0, zone).Store(&intfs); err != nil {
 		return err
 	}
 	// Return if interface is already part of the zone
 	if contains(intfs, intf) {
-		log.G(context.TODO()).Infof("Firewalld: interface %s already part of %s zone, returning", intf, dockerZone)
+		log.G(context.TODO()).Infof("Firewalld: interface %s already part of %s zone, returning", intf, zone)
 		return nil
 	}
 
-	log.G(context.TODO()).Debugf("Firewalld: adding %s interface to %s zone", intf, dockerZone)
+	log.G(context.TODO()).Debugf("Firewalld: adding %s interface to %s zone", intf, zone)
 	// Runtime
-	if err := connection.sysObj.Call(dbusInterface+".zone.addInterface", 0, dockerZone, intf).Err; err != nil {
+	if err := connection.sysObj.Call(dbusInterface+".zone.addInterface", 0, zone, intf).Err; err != nil {
 		return err
 	}
 	return nil
 }
 
-// DelInterfaceFirewalld removes the interface from the trusted zone It is a
-// no-op if firewalld is not running.
-func DelInterfaceFirewalld(intf string) error {
+// DelInterfaceFirewalld removes the interface from the given firewalld zone. If
+// zone is empty, the default "docker" zone is used. It is a no-op if firewalld
+// is not running.
+func DelInterfaceFirewalld(intf, zone string) error {
 	if !firewalldRunning {
 		return nil
+	}
+	if zone == "" {
+		zone = dockerZone
 	}
 
 	var intfs []string
 	// Check if interface is part of the zone
-	if err := connection.sysObj.Call(dbusInterface+".zone.getInterfaces", 0, dockerZone).Store(&intfs); err != nil {
+	if err := connection.sysObj.Call(dbusInterface+".zone.getInterfaces", 0, zone).Store(&intfs); err != nil {
 		return err
 	}
 	// Remove interface if it exists
 	if !contains(intfs, intf) {
-		return &interfaceNotFound{fmt.Errorf("firewalld: interface %q not found in %s zone", intf, dockerZone)}
+		return &interfaceNotFound{fmt.Errorf("firewalld: interface %q not found in %s zone", intf, zone)}
 	}
 
-	log.G(context.TODO()).Debugf("Firewalld: removing %s interface from %s zone", intf, dockerZone)
+	log.G(context.TODO()).Debugf("Firewalld: removing %s interface from %s zone", intf, zone)
 	// Runtime
-	if err := connection.sysObj.Call(dbusInterface+".zone.removeInterface", 0, dockerZone, intf).Err; err != nil {
+	if err := connection.sysObj.Call(dbusInterface+".zone.removeInterface", 0, zone, intf).Err; err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Hi! This is my first PR in this project, hope everything is alright! :slightly_smiling_face: 

**- What I did**

I've added a `firewalld_zone` option for bridge networks, to set a custom firewalld zone when creating the network: `com.docker.network.bridge.firewalld_zone`

Some background can be found in #52642, even if this PR does not solve that particular issue (it addresses the problem where firewalld can be used to filter traffic between Docker networks). 

**- How I did it**

* Added a new bridge label constant for firewalld_zone.
* Extended the bridge network configuration to parse and carry the new option.
* Updated firewalld interface add/remove calls to accept a zone argument and fall back to docker when empty.
* Included the new field in bridge network JSON marshal/unmarshal so it persists across daemon restarts.

**- How to verify it**

1. Start dockerd with firewalld enabled.
2. Create a network with: `docker network create -o com.docker.network.bridge.firewalld_zone=trusted mynet`
3. Confirm the bridge interface is in the trusted zone using `firewall-cmd --list-all-zones`.
4. Create another network without the option and confirm it still uses docker zone.
5. Restart dockerd and confirm that the custom zone assignment still applies for the existing network and that there are no error messages in the daemon log.

**- Human readable description for the release notes**

```markdown changelog
Added support for configuring the firewalld zone per bridge network using com.docker.network.bridge.firewalld_zone.
```

