### PR TITLE
[25.0 backport] daemon: Decompress archives before entering container filesystem

### DIFF
--- a/daemon/archive_unix.go
+++ b/daemon/archive_unix.go
@@ -101,6 +101,17 @@ func (daemon *Daemon) containerExtractToDir(container *container.Container, path
 	container.Lock()
 	defer container.Unlock()
 
+	// Decompress the archive before entering the container filesystem.
+	// DecompressStream may invoke external binaries (xz, unpigz) resolved
+	// via PATH. Running it inside RunInFS would resolve those binaries
+	// from the container filesystem, allowing a malicious container to
+	// execute arbitrary code as host root.
+	decompressed, err := archive.DecompressStream(content)
+	if err != nil {
+		return err
+	}
+	defer decompressed.Close()
+
 	cfs, err := daemon.openContainerFS(container)
 	if err != nil {
 		return err
@@ -150,7 +161,7 @@ func (daemon *Daemon) containerExtractToDir(container *container.Container, path
 			}
 		}
 
-		return archive.Untar(content, absPath, options)
+		return archive.UntarUncompressed(decompressed, absPath, options)
 	})
 	if err != nil {
 		return err

--- a/integration/container/copy_linux_test.go
+++ b/integration/container/copy_linux_test.go
@@ -1,0 +1,89 @@
+package container // import "github.com/docker/docker/integration/container"
+
+import (
+	"archive/tar"
+	"bytes"
+	"os/exec"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/integration/internal/build"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/testutil"
+	"github.com/docker/docker/testutil/daemon"
+	"github.com/docker/docker/testutil/fakecontext"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
+)
+
+// TestCopyToContainerDecompressOnHost verifies that archive decompression
+// happens on the host, not inside the container filesystem.
+//
+// A malicious container could place a trojan binary at /usr/bin/xz. If
+// decompression ran inside RunInFS, dockerd would execute that binary as
+// host root. By decompressing before entering the container FS, we ensure
+// only host binaries are used.
+func TestCopyToContainerDecompressOnHost(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot start daemon on remote test run")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	skip.If(t, testEnv.IsRootless)
+
+	_, err := exec.LookPath("xz")
+	skip.If(t, err != nil, "xz not found in PATH")
+
+	t.Parallel()
+
+	ctx := testutil.StartSpan(baseContext, t)
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t, "--iptables=false")
+	defer d.Stop(t)
+
+	apiClient := d.NewClientT(t)
+
+	buildCtx := fakecontext.New(t, "", fakecontext.WithDockerfile(`
+		FROM busybox
+		RUN printf '#!/bin/sh\ntouch /compromised\n' > /bin/xz && chmod +x /bin/xz
+	`))
+	defer buildCtx.Close()
+
+	imageID := build.Do(ctx, t, apiClient, buildCtx)
+
+	cID := container.Run(ctx, t, apiClient, container.WithImage(imageID), container.WithCmd("sleep", "infinity"))
+	defer apiClient.ContainerRemove(ctx, cID, containertypes.RemoveOptions{Force: true})
+
+	// Create an xz-compressed tar archive containing a single file.
+	var plainTar bytes.Buffer
+	tw := tar.NewWriter(&plainTar)
+	content := []byte("hello world")
+	_ = tw.WriteHeader(&tar.Header{
+		Name: "hello.txt",
+		Mode: 0o644,
+		Size: int64(len(content)),
+	})
+	_, _ = tw.Write(content)
+	_ = tw.Close()
+
+	var xzBuf bytes.Buffer
+	xzCmd := exec.Command("xz", "-z")
+	xzCmd.Stdin = &plainTar
+	xzCmd.Stdout = &xzBuf
+	err = xzCmd.Run()
+	assert.NilError(t, err, "failed to compress tar with xz")
+
+	err = apiClient.CopyToContainer(ctx, cID, "/tmp", &xzBuf, types.CopyToContainerOptions{})
+	assert.NilError(t, err)
+
+	// Verify the file was extracted correctly.
+	execRes, err := container.Exec(ctx, apiClient, cID, []string{"cat", "/tmp/hello.txt"})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(execRes.ExitCode, 0))
+	assert.Check(t, is.Equal(execRes.Stdout(), "hello world"))
+
+	// The malicious /usr/bin/xz inside the container must NOT have been executed.
+	execRes, err = container.Exec(ctx, apiClient, cID, []string{"test", "-f", "/compromised"})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(execRes.ExitCode, 1), "malicious xz binary inside container was executed")
+}

--- a/integration/internal/build/build.go
+++ b/integration/internal/build/build.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -10,6 +11,8 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/testutil/fakecontext"
+	"github.com/gogo/protobuf/proto"
+	controlapi "github.com/moby/buildkit/api/services/control"
 	"gotest.tools/v3/assert"
 )
 
@@ -30,6 +33,7 @@ func Do(ctx context.Context, t *testing.T, client client.APIClient, buildCtx *fa
 // GetImageIDFromBody reads the image ID from the build response body.
 func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 	var id string
+	buf := bytes.NewBuffer(nil)
 	dec := json.NewDecoder(body)
 	for {
 		var jm jsonmessage.JSONMessage
@@ -38,6 +42,19 @@ func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 			break
 		}
 		assert.NilError(t, err)
+
+		if handled := processBuildkitAux(t, &jm, &id); handled {
+			continue
+		}
+
+		buf.Reset()
+		jm.Display(buf, false)
+		if buf.Len() == 0 {
+			continue
+		}
+
+		t.Log(buf.String())
+
 		if jm.Aux == nil {
 			continue
 		}
@@ -48,11 +65,49 @@ func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 				continue
 			}
 			id = br.ID
-			break
+			continue
 		}
+
+		t.Log("Raw Aux", string(*jm.Aux))
 	}
 	_, _ = io.Copy(io.Discard, body)
 
 	assert.Assert(t, id != "", "could not read image ID from build output")
 	return id
+}
+
+func processBuildkitAux(t *testing.T, jm *jsonmessage.JSONMessage, id *string) bool {
+	if jm.ID == "moby.buildkit.trace" {
+		var dt []byte
+		if err := json.Unmarshal(*jm.Aux, &dt); err != nil {
+			t.Log("Error unmarshalling buildkit trace", err)
+			return true
+		}
+		var sr controlapi.StatusResponse
+		if err := proto.Unmarshal(dt, &sr); err != nil {
+			t.Log("Error unmarshalling buildkit trace proto", err)
+			return true
+		}
+		for _, vtx := range sr.GetVertexes() {
+			t.Log(vtx.String())
+		}
+		for _, vtx := range sr.GetStatuses() {
+			t.Log(vtx.String())
+		}
+		for _, vtx := range sr.GetLogs() {
+			t.Log(vtx.String())
+		}
+		for _, vtx := range sr.GetWarnings() {
+			t.Log(vtx.String())
+		}
+		return true
+	}
+	if jm.ID == "moby.image.id" {
+		var br types.BuildResult
+		if err := json.Unmarshal(*jm.Aux, &br); err == nil {
+			*id = br.ID
+			return true
+		}
+	}
+	return false
 }

--- a/integration/internal/build/build.go
+++ b/integration/internal/build/build.go
@@ -29,12 +29,10 @@ func Do(ctx context.Context, t *testing.T, client client.APIClient, buildCtx *fa
 
 // GetImageIDFromBody reads the image ID from the build response body.
 func GetImageIDFromBody(t *testing.T, body io.Reader) string {
-	var (
-		jm  jsonmessage.JSONMessage
-		br  types.BuildResult
-		dec = json.NewDecoder(body)
-	)
+	var id string
+	dec := json.NewDecoder(body)
 	for {
+		var jm jsonmessage.JSONMessage
 		err := dec.Decode(&jm)
 		if err == io.EOF {
 			break
@@ -43,10 +41,18 @@ func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 		if jm.Aux == nil {
 			continue
 		}
-		assert.NilError(t, json.Unmarshal(*jm.Aux, &br))
-		assert.Assert(t, br.ID != "", "could not read image ID from build output")
-		break
+
+		var br types.BuildResult
+		if err := json.Unmarshal(*jm.Aux, &br); err == nil {
+			if br.ID == "" {
+				continue
+			}
+			id = br.ID
+			break
+		}
 	}
-	io.Copy(io.Discard, body)
-	return br.ID
+	_, _ = io.Copy(io.Discard, body)
+
+	assert.Assert(t, id != "", "could not read image ID from build output")
+	return id
 }


### PR DESCRIPTION
- backport: https://github.com/moby/moby/security/advisories/GHSA-x86f-5xw2-fm2r

Move decompression outside RunInFS to prevent executing attacker-controlled binaries from within the container filesystem.

When dockerd handles `PUT /containers/{id}/archive`, it switches root into the container's filesystem before extracting the archive. Previously, archive.Untar was called inside RunInFS, which meant decompression binaries (xz, unpigz) were resolved via PATH inside the container's filesystem. A malicious binary at /usr/bin/xz in the container would be executed as host root.

Fix by calling decompressing the archive before entering the container filesystem, then using unpacking the uncompressed tar stream inside RunInFS.
This ensures decompression binaries are always resolved from the host filesystem.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- fixed CVE-2026-41567
```

**- A picture of a cute animal (not mandatory but encouraged)**

