### PR TITLE
[25.0 backport] daemon/copy: Fix symlink escape in mount destination creation

### DIFF
--- a/daemon/containerfs_linux.go
+++ b/daemon/containerfs_linux.go
@@ -19,7 +19,6 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/internal/mounttree"
 	"github.com/docker/docker/internal/unshare"
-	"github.com/docker/docker/pkg/fileutils"
 )
 
 type future struct {
@@ -83,6 +82,13 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
 			if err := mount.MakeRSlave("/"); err != nil {
 				return err
 			}
+
+			root, err := os.OpenRoot(container.BaseFS)
+			if err != nil {
+				return fmt.Errorf("open container root: %w", err)
+			}
+			defer root.Close()
+
 			for _, m := range mounts {
 				dest, err := container.GetResourcePath(m.Destination)
 				if err != nil {
@@ -94,7 +100,7 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
 				if err != nil {
 					return err
 				}
-				if err := fileutils.CreateIfNotExists(dest, stat.IsDir()); err != nil {
+				if err := createIfNotExists(root, strings.TrimPrefix(m.Destination, "/"), stat.IsDir()); err != nil {
 					return err
 				}
 
@@ -240,6 +246,27 @@ func (vw *containerFSView) Stat(ctx context.Context, path string) (*types.Contai
 		return nil
 	})
 	return stat, err
+}
+
+// createIfNotExists creates a file or a directory only if it does not already exist.
+// The path is scoped to root using [os.Root] to prevent symlink escape attacks.
+func createIfNotExists(root *os.Root, unsafePath string, isDir bool) error {
+	if isDir {
+		return root.MkdirAll(unsafePath, 0o755)
+	}
+
+	parent := filepath.Dir(unsafePath)
+	if parent != "." && parent != "/" {
+		if err := root.MkdirAll(parent, 0o755); err != nil {
+			return err
+		}
+	}
+
+	f, err := root.OpenFile(unsafePath, os.O_CREATE|os.O_WRONLY, 0o755)
+	if err != nil {
+		return err
+	}
+	return f.Close()
 }
 
 // makeMountRRO makes the mount recursively read-only.

--- a/daemon/containerfs_linux_test.go
+++ b/daemon/containerfs_linux_test.go
@@ -1,0 +1,45 @@
+package daemon // import "github.com/docker/docker/daemon"
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCreateIfNotExists(t *testing.T) {
+	t.Run("directory", func(t *testing.T) {
+		dir := t.TempDir()
+		root, err := os.OpenRoot(dir)
+		assert.NilError(t, err)
+		defer root.Close()
+
+		err = createIfNotExists(root, "tocreate", true)
+		assert.NilError(t, err)
+
+		fileinfo, err := os.Stat(filepath.Join(dir, "tocreate"))
+		assert.NilError(t, err, "Did not create destination")
+		assert.Assert(t, fileinfo.IsDir(), "Should have been a dir, seems it's not")
+
+		err = createIfNotExists(root, "tocreate", true)
+		assert.NilError(t, err, "Should not fail if already exists")
+	})
+	t.Run("file", func(t *testing.T) {
+		dir := t.TempDir()
+		root, err := os.OpenRoot(dir)
+		assert.NilError(t, err)
+		defer root.Close()
+
+		err = createIfNotExists(root, "file/to/create", false)
+		assert.NilError(t, err)
+
+		fileinfo, err := os.Stat(filepath.Join(dir, "file/to/create"))
+		assert.NilError(t, err, "Did not create destination")
+
+		assert.Assert(t, !fileinfo.IsDir(), "Should have been a file, but created a directory")
+
+		err = createIfNotExists(root, "file/to/create", false)
+		assert.NilError(t, err, "Should not fail if already exists")
+	})
+}


### PR DESCRIPTION
- backport: https://github.com/moby/moby/security/advisories/GHSA-vp62-88p7-qqf5

Use os.Root to scope all filesystem operations in createIfNotExists to the container root directory.

This prevents a TOCTOU attack where a container process swaps a path component with a symlink between GetResourcePath resolution and directory/file creation, which could allow writing to arbitrary host paths outside the container.