### PR TITLE
daemon: support per-device blkio throttle in ContainerUpdate

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -26,6 +26,13 @@ keywords: "API, Docker, rcli, REST, documentation"
   omitted or `false`, each entry contains only the descriptor and predicate
   type, and statement blobs are not read. The response is a JSON array of
   `AttestationStatement` objects.
+* `POST /containers/{id}/update` now supports per-device blkio resource
+  settings through the `BlkioWeightDevice`, `BlkioDeviceReadBps`,
+  `BlkioDeviceWriteBps`, `BlkioDeviceReadIOps`, and `BlkioDeviceWriteIOps`
+  fields. These fields were previously present in the request schema but were
+  ignored by the daemon. Omit a field or set it to `null` to leave the current
+  per-device rules unchanged. Set it to an empty array to clear the current
+  per-device rules for that resource type.
 
 ## v1.54 API changes
 

--- a/daemon/container/container_unix.go
+++ b/daemon/container/container_unix.go
@@ -269,6 +269,21 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 	if resources.BlkioWeight != 0 {
 		cResources.BlkioWeight = resources.BlkioWeight
 	}
+	if resources.BlkioWeightDevice != nil {
+		cResources.BlkioWeightDevice = resources.BlkioWeightDevice
+	}
+	if resources.BlkioDeviceReadBps != nil {
+		cResources.BlkioDeviceReadBps = resources.BlkioDeviceReadBps
+	}
+	if resources.BlkioDeviceWriteBps != nil {
+		cResources.BlkioDeviceWriteBps = resources.BlkioDeviceWriteBps
+	}
+	if resources.BlkioDeviceReadIOps != nil {
+		cResources.BlkioDeviceReadIOps = resources.BlkioDeviceReadIOps
+	}
+	if resources.BlkioDeviceWriteIOps != nil {
+		cResources.BlkioDeviceWriteIOps = resources.BlkioDeviceWriteIOps
+	}
 	if resources.CPUShares != 0 {
 		cResources.CPUShares = resources.CPUShares
 	}

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -516,8 +516,16 @@ func (c *containerRouter) postContainerUpdate(ctx context.Context, w http.Respon
 	if err := httputils.ReadJSON(r, &updateConfig); err != nil {
 		return err
 	}
-	if versions.LessThan(httputils.VersionFromContext(ctx), "1.40") {
+	version := httputils.VersionFromContext(ctx)
+	if versions.LessThan(version, "1.40") {
 		updateConfig.PidsLimit = nil
+	}
+	if versions.LessThan(version, "1.55") {
+		updateConfig.BlkioWeightDevice = nil
+		updateConfig.BlkioDeviceReadBps = nil
+		updateConfig.BlkioDeviceWriteBps = nil
+		updateConfig.BlkioDeviceReadIOps = nil
+		updateConfig.BlkioDeviceWriteIOps = nil
 	}
 
 	if updateConfig.PidsLimit != nil && *updateConfig.PidsLimit <= 0 {

--- a/daemon/update.go
+++ b/daemon/update.go
@@ -93,7 +93,12 @@ func (daemon *Daemon) update(name string, hostConfig *container.HostConfig) erro
 		return err
 	}
 
-	if err := tsk.UpdateResources(context.TODO(), toContainerdResources(hostConfig.Resources)); err != nil {
+	resources, err := toContainerdResources(hostConfig.Resources)
+	if err != nil {
+		restoreConfig = true
+		return errCannotUpdate(ctr.ID, err)
+	}
+	if err := tsk.UpdateResources(context.TODO(), resources); err != nil {
 		restoreConfig = true
 		// TODO: it would be nice if containerd responded with better errors here so we can classify this better.
 		return errCannotUpdate(ctr.ID, errdefs.System(err))

--- a/daemon/update_linux.go
+++ b/daemon/update_linux.go
@@ -8,13 +8,59 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func toContainerdResources(resources container.Resources) *libcontainerdtypes.Resources {
+func toContainerdResources(resources container.Resources) (*libcontainerdtypes.Resources, error) {
 	var r libcontainerdtypes.Resources
 
-	if resources.BlkioWeight != 0 {
-		r.BlockIO = &specs.LinuxBlockIO{
-			Weight: &resources.BlkioWeight,
+	// little helper to lazily initialize the BlockIO struct only if needed
+	blockIO := func() *specs.LinuxBlockIO {
+		if r.BlockIO == nil {
+			r.BlockIO = &specs.LinuxBlockIO{}
 		}
+		return r.BlockIO
+	}
+
+	weightDevices, err := getBlkioWeightDevices(resources)
+	if err != nil {
+		return nil, err
+	}
+	if resources.BlkioWeightDevice != nil {
+		blockIO().WeightDevice = weightDevices
+	}
+
+	readBpsDevices, err := getBlkioThrottleDevices(resources.BlkioDeviceReadBps)
+	if err != nil {
+		return nil, err
+	}
+	if resources.BlkioDeviceReadBps != nil {
+		blockIO().ThrottleReadBpsDevice = readBpsDevices
+	}
+
+	writeBpsDevices, err := getBlkioThrottleDevices(resources.BlkioDeviceWriteBps)
+	if err != nil {
+		return nil, err
+	}
+	if resources.BlkioDeviceWriteBps != nil {
+		blockIO().ThrottleWriteBpsDevice = writeBpsDevices
+	}
+
+	readIOpsDevices, err := getBlkioThrottleDevices(resources.BlkioDeviceReadIOps)
+	if err != nil {
+		return nil, err
+	}
+	if resources.BlkioDeviceReadIOps != nil {
+		blockIO().ThrottleReadIOPSDevice = readIOpsDevices
+	}
+
+	writeIOpsDevices, err := getBlkioThrottleDevices(resources.BlkioDeviceWriteIOps)
+	if err != nil {
+		return nil, err
+	}
+	if resources.BlkioDeviceWriteIOps != nil {
+		blockIO().ThrottleWriteIOPSDevice = writeIOpsDevices
+	}
+
+	if resources.BlkioWeight != 0 {
+		blockIO().Weight = &resources.BlkioWeight
 	}
 
 	cpu := specs.LinuxCPU{
@@ -68,5 +114,5 @@ func toContainerdResources(resources container.Resources) *libcontainerdtypes.Re
 	}
 
 	r.Pids = getPidsLimit(resources)
-	return &r
+	return &r, nil
 }

--- a/daemon/update_linux_test.go
+++ b/daemon/update_linux_test.go
@@ -7,5 +7,9 @@ import (
 )
 
 func TestToContainerdResources_Defaults(t *testing.T) {
-	checkResourcesAreUnset(t, toContainerdResources(container.Resources{}))
+	r, err := toContainerdResources(container.Resources{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkResourcesAreUnset(t, r)
 }

--- a/daemon/update_windows.go
+++ b/daemon/update_windows.go
@@ -5,7 +5,7 @@ import (
 	libcontainerdtypes "github.com/moby/moby/v2/daemon/internal/libcontainerd/types"
 )
 
-func toContainerdResources(resources container.Resources) *libcontainerdtypes.Resources {
+func toContainerdResources(resources container.Resources) (*libcontainerdtypes.Resources, error) {
 	// We don't support update, so do nothing
-	return nil
+	return nil, nil
 }

--- a/integration/container/update_linux_test.go
+++ b/integration/container/update_linux_test.go
@@ -2,16 +2,20 @@ package container
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/moby/moby/api/types/blkiodev"
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/request"
+	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
@@ -212,4 +216,121 @@ func TestUpdatePidsLimit(t *testing.T) {
 			assert.Equal(t, out, test.expectCg)
 		})
 	}
+}
+
+// blkioTestDevice finds a usable block device on the host by examining the
+// device backing the root filesystem.  The returned path (e.g. "/dev/sda")
+// and the decimal major:minor string are suitable for docker update flags and
+// cgroup file lookups respectively.
+func blkioTestDevice(t *testing.T) (devPath, majMin string) {
+	t.Helper()
+
+	var st unix.Stat_t
+	assert.NilError(t, unix.Stat("/", &st), "stat /")
+
+	major := unix.Major(st.Dev)
+	minor := unix.Minor(st.Dev)
+
+	// Resolve the device name via sysfs so we get a real /dev/… path.
+	uevent, err := os.ReadFile(fmt.Sprintf("/sys/dev/block/%d:%d/uevent", major, minor))
+	if err != nil {
+		t.Skipf("cannot resolve block device for / from sysfs: %v", err)
+	}
+	var name string
+	for _, line := range strings.Split(string(uevent), "\n") {
+		if after, ok := strings.CutPrefix(line, "DEVNAME="); ok {
+			name = strings.TrimSpace(after)
+			break
+		}
+	}
+	if name == "" {
+		t.Skip("DEVNAME not found in sysfs uevent for / block device")
+	}
+	return "/dev/" + name, fmt.Sprintf("%d:%d", major, minor)
+}
+
+// parseIOMax returns the value of field (rbps/wbps/riops/wiops) for the given
+// major:minor device from a cgroup v2 io.max file content.
+func parseIOMax(content, majMin, field string) string {
+	for _, line := range strings.Split(content, "\n") {
+		if !strings.HasPrefix(line, majMin+" ") {
+			continue
+		}
+		for _, part := range strings.Fields(line[len(majMin)+1:]) {
+			if k, v, ok := strings.Cut(part, "="); ok && k == field {
+				return v
+			}
+		}
+	}
+	return ""
+}
+
+// TestUpdateBlkioThrottleDevices verifies that docker update correctly applies
+// per-device blkio throttle limits to the container's cgroup.
+//
+// On cgroup v2 the limits are reflected in /sys/fs/cgroup/io.max inside the
+// container.  On cgroup v1 only the API-level values are verified (the blkio
+// throttle files are not bind-mounted into the container namespace).
+func TestUpdateBlkioThrottleDevices(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	skip.If(t, testEnv.DaemonInfo.CgroupDriver == "none")
+
+	devPath, majMin := blkioTestDevice(t)
+
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	cID := container.Run(ctx, t, apiClient)
+
+	const (
+		readBps   uint64 = 5 * 1024 * 1024 // 5 MiB/s
+		writeBps  uint64 = 2 * 1024 * 1024 // 2 MiB/s
+		readIops  uint64 = 100
+		writeIops uint64 = 50
+	)
+
+	_, err := apiClient.ContainerUpdate(ctx, cID, client.ContainerUpdateOptions{
+		Resources: &containertypes.Resources{
+			BlkioDeviceReadBps:   []*blkiodev.ThrottleDevice{{Path: devPath, Rate: readBps}},
+			BlkioDeviceWriteBps:  []*blkiodev.ThrottleDevice{{Path: devPath, Rate: writeBps}},
+			BlkioDeviceReadIOps:  []*blkiodev.ThrottleDevice{{Path: devPath, Rate: readIops}},
+			BlkioDeviceWriteIOps: []*blkiodev.ThrottleDevice{{Path: devPath, Rate: writeIops}},
+		},
+	})
+	assert.NilError(t, err)
+
+	// Verify API-level values are persisted.
+	inspect, err := apiClient.ContainerInspect(ctx, cID, client.ContainerInspectOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, is.Len(inspect.Container.HostConfig.BlkioDeviceReadBps, 1))
+	assert.Check(t, is.Equal(inspect.Container.HostConfig.BlkioDeviceReadBps[0].Rate, readBps))
+	assert.Assert(t, is.Len(inspect.Container.HostConfig.BlkioDeviceWriteBps, 1))
+	assert.Check(t, is.Equal(inspect.Container.HostConfig.BlkioDeviceWriteBps[0].Rate, writeBps))
+	assert.Assert(t, is.Len(inspect.Container.HostConfig.BlkioDeviceReadIOps, 1))
+	assert.Check(t, is.Equal(inspect.Container.HostConfig.BlkioDeviceReadIOps[0].Rate, readIops))
+	assert.Assert(t, is.Len(inspect.Container.HostConfig.BlkioDeviceWriteIOps, 1))
+	assert.Check(t, is.Equal(inspect.Container.HostConfig.BlkioDeviceWriteIOps[0].Rate, writeIops))
+
+	// On cgroup v2 verify the limits landed in io.max inside the container.
+	if testEnv.DaemonInfo.CgroupVersion != "2" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	res, err := container.Exec(ctx, apiClient, cID, []string{"cat", "/sys/fs/cgroup/io.max"})
+	assert.NilError(t, err)
+	assert.Assert(t, is.Len(res.Stderr(), 0))
+	assert.Equal(t, 0, res.ExitCode)
+
+	ioMax := res.Stdout()
+	assert.Check(t, is.Equal(parseIOMax(ioMax, majMin, "rbps"), strconv.FormatUint(readBps, 10)),
+		"io.max rbps for %s (io.max content: %q)", majMin, ioMax)
+	assert.Check(t, is.Equal(parseIOMax(ioMax, majMin, "wbps"), strconv.FormatUint(writeBps, 10)),
+		"io.max wbps for %s (io.max content: %q)", majMin, ioMax)
+	assert.Check(t, is.Equal(parseIOMax(ioMax, majMin, "riops"), strconv.FormatUint(readIops, 10)),
+		"io.max riops for %s (io.max content: %q)", majMin, ioMax)
+	assert.Check(t, is.Equal(parseIOMax(ioMax, majMin, "wiops"), strconv.FormatUint(writeIops, 10)),
+		"io.max wiops for %s (io.max content: %q)", majMin, ioMax)
 }


### PR DESCRIPTION
Disclaimer: This was done with the help of Claude Sonnet 4.6.

But I've reviewed and tested manually the change.

## Description

`POST /containers/{id}/update` accepts `BlkioWeightDevice`, `BlkioDeviceReadBps`, `BlkioDeviceWriteBps`, `BlkioDeviceReadIOps`, and `BlkioDeviceWriteIOps` in its `Resources` body, but these five fields were silently ignored — the API returns 200 OK but nothing is written to cgroupv2 `io.max` or the cgroupv1 blkio throttle files.

Fixes #52650.

## Root cause

`toContainerdResources` in `daemon/update_linux.go` only mapped `BlkioWeight` into `specs.LinuxBlockIO`; the per-device fields were never converted so `tsk.UpdateResources` had nothing to apply:

```go
// before
if resources.BlkioWeight != 0 {
    r.BlockIO = &specs.LinuxBlockIO{
        Weight: &resources.BlkioWeight,
        // WeightDevice, ThrottleRead/WriteBpsDevice, ThrottleRead/WriteIOPSDevice — missing
    }
}
```

## Fix

Call the existing `getBlkioWeightDevices` and `getBlkioThrottleDevices` helpers (already used in `oci_linux.go` for container creation) to populate all five fields. The function signature gains an `error` return so that `stat(2)` failures on invalid device paths are surfaced to the caller rather than being silently dropped.

The Windows stub is updated to match the new signature.

## Testing

Verified with a manual test against a running container on cgroupv2 (Colima / Ubuntu 24.04):
```bash
# before this fix — io.max is empty after ContainerUpdate with BlkioDeviceReadBps
# after this fix — io.max contains the throttle entry, e.g.:
# 8:0 rbps=5242880 wbps=max riops=max wiops=max
```



```markdown changelog
`POST /containers/{id}/update` now supports per-device blkio resource settings.
```