### PR TITLE
daemon: resolve in-container symlinks before os.Root mount ops

### DIFF
--- a/daemon/containerfs_linux.go
+++ b/daemon/containerfs_linux.go
@@ -100,10 +100,16 @@ func (daemon *Daemon) openContainerFS(ctr *container.Container) (_ *containerFSV
 
 			// TODO(vvoland): Refactor this after security release.
 			for _, m := range mounts {
-				// Destination is an absolute path within container
-				// filesystem. For the os.Root to work, we need to convert it
-				// to a path relative to root fs /
-				relDest, err := filepath.Rel("/", m.Destination)
+				// Walk m.Destination through the container's symlinks before
+				// passing it to os.Root, which refuses absolute symlinks
+				// (e.g. the common /var/run -> /run). The resolution itself
+				// is lexical; subsequent os.Root operations still enforce
+				// the GHSA-vp62-88p7-qqf5 / GHSA-rg2x-37c3-w2rh protections.
+				resolved, err := ctr.GetResourcePath(m.Destination)
+				if err != nil {
+					return fmt.Errorf("resolve mount destination %q: %w", m.Destination, err)
+				}
+				relDest, err := filepath.Rel(ctr.BaseFS, resolved)
 				if err != nil {
 					return fmt.Errorf("make destination relative: %w", err)
 				}

--- a/integration/container/copy_linux_test.go
+++ b/integration/container/copy_linux_test.go
@@ -1,0 +1,66 @@
+package container
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mounttypes "github.com/moby/moby/api/types/mount"
+	"github.com/moby/moby/client"
+	"github.com/moby/moby/v2/integration/internal/build"
+	"github.com/moby/moby/v2/integration/internal/container"
+	"github.com/moby/moby/v2/internal/testutil"
+	"github.com/moby/moby/v2/internal/testutil/fakecontext"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/skip"
+)
+
+// TestCopyWithAbsoluteSymlinkedMountTarget was introduced as a regression test
+// for https://github.com/moby/moby/issues/52653.
+//
+// The security fix in GHSA-vp62-88p7-qqf5 switched openContainerFS to use
+// os.Root for the mount-destination operations.
+// os.Root refuses to follow absolute symlinks, but distro images commonly ship
+// /var/run as an absolute symlink to /run.
+// As a result, any container with a bind mount whose target traversed such a
+// symlink (e.g. -v /host/sock:/var/run/docker.sock) made `docker cp` fail.
+func TestCopyWithAbsoluteSymlinkedMountTarget(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	// Build an image with an absolute in-container symlink along the mount
+	// target path.
+	// Stock distro images expose this shape via /var/run -> /run, but we set
+	// up our own /sockets -> /root pair so the test does not depend on any
+	// particular base image's layout.
+	buildCtx := fakecontext.New(t, "",
+		fakecontext.WithDockerfile(`FROM busybox
+RUN touch /root/nil && ln -s /root /sockets
+`),
+	)
+	defer buildCtx.Close()
+	imgID := build.Do(ctx, t, apiClient, buildCtx, client.ImageBuildOptions{})
+
+	// Use testutil.TempDir so the rootless daemon can access the bind-mount
+	// source: t.TempDir() creates a 0700 parent that the fake-root user
+	// cannot stat.
+	srcDir := testutil.TempDir(t)
+	assert.NilError(t, os.WriteFile(filepath.Join(srcDir, "sock"), nil, 0o644))
+
+	cid := container.Create(ctx, t, apiClient,
+		container.WithImage(imgID),
+		container.WithMount(mounttypes.Mount{
+			Type:   mounttypes.TypeBind,
+			Source: filepath.Join(srcDir, "sock"),
+			Target: "/sockets/docker.sock",
+		}),
+	)
+
+	_, err := apiClient.CopyToContainer(ctx, cid, client.CopyToContainerOptions{
+		DestinationPath: "/sockets/",
+		Content:         bytes.NewReader(nil),
+	})
+	assert.NilError(t, err)
+}


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/52653

The security fix in GHSA-vp62-88p7-qqf5 switched openContainerFS to os.Root for mount-destination operations, but stopped walking the destination through in-container symlinks.

os.Root refuses to follow absolute symlinks, so any container whose image had an absolute symlink along the mount target's path (e.g. the common /var/run -> /run in ubuntu/alpine/busybox) broke `docker cp`.

Walk m.Destination through ctr.GetResourcePath first which follows symlinks to get a path relative to BaseFS, then keep using os.Root for the actual MkdirAll/OpenFile/Open calls.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix `docker cp` failing with "mkdirat: file exists" when a container has a bind mount whose target traverses an in-container symlink (e.g. `/var/run -> /run`).
```

**- A picture of a cute animal (not mandatory but encouraged)**

