### PR TITLE
[25.0 backport] Fix bind mount target redirection via symlink swap during docker cp

### DIFF
--- a/daemon/containerfs_linux.go
+++ b/daemon/containerfs_linux.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
+	"strconv"
 
 	"github.com/containerd/log"
 	"github.com/hashicorp/go-multierror"
@@ -89,10 +89,14 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
 			}
 			defer root.Close()
 
+			// TODO(vvoland): Refactor this after security release.
 			for _, m := range mounts {
-				dest, err := container.GetResourcePath(m.Destination)
+				// Destination is an absolute path within container
+				// filesystem. For the os.Root to work, we need to convert it
+				// to a path relative to root fs /
+				relDest, err := filepath.Rel("/", m.Destination)
 				if err != nil {
-					return err
+					return fmt.Errorf("make destination relative: %w", err)
 				}
 
 				var stat os.FileInfo
@@ -100,7 +104,7 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
 				if err != nil {
 					return err
 				}
-				if err := createIfNotExists(root, strings.TrimPrefix(m.Destination, "/"), stat.IsDir()); err != nil {
+				if err := createIfNotExists(root, relDest, stat.IsDir()); err != nil {
 					return err
 				}
 
@@ -108,9 +112,7 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
 				if m.NonRecursive {
 					bindMode = "bind"
 				}
-				writeMode := "ro"
 				if m.Writable {
-					writeMode = "rw"
 					if m.ReadOnlyNonRecursive {
 						return errors.New("options conflict: Writable && ReadOnlyNonRecursive")
 					}
@@ -120,6 +122,37 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
 				}
 				if m.ReadOnlyNonRecursive && m.ReadOnlyForceRecursive {
 					return errors.New("options conflict: ReadOnlyNonRecursive && ReadOnlyForceRecursive")
+				}
+
+				// Open the mount target through os.Root so we have a
+				// file descriptor pinning the resolved inode. Using
+				// /proc/self/fd/<fd> as the mount target prevents any
+				// subsequent symlink swap from redirecting the mount.
+				targetFile, err := root.Open(relDest)
+				if err != nil {
+					return fmt.Errorf("open mount target %q: %w", m.Destination, err)
+				}
+				targetPath := "/proc/self/fd/" + strconv.FormatUint(uint64(targetFile.Fd()), 10)
+
+				// The kernel rejects remount and propagation-change syscalls
+				// when the target is a /proc/self/fd path. Only the initial
+				// bind mount works on such paths, so we perform that via the
+				// fd path for TOCTOU safety and then resolve the real path for
+				// the read-only remount and propagation change.
+				if err := mount.Mount(m.Source, targetPath, "", bindMode); err != nil {
+					targetFile.Close()
+					return err
+				}
+				realPath, err := os.Readlink(targetPath)
+				if err != nil {
+					targetFile.Close()
+					return fmt.Errorf("readlink %s: %w", targetPath, err)
+				}
+				if !m.Writable {
+					if err := mount.Mount("", realPath, "", "ro,remount,bind"); err != nil {
+						targetFile.Close()
+						return err
+					}
 				}
 
 				// openContainerFS() is called for temporary mounts
@@ -132,20 +165,21 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
 				// all these mounts rprivate.  Do not use propagation
 				// property of volume as that should apply only when
 				// mounting happens inside the container.
-				opts := strings.Join([]string{bindMode, writeMode, "rprivate"}, ",")
-				if err := mount.Mount(m.Source, dest, "", opts); err != nil {
+				if err := mount.MakeRPrivate(realPath); err != nil {
+					targetFile.Close()
 					return err
 				}
 
 				if !m.Writable && !m.ReadOnlyNonRecursive {
-					if err := makeMountRRO(dest); err != nil {
+					if err := makeMountRRO(realPath); err != nil {
+						targetFile.Close()
 						if m.ReadOnlyForceRecursive {
 							return err
-						} else {
-							log.G(context.TODO()).WithError(err).Debugf("Failed to make %q recursively read-only", dest)
 						}
+						log.G(context.TODO()).WithError(err).Debugf("Failed to make %q recursively read-only", m.Destination)
 					}
 				}
+				targetFile.Close()
 			}
 
 			return mounttree.SwitchRoot(container.BaseFS)

--- a/daemon/containerfs_linux.go
+++ b/daemon/containerfs_linux.go
@@ -91,10 +91,16 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
 
 			// TODO(vvoland): Refactor this after security release.
 			for _, m := range mounts {
-				// Destination is an absolute path within container
-				// filesystem. For the os.Root to work, we need to convert it
-				// to a path relative to root fs /
-				relDest, err := filepath.Rel("/", m.Destination)
+				// Walk m.Destination through the container's symlinks before
+				// passing it to os.Root, which refuses absolute symlinks
+				// (e.g. the common /var/run -> /run). The resolution itself
+				// is lexical; subsequent os.Root operations still enforce
+				// the GHSA-vp62-88p7-qqf5 / GHSA-rg2x-37c3-w2rh protections.
+				resolved, err := container.GetResourcePath(m.Destination)
+				if err != nil {
+					return fmt.Errorf("resolve mount destination %q: %w", m.Destination, err)
+				}
+				relDest, err := filepath.Rel(container.BaseFS, resolved)
 				if err != nil {
 					return fmt.Errorf("make destination relative: %w", err)
 				}

--- a/integration/container/copy_linux_test.go
+++ b/integration/container/copy_linux_test.go
@@ -3,11 +3,14 @@ package container // import "github.com/docker/docker/integration/container"
 import (
 	"archive/tar"
 	"bytes"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
+	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/integration/internal/build"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/testutil"
@@ -86,4 +89,50 @@ func TestCopyToContainerDecompressOnHost(t *testing.T) {
 	execRes, err = container.Exec(ctx, apiClient, cID, []string{"test", "-f", "/compromised"})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(execRes.ExitCode, 1), "malicious xz binary inside container was executed")
+}
+
+// TestCopyWithAbsoluteSymlinkedMountTarget was introduced as a regression test
+// for https://github.com/moby/moby/issues/52653.
+//
+// The security fix in GHSA-vp62-88p7-qqf5 switched openContainerFS to use
+// os.Root for the mount-destination operations.
+// os.Root refuses to follow absolute symlinks, but distro images commonly ship
+// /var/run as an absolute symlink to /run.
+// As a result, any container with a bind mount whose target traversed such a
+// symlink (e.g. -v /host/sock:/var/run/docker.sock) made `docker cp` fail.
+func TestCopyWithAbsoluteSymlinkedMountTarget(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	// Build an image with an absolute in-container symlink along the mount
+	// target path.
+	// Stock distro images expose this shape via /var/run -> /run, but we set
+	// up our own /sockets -> /root pair so the test does not depend on any
+	// particular base image's layout.
+	buildCtx := fakecontext.New(t, "",
+		fakecontext.WithDockerfile(`FROM busybox
+RUN touch /root/nil && ln -s /root /sockets
+`),
+	)
+	defer buildCtx.Close()
+	imgID := build.Do(ctx, t, apiClient, buildCtx)
+
+	// Use testutil.TempDir so the rootless daemon can access the bind-mount
+	// source: t.TempDir() creates a 0700 parent that the fake-root user
+	// cannot stat.
+	srcDir := testutil.TempDir(t)
+	assert.NilError(t, os.WriteFile(filepath.Join(srcDir, "sock"), nil, 0o644))
+
+	cid := container.Create(ctx, t, apiClient,
+		container.WithImage(imgID),
+		container.WithMount(mounttypes.Mount{
+			Type:   mounttypes.TypeBind,
+			Source: filepath.Join(srcDir, "sock"),
+			Target: "/sockets/docker.sock",
+		}),
+	)
+
+	err := apiClient.CopyToContainer(ctx, cid, "/sockets/", bytes.NewReader(nil), types.CopyToContainerOptions{})
+	assert.NilError(t, err)
 }


### PR DESCRIPTION
- backport: https://github.com/advisories/GHSA-rg2x-37c3-w2rh
- backport: #52655

Pin mount targets via /proc/self/fd file descriptors to prevent TOCTOU attacks.

Previously, a container process could swap a path component with a symlink between GetResourcePath resolution and directory/file creation or mount, allowing writes to arbitrary host paths outside the container.

Open the resolved destination through os.Root to get a pinned fd, then mount onto /proc/self/fd/<fd> instead of re-resolving the container-relative path. This closes the TOCTOU window between createIfNotExists and mount.

Because the kernel rejects remount and propagation-change syscalls on /proc/self/fd paths, the initial bind mount uses the fd path for safety, then Readlink resolves the real path for the subsequent read-only remount and rprivate propagation change.


(cherry picked from commit 43fa458a9c40873867e75221454de10709b04236)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- fixed CVE-2026-42306
```

**- A picture of a cute animal (not mandatory but encouraged)**

