### PR TITLE
networkdb: fix bulkSyncNode race

### DIFF
--- a/daemon/libnetwork/networkdb/cluster.go
+++ b/daemon/libnetwork/networkdb/cluster.go
@@ -11,6 +11,7 @@ import (
 	"net/netip"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/containerd/log"
@@ -598,6 +599,15 @@ func (nDB *NetworkDB) bulkSync(nodes []string, all bool) ([]string, error) {
 // single peer node. It can be unsolicited or can be in response to an
 // unsolicited bulk sync
 func (nDB *NetworkDB) bulkSyncNode(networks []string, node string, unsolicited bool) error {
+	// Only one bulkSyncNode call per target node at a time. Without
+	// this, concurrent calls race to write bulkSyncAckTbl[node] and
+	// the losers' channels never get closed, so they sit around for
+	// 30s waiting for an ack that won't come.
+	// https://github.com/moby/moby/issues/51701
+	mu, _ := nDB.bulkSyncNodeMu.LoadOrStore(node, &sync.Mutex{})
+	mu.(*sync.Mutex).Lock()
+	defer mu.(*sync.Mutex).Unlock()
+
 	var msgs [][]byte
 
 	var unsolMsg string

--- a/daemon/libnetwork/networkdb/networkdb.go
+++ b/daemon/libnetwork/networkdb/networkdb.go
@@ -83,6 +83,10 @@ type NetworkDB struct {
 	// waiting for an ack.
 	bulkSyncAckTbl map[string]chan struct{}
 
+	// Guards bulkSyncNode so only one call per target node runs
+	// at a time. See bulkSyncNode for why this matters.
+	bulkSyncNodeMu sync.Map
+
 	// Broadcast queue for network event gossip.
 	networkBroadcasts *memberlist.TransmitLimitedQueue
 

--- a/daemon/libnetwork/networkdb/networkdb_test.go
+++ b/daemon/libnetwork/networkdb/networkdb_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"text/tabwriter"
@@ -17,6 +18,7 @@ import (
 	"github.com/docker/go-events"
 	"github.com/hashicorp/memberlist"
 	"github.com/moby/moby/v2/daemon/internal/stringid"
+	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/poll"
@@ -462,6 +464,88 @@ func TestNetworkDBBulkSync(t *testing.T) {
 	}
 
 	closeNetworkDBInstances(t, dbs)
+}
+
+// logrus hook that counts entries whose message contains substr.
+type timeoutCounter struct {
+	substr string
+	count  atomic.Int32
+}
+
+func (h *timeoutCounter) Levels() []logrus.Level { return logrus.AllLevels }
+
+func (h *timeoutCounter) Fire(entry *logrus.Entry) error {
+	if strings.Contains(entry.Message, h.substr) {
+		h.count.Add(1)
+	}
+	return nil
+}
+
+// Regression test for https://github.com/moby/moby/issues/51701
+//
+// Fires 4 concurrent bulkSyncNode calls at the same target. Without
+// the per-node mutex, all but the last caller's ack channel gets
+// overwritten in bulkSyncAckTbl and never closed, so those callers
+// sit for 30s each waiting for nothing.
+//
+// We hook into logrus and count "timed out" messages instead of using
+// a wall-clock deadline, so this fails deterministically on broken
+// code even if the Go test timeout is long enough.
+func TestBulkSyncNodeConcurrent(t *testing.T) {
+	hook := &timeoutCounter{substr: "timed out"}
+	logrus.StandardLogger().AddHook(hook)
+	origHooks := logrus.StandardLogger().Hooks
+	t.Cleanup(func() { logrus.StandardLogger().ReplaceHooks(origHooks) })
+
+	dbs := createNetworkDBInstances(t, 2, "node", DefaultConfig())
+	defer closeNetworkDBInstances(t, dbs)
+
+	err := dbs[0].JoinNetwork("network1")
+	assert.NilError(t, err)
+
+	dbs[1].verifyNetworkExistence(t, dbs[0].config.NodeID, "network1", true)
+
+	err = dbs[1].JoinNetwork("network1")
+	assert.NilError(t, err)
+
+	dbs[0].verifyNetworkExistence(t, dbs[1].config.NodeID, "network1", true)
+
+	for i := range 50 {
+		err = dbs[0].CreateEntry("test_table", "network1",
+			fmt.Sprintf("key%d", i),
+			fmt.Appendf(nil, "val%d", i))
+		assert.NilError(t, err)
+	}
+
+	const N = 4
+	start := make(chan struct{})
+	errs := make([]error, N)
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := range N {
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			errs[idx] = dbs[1].bulkSyncNode(
+				[]string{"network1"}, dbs[0].config.NodeID, true)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NilError(t, err, "bulkSyncNode call %d", i)
+	}
+
+	// No bulk sync should have timed out. On broken code this is N-1.
+	assert.Equal(t, hook.count.Load(), int32(0),
+		"expected 0 bulk sync timeouts, but some ack channels were orphaned")
+
+	dbs[1].RLock()
+	remaining := len(dbs[1].bulkSyncAckTbl)
+	dbs[1].RUnlock()
+	assert.Equal(t, remaining, 0,
+		"bulkSyncAckTbl should be empty after all syncs complete")
 }
 
 func TestNetworkDBCRUDMediumCluster(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed a race condition in `bulkSyncNode` where concurrent calls targeting the same peer overwrite each other's `ack` channel in `nDB.bulkSyncAckTbl`. The channels never get closed, so the callers block for 30 seconds waiting. In practice this delays DNS resolution on newly joined swarm worker nodes by ~30s.

Fixes #51701
Fixes #47396
Fixes #41524
**- How I did it**

Added a per-node mutex (`sync.Map` of `*sync.Mutex`) that serializes `bulkSyncNode` calls to the same target. Concurrent syncs to different peers remain parallel. The lock is acquired at the top of `bulkSyncNode` and released on return, thus only one goroutine at a time can write to `bulkSyncAckTbl` for a selected node.

files changed:
- `daemon/libnetwork/networkdb/networkdb.go` — new `bulkSyncNodeMu sync.Map` field
- `daemon/libnetwork/networkdb/cluster.go` — lock/unlock at entry of `bulkSyncNode`
- `daemon/libnetwork/networkdb/networkdb_test.go` — add regression test

:robot: disclosure: AI `perplexity "deep research"` was used to facilitate the creation of this PR 

**- How to verify it**
`make test-unit TESTDIRS=./daemon/libnetwork/networkdb/ TESTFLAGS="-run TestBulkSyncNodeConcurrent"`

The test execs 4 concurrent `bulkSyncNode` calls at the same target and asserts that no "timed out" log messages appear. Without the fix the test should fail (orphaned channels produce timeouts). With the fix all calls complete in sequence without any timeout.

We are running a custom build of `dockerd` including this fix for some days and have not seen the bug occur so far (usually it happens >1 times per day, as observable in the characteristic "bulk sync timed out' logline in the docker syslogs, see assoc. bug tickets)

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fixed a race condition in overlay network bulk sync that caused ~30s DNS resolution delays on newly joined swarm nodes.
```

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="255" height="303" alt="image" src="https://github.com/user-attachments/assets/b1539a7e-536f-4d89-9996-625f20f8f80c" />

