### PR TITLE
c8d: tolerate NotFound when walking children for disk usage

### DIFF
--- a/daemon/containerd/handlers.go
+++ b/daemon/containerd/handlers.go
@@ -25,7 +25,7 @@ func presentChildrenHandler(store content.Store, h c8dimages.HandlerFunc) c8dima
 		_, err := store.Info(ctx, desc.Digest)
 		if err != nil {
 			if cerrdefs.IsNotFound(err) {
-				return nil, nil
+				return nil, c8dimages.ErrSkipDesc
 			}
 			return nil, err
 		}
@@ -37,6 +37,9 @@ func presentChildrenHandler(store content.Store, h c8dimages.HandlerFunc) c8dima
 
 		c, err := c8dimages.Children(ctx, store, desc)
 		if err != nil {
+			if cerrdefs.IsNotFound(err) {
+				return nil, c8dimages.ErrSkipDesc
+			}
 			return nil, err
 		}
 		children = append(children, c...)


### PR DESCRIPTION
When `docker system df` runs concurrently with image prune, a blob can be removed between presentChildrenHandler's store.Info check and the c8dimages.Children call that reads it, failing the API with "NotFound: content digest sha256:...: not found".

PR #51979 fixed the same race in the snapshotter path; this handles it in the content-store walk. Treat NotFound from c8dimages.Children like the store.Info NotFound branch above it: the content is gone, so it has no children. Other errors still propagate.

Fixes #52538


```markdown changelog
Reduce `docker system df` errors when images are pruned at the same time with the containerd image store.
```