### PR TITLE
releases: Clarify last released Docker version

### DIFF
--- a/releases/versions.yaml
+++ b/releases/versions.yaml
@@ -1,4 +1,4 @@
 ---
 docker:
-  current: "29.5.2"
+  last: "29.5.2"
   next: "29.5.3"


### PR DESCRIPTION
### releases: Clarify last released Docker version

  Rename the release metadata key from current to last so it describes the version it stores more accurately.

  The value represents the most recent completed Docker release, while next continues to track the upcoming release.