### PR TITLE
renovate: Add release-age cooldown

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,8 @@
     ":gitSignOff"
   ],
   "postUpdateOptions": ["gomodTidy"],
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
### renovate: Add release-age cooldown

  Delay regular dependency updates until releases are at least 3 days old, using strict internal checks so Renovate waits before creating branches or PRs.