### PR TITLE
rootless: fix detach-netns mode setup

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -240,7 +240,7 @@ else
 	netns="/proc/self/ns/net"
 	case "$DOCKERD_ROOTLESS_ROOTLESSKIT_DETACH_NETNS" in
 		1 | true)
-			netns="$ROOTLESSKIT_STATE_DIR/netns"
+			netns="$DOCKERD_ROOTLESS_ROOTLESSKIT_STATE_DIR/netns"
 			;;
 	esac
 	# When running with --firewall-backend=nftables, IP forwarding needs to be enabled


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Environment: Ubuntu 24.04.3, Docker v29.5.0~v29.5.2 (rootless)

I encountered a problem that, on rootless with detach-netns and enable-host-looback, cannot connect from container to host (`10.0.2.2`).

**- What I did**

Fixed detach-netns setup in `dockerd-rootless.sh`.

**- How I did it**

https://github.com/moby/moby/blob/3e4638b7c8e7a2b22a4555f152e3e02ae8330738/contrib/dockerd-rootless.sh#L243

`ROOTLESSKIT_STATE_DIR` is an "unsourced" variable here, in fact this is unset in default systemd conf so `netns` is set to `/netns` invalid value.
For consistency in a whole script, should use `DOCKERD_ROOTLESS_ROOTLESSKIT_STATE_DIR` instead of `ROOTLESSKIT_STATE_DIR`.

**- How to verify it**

Replaced `ROOTLESSKIT_STATE_DIR` with `DOCKERD_ROOTLESS_ROOTLESSKIT_STATE_DIR` and restart docker, and confirmed connect from container to host `10.0.2.2`.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fixed rootless detach-netns setup; especially a behavior with enable-host-loopback.
```

**- A picture of a cute animal (not mandatory but encouraged)**

