### PR TITLE
man: document dockerd --firewall-backend

### DIFF
--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -32,6 +32,7 @@ dockerd - Enable daemon mode
 [**--exec-root**[=*/var/run/docker*]]
 [**--experimental**[=**false**]]
 [**--feature**[=*NAME*[=**true**|**false**]]
+[**--firewall-backend**[=*BACKEND*]]
 [**--fixed-cidr**[=*FIXED-CIDR*]]
 [**--fixed-cidr-v6**[=*FIXED-CIDR-V6*]]
 [**-G**|**--group**[=*docker*]]
@@ -222,6 +223,9 @@ Bridge networks will accept packets with this firewall mark/mask.
   file produces an error. The feature option can be specified multiple times
   to configure multiple features.
   Usage example: `--feature containerd-snapshotter` or `--feature containerd-snapshotter=true`.
+
+**--firewall-backend**=""
+  Firewall backend to use, iptables or nftables.
 
 **--fixed-cidr**=""
   IPv4 subnet for the default bridge network (e.g., 10.20.0.0/16); this


### PR DESCRIPTION
## Description

Documents the `--firewall-backend` daemon option in the `dockerd` manual page.

The option is listed by `dockerd --help`, but was missing from `man dockerd`.

Fixes #52695

## Testing

- `git diff --check`
- `rg -n "firewall-backend" man/dockerd.8.md`