### PR TITLE
libnetwork/overlay: continue neighbor cleanup after FDB delete failure

### DIFF
--- a/daemon/libnetwork/drivers/overlay/peerdb.go
+++ b/daemon/libnetwork/drivers/overlay/peerdb.go
@@ -195,7 +195,7 @@ func (n *network) peerDelete(eid string, peerIP netip.Prefix, peerMac hashable.M
 		logger.Warn("Peer entry was not in db")
 	}
 	if vtep.IsValid() {
-		err := n.deleteNeighbor(peerIP, peerMac, vtep)
+		err := n.deleteNeighbor(peerIP, peerMac, vtep, dbEntries)
 		if err != nil {
 			if dbEntries > 0 && errors.As(err, &osl.NeighborSearchError{}) {
 				// We fall in here if there is a transient state and if the neighbor that is being deleted
@@ -223,7 +223,7 @@ func (n *network) peerDelete(eid string, peerIP netip.Prefix, peerMac hashable.M
 
 // deleteNeighbor removes programming from the kernel for the given peer to be
 // reachable through the VXLAN tunnel. It is the inverse of [driver.addNeighbor].
-func (n *network) deleteNeighbor(peerIP netip.Prefix, peerMac hashable.MACAddr, vtep netip.Addr) error {
+func (n *network) deleteNeighbor(peerIP netip.Prefix, peerMac hashable.MACAddr, vtep netip.Addr, dbEntries int) error {
 	if n.sbox == nil {
 		return nil
 	}
@@ -238,17 +238,22 @@ func (n *network) deleteNeighbor(peerIP netip.Prefix, peerMac hashable.MACAddr, 
 	if s == nil {
 		return fmt.Errorf("could not find the subnet %q in network %q", peerIP.String(), n.id)
 	}
+	var errs []error
+	fdbDeleteFailed := false
 	// Remove fdb entry to the bridge for the peer mac
 	if n.fdbCnt.Add(hashable.IPMACFrom(vtep, peerMac), -1) == 0 {
 		if err := n.sbox.DeleteNeighbor(vtep.AsSlice(), peerMac.AsSlice(), osl.WithLinkName(s.vxlanName), osl.WithFamily(syscall.AF_BRIDGE)); err != nil {
-			return fmt.Errorf("could not delete fdb entry in the sandbox: %w", err)
+			errs = append(errs, fmt.Errorf("could not delete fdb entry in the sandbox: %w", err))
+			fdbDeleteFailed = true
 		}
 	}
 
 	// Delete neighbor entry for the peer IP
-	if err := n.sbox.DeleteNeighbor(peerIP.Addr().AsSlice(), peerMac.AsSlice(), osl.WithLinkName(s.vxlanName)); err != nil {
-		return fmt.Errorf("could not delete neighbor entry in the sandbox:%v", err)
+	if !fdbDeleteFailed || dbEntries == 0 {
+		if err := n.sbox.DeleteNeighbor(peerIP.Addr().AsSlice(), peerMac.AsSlice(), osl.WithLinkName(s.vxlanName)); err != nil {
+			errs = append(errs, fmt.Errorf("could not delete neighbor entry in the sandbox: %w", err))
+		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }


### PR DESCRIPTION
## Description

This addresses one overlay peer cleanup path related to #52661.

Currently, an FDB delete failure can cause `deleteNeighbor` to return before ARP/neigh cleanup is attempted. If there are no remaining peer DB entries for the IP, that can leave the permanent neighbor entry behind even though the peer cleanup path was reached.

This keeps the existing `dbEntries > 0` guard, so duplicate/transient IP cases still preserve the neighbor entry. When `dbEntries == 0`, ARP/neigh cleanup is attempted even if FDB cleanup failed.

Both cleanup errors are preserved with `errors.Join`.

Addresses #52661

## Testing

- `gofmt -w daemon/libnetwork/drivers/overlay/peerdb.go`
- `git diff --check`
- `go test -run '^$' ./daemon/libnetwork/drivers/overlay`
- `go test -run '^$' ./daemon/libnetwork/osl`
- `GOOS=linux GOARCH=amd64 go test -c ./daemon/libnetwork/drivers/overlay`
- `GOOS=linux GOARCH=amd64 go test -c ./daemon/libnetwork/osl`
- `go test ./daemon/libnetwork/drivers/overlay`
- `go test ./daemon/libnetwork/osl`

Note: local runtime tests were run from a Windows Go environment, so they do not exercise live Linux netns/CAP_NET_ADMIN behavior.