### PR TITLE
fix: propagate registry auth error in swarm image pull

### DIFF
--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -174,6 +174,14 @@ func (r *controller) Prepare(ctx context.Context) error {
 				// If you don't want this behavior, lock down your image to an
 				// immutable tag or digest.
 				log.G(ctx).WithError(r.pullErr).Error("pulling image failed")
+
+				// If the pull failed with an authentication error, return it
+				// so the actual cause is propagated instead of the misleading
+				// "No such image" error that would otherwise result from the
+				// container create below.
+				if cerrdefs.IsUnauthorized(r.pullErr) {
+					return r.pullErr
+				}
 			}
 		}
 	}

--- a/daemon/internal/distribution/errors.go
+++ b/daemon/internal/distribution/errors.go
@@ -106,6 +106,8 @@ func translatePullError(err error, ref reference.Named) error {
 		switch v.Code {
 		case errcode.ErrorCodeDenied, v2.ErrorCodeManifestUnknown, v2.ErrorCodeNameUnknown:
 			return notFoundError{v, ref}
+		case errcode.ErrorCodeUnauthorized:
+			return errdefs.Unauthorized(v)
 		}
 	case xfer.DoNotRetry:
 		return translatePullError(v.Err, ref)


### PR DESCRIPTION
Fixes #52570

When a worker pull fails with 'unauthorized: authentication required',
the error was being swallowed and replaced with a misleading
'No such image' message. This fix ensures the actual registry error
is propagated so operators see the real cause.

```markdown changelog
Fix a bug where registry authentication failures during worker image pulls were reported as a misleading “No such image” error.
```