### PR TITLE
Prefer runtime-hook based injection for NVIDIA devices

### DIFF
--- a/daemon/devices_nvidia_linux.go
+++ b/daemon/devices_nvidia_linux.go
@@ -39,6 +39,16 @@ func getNVIDIADeviceDrivers() map[string]*deviceDriver {
 	var composite firstSuccessfulUpdater
 	nvidiaDrivers := make(map[string]*deviceDriver)
 
+	if _, err := exec.LookPath(nvidiaContainerRuntimeHookExecutableName); err == nil {
+		// Register a driver specific to the nvidia-container-runtime-hook if present.
+		// This has no capabilities associated to not inadvertently match requests.
+		runtimeHookDeviceDriver := &deviceDriver{
+			updateSpec: injectNVIDIARuntimeHook,
+		}
+		nvidiaDrivers["nvidia.runtime-hook"] = runtimeHookDeviceDriver
+		composite = append(composite, runtimeHookDeviceDriver.updateSpec)
+	}
+
 	if _, err := exec.LookPath(nvidiaCDIHookExecutableName); err == nil {
 		// Register a driver specific to CDI if present.
 		// This has no capabilities associated to not inadvertently match requests.
@@ -49,16 +59,6 @@ func getNVIDIADeviceDrivers() map[string]*deviceDriver {
 		}
 		nvidiaDrivers["nvidia.cdi"] = cdiDeviceDriver
 		composite = append(composite, cdiDeviceDriver.updateSpec)
-	}
-
-	if _, err := exec.LookPath(nvidiaContainerRuntimeHookExecutableName); err == nil {
-		// Register a driver specific to the nvidia-container-runtime-hook if present.
-		// This has no capabilities associated to not inadvertently match requests.
-		runtimeHookDeviceDriver := &deviceDriver{
-			updateSpec: injectNVIDIARuntimeHook,
-		}
-		nvidiaDrivers["nvidia.runtime-hook"] = runtimeHookDeviceDriver
-		composite = append(composite, runtimeHookDeviceDriver.updateSpec)
 	}
 
 	if len(nvidiaDrivers) == 0 {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I changed the order or precedence for handling of the --gpus flag to prefer injection using the `nvidia-container-runtime-hook` over injection using CDI. This ensures that the changes from #50228 do not break use cases where CDI specs may be present but out of date. (e.g. MIG devices as reported in #51942).

**- How I did it**

Changed the ordering of the spec updaters for NVIDIA GPUs. This reverts the default behaviour to prefer the `nvidia-contianer-runtime-hook` to handle the `--gpus` flag instead of first attempting CDI device injection.

**- How to verify it**

On a system with BOTH `nvidia-container-runtime-hook` and the `nvidia-cdi-hook` executable installed, run a container requesting a GPU. Ensure that the `NVIDIA_VISIBLE_DEVICES` envvar is set to `all` in the container and not `void`:
```
$ docker run --rm -ti --gpus=all ubuntu env | grep NVIDIA_VISIBLE_DEVICES
NVIDIA_VISIBLE_DEVICES=all
```

When using CDI-based injection this would show:
```
$ docker run --rm -ti --gpus=all ubuntu env | grep NVIDIA_VISIBLE
NVIDIA_VISIBLE_DEVICES=void
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Prefer `nvidia-container-runtime-hook`-based device injection over CDI for the `--gpus` flag. This fixes the injection of MIG devices.
```

**- A picture of a cute animal (not mandatory but encouraged)**

