### PR TITLE
daemon/libnetwork/osl: stop draining after LinkSubscribe timeout

### DIFF
--- a/daemon/libnetwork/osl/interface_linux.go
+++ b/daemon/libnetwork/osl/interface_linux.go
@@ -455,6 +455,7 @@ func waitForIfUpped(ctx context.Context, ns netns.NsHandle, ifIndex int) (bool, 
 				}
 			case <-drainTimerC:
 				log.G(ctx).Warn("timeout while waiting for LinkSubscribe to terminate")
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
The `waitForIfUpped` cleanup path says it stops `LinkSubscribe` and drains the result channel until the channel closes or a timeout is reached. The timeout case currently only logs a warning, then continues waiting on the same channel.

That means the cleanup can still block indefinitely after reporting that `LinkSubscribe` did not terminate in time. Return from the drain loop after logging the timeout so the cleanup path is actually bounded.

Validation:
- `git diff --check origin/master...HEAD`
- `go test -run '^$' ./daemon/libnetwork/osl`
