### PR TITLE
daemon: bound startup goroutine creation

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -237,8 +237,10 @@ func (daemon *Daemon) loadContainers(ctx context.Context) (map[string]map[string
 
 	for _, v := range dir {
 		id := v.Name()
+		if err := sem.Acquire(context.WithoutCancel(ctx), 1); err != nil {
+			return nil, errors.Wrap(err, "failed to start container load task")
+		}
 		group.Go(func() {
-			_ = sem.Acquire(context.WithoutCancel(ctx), 1)
 			defer sem.Release(1)
 
 			c, err := daemon.load(id)
@@ -290,13 +292,13 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 	removeContainers := make(map[string]*container.Container)
 	restartContainers := make(map[*container.Container]chan struct{})
 	activeSandboxes := make(map[string]any)
+	failedRegistrations := make(map[string]struct{})
 
 	for _, c := range containers {
+		if err := sem.Acquire(context.WithoutCancel(ctx), 1); err != nil {
+			return errors.Wrap(err, "failed to start container registration task")
+		}
 		group.Go(func() {
-			if err := sem.Acquire(context.WithoutCancel(ctx), 1); err != nil {
-				// ctx is done; should never happen.
-				return
-			}
 			defer sem.Release(1)
 
 			logger := log.G(ctx).WithField("container", c.ID)
@@ -317,25 +319,26 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 			if err := daemon.registerName(c); err != nil {
 				logger.WithError(err).Errorf("failed to register container name: %s", c.Name)
 				mapLock.Lock()
-				delete(containers, c.ID)
+				failedRegistrations[c.ID] = struct{}{}
 				mapLock.Unlock()
 				return
 			}
 			if err := daemon.register(ctx, c); err != nil {
 				logger.WithError(err).Error("failed to register container")
 				mapLock.Lock()
-				delete(containers, c.ID)
+				failedRegistrations[c.ID] = struct{}{}
 				mapLock.Unlock()
 				return
 			}
 		})
 	}
 	group.Wait()
+	for id := range failedRegistrations {
+		delete(containers, id)
+	}
 
 	for _, c := range containers {
-		group.Add(1)
-		go func(c *container.Container) {
-			defer group.Done()
+		group.Go(func() {
 			_ = sem.Acquire(context.Background(), 1)
 			defer sem.Release(1)
 
@@ -580,7 +583,7 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 			}
 			c.Unlock()
 			logger(c).Debug("done restoring container")
-		}(c)
+		})
 	}
 	group.Wait()
 
@@ -612,17 +615,16 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 
 	// Now that all the containers are registered, register the links
 	for _, c := range containers {
-		group.Add(1)
-		go func(c *container.Container) {
-			_ = sem.Acquire(context.Background(), 1)
+		if err := sem.Acquire(context.Background(), 1); err != nil {
+			return errors.Wrap(err, "failed to start container link registration task")
+		}
+		group.Go(func() {
+			defer sem.Release(1)
 
 			if err := daemon.registerLinks(c); err != nil {
 				log.G(ctx).WithField("container", c.ID).WithError(err).Error("failed to register link for container")
 			}
-
-			sem.Release(1)
-			group.Done()
-		}(c)
+		})
 	}
 	group.Wait()
 
@@ -666,23 +668,23 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 	group.Wait()
 
 	for id, c := range removeContainers {
-		group.Add(1)
-		go func(cid string, c *container.Container) {
-			_ = sem.Acquire(context.Background(), 1)
-			defer group.Done()
+		if err := sem.Acquire(context.Background(), 1); err != nil {
+			return errors.Wrap(err, "failed to start container removal task")
+		}
+		group.Go(func() {
 			defer sem.Release(1)
 
 			if c.State.IsDead() {
 				if err := daemon.cleanupContainer(c, backend.ContainerRmConfig{ForceRemove: true, RemoveVolume: true}); err != nil {
-					log.G(ctx).WithField("container", cid).WithError(err).Error("failed to remove dead container")
+					log.G(ctx).WithField("container", id).WithError(err).Error("failed to remove dead container")
 				}
 				return
 			}
 
-			if err := daemon.containerRm(&cfg.Config, cid, &backend.ContainerRmConfig{ForceRemove: true, RemoveVolume: true}); err != nil {
-				log.G(ctx).WithField("container", cid).WithError(err).Error("failed to remove container")
+			if err := daemon.containerRm(&cfg.Config, id, &backend.ContainerRmConfig{ForceRemove: true, RemoveVolume: true}); err != nil {
+				log.G(ctx).WithField("container", id).WithError(err).Error("failed to remove container")
 			}
-		}(id, c)
+		})
 	}
 	group.Wait()
 
@@ -703,17 +705,16 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 			continue
 		}
 
-		group.Add(1)
-		go func(c *container.Container) {
-			_ = sem.Acquire(context.Background(), 1)
+		if err := sem.Acquire(context.Background(), 1); err != nil {
+			return errors.Wrap(err, "failed to start mountpoint preparation task")
+		}
+		group.Go(func() {
+			defer sem.Release(1)
 
 			if err := daemon.prepareMountPoints(c); err != nil {
 				log.G(ctx).WithField("container", c.ID).WithError(err).Error("failed to prepare mountpoints for container")
 			}
-
-			sem.Release(1)
-			group.Done()
-		}(c)
+		})
 	}
 	group.Wait()
 
@@ -748,21 +749,17 @@ func (daemon *Daemon) restartSwarmContainers(ctx context.Context, cfg *configSto
 		// swarm endpoint now that the cluster is
 		// initialized.
 		if cfg.AutoRestart && c.ShouldRestart() && c.NetworkSettings.HasSwarmEndpoint && c.HasBeenStartedBefore {
-			group.Add(1)
-			go func(c *container.Container) {
-				if err := sem.Acquire(ctx, 1); err != nil {
-					// ctx is done.
-					group.Done()
-					return
-				}
+			if err := sem.Acquire(ctx, 1); err != nil {
+				log.G(ctx).WithField("container", c.ID).WithError(err).Error("failed to start swarm container restart task")
+				break
+			}
+			group.Go(func() {
+				defer sem.Release(1)
 
 				if err := daemon.containerStart(ctx, cfg, c, "", "", true); err != nil {
 					log.G(ctx).WithField("container", c.ID).WithError(err).Error("failed to start swarm container")
 				}
-
-				sem.Release(1)
-				group.Done()
-			}(c)
+			})
 		}
 	}
 	group.Wait()


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/moby/moby/pull/38301: make the existing startup semaphore bound goroutine creation as well as active startup work.

Several daemon startup phases currently start one goroutine per container and acquire the startup semaphore inside each goroutine. With many containers, that still allows an unbounded number of goroutines to sit behind the semaphore.

This acquires the existing semaphore before starting each worker goroutine at the affected startup phases while preserving the existing `adjustParallelLimit(len(...), 128*runtime.NumCPU())` policy. If the semaphore cannot be acquired, startup paths now return that error instead of silently skipping work. The swarm restart path cannot return an error, so it logs the acquire failure and stops scheduling more restart work.

The registration pass no longer mutates the iterated `containers` map from worker goroutines: failed registrations are collected under the existing lock and removed from the map after `group.Wait()`. The container restore pass uses `group.Go` for consistency/readability. The container restart phase is left on the old shape because it has notifier dependencies between restarting containers.

## Release notes (optional)

```markdown changelog

```

## Validation

- `gofmt -w daemon/daemon.go`
- `git diff --check`
- `go test -tags 'netgo journald no_libnftables' ./daemon -run '^$' -count=1`
- `go test -tags 'netgo journald no_libnftables' ./daemon -count=1` timed out after 10m in existing `TestIfaceAddrs/Multiple` while waiting on `netnsutils.SetupTestOSContextEx`; this is unrelated to the startup semaphore changes.

`no_libnftables` was used because this local environment does not have `libnftables.pc` installed; without that tag the daemon package fails during cgo pkg-config discovery before reaching these tests.

Created with: Codex