### PR TITLE
Add GitHub Actions flaky test detector

### DIFF
--- a/.github/workflows/flaky-detector-ci.yml
+++ b/.github/workflows/flaky-detector-ci.yml
@@ -1,0 +1,44 @@
+name: Flaky detector CI
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - 'master'
+      - '[0-9]+.[0-9]+'
+      - '[0-9]+.x'
+    paths:
+      - '.github/workflows/flaky-detector-ci.yml'
+      - '.github/workflows/flaky-test-tracker.yml'
+      - 'internal/ci/analyze-tests/**'
+  pull_request:
+    paths:
+      - '.github/workflows/flaky-detector-ci.yml'
+      - '.github/workflows/flaky-test-tracker.yml'
+      - 'internal/ci/analyze-tests/**'
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: internal/ci/analyze-tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: internal/ci/analyze-tests/go.mod
+          cache-dependency-path: internal/ci/analyze-tests/go.sum
+      - name: Test
+        run: go test ./...
+      - name: Lint
+        run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.2 run ./...

--- a/.github/workflows/flaky-test-tracker.yml
+++ b/.github/workflows/flaky-test-tracker.yml
@@ -1,0 +1,36 @@
+name: Flaky test tracker
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      write_issues:
+        description: 'Create/update GitHub issues. Defaults to dry-run when unchecked.'
+        required: false
+        type: boolean
+        default: false
+      verbose:
+        description: 'Print artifact discovery diagnostics.'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  detect-flaky-tests:
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Track flaky tests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WRITE_ISSUES: ${{ inputs.write_issues && '1' || '0' }}
+          VERBOSE: ${{ inputs.verbose && '1' || '0' }}
+        working-directory: internal/ci/analyze-tests
+        run: go run .

--- a/internal/ci/analyze-tests/aggregate.go
+++ b/internal/ci/analyze-tests/aggregate.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+)
+
+const (
+	cacheDir             = ".flaky-cache"
+	defaultBranch        = "master"
+	maxParallelArtifacts = 8
+)
+
+// testEvent is one pass or fail record for a single Go test.
+type testEvent struct {
+	Action  string
+	Package string
+	Test    string
+	RunID   int64
+	PRHead  string
+	Master  bool
+}
+
+// result aggregates all observed pass and fail events for one test.
+type result struct {
+	Passes         int
+	Failures       int
+	FailedRunIDs   map[int64]struct{}
+	FailedPRHeads  map[string]struct{}
+	FailedOnMaster bool
+	Package        string
+	Test           string
+}
+
+// aggregateArtifacts downloads, parses, and aggregates test events from all
+// selected artifacts.
+func aggregateArtifacts(ctx context.Context, gh *githubClient, artifacts []artifact) (map[string]*result, error) {
+	jobs := make(chan int)
+	events := make(chan []testEvent)
+	var wg sync.WaitGroup
+	var firstErr error
+	var errMu sync.Mutex
+
+	for range maxParallelArtifacts {
+		wg.Go(func() {
+			for i := range jobs {
+				a := artifacts[i]
+				slog.Info("processing artifact", "artifact", a.Name, "run_id", a.WorkflowRun.ID, "index", i+1, "total", len(artifacts))
+				es, err := processArtifact(ctx, gh, a)
+				if err != nil {
+					errMu.Lock()
+					if firstErr == nil {
+						firstErr = err
+					}
+					errMu.Unlock()
+					continue
+				}
+				if len(es) > 0 {
+					events <- es
+				}
+			}
+		})
+	}
+
+	go func() {
+		for i := range artifacts {
+			jobs <- i
+		}
+		close(jobs)
+		wg.Wait()
+		close(events)
+	}()
+
+	results := map[string]*result{}
+	for es := range events {
+		for _, e := range es {
+			key := e.Package + "|" + e.Test
+			r := results[key]
+			if r == nil {
+				r = &result{Package: e.Package, Test: e.Test, FailedRunIDs: map[int64]struct{}{}, FailedPRHeads: map[string]struct{}{}}
+				results[key] = r
+			}
+			switch e.Action {
+			case "pass":
+				r.Passes++
+			case "fail":
+				r.Failures++
+				r.FailedRunIDs[e.RunID] = struct{}{}
+				if e.Master {
+					r.FailedOnMaster = true
+				} else if e.PRHead != "" {
+					r.FailedPRHeads[e.PRHead] = struct{}{}
+				}
+			}
+		}
+	}
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return results, nil
+}
+
+// processArtifact ensures an artifact is available locally and annotates parsed
+// test events with workflow-run metadata.
+func processArtifact(ctx context.Context, gh *githubClient, a artifact) ([]testEvent, error) {
+	dest := filepath.Join(cacheDir, strconv.FormatInt(a.WorkflowRun.ID, 10), a.Name)
+	if _, err := os.Stat(dest); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		if err := downloadAndExtract(ctx, gh, a, dest); err != nil {
+			_ = os.RemoveAll(dest)
+			return nil, err
+		}
+	}
+	events, err := parseReports(dest)
+	if err != nil {
+		return nil, err
+	}
+	for i := range events {
+		events[i].RunID = a.WorkflowRun.ID
+		events[i].Master = a.WorkflowRun.HeadBranch == defaultBranch
+		events[i].PRHead = prHead(a)
+	}
+	return events, nil
+}
+
+// prHead returns a stable pull-request head identifier for cross-fork branch
+// names, or an empty string for master and unknown heads.
+func prHead(a artifact) string {
+	if a.WorkflowRun.HeadBranch == "" || a.WorkflowRun.HeadBranch == defaultBranch {
+		return ""
+	}
+	return fmt.Sprintf("%d:%s", a.WorkflowRun.HeadRepositoryID, a.WorkflowRun.HeadBranch)
+}

--- a/internal/ci/analyze-tests/artifacts.go
+++ b/internal/ci/analyze-tests/artifacts.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v68/github"
+)
+
+const (
+	artifactPageSize = 100 // GitHub's REST API caps per_page at 100.
+	maxArtifactPages = 40
+)
+
+// artifact is the subset of a GitHub Actions artifact response used here.
+type artifact struct {
+	ID          int64
+	Name        string
+	CreatedAt   time.Time
+	Expired     bool
+	WorkflowRun artifactWorkflowRun
+}
+
+// artifactWorkflowRun is the workflow metadata attached to an artifact.
+type artifactWorkflowRun struct {
+	ID               int64
+	HeadBranch       string
+	HeadRepositoryID int64
+}
+
+// artifactFilterStats records why artifacts were kept or skipped.
+type artifactFilterStats struct {
+	Seen                 int
+	Selected             int
+	Expired              int
+	MissingWorkflowRunID int
+	WrongPrefix          int
+}
+
+// fetchArtifacts collects the non-expired test-result artifacts visible in the
+// configured GitHub artifact page limit.
+func (g *githubClient) fetchArtifacts(ctx context.Context) ([]artifact, error) {
+	slog.Info("fetching test result artifacts")
+	owner, repo, err := g.repoParts()
+	if err != nil {
+		return nil, err
+	}
+	api := g.githubAPI()
+	var out []artifact
+	var total artifactFilterStats
+	for page := 1; page <= maxArtifactPages; page++ {
+		list, _, err := api.Actions.ListArtifacts(ctx, owner, repo, &github.ListArtifactsOptions{
+			ListOptions: github.ListOptions{PerPage: artifactPageSize, Page: page},
+		})
+		if err != nil {
+			return nil, g.githubError("list workflow artifacts", err)
+		}
+		artifacts := normalizeArtifacts(list.Artifacts)
+		if g.verbose {
+			slog.Info("received artifact page", "page", page, "count", len(artifacts))
+			if first, last, ok := artifactTimeRange(artifacts); ok {
+				slog.Info("artifact page time range", "page", page, "newest", first.Format(time.RFC3339), "oldest", last.Format(time.RFC3339))
+			}
+		}
+		if len(artifacts) == 0 {
+			break
+		}
+
+		selected, stats := filterArtifacts(artifacts)
+		out = append(out, selected...)
+		total.add(stats)
+		if g.verbose {
+			slog.Info("filtered artifact page", "page", page, "selected", stats.Selected, "expired", stats.Expired, "missing_run", stats.MissingWorkflowRunID, "wrong_prefix", stats.WrongPrefix)
+		}
+	}
+	if g.verbose {
+		slog.Info("artifact scan summary", "seen", total.Seen, "selected", total.Selected, "expired", total.Expired, "missing_run", total.MissingWorkflowRunID, "wrong_prefix", total.WrongPrefix)
+		if total.Seen == maxArtifactPages*artifactPageSize {
+			slog.Info("artifact scan stopped at page limit", "pages", maxArtifactPages)
+		}
+	}
+	return out, nil
+}
+
+// normalizeArtifacts converts go-github's pointer-heavy artifact type into the
+// small value type used by the analyzer.
+func normalizeArtifacts(in []*github.Artifact) []artifact {
+	out := make([]artifact, 0, len(in))
+	for _, a := range in {
+		if a == nil {
+			continue
+		}
+		na := artifact{
+			ID:        a.GetID(),
+			Name:      a.GetName(),
+			CreatedAt: a.GetCreatedAt().Time,
+			Expired:   a.GetExpired(),
+		}
+		if wr := a.GetWorkflowRun(); wr != nil {
+			na.WorkflowRun = artifactWorkflowRun{
+				ID:               wr.GetID(),
+				HeadBranch:       wr.GetHeadBranch(),
+				HeadRepositoryID: wr.GetHeadRepositoryID(),
+			}
+		}
+		out = append(out, na)
+	}
+	return out
+}
+
+// filterArtifacts keeps only test-result artifacts that can be traced back to a
+// workflow run.
+func filterArtifacts(artifacts []artifact) ([]artifact, artifactFilterStats) {
+	stats := artifactFilterStats{Seen: len(artifacts)}
+	selected := make([]artifact, 0, len(artifacts))
+	for _, a := range artifacts {
+		switch {
+		case a.Expired:
+			stats.Expired++
+		case a.WorkflowRun.ID == 0:
+			stats.MissingWorkflowRunID++
+		case !strings.HasPrefix(a.Name, "test-results-"):
+			stats.WrongPrefix++
+		default:
+			selected = append(selected, a)
+			stats.Selected++
+		}
+	}
+	return selected, stats
+}
+
+// add folds another page's filter statistics into the receiver.
+func (s *artifactFilterStats) add(other artifactFilterStats) {
+	s.Seen += other.Seen
+	s.Selected += other.Selected
+	s.Expired += other.Expired
+	s.MissingWorkflowRunID += other.MissingWorkflowRunID
+	s.WrongPrefix += other.WrongPrefix
+}
+
+// artifactTimeRange returns the newest and oldest timestamps in a page.
+func artifactTimeRange(artifacts []artifact) (time.Time, time.Time, bool) {
+	if len(artifacts) == 0 {
+		return time.Time{}, time.Time{}, false
+	}
+	first := artifacts[0].CreatedAt
+	last := artifacts[0].CreatedAt
+	for _, a := range artifacts[1:] {
+		if a.CreatedAt.After(first) {
+			first = a.CreatedAt
+		}
+		if a.CreatedAt.Before(last) {
+			last = a.CreatedAt
+		}
+	}
+	return first, last, true
+}

--- a/internal/ci/analyze-tests/config.go
+++ b/internal/ci/analyze-tests/config.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// config contains runtime options resolved from flags, environment variables,
+// and GitHub CLI defaults.
+type config struct {
+	repo        string
+	writeIssues bool
+	verbose     bool
+	summaryPath string
+}
+
+// parseConfig resolves command-line flags and environment variables.
+// REPO overrides auto-detection through gh, WRITE_ISSUES=1 enables mutation,
+// and VERBOSE=1 enables artifact discovery diagnostics.
+func parseConfig(ctx context.Context, args []string) (config, error) {
+	fs := flag.NewFlagSet("analyze-tests", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	writeIssues := fs.Bool("write-issues", false, "create/update GitHub issues")
+	verbose := fs.Bool("verbose", false, "print artifact discovery diagnostics")
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+	if fs.NArg() != 0 {
+		return config{}, fmt.Errorf("unknown argument: %s", fs.Arg(0))
+	}
+
+	repo := os.Getenv("REPO")
+	if repo == "" {
+		var err error
+		repo, err = resolveRepo(ctx)
+		if err != nil {
+			return config{}, err
+		}
+	}
+
+	return config{
+		repo:        repo,
+		writeIssues: *writeIssues || os.Getenv("WRITE_ISSUES") == "1",
+		verbose:     *verbose || os.Getenv("VERBOSE") == "1",
+		summaryPath: firstNonEmpty(os.Getenv("GITHUB_SUMMARY"), os.Getenv("GITHUB_STEP_SUMMARY")),
+	}, nil
+}
+
+// resolveRepo asks gh for the current repository in owner/name form.
+func resolveRepo(ctx context.Context) (string, error) {
+	out, err := runCommand(ctx, "gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner")
+	if err != nil {
+		return "", errors.New("could not detect repo; set REPO= explicitly")
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// resolveToken returns a GitHub API token from environment or gh auth.
+// The analyzer can still run unauthenticated, but API rate limits are lower.
+func resolveToken(ctx context.Context) string {
+	if token := firstNonEmpty(os.Getenv("GH_TOKEN"), os.Getenv("GITHUB_TOKEN")); token != "" {
+		return token
+	}
+	out, err := runCommand(ctx, "gh", "auth", "token")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}

--- a/internal/ci/analyze-tests/github.go
+++ b/internal/ci/analyze-tests/github.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/go-github/v68/github"
+)
+
+// githubClient is the small GitHub REST API client used by the analyzer.
+// It intentionally covers only the endpoints needed for workflow artifacts,
+// issue tracking, and labels.
+type githubClient struct {
+	repo    string
+	token   string
+	client  *http.Client
+	verbose bool
+}
+
+// githubAPI returns a go-github client configured like the local REST client.
+func (g *githubClient) githubAPI() *github.Client {
+	c := github.NewClient(g.client)
+	if g.token != "" {
+		c = c.WithAuthToken(g.token)
+	}
+	return c
+}
+
+// repoParts splits the configured owner/name repository string.
+func (g *githubClient) repoParts() (string, string, error) {
+	owner, repo, ok := strings.Cut(g.repo, "/")
+	if !ok || owner == "" || repo == "" {
+		return "", "", fmt.Errorf("invalid repo %q, expected owner/name", g.repo)
+	}
+	return owner, repo, nil
+}
+
+// downloadArtifact downloads the zip archive for one GitHub Actions artifact.
+func (g *githubClient) downloadArtifact(ctx context.Context, artifactID int64) ([]byte, error) {
+	owner, repo, err := g.repoParts()
+	if err != nil {
+		return nil, err
+	}
+	u, _, err := g.githubAPI().Actions.DownloadArtifact(ctx, owner, repo, artifactID, 0)
+	if err != nil {
+		return nil, g.githubError("get artifact download URL", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, g.httpStatusError("GET", u.String(), resp, body)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func (g *githubClient) githubError(operation string, err error) error {
+	var ghErr *github.ErrorResponse
+	if !errors.As(err, &ghErr) || ghErr.Response == nil {
+		return fmt.Errorf("%s for repo %s: %w", operation, g.repo, err)
+	}
+
+	resp := ghErr.Response
+	parts := []string{
+		fmt.Sprintf("%s for repo %s failed", operation, g.repo),
+		fmt.Sprintf("status=%s", resp.Status),
+	}
+	if resp.Request != nil && resp.Request.URL != nil {
+		parts = append(parts, fmt.Sprintf("endpoint=%s", resp.Request.URL.Redacted()))
+	}
+	parts = append(parts, fmt.Sprintf("authenticated=%t", g.token != ""))
+	if requestID := resp.Header.Get("X-GitHub-Request-Id"); requestID != "" {
+		parts = append(parts, fmt.Sprintf("github_request_id=%s", requestID))
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		parts = append(parts, "hint=check GH_TOKEN/GITHUB_TOKEN or gh auth token; token needs access to repository Actions artifacts")
+	}
+
+	return fmt.Errorf("%s: %w", strings.Join(parts, "; "), err)
+}
+
+func (g *githubClient) httpStatusError(method, url string, resp *http.Response, body []byte) error {
+	parts := []string{
+		fmt.Sprintf("%s %s failed", method, url),
+		fmt.Sprintf("status=%s", resp.Status),
+		fmt.Sprintf("authenticated=%t", g.token != ""),
+	}
+	if requestID := resp.Header.Get("X-GitHub-Request-Id"); requestID != "" {
+		parts = append(parts, fmt.Sprintf("github_request_id=%s", requestID))
+	}
+	if trimmed := strings.TrimSpace(string(body)); trimmed != "" {
+		parts = append(parts, fmt.Sprintf("body=%q", trimmed))
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		parts = append(parts, "hint=check GH_TOKEN/GITHUB_TOKEN or gh auth token; token needs access to repository Actions artifacts")
+	}
+
+	return errors.New(strings.Join(parts, "; "))
+}

--- a/internal/ci/analyze-tests/go.mod
+++ b/internal/ci/analyze-tests/go.mod
@@ -1,0 +1,13 @@
+module github.com/moby/moby/v2/internal/ci/analyze-tests
+
+go 1.26
+
+require (
+	github.com/google/go-github/v68 v68.0.0
+	gotest.tools/v3 v3.5.2
+)
+
+require (
+	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
+)

--- a/internal/ci/analyze-tests/go.sum
+++ b/internal/ci/analyze-tests/go.sum
@@ -1,0 +1,10 @@
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v68 v68.0.0 h1:ZW57zeNZiXTdQ16qrDiZ0k6XucrxZ2CGmoTvcCyQG6s=
+github.com/google/go-github/v68 v68.0.0/go.mod h1:K9HAUBovM2sLwM408A18h+wd9vqdLOEqTUCbnRIcx68=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
+gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=

--- a/internal/ci/analyze-tests/issues.go
+++ b/internal/ci/analyze-tests/issues.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v68/github"
+)
+
+const (
+	label         = "status/flaky-test"
+	historyMarker = "flaky-history:json"
+	maxIssuePages = 5
+)
+
+// historyData is persisted in an HTML comment inside each managed issue.
+type historyData struct {
+	FirstSeen string       `json:"first_seen"`
+	History   []historyRow `json:"history"`
+}
+
+// historyRow records one analyzer observation for a managed issue.
+type historyRow struct {
+	Date     string `json:"date"`
+	Passes   int    `json:"passes"`
+	Failures int    `json:"failures"`
+	Rate     string `json:"rate"`
+}
+
+// upsertIssue creates or updates the GitHub issue that tracks one test result.
+// In dry-run mode it only reports the action that would be taken.
+func upsertIssue(ctx context.Context, gh *githubClient, write bool, r *result, classification string, ratePct int) error {
+	title := issueTitle(r)
+	existing, err := findIssue(ctx, gh, title)
+	if err != nil {
+		return err
+	}
+
+	body, err := buildIssueBody(ctx, gh, existing, r, classification, ratePct)
+	if err != nil {
+		return err
+	}
+
+	if !write {
+		if existing != "" {
+			slog.Info("dry-run would update issue", "issue", existing, "title", title)
+		} else {
+			slog.Info("dry-run would create issue", "title", title)
+		}
+		return nil
+	}
+	return writeIssue(ctx, gh, existing, title, body)
+}
+
+// issueTitle returns the managed GitHub issue title for a test result.
+func issueTitle(r *result) string {
+	leaf := r.Test[strings.LastIndex(r.Test, "/")+1:]
+	return "Flaky test: " + leaf
+}
+
+// buildIssueBody loads prior issue history and renders the next body.
+func buildIssueBody(ctx context.Context, gh *githubClient, issueNumber string, r *result, classification string, ratePct int) (string, error) {
+	existingHistory, err := loadIssueHistory(ctx, gh, issueNumber)
+	if err != nil {
+		return "", err
+	}
+	history := updateHistory(existingHistory, r.Passes, r.Failures, strconv.Itoa(ratePct))
+	return renderIssueBody(gh.repo, r, classification, ratePct, history)
+}
+
+// loadIssueHistory returns stored history for an existing issue.
+// A missing issue number means the issue does not exist yet.
+func loadIssueHistory(ctx context.Context, gh *githubClient, issueNumber string) (historyData, error) {
+	if issueNumber == "" {
+		return historyData{}, nil
+	}
+	owner, repo, err := gh.repoParts()
+	if err != nil {
+		return historyData{}, err
+	}
+	number, err := strconv.Atoi(issueNumber)
+	if err != nil {
+		return historyData{}, err
+	}
+	issue, _, err := gh.githubAPI().Issues.Get(ctx, owner, repo, number)
+	if err != nil {
+		return historyData{}, err
+	}
+	return extractHistory(issue.GetBody()), nil
+}
+
+// writeIssue applies a rendered issue body to GitHub.
+func writeIssue(ctx context.Context, gh *githubClient, existing, title, body string) error {
+	if err := ensureLabel(ctx, gh); err != nil {
+		return err
+	}
+	if existing != "" {
+		return updateIssue(ctx, gh, existing, title, body)
+	}
+	return createIssue(ctx, gh, title, body)
+}
+
+// createIssue creates a new managed issue.
+func createIssue(ctx context.Context, gh *githubClient, title, body string) error {
+	slog.Info("creating issue", "title", title)
+	owner, repo, err := gh.repoParts()
+	if err != nil {
+		return err
+	}
+	labels := []string{label}
+	_, _, err = gh.githubAPI().Issues.Create(ctx, owner, repo, &github.IssueRequest{
+		Title:  new(title),
+		Body:   new(body),
+		Labels: &labels,
+	})
+	return err
+}
+
+// updateIssue updates an existing managed issue and reopens it when necessary.
+func updateIssue(ctx context.Context, gh *githubClient, issueNumber, title, body string) error {
+	slog.Info("updating issue", "issue", issueNumber, "title", title)
+	owner, repo, err := gh.repoParts()
+	if err != nil {
+		return err
+	}
+	number, err := strconv.Atoi(issueNumber)
+	if err != nil {
+		return err
+	}
+	issue, _, err := gh.githubAPI().Issues.Edit(ctx, owner, repo, number, &github.IssueRequest{Body: new(body)})
+	if err != nil {
+		return err
+	}
+	return reopenIssueIfClosed(ctx, gh, issue)
+}
+
+// reopenIssueIfClosed reopens a managed issue after its body is refreshed.
+func reopenIssueIfClosed(ctx context.Context, gh *githubClient, issue *github.Issue) error {
+	if !strings.EqualFold(issue.GetState(), "closed") {
+		return nil
+	}
+	owner, repo, err := gh.repoParts()
+	if err != nil {
+		return err
+	}
+	slog.Info("reopening closed issue", "issue", issue.GetNumber())
+	_, _, err = gh.githubAPI().Issues.Edit(ctx, owner, repo, issue.GetNumber(), &github.IssueRequest{State: new("open")})
+	return err
+}
+
+// findIssue finds an existing managed issue with exactly the requested title.
+func findIssue(ctx context.Context, gh *githubClient, title string) (string, error) {
+	owner, repo, err := gh.repoParts()
+	if err != nil {
+		return "", err
+	}
+	for page := 1; page <= maxIssuePages; page++ {
+		issues, _, err := gh.githubAPI().Issues.ListByRepo(ctx, owner, repo, &github.IssueListByRepoOptions{
+			State:  "all",
+			Labels: []string{label},
+			ListOptions: github.ListOptions{
+				PerPage: 100,
+				Page:    page,
+			},
+		})
+		if err != nil {
+			return "", err
+		}
+		if len(issues) == 0 {
+			return "", nil
+		}
+		for _, issue := range issues {
+			if !issue.IsPullRequest() && issue.GetTitle() == title {
+				return strconv.Itoa(issue.GetNumber()), nil
+			}
+		}
+	}
+	return "", nil
+}
+
+// ensureLabel creates the tracking label when it is missing.
+func ensureLabel(ctx context.Context, gh *githubClient) error {
+	owner, repo, err := gh.repoParts()
+	if err != nil {
+		return err
+	}
+	if _, _, err := gh.githubAPI().Issues.GetLabel(ctx, owner, repo, label); err == nil {
+		return nil
+	} else {
+		var ghErr *github.ErrorResponse
+		if !errors.As(err, &ghErr) || ghErr.Response == nil || ghErr.Response.StatusCode != http.StatusNotFound {
+			return err
+		}
+	}
+	slog.Info("creating label", "label", label)
+	_, _, err = gh.githubAPI().Issues.CreateLabel(ctx, owner, repo, &github.Label{
+		Name:        new(label),
+		Description: new("Flaky test detected by CI"),
+		Color:       new("e11d48"),
+	})
+	var ghErr *github.ErrorResponse
+	if errors.As(err, &ghErr) && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusUnprocessableEntity {
+		return nil
+	}
+	return err
+}
+
+// extractHistory reads the hidden JSON history block from an issue body.
+func extractHistory(body string) historyData {
+	prefix := "<!-- " + historyMarker + " "
+	start := strings.Index(body, prefix)
+	if start == -1 {
+		return historyData{}
+	}
+	start += len(prefix)
+	end := strings.Index(body[start:], " -->")
+	if end == -1 {
+		return historyData{}
+	}
+	var h historyData
+	_ = json.Unmarshal([]byte(body[start:start+end]), &h)
+	return h
+}
+
+// updateHistory inserts or replaces today's history row.
+func updateHistory(existing historyData, passes, failures int, rate string) historyData {
+	today := time.Now().UTC().Format("2006-01-02")
+	if existing.FirstSeen == "" {
+		return historyData{FirstSeen: today, History: []historyRow{{Date: today, Passes: passes, Failures: failures, Rate: rate}}}
+	}
+	row := historyRow{Date: today, Passes: passes, Failures: failures, Rate: rate}
+	for i := range existing.History {
+		if existing.History[i].Date == today {
+			existing.History[i] = row
+			return existing
+		}
+	}
+	existing.History = append([]historyRow{row}, existing.History...)
+	return existing
+}
+
+// renderIssueBody produces the full Markdown body for a managed issue.
+func renderIssueBody(repo string, r *result, classification string, ratePct int, history historyData) (string, error) {
+	statusIcon := "🔴"
+	statusLabel := "Consistently failing (never passed in observed artifacts)"
+	if classification == "flaky" {
+		statusIcon = "🟡"
+		statusLabel = "Flaky (passes and fails intermittently)"
+	}
+
+	runLinks := "_None recorded._\n"
+	if len(r.FailedRunIDs) > 0 {
+		ids := make([]int64, 0, len(r.FailedRunIDs))
+		for id := range r.FailedRunIDs {
+			ids = append(ids, id)
+		}
+		slices.Sort(ids)
+		var b strings.Builder
+		for _, id := range ids {
+			fmt.Fprintf(&b, "- [Run #%d](https://github.com/%s/actions/runs/%d)\n", id, repo, id)
+		}
+		runLinks = b.String()
+	}
+
+	var historyTable strings.Builder
+	historyTable.WriteString("| Date | Passes | Failures | Rate |\n")
+	historyTable.WriteString("| --- | --- | --- | --- |\n")
+	for _, row := range history.History {
+		fmt.Fprintf(&historyTable, "| %s | %d | %d | %s%% |\n", row.Date, row.Passes, row.Failures, row.Rate)
+	}
+
+	historyJSON, err := json.Marshal(history)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf(`## %s %s
+
+**Test:** %s
+**Package:** %s
+**First seen:** %s
+
+### Failed runs
+
+%s### Failure rate history
+
+%s
+
+### How to investigate
+
+1. Search for this test name in recent [CI workflow runs](https://github.com/%s/actions)
+2. Check the test report artifacts for failure details
+3. Look for timing-dependent assertions, resource leaks, or shared state
+
+---
+_This issue is automatically managed by the [flaky test tracker](https://github.com/%s/actions/workflows/flaky-test-tracker.yml)._
+
+<!-- %s %s -->
+`, statusIcon, statusLabel, "`"+r.Test+"`", "`"+r.Package+"`", history.FirstSeen, runLinks, historyTable.String(), repo, repo, historyMarker, historyJSON), nil
+}

--- a/internal/ci/analyze-tests/main.go
+++ b/internal/ci/analyze-tests/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func main() {
+	configureLogging()
+	if err := run(context.Background(), os.Args[1:]); err != nil {
+		slog.Error("analyzer failed", "error", err)
+		os.Exit(1)
+	}
+}
+
+// run executes the analyzer once.
+// It fetches GitHub Actions test-result artifacts, aggregates pass/fail events,
+// and creates or updates tracking issues for qualifying flaky tests.
+func run(ctx context.Context, args []string) error {
+	cfg, err := parseConfig(ctx, args)
+	if err != nil {
+		return err
+	}
+
+	if !cfg.writeIssues {
+		slog.Info("dry-run mode", "hint", "pass --write-issues or set WRITE_ISSUES=1 to create/update issues")
+	}
+
+	slog.Info("repository selected", "repo", cfg.repo)
+	slog.Info("fetching test result artifacts", "limit", maxArtifactPages*artifactPageSize)
+	if cfg.verbose {
+		slog.Info("verbose artifact diagnostics enabled")
+	}
+
+	gh := &githubClient{repo: cfg.repo, token: resolveToken(ctx), client: http.DefaultClient, verbose: cfg.verbose}
+	artifacts, err := gh.fetchArtifacts(ctx)
+	if err != nil {
+		return err
+	}
+	if len(artifacts) == 0 {
+		slog.Info("no test result artifacts found")
+		return writeGitHubSummary(cfg.summaryPath, nil, cfg.writeIssues)
+	}
+
+	slog.Info("found test result artifacts", "count", len(artifacts))
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return err
+	}
+
+	results, err := aggregateArtifacts(ctx, gh, artifacts)
+	if err != nil {
+		return err
+	}
+
+	problems := filterProblemResults(results)
+	if len(problems) == 0 {
+		slog.Info("no test failures found")
+		return writeGitHubSummary(cfg.summaryPath, nil, cfg.writeIssues)
+	}
+
+	slog.Info("tests with failures", "count", len(problems))
+
+	flakyCount := 0
+	failingCount := 0
+	var summaryRows []summaryRow
+	for _, key := range sortedKeys(problems) {
+		r := problems[key]
+		total := r.Passes + r.Failures
+		ratePct := r.Failures * 100 / total
+		classification := "failing"
+		if r.Passes > 0 {
+			classification = "flaky"
+			flakyCount++
+		} else {
+			failingCount++
+		}
+
+		slog.Info("test failure summary", "classification", strings.ToUpper(classification), "test", r.Test, "failures", r.Failures, "total", total, "rate_percent", ratePct)
+		summaryRows = append(summaryRows, summaryRow{Result: r, Classification: classification, RatePct: ratePct})
+		if err := upsertIssue(ctx, gh, cfg.writeIssues, r, classification, ratePct); err != nil {
+			return err
+		}
+	}
+
+	slog.Info("done", "flaky", flakyCount, "consistently_failing", failingCount)
+	return writeGitHubSummary(cfg.summaryPath, summaryRows, cfg.writeIssues)
+}

--- a/internal/ci/analyze-tests/main_test.go
+++ b/internal/ci/analyze-tests/main_test.go
@@ -1,0 +1,309 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v68/github"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestParseConfigVerboseFlagAndEnv(t *testing.T) {
+	t.Setenv("REPO", "owner/repo")
+	t.Setenv("VERBOSE", "")
+
+	cfg, err := parseConfig(context.Background(), []string{"--verbose"})
+	assert.NilError(t, err)
+	assert.Assert(t, cfg.verbose)
+
+	t.Setenv("VERBOSE", "1")
+	cfg, err = parseConfig(context.Background(), nil)
+	assert.NilError(t, err)
+	assert.Assert(t, cfg.verbose)
+}
+
+func TestParseConfigSummaryPath(t *testing.T) {
+	t.Setenv("REPO", "owner/repo")
+	t.Setenv("GITHUB_SUMMARY", "custom-summary.md")
+	t.Setenv("GITHUB_STEP_SUMMARY", "step-summary.md")
+
+	cfg, err := parseConfig(context.Background(), nil)
+	assert.NilError(t, err)
+	assert.Assert(t, is.Equal(cfg.summaryPath, "custom-summary.md"))
+}
+
+func TestWriteGitHubSummaryDryRun(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "summary.md")
+	err := writeGitHubSummary(path, []summaryRow{{
+		Result: &result{
+			Passes:   2,
+			Failures: 1,
+			Package:  "pkg",
+			Test:     "TestFlaky",
+		},
+		Classification: "flaky",
+		RatePct:        33,
+	}}, false)
+	assert.NilError(t, err)
+
+	content, err := os.ReadFile(path)
+	assert.NilError(t, err)
+	summary := string(content)
+	assert.Assert(t, strings.Contains(summary, "Issue updates: dry-run; no issues were created or edited."))
+	assert.Assert(t, strings.Contains(summary, "| FLAKY | `TestFlaky` | `pkg` | 2 | 1 | 33% |"))
+}
+
+func TestWriteGitHubSummaryNoRows(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "summary.md")
+	err := writeGitHubSummary(path, nil, false)
+	assert.NilError(t, err)
+
+	content, err := os.ReadFile(path)
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(string(content), "No qualifying flaky tests were detected."))
+}
+
+func TestParseReportFileReturnsRelevantEvents(t *testing.T) {
+	report := strings.NewReader(strings.Join([]string{
+		`{"Action":"run","Package":"pkg","Test":"TestIgnored"}`,
+		`{"Action":"pass","Package":"pkg","Test":"TestPass"}`,
+		`{"Action":"fail","Test":"TestFailUnknownPackage"}`,
+		`{"Action":"fail","Package":"pkg"}`,
+	}, "\n"))
+
+	events, err := parseReportFile(report)
+	assert.NilError(t, err)
+	assert.Assert(t, is.Len(events, 2))
+	assert.Assert(t, is.DeepEqual(events[0], testEvent{
+		Action:  "pass",
+		Package: "pkg",
+		Test:    "TestPass",
+	}))
+	assert.Assert(t, is.DeepEqual(events[1], testEvent{
+		Action:  "fail",
+		Package: "unknown",
+		Test:    "TestFailUnknownPackage",
+	}))
+}
+
+func TestParseReportFileReturnsMalformedJSONError(t *testing.T) {
+	_, err := parseReportFile(strings.NewReader(`{"Action":"pass"`))
+	assert.Assert(t, err != nil)
+}
+
+func TestGitHubErrorAddsUnauthorizedContext(t *testing.T) {
+	endpoint, err := url.Parse("https://api.github.com/repos/owner/repo/actions/artifacts")
+	assert.NilError(t, err)
+	ghErr := &github.ErrorResponse{
+		Response: &http.Response{
+			Status:     "401 Unauthorized",
+			StatusCode: http.StatusUnauthorized,
+			Header:     http.Header{},
+			Request:    &http.Request{URL: endpoint},
+		},
+	}
+	ghErr.Response.Header.Set("X-GitHub-Request-Id", "abc123")
+
+	err = (&githubClient{repo: "owner/repo"}).githubError("list workflow artifacts", ghErr)
+	msg := err.Error()
+	assert.Assert(t, strings.Contains(msg, "list workflow artifacts for repo owner/repo failed"))
+	assert.Assert(t, strings.Contains(msg, "status=401 Unauthorized"))
+	assert.Assert(t, strings.Contains(msg, "endpoint=https://api.github.com/repos/owner/repo/actions/artifacts"))
+	assert.Assert(t, strings.Contains(msg, "authenticated=false"))
+	assert.Assert(t, strings.Contains(msg, "github_request_id=abc123"))
+	assert.Assert(t, strings.Contains(msg, "hint=check GH_TOKEN/GITHUB_TOKEN or gh auth token"))
+}
+
+func TestGitHubActionsHandlerWritesAnnotations(t *testing.T) {
+	read, write, err := os.Pipe()
+	assert.NilError(t, err)
+	stdout := os.Stdout
+	os.Stdout = write
+	t.Cleanup(func() { os.Stdout = stdout })
+
+	var logs bytes.Buffer
+	handler := &GitHubActionsHandler{
+		Handler: slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo}),
+	}
+	logger := slog.New(handler)
+	logger.Info("starting")
+	logger.Warn("careful")
+	logger.Error("failed")
+
+	assert.NilError(t, write.Close())
+	out, err := io.ReadAll(read)
+	assert.NilError(t, err)
+	assert.NilError(t, read.Close())
+
+	assert.Assert(t, strings.Contains(string(out), "::notice::starting"))
+	assert.Assert(t, strings.Contains(string(out), "::warning::careful"))
+	assert.Assert(t, strings.Contains(string(out), "::error::failed"))
+	assert.Assert(t, strings.Contains(logs.String(), "msg=starting"))
+}
+
+func TestGitHubActionsLoggingOmitsTime(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(&GitHubActionsHandler{
+		Handler: slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo}),
+	})
+
+	logger.Info("starting")
+
+	assert.Assert(t, !strings.Contains(logs.String(), "time="))
+	assert.Assert(t, strings.Contains(logs.String(), "level=INFO"))
+	assert.Assert(t, strings.Contains(logs.String(), "msg=starting"))
+}
+
+func TestFilterArtifactsReportsSkipReasons(t *testing.T) {
+	createdAt := time.Date(2026, 5, 27, 10, 0, 0, 0, time.UTC)
+	artifacts := []artifact{
+		newArtifact("test-results-unit", createdAt, false, 100),
+		newArtifact("test-results-expired", createdAt, true, 101),
+		newArtifact("test-results-missing-run", createdAt, false, 0),
+		newArtifact("test-reports-unit", createdAt, false, 103),
+	}
+
+	selected, stats := filterArtifacts(artifacts)
+	assert.Assert(t, is.Len(selected, 1))
+	assert.Assert(t, is.Equal(selected[0].Name, "test-results-unit"))
+	assert.Assert(t, is.DeepEqual(stats, artifactFilterStats{
+		Seen:                 4,
+		Selected:             1,
+		Expired:              1,
+		MissingWorkflowRunID: 1,
+		WrongPrefix:          1,
+	}))
+}
+
+func TestNormalizeArtifactsKeepsGitHubFields(t *testing.T) {
+	createdAt := time.Date(2026, 5, 27, 11, 6, 27, 0, time.UTC)
+	artifacts := normalizeArtifacts([]*github.Artifact{{
+		ID:        github.Ptr[int64](123),
+		Name:      new("test-results-unit"),
+		CreatedAt: &github.Timestamp{Time: createdAt},
+		Expired:   new(false),
+		WorkflowRun: &github.ArtifactWorkflowRun{
+			ID:               github.Ptr[int64](456),
+			HeadBranch:       new("feature"),
+			HeadRepositoryID: github.Ptr[int64](789),
+		},
+	}})
+
+	assert.Assert(t, is.Len(artifacts, 1))
+	a := artifacts[0]
+	assert.Assert(t, is.Equal(a.ID, int64(123)))
+	assert.Assert(t, is.Equal(a.Name, "test-results-unit"))
+	assert.Assert(t, is.Equal(a.WorkflowRun.ID, int64(456)))
+	assert.Assert(t, is.Equal(a.WorkflowRun.HeadBranch, "feature"))
+	assert.Assert(t, is.Equal(a.WorkflowRun.HeadRepositoryID, int64(789)))
+	assert.Assert(t, a.CreatedAt.Equal(createdAt))
+}
+
+func newArtifact(name string, createdAt time.Time, expired bool, runID int64) artifact {
+	a := artifact{Name: name, CreatedAt: createdAt, Expired: expired}
+	a.WorkflowRun.ID = runID
+	return a
+}
+
+func TestFilterProblemResultsAggregatesAndDropsParents(t *testing.T) {
+	results := map[string]*result{
+		"pkg|TestParent": {
+			Passes:        1,
+			Failures:      1,
+			FailedRunIDs:  map[int64]struct{}{101: {}},
+			FailedPRHeads: map[string]struct{}{"1:pr-a": {}, "1:pr-b": {}},
+			Package:       "pkg",
+			Test:          "TestParent",
+		},
+		"pkg|TestParent/TestLeaf": {
+			Passes:        2,
+			Failures:      1,
+			FailedRunIDs:  map[int64]struct{}{101: {}},
+			FailedPRHeads: map[string]struct{}{"1:pr-a": {}, "1:pr-b": {}},
+			Package:       "pkg",
+			Test:          "TestParent/TestLeaf",
+		},
+		"pkg|TestPassing": {
+			Passes:        3,
+			FailedRunIDs:  map[int64]struct{}{},
+			FailedPRHeads: map[string]struct{}{},
+			Package:       "pkg",
+			Test:          "TestPassing",
+		},
+	}
+
+	problems := filterProblemResults(results)
+	assert.Assert(t, is.Len(problems, 1))
+
+	leaf := problems["pkg|TestParent/TestLeaf"]
+	assert.Assert(t, leaf != nil)
+	assert.Assert(t, is.Equal(leaf.Passes, 2))
+	assert.Assert(t, is.Equal(leaf.Failures, 1))
+	_, ok := leaf.FailedRunIDs[101]
+	assert.Assert(t, ok)
+}
+
+func TestFilterProblemResultsRequiresMasterOrTwoPRs(t *testing.T) {
+	results := map[string]*result{
+		"pkg|TestSinglePR": {
+			Passes:        1,
+			Failures:      1,
+			FailedRunIDs:  map[int64]struct{}{101: {}},
+			FailedPRHeads: map[string]struct{}{"1:pr-a": {}},
+			Package:       "pkg",
+			Test:          "TestSinglePR",
+		},
+		"pkg|TestTwoPRs": {
+			Passes:        1,
+			Failures:      2,
+			FailedRunIDs:  map[int64]struct{}{201: {}, 202: {}},
+			FailedPRHeads: map[string]struct{}{"1:pr-a": {}, "1:pr-b": {}},
+			Package:       "pkg",
+			Test:          "TestTwoPRs",
+		},
+		"pkg|TestMaster": {
+			Passes:         1,
+			Failures:       1,
+			FailedRunIDs:   map[int64]struct{}{301: {}},
+			FailedPRHeads:  map[string]struct{}{},
+			FailedOnMaster: true,
+			Package:        "pkg",
+			Test:           "TestMaster",
+		},
+		"pkg|TestOnlyFails": {
+			Failures:      2,
+			FailedRunIDs:  map[int64]struct{}{401: {}, 402: {}},
+			FailedPRHeads: map[string]struct{}{"1:pr-a": {}, "1:pr-b": {}},
+			Package:       "pkg",
+			Test:          "TestOnlyFails",
+		},
+	}
+
+	problems := filterProblemResults(results)
+	assert.Assert(t, is.Nil(problems["pkg|TestSinglePR"]))
+	assert.Assert(t, problems["pkg|TestTwoPRs"] != nil)
+	assert.Assert(t, problems["pkg|TestMaster"] != nil)
+	assert.Assert(t, is.Nil(problems["pkg|TestOnlyFails"]))
+}
+
+func TestUpdateHistoryReplacesToday(t *testing.T) {
+	existing := updateHistory(historyData{}, 1, 2, "66")
+	updated := updateHistory(existing, 3, 4, "57")
+
+	assert.Assert(t, is.Len(updated.History, 1))
+	row := updated.History[0]
+	assert.Assert(t, is.Equal(row.Passes, 3))
+	assert.Assert(t, is.Equal(row.Failures, 4))
+	assert.Assert(t, is.Equal(row.Rate, "57"))
+	assert.Assert(t, updated.FirstSeen != "")
+}

--- a/internal/ci/analyze-tests/reports.go
+++ b/internal/ci/analyze-tests/reports.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const maxExtractedArtifactFileSize = 100 << 20
+
+// downloadAndExtract downloads one artifact zip and extracts safe relative file
+// paths into dest.
+func downloadAndExtract(ctx context.Context, gh *githubClient, a artifact, dest string) error {
+	data, err := gh.downloadArtifact(ctx, a.ID)
+	if err != nil {
+		return err
+	}
+	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return err
+	}
+	root, err := os.OpenRoot(dest)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	for _, f := range r.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		if f.UncompressedSize64 > maxExtractedArtifactFileSize {
+			return fmt.Errorf("artifact file %q is too large: %d bytes", f.Name, f.UncompressedSize64)
+		}
+		if err := root.MkdirAll(filepath.Dir(f.Name), 0o755); err != nil {
+			return err
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		out, err := root.OpenFile(f.Name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+		if err != nil {
+			rc.Close()
+			return err
+		}
+		limited := io.LimitReader(rc, maxExtractedArtifactFileSize+1)
+		n, copyErr := io.Copy(out, limited)
+		if err := errors.Join(out.Close(), rc.Close(), copyErr); err != nil {
+			return err
+		}
+		if n > maxExtractedArtifactFileSize {
+			return fmt.Errorf("artifact file %q exceeds %d bytes", f.Name, maxExtractedArtifactFileSize)
+		}
+	}
+	return nil
+}
+
+// parseReports reads go test JSON report files from an extracted artifact.
+// Only package-level test pass and fail events are retained.
+func parseReports(dir string) ([]testEvent, error) {
+	var events []testEvent
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+
+	err = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, "-go-test-report.json") {
+			return err
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		file, err := root.Open(rel)
+		if err != nil {
+			return err
+		}
+		parsed, err := parseReportFile(file)
+		if closeErr := file.Close(); err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			return err
+		}
+		events = append(events, parsed...)
+		return nil
+	})
+	return events, err
+}
+
+// parseReportFile decodes the newline-delimited go test JSON events in file.
+func parseReportFile(file io.Reader) ([]testEvent, error) {
+	var events []testEvent
+	dec := json.NewDecoder(file)
+	for {
+		var rec struct {
+			Action  string `json:"Action"`
+			Package string `json:"Package"`
+			Test    string `json:"Test"`
+		}
+		if err := dec.Decode(&rec); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		if (rec.Action == "pass" || rec.Action == "fail") && rec.Test != "" {
+			if rec.Package == "" {
+				rec.Package = "unknown"
+			}
+			events = append(events, testEvent{Action: rec.Action, Package: rec.Package, Test: rec.Test})
+		}
+	}
+	return events, nil
+}

--- a/internal/ci/analyze-tests/results.go
+++ b/internal/ci/analyze-tests/results.go
@@ -1,0 +1,60 @@
+package main
+
+import "strings"
+
+// filterProblemResults returns tests that look flaky enough to track.
+// A test must have at least one pass, at least one failure, and either fail on
+// master or fail across at least two pull-request heads.
+func filterProblemResults(results map[string]*result) map[string]*result {
+	deduped := map[string]*result{}
+	for _, r := range results {
+		key := r.Package + "|" + r.Test
+		d := deduped[key]
+		if d == nil {
+			d = &result{Package: r.Package, Test: r.Test, FailedRunIDs: map[int64]struct{}{}, FailedPRHeads: map[string]struct{}{}}
+			deduped[key] = d
+		}
+		d.Passes += r.Passes
+		d.Failures += r.Failures
+		for runID := range r.FailedRunIDs {
+			d.FailedRunIDs[runID] = struct{}{}
+		}
+		for prHead := range r.FailedPRHeads {
+			d.FailedPRHeads[prHead] = struct{}{}
+		}
+		d.FailedOnMaster = d.FailedOnMaster || r.FailedOnMaster
+	}
+
+	problem := map[string]*result{}
+	var tests []string
+	for _, r := range deduped {
+		if r.Failures > 0 {
+			tests = append(tests, r.Test)
+		}
+	}
+	for key, r := range deduped {
+		if r.Failures == 0 || r.Passes == 0 || !hasQualifyingFailureSource(r) || hasFailingSubtest(r.Test, tests) {
+			continue
+		}
+		problem[key] = r
+	}
+	return problem
+}
+
+// hasQualifyingFailureSource reports whether failures came from trusted enough
+// sources to avoid filing issues for one-off pull-request breakage.
+func hasQualifyingFailureSource(r *result) bool {
+	return r.FailedOnMaster || len(r.FailedPRHeads) >= 2
+}
+
+// hasFailingSubtest reports whether test has a failing descendant subtest.
+// Parent test failures are skipped when a more specific subtest also failed.
+func hasFailingSubtest(test string, tests []string) bool {
+	prefix := test + "/"
+	for _, candidate := range tests {
+		if strings.HasPrefix(candidate, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ci/analyze-tests/summary.go
+++ b/internal/ci/analyze-tests/summary.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// summaryRow is one flaky-test detection result for the GitHub Actions summary.
+type summaryRow struct {
+	Result         *result
+	Classification string
+	RatePct        int
+}
+
+// writeGitHubSummary appends the analyzer result to the GitHub Actions summary.
+func writeGitHubSummary(path string, rows []summaryRow, writeIssues bool) error {
+	if path == "" {
+		return nil
+	}
+
+	var b strings.Builder
+	b.WriteString("## Flaky test detection\n\n")
+	if writeIssues {
+		b.WriteString("Issue updates: enabled.\n\n")
+	} else {
+		b.WriteString("Issue updates: dry-run; no issues were created or edited.\n\n")
+	}
+
+	if len(rows) == 0 {
+		b.WriteString("No qualifying flaky tests were detected.\n")
+		return appendSummary(path, b.String())
+	}
+
+	b.WriteString("| Classification | Test | Package | Passes | Failures | Failure rate |\n")
+	b.WriteString("| --- | --- | --- | ---: | ---: | ---: |\n")
+	for _, row := range rows {
+		r := row.Result
+		fmt.Fprintf(&b, "| %s | `%s` | `%s` | %d | %d | %d%% |\n",
+			strings.ToUpper(row.Classification), r.Test, r.Package, r.Passes, r.Failures, row.RatePct)
+	}
+
+	return appendSummary(path, b.String())
+}
+
+func appendSummary(path, content string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(content)
+	return err
+}

--- a/internal/ci/analyze-tests/util.go
+++ b/internal/ci/analyze-tests/util.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+// configureLogging installs the process-wide logger used by the analyzer.
+func configureLogging() {
+	githubActions := os.Getenv("GITHUB_ACTIONS") == "true"
+	var handler slog.Handler = slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})
+	if githubActions {
+		handler = &GitHubActionsHandler{Handler: handler}
+	}
+	slog.SetDefault(slog.New(handler))
+}
+
+// GitHubActionsHandler emits GitHub Actions workflow annotations for log records.
+type GitHubActionsHandler struct {
+	slog.Handler
+}
+
+// Handle writes a workflow annotation before delegating to the wrapped handler.
+func (h *GitHubActionsHandler) Handle(ctx context.Context, r slog.Record) error {
+	level := r.Level
+	msg := r.Message
+
+	switch {
+	case level >= slog.LevelError:
+		fmt.Printf("::error::%s\n", msg)
+	case level >= slog.LevelWarn:
+		fmt.Printf("::warning::%s\n", msg)
+	default:
+		fmt.Printf("::notice::%s\n", msg)
+	}
+
+	r.Time = time.Time{}
+	return h.Handler.Handle(ctx, r)
+}
+
+// WithAttrs preserves GitHub Actions annotations for derived loggers.
+func (h *GitHubActionsHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &GitHubActionsHandler{Handler: h.Handler.WithAttrs(attrs)}
+}
+
+// WithGroup preserves GitHub Actions annotations for derived loggers.
+func (h *GitHubActionsHandler) WithGroup(name string) slog.Handler {
+	return &GitHubActionsHandler{Handler: h.Handler.WithGroup(name)}
+}
+
+// sortedKeys returns the map keys in deterministic string order.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// runCommand executes a subprocess and returns stdout.
+// Stderr is included in returned errors to make CI failures actionable.
+func runCommand(ctx context.Context, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}
+
+// firstNonEmpty returns the first non-empty value in order.
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Add a scheduled analyzer that scans recent GitHub Actions test artifacts for repeated failures and opens or updates tracking issues.