### PR TITLE
daemon: keep inserted iptables rules at chain head

### DIFF
--- a/daemon/libnetwork/iptables/iptables.go
+++ b/daemon/libnetwork/iptables/iptables.go
@@ -513,10 +513,15 @@ func (r Rule) Append() error {
 	return r.ensure(Append)
 }
 
-// Insert inserts the rule at the head of the chain. If the rule already exists anywhere in the
-// chain, this is a no-op.
+// Insert inserts the rule at the head of the chain. If the rule already exists
+// anywhere in the chain, it is moved to the head.
 func (r Rule) Insert() error {
-	return r.ensure(Insert)
+	if r.Exists() {
+		if err := r.exec(Delete); err != nil {
+			return err
+		}
+	}
+	return r.exec(Insert)
 }
 
 // Delete deletes the rule from the kernel. If the rule does not exist, this is a no-op.

--- a/daemon/libnetwork/iptables/iptables_test.go
+++ b/daemon/libnetwork/iptables/iptables_test.go
@@ -293,10 +293,27 @@ func TestRule(t *testing.T) {
 -A TESTCHAIN -j ACCEPT
 `)
 
+	rule = Rule{IPVer: IPv4, Table: Filter, Chain: "TESTCHAIN", Args: []string{"-j", "DROP"}}
+	assert.NilError(t, rule.Insert())
+	assert.Equal(t, mustDumpChain(t, Filter, "TESTCHAIN"), `-N TESTCHAIN
+-A TESTCHAIN -j DROP
+-A TESTCHAIN -j RETURN
+-A TESTCHAIN -j ACCEPT
+`)
+
+	rule = Rule{IPVer: IPv4, Table: Filter, Chain: "TESTCHAIN", Args: []string{"-j", "RETURN"}}
+	assert.NilError(t, rule.Insert())
+	assert.Equal(t, mustDumpChain(t, Filter, "TESTCHAIN"), `-N TESTCHAIN
+-A TESTCHAIN -j RETURN
+-A TESTCHAIN -j DROP
+-A TESTCHAIN -j ACCEPT
+`)
+
 	assert.NilError(t, rule.Delete())
 	assert.Equal(t, rule.Exists(), false)
 	assert.Equal(t, mustDumpChain(t, Filter, "TESTCHAIN"), `-N TESTCHAIN
--A TESTCHAIN -j RETURN
+-A TESTCHAIN -j DROP
+-A TESTCHAIN -j ACCEPT
 `)
 
 	// Test that Delete is idempotent


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/52666

  ## Summary

  Update iptables `Rule.Insert` so an existing rule is moved back to the head of its chain instead of being left in its current position.

  This keeps rules that depend on top-of-chain ordering, such as `bridge-accept-fwmark`, ahead of later inserted Docker forwarding jumps.

## Testing

  - `env GOOS=linux go test -c ./daemon/libnetwork/iptables -o /private/tmp/moby-iptables.test`