### PR TITLE
daemon/containerd: push down reference and dangling filters to containerd store

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -80,7 +80,7 @@ func (i *ImageService) Images(ctx context.Context, opts imagebackend.ListOptions
 		return nil, err
 	}
 
-	imgs, err := i.images.List(ctx)
+	imgs, err := i.images.List(ctx, filters.BuildCtrdImageFilters(opts.Filters, imageNameDanglingPrefix)...)
 	if err != nil {
 		return nil, err
 	}
@@ -583,7 +583,10 @@ type imageFilterFunc func(image c8dimages.Image) bool
 // setupFilters constructs an imageFilterFunc from the given imageFilters.
 //
 // filterFunc is a function that checks whether given image matches the filters.
-// TODO(thaJeztah): reimplement filters using containerd filters if possible: see https://github.com/moby/moby/issues/43845
+// Push-downable filters (reference, dangling=true) are handled by [buildCtrdFilters]
+// and pre-applied on the containerd store. The remaining filters here act as the
+// authoritative Go-side pass.
+// TODO(thaJeztah): push down remaining filters where possible: see https://github.com/moby/moby/issues/43845
 func (i *ImageService) setupFilters(ctx context.Context, imageFilters filters.Args) (filterFunc imageFilterFunc, outErr error) {
 	var fltrs []imageFilterFunc
 	err := imageFilters.WalkValues("before", func(value string) error {

--- a/daemon/containerd/image_list_test.go
+++ b/daemon/containerd/image_list_test.go
@@ -505,3 +505,4 @@ func TestComputeSharedSizeIncludesSharedContentBlobs(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(sharedSize, int64(120)))
 }
+

--- a/daemon/internal/filters/ctrd.go
+++ b/daemon/internal/filters/ctrd.go
@@ -1,0 +1,127 @@
+package filters
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/distribution/reference"
+)
+
+// ErrNotConvertible is returned by ReferenceToCtrdFilter when the pattern
+// cannot be expressed as a containerd filter expression (e.g. when the name
+// part contains glob characters that prevent safe normalization).
+var ErrNotConvertible = errors.New("pattern cannot be converted to a containerd filter")
+
+// ReferenceToCtrdFilter converts a Docker "reference" filter pattern to a
+// containerd name filter expression.
+//
+// Containerd stores names in their canonical form (e.g.
+// "docker.io/library/alpine:latest"). This function normalizes the name part
+// of the pattern before building the filter expression.
+//
+// The returned expression is conservative: it may match more images than the
+// Go-side reference filter would accept, but will never exclude images that
+// would pass.
+//
+// Returns [ErrNotConvertible] if the pattern cannot be safely expressed as a
+// containerd filter.
+func ReferenceToCtrdFilter(pattern string) (string, error) {
+	// '@' takes precedence over ':': "name@digest" must not be split at the
+	// ':' inside the digest algorithm prefix (e.g. "sha256:...").
+	var namePart, tagPart, sep string
+	if i := strings.IndexByte(pattern, '@'); i >= 0 {
+		namePart, tagPart, sep = pattern[:i], pattern[i+1:], "@"
+	} else if i := strings.IndexByte(pattern, ':'); i >= 0 {
+		namePart, tagPart, sep = pattern[:i], pattern[i+1:], ":"
+	} else {
+		namePart = pattern
+	}
+
+	// Glob characters in the name part prevent safe normalization.
+	if strings.ContainsAny(namePart, "*?[") {
+		return "", ErrNotConvertible
+	}
+
+	normalizedRef, err := reference.ParseNormalizedNamed(namePart)
+	if err != nil {
+		return "", ErrNotConvertible
+	}
+	canonicalName := normalizedRef.Name()
+
+	switch sep {
+	case "":
+		// No tag/digest: match any tag or digest of this image.
+		nameRegex := "^" + regexp.QuoteMeta(canonicalName) + "[:@]"
+		return "name~=" + strconv.Quote(nameRegex), nil
+	case "@":
+		if strings.ContainsAny(tagPart, "*?[") {
+			return "", ErrNotConvertible
+		}
+		return fmt.Sprintf("name==%q", canonicalName+"@"+tagPart), nil
+	default: // ":"
+		if !strings.ContainsAny(tagPart, "*?[") {
+			return fmt.Sprintf("name==%q", canonicalName+":"+tagPart), nil
+		}
+		// Tag contains glob characters: convert to regex.
+		tagRegex := "^" + regexp.QuoteMeta(canonicalName) + ":" + tagGlobToRegex(tagPart) + "$"
+		return "name~=" + strconv.Quote(tagRegex), nil
+	}
+}
+
+// BuildCtrdImageFilters translates Docker image filter args into containerd
+// image store filter strings that can pre-filter before Go-side filtering.
+//
+// danglingPrefix is the name prefix used to identify dangling images in the
+// containerd store (e.g. "moby-dangling@").
+//
+// Each returned string is a separate argument to the containerd image store
+// List call; containerd treats multiple arguments as OR semantics, which
+// naturally models Docker's reference filter where multiple values are also
+// OR-ed.
+//
+// The returned expressions are conservative: they may match more images than
+// the full Docker filter accepts, but will never exclude images that would pass.
+func BuildCtrdImageFilters(imageFilters Args, danglingPrefix string) []string {
+	var ctrdFilters []string
+
+	// reference: each value is OR-ed, which matches containerd's per-arg OR semantics.
+	for _, ref := range imageFilters.Get("reference") {
+		f, err := ReferenceToCtrdFilter(ref)
+		if err != nil {
+			// Pattern cannot be pushed down; Go-side filtering will handle it.
+			continue
+		}
+		ctrdFilters = append(ctrdFilters, f)
+	}
+
+	// dangling=true: only dangling images have names prefixed with danglingPrefix.
+	if imageFilters.Contains("dangling") {
+		if v, err := imageFilters.GetBoolOrDefault("dangling", false); err == nil && v {
+			ctrdFilters = append(ctrdFilters, "name~="+strconv.Quote("^"+danglingPrefix))
+		}
+	}
+
+	return ctrdFilters
+}
+
+// tagGlobToRegex converts a path.Match glob (tag position, no "/" separators)
+// to a Go regexp string.
+func tagGlobToRegex(glob string) string {
+	var sb strings.Builder
+	for _, ch := range glob {
+		switch ch {
+		case '*':
+			sb.WriteString(".*")
+		case '?':
+			sb.WriteByte('.')
+		case '[', ']':
+			sb.WriteRune(ch)
+		default:
+			sb.WriteString(regexp.QuoteMeta(string(ch)))
+		}
+	}
+	return sb.String()
+}

--- a/daemon/internal/filters/ctrd_test.go
+++ b/daemon/internal/filters/ctrd_test.go
@@ -1,0 +1,121 @@
+package filters_test
+
+import (
+	"testing"
+
+	"github.com/moby/moby/v2/daemon/internal/filters"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+const testDanglingPrefix = "moby-dangling@"
+
+func TestBuildCtrdImageFilters(t *testing.T) {
+	newArgs := func(kv ...string) filters.Args {
+		args := filters.NewArgs()
+		for i := 0; i+1 < len(kv); i += 2 {
+			args.Add(kv[i], kv[i+1])
+		}
+		return args
+	}
+
+	t.Run("no filters returns empty", func(t *testing.T) {
+		got := filters.BuildCtrdImageFilters(filters.NewArgs(), testDanglingPrefix)
+		assert.Check(t, is.Len(got, 0))
+	})
+
+	t.Run("single reference", func(t *testing.T) {
+		got := filters.BuildCtrdImageFilters(newArgs("reference", "alpine:latest"), testDanglingPrefix)
+		assert.Assert(t, is.Len(got, 1))
+		assert.Check(t, is.Equal(got[0], `name=="docker.io/library/alpine:latest"`))
+	})
+
+	t.Run("multiple references produce one entry each", func(t *testing.T) {
+		args := filters.NewArgs()
+		args.Add("reference", "alpine:latest")
+		args.Add("reference", "nginx:latest")
+		got := filters.BuildCtrdImageFilters(args, testDanglingPrefix)
+		assert.Assert(t, is.Len(got, 2))
+	})
+
+	t.Run("dangling true", func(t *testing.T) {
+		got := filters.BuildCtrdImageFilters(newArgs("dangling", "true"), testDanglingPrefix)
+		assert.Assert(t, is.Len(got, 1))
+		assert.Check(t, is.Equal(got[0], `name~="^moby-dangling@"`))
+	})
+
+	t.Run("dangling false produces no containerd filter", func(t *testing.T) {
+		got := filters.BuildCtrdImageFilters(newArgs("dangling", "false"), testDanglingPrefix)
+		assert.Check(t, is.Len(got, 0))
+	})
+
+	t.Run("non-pushable filter types produce no containerd filters", func(t *testing.T) {
+		got := filters.BuildCtrdImageFilters(newArgs("label", "foo=bar", "before", "alpine:latest"), testDanglingPrefix)
+		assert.Check(t, is.Len(got, 0))
+	})
+}
+
+func TestReferenceToCtrdFilter(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		pattern     string
+		expected    string
+		expectErr   error
+	}{
+		{
+			name:     "exact name and tag",
+			pattern:  "alpine:latest",
+			expected: `name=="docker.io/library/alpine:latest"`,
+		},
+		{
+			name:     "name only, no tag",
+			pattern:  "alpine",
+			expected: `name~="^docker\\.io/library/alpine[:@]"`,
+		},
+		{
+			name:     "fully qualified name and tag",
+			pattern:  "docker.io/library/nginx:1.25",
+			expected: `name=="docker.io/library/nginx:1.25"`,
+		},
+		{
+			name:     "custom registry with name and tag",
+			pattern:  "registry.example.com/myapp:v2",
+			expected: `name=="registry.example.com/myapp:v2"`,
+		},
+		{
+			name:     "tag glob",
+			pattern:  "alpine:*",
+			expected: `name~="^docker\\.io/library/alpine:.*$"`,
+		},
+		{
+			name:     "tag glob with prefix",
+			pattern:  "nginx:1.*",
+			expected: `name~="^docker\\.io/library/nginx:1\\..*$"`,
+		},
+		{
+			name:      "glob in name part is not pushed down",
+			pattern:   "*:latest",
+			expectErr: filters.ErrNotConvertible,
+		},
+		{
+			name:      "glob in name part with slash is not pushed down",
+			pattern:   "*/redis",
+			expectErr: filters.ErrNotConvertible,
+		},
+		{
+			name:     "digest reference",
+			pattern:  "alpine@sha256:1234abcd",
+			expected: `name=="docker.io/library/alpine@sha256:1234abcd"`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := filters.ReferenceToCtrdFilter(tc.pattern)
+			if tc.expectErr != nil {
+				assert.Check(t, is.ErrorIs(err, tc.expectErr))
+				return
+			}
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(got, tc.expected))
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/moby/moby/issues/43845

## Summary

Pass containerd filter expressions to `images.Store.List` for `reference` and
`dangling=true` filters, so containerd's BoltDB metadata store pre-filters
before returning results to the daemon.

Previously, `i.images.List` always fetched every image then filtered in Go.
With this change:

| Docker filter | Containerd filter |
|---|---|
| `reference=alpine:latest` | `name=="docker.io/library/alpine:latest"` |
| `reference=alpine` | `name~="^docker\.io/library/alpine[:@]"` |
| `reference=alpine:1.*` | `name~="^docker\.io/library/alpine:1\..*$"` |
| `dangling=true` | `name~="^moby-dangling@"` |

The reference-to-containerd-filter translation logic lives in a new
`daemon/internal/filters/ctrd.go` file so it can be reused by other callers.
Filters that cannot be expressed in containerd's filter language (`before`,
`since`, `until`, `label`, `label!`) remain evaluated Go-side.

The containerd filters are conservative: they may return a superset of the
final result but will never exclude images the Go-side filter would accept.

## Release notes (optional)

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)

Created with: Claude Code