### PR TITLE
Add Docker Agent PR reviewer workflow

### DIFF
--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -1,0 +1,42 @@
+name: PR Review - Trigger
+on:
+  pull_request:
+    types: [ready_for_review, opened, review_requested]
+  pull_request_review_comment:
+    types: [created]
+
+permissions: {}
+
+# Deduplicate simultaneous pull_request events for the same fork PR.
+# When reviewers are requested at the same time, GitHub fires multiple
+# review_requested events. Without this group each event triggers a
+# separate review via workflow_run, producing duplicate reviews.
+concurrency:
+  group: pr-review-trigger-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  save-context:
+    if: github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save event context
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMENT_JSON: ${{ toJSON(github.event.comment) }}
+        run: |
+          mkdir -p context
+          printf '%s' "${{ github.event_name }}" > context/event_name.txt
+          printf '%s' "$PR_NUMBER" > context/pr_number.txt
+          printf '%s' "$PR_HEAD_SHA" > context/pr_head_sha.txt
+          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            printf '%s' "$COMMENT_JSON" > context/comment.json
+          fi
+
+      - name: Upload context
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-review-context
+          path: context/
+          retention-days: 1

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,25 @@
+name: PR Review
+on:
+  issue_comment:
+    types: [created]
+  workflow_run:
+    workflows: ["PR Review - Trigger"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@e96a4bb40cac114f64358621e1d08346c8eadc8c # v2.0.1
+    permissions:
+      contents: read       # Read repository files and PR diffs
+      pull-requests: write # Post review comments
+      issues: write        # Create security incident issues if secrets detected
+      checks: write        # (Optional) Show review progress as a check run
+      #id-token: write     # Required for OIDC authentication to AWS Secrets Manager
+      actions: read        # Download artifacts from trigger workflow
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    with:
+      trigger-run-id: ${{ github.event_name == 'workflow_run' && format('{0}', github.event.workflow_run.id) || '' }}


### PR DESCRIPTION
## Summary

Based on https://github.com/docker/docker-agent-action/blob/main/review-pr/README.md

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
