### PR TITLE
integration-cli: Deflake TestDockerCLICpSuite

### DIFF
--- a/integration-cli/docker_cli_cp_utils_test.go
+++ b/integration-cli/docker_cli_cp_utils_test.go
@@ -136,7 +136,10 @@ func makeTestContainer(t *testing.T, options testContainerOptions) (containerID 
 		options.command = "#(nop)"
 	}
 
-	args := []string{"run", "-d"}
+	cidDir := t.TempDir()
+	cidFile := filepath.Join(cidDir, "cid")
+
+	args := []string{"run", "--cidfile", cidFile}
 
 	for _, volume := range options.volumes {
 		args = append(args, "-v", volume)
@@ -152,17 +155,12 @@ func makeTestContainer(t *testing.T, options testContainerOptions) (containerID 
 
 	args = append(args, "busybox", "/bin/sh", "-c", options.command)
 
-	out := cli.DockerCmd(t, args...).Combined()
+	cli.DockerCmd(t, args...)
 
-	containerID = strings.TrimSpace(out)
-
-	out = cli.DockerCmd(t, "wait", containerID).Combined()
-
-	exitCode := strings.TrimSpace(out)
-	if exitCode != "0" {
-		out = cli.DockerCmd(t, "logs", containerID).Combined()
-	}
-	assert.Equal(t, exitCode, "0", "failed to make test container: %s", out)
+	containerIDBytes, err := os.ReadFile(cidFile)
+	assert.NilError(t, err)
+	containerID = strings.TrimSpace(string(containerIDBytes))
+	assert.Assert(t, containerID != "", "failed to read container ID from %s", cidFile)
 
 	return containerID
 }


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

The cp integration fixture only needs a stopped container with prepared filesystem content.

Running the container detached and immediately calling `docker wait` adds an extra daemon wait request that can race with short-lived fixture containers and fail before the copy behavior is exercised.

Run the fixture command in the foreground and capture the resulting container ID with a cidfile so the container remains available for later cp assertions without the separate wait endpoint.


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
