### PR TITLE
gha/test: Extract mode selection to the caller

### DIFF
--- a/.github/workflows/.test-unit.yml
+++ b/.github/workflows/.test-unit.yml
@@ -13,10 +13,10 @@ on:
         required: false
         type: string
         default: amd64
-      runner:
+      runnerSuffix:
         required: false
         type: string
-        default: ubuntu-24.04
+        default: ""
     secrets:
       CODECOV_TOKEN:
         required: false
@@ -30,7 +30,7 @@ env:
 
 jobs:
   unit:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ubuntu-24.04${{ inputs.runnerSuffix }}
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     strategy:

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -13,10 +13,14 @@ on:
         required: false
         type: string
         default: amd64
-      runner:
+      runnerSuffix:
         required: false
         type: string
-        default: ubuntu-24.04
+        default: ""
+      extraModes:
+        required: false
+        type: string
+        default: '[]'
       storage:
         required: true
         type: string
@@ -38,7 +42,7 @@ env:
 
 jobs:
   docker-py:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ubuntu-24.04${{ inputs.runnerSuffix }}
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -94,7 +98,7 @@ jobs:
           retention-days: 1
 
   integration-flaky:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ubuntu-24.04${{ inputs.runnerSuffix }}
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -140,30 +144,23 @@ jobs:
         id: set
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          INPUT_ARCH: ${{ inputs.arch }}
-          INPUT_RUNNER: ${{ inputs.runner }}
-          INPUT_STORAGE: ${{ inputs.storage }}
+          MATRIX_ARCH: ${{ inputs.arch }}
+          MATRIX_EXTRA_MODES: ${{ inputs.extraModes }}
+          MATRIX_RUNNER_SUFFIX: ${{ inputs.runnerSuffix }}
         with:
           script: |
-            const arch = core.getInput('arch', { required: true });
-            const runner = core.getInput('runner', { required: true });
-            const storage = core.getInput('storage', { required: true });
+            const arch = `${{ env.MATRIX_ARCH }}`;
+            const extraModes = JSON.parse(`${{ env.MATRIX_EXTRA_MODES }}`);
+            const runnerSuffix = `${{ env.MATRIX_RUNNER_SUFFIX }}`;
             let includes = [
-              { os: 'ubuntu-22.04', mode: '' },
-              { os: 'ubuntu-22.04', mode: 'rootless' },
-              { os: 'ubuntu-22.04', mode: 'systemd' },
-              { os: 'ubuntu-24.04', mode: '' },
-              { os: 'ubuntu-24.04', mode: 'rootless' },
-              { os: 'ubuntu-24.04', mode: 'systemd' },
-              // { os: 'ubuntu-24.04', mode: 'rootless-systemd' }, // FIXME: https://github.com/moby/moby/issues/44084
+              { arch: arch, runner: `ubuntu-24.04${runnerSuffix}`, mode: '' },
             ];
-            if (arch != "amd64") {
-              includes = includes.filter(item => item.os == 'ubuntu-24.04').map(item => ({ ...item, os: runner }));
-            }
-            if (storage == "snapshotter") {
-              includes.push({ os: arch == "amd64" ? 'ubuntu-24.04' : runner, mode: 'iptables+firewalld' });
-              includes.push({ os: arch == "amd64" ? 'ubuntu-24.04' : runner, mode: 'nftables' });
-              includes.push({ os: arch == "amd64" ? 'ubuntu-24.04' : runner, mode: 'nftables+firewalld' });
+            includes.push(...extraModes.map(mode => ({ arch: arch, runner: `ubuntu-24.04${runnerSuffix}`, mode: mode })));
+
+            if (arch == "amd64") {
+              includes.push({ arch: arch, runner: 'ubuntu-22.04', mode: '' });
+              includes.push({ arch: arch, runner: 'ubuntu-22.04', mode: 'rootless' });
+              includes.push({ arch: arch, runner: 'ubuntu-22.04', mode: 'systemd' });
             }
             await core.group(`Set matrix`, async () => {
               core.info(`matrix: ${JSON.stringify(includes)}`);
@@ -171,7 +168,7 @@ jobs:
             });
 
   integration:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     needs:
@@ -214,7 +211,7 @@ jobs:
           echo "CACHE_DEV_SCOPE=${CACHE_DEV_SCOPE}" >> $GITHUB_ENV
       -
         name: Set up AppArmor for RootlessKit
-        if: contains(matrix.mode, 'rootless') && matrix.os != 'ubuntu-22.04'
+        if: contains(matrix.mode, 'rootless') && matrix.runner != 'ubuntu-22.04'
         run: |
           cat <<EOT | sudo tee "/etc/apparmor.d/usr.local.bin.rootlesskit"
           abi <abi/4.0>,
@@ -251,9 +248,9 @@ jobs:
         if: always()
         env:
           MATRIX_MODE: ${{ matrix.mode }}
-          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_RUNNER: ${{ matrix.runner }}
         run: |
-          reportsName=$MATRIX_OS
+          reportsName=$MATRIX_RUNNER
           if [ -n "$MATRIX_MODE" ]; then
             reportsName="$reportsName-$MATRIX_MODE"
           fi
@@ -330,7 +327,7 @@ jobs:
           fi
 
   integration-cli-prepare:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ubuntu-24.04${{ inputs.runnerSuffix }}
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     outputs:
@@ -425,7 +422,7 @@ jobs:
             });
 
   integration-cli:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ubuntu-24.04${{ inputs.runnerSuffix }}
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,19 +85,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Only amd64 gets the full matrix
           - arch: amd64
-            runner: ubuntu-24.04
+            storage: snapshotter
+            runnerSuffix: ""
+            extraModes: '["rootless", "systemd", "iptables+firewalld", "nftables", "nftables+firewalld"]'
+            # FIXME: add rootless-systemd once https://github.com/moby/moby/issues/44084 is resolved.
+          - arch: amd64
             storage: graphdriver
-          - arch: amd64
-            runner: ubuntu-24.04
-            storage: snapshotter
+            runnerSuffix: ""
+            extraModes: '["rootless", "systemd"]'
+            # FIXME: add rootless-systemd once https://github.com/moby/moby/issues/44084 is resolved.
           - arch: arm64
-            runner: ubuntu-24.04-arm
             storage: snapshotter
+            runnerSuffix: "-arm"
+            extraModes: '[]'
     with:
       arch: ${{ matrix.arch }}
-      runner: ${{ matrix.runner }}
       storage: ${{ matrix.storage }}
+      runnerSuffix: ${{ matrix.runnerSuffix }}
+      extraModes: ${{ matrix.extraModes }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -112,12 +119,12 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            runner: ubuntu-24.04
+            runnerSuffix: ""
           - arch: arm64
-            runner: ubuntu-24.04-arm
+            runnerSuffix: "-arm"
     with:
       arch: ${{ matrix.arch }}
-      runner: ${{ matrix.runner }}
+      runnerSuffix: ${{ matrix.runnerSuffix }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
- follow up to: https://github.com/moby/moby/pull/52719

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

The integration matrix now starts from the default runner row and lets the caller provide extra modes.
    
This keeps native arm64 on the single default mode while amd64 retains expanded coverage.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
