### PR TITLE
daemon: re-mount image layer on restart to fix subpath access

### DIFF
--- a/daemon/mounts.go
+++ b/daemon/mounts.go
@@ -24,8 +24,20 @@ func (daemon *Daemon) prepareMountPoints(container *container.Container) error {
 			if err != nil {
 				return err
 			}
-
 			config.Layer = layer
+
+			if !alive {
+				// The overlay2 merged/ directory does not survive daemon
+				// shutdown; re-mount to get a valid path. safepath.Join (used
+				// for subpath mounts) calls filepath.EvalSymlinks on
+				// config.Source and fails with ENOENT if the path is stale.
+				// Balanced by the Unmount in removeMountPoints at deletion.
+				srcPath, err := layer.Mount("")
+				if err != nil {
+					return err
+				}
+				config.Source = srcPath
+			}
 		}
 
 		if config.Volume == nil {

--- a/integration/volume/mount_test.go
+++ b/integration/volume/mount_test.go
@@ -434,7 +434,6 @@ func TestRunMountImageSubpathDaemonRestart(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "image mounts not supported on Windows")
 
 	skip.If(t, testEnv.IsRootless, "FIXME: https://github.com/moby/moby/issues/50999")
-	skip.If(t, !testEnv.UsingSnapshotter(), "FIXME: https://github.com/moby/moby/issues/50999")
 
 	t.Parallel()
 


### PR DESCRIPTION
## Description

Containers with `type: image` volumes and a `subpath` fail to start after a daemon restart:

```
cannot access path /var/lib/docker/overlay2/{id}/merged/usr: lstat ... no such file or directory
```

This only affects graphdriver (overlay2); the containerd snapshotter is not affected.

**Root cause:** `prepareMountPoints` restores the `Layer` reference via `GetLayerByID` but never re-mounts the layer. With graphdriver, the overlay2 `merged/` directory is removed on daemon shutdown, leaving `config.Source` pointing to a stale path. When `setupMounts` calls `safepath.Join(ctx, m.Source, subpath)`, `evaluatePath` calls `filepath.EvalSymlinks(m.Source)` and fails with `ENOENT`.

**Fix:** Call `layer.Mount("")` for stopped containers (`alive=false`) to re-mount the overlay and update `config.Source` with the live path. The `alive` guard avoids double-mounting live-restored running containers where the overlay is still active. The existing `Unmount` in `removeMountPoints` balances this `Mount` at deletion time.

Enables the regression test `TestRunMountImageSubpathDaemonRestart` (added in #51831) which was previously skipped for graphdriver.

Fixes: #50999

## How to verify

```
make test-integration TESTFLAGS="-run TestRunMountImageSubpathDaemonRestart" TEST_FILTER=volume
```

## Release notes (optional)

```release-note
Fixed a bug where containers with `type=image` volume mounts and a `subpath` failed to start after a daemon restart when using graphdriver (overlay2).
```

## A picture of a cute animal

🦦

Created with: Claude Code