### PR TITLE
rootless: fix plugin install by running ToRootless on plugin spec

### DIFF
--- a/daemon/pkg/plugin/v2/plugin_linux.go
+++ b/daemon/pkg/plugin/v2/plugin_linux.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 
 	"github.com/moby/moby/api/types/plugin"
+	"github.com/moby/moby/v2/daemon/internal/rootless"
 	"github.com/moby/moby/v2/daemon/internal/rootless/mountopts"
+	"github.com/moby/moby/v2/daemon/internal/rootless/specconv"
 	"github.com/moby/moby/v2/daemon/pkg/oci"
 	"github.com/moby/moby/v2/internal/sliceutil"
 	"github.com/moby/sys/userns"
@@ -139,7 +141,7 @@ func (p *Plugin) InitSpec(execRoot string) (*specs.Spec, error) {
 		p.modifyRuntimeSpec(&s)
 	}
 
-	// Rootless mode requires modifying the mount flags
+	// When the daemon is running inside a user namesapce, it requires modifying the mount flags
 	// https://github.com/moby/moby/issues/47248#issuecomment-1927776700
 	// https://github.com/moby/moby/pull/47558
 	if userns.RunningInUserNS() {
@@ -165,6 +167,14 @@ func (p *Plugin) InitSpec(execRoot string) (*specs.Spec, error) {
 					}
 					m.Options = sliceutil.Dedup(append(m.Options, unpriv...))
 				}
+			}
+		}
+
+		// Even when RunningInUserNS returns true, RunningWithRootlessKit may return false.
+		// e.g., rootful daemon running in an "unprivileged" LXD/Incus.
+		if rootless.RunningWithRootlessKit() {
+			if err := specconv.ToRootless(&s, nil); err != nil {
+				return nil, errors.Wrap(err, "failed to convert plugin spec for rootless")
 			}
 		}
 	}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- Fixes: #52673

## Summary

Plugin specs built by (*v2.Plugin).InitSpec never went through daemon/internal/rootless/specconv.ToRootless, so the /sys fix-up for network=host under detach-netns (added in 84aedb805 "rootless: support detach-netns mode") was skipped for plugins. This made `docker plugin install` fail in rootless mode.

Apply the same rootless conversion that container specs receive in daemon/oci_linux.go, gated on rootless.RunningWithRootlessKit().


Note: used Claude


Testing:
```
docker plugin install grafana/loki-docker-driver:3.7.0-$(go env GOARCH)
```
It was previously failing due to `error mounting "sysfs" to rootfs at "/sys": mount src=sysfs, dst=/sys, dstFd=/proc/thread-self/fd/14, flags=MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC: operation not permitted`


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Fix installation of plugins that require host networking
```

## A picture of a cute animal (not mandatory but encouraged)
