### PR TITLE
integration/d/nri: close synchronized channel exactly once

### DIFF
--- a/integration/daemon/nri/plugin.go
+++ b/integration/daemon/nri/plugin.go
@@ -21,6 +21,7 @@ package nri
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/containerd/log"
@@ -37,10 +38,11 @@ type builtinPluginConfig struct {
 }
 
 type builtinPlugin struct {
-	stub         stub.Stub
-	logG         func(context.Context) *log.Entry
-	config       builtinPluginConfig
-	synchronized chan struct{}
+	stub            stub.Stub
+	logG            func(context.Context) *log.Entry
+	config          builtinPluginConfig
+	synchronized    chan struct{}
+	synchronizeOnce sync.Once
 }
 
 // startBuiltinPlugin turns the test binary into an NRI plugin, or fails the test.
@@ -83,11 +85,9 @@ func (p *builtinPlugin) Configure(ctx context.Context, config, runtime, version 
 func (p *builtinPlugin) Synchronize(ctx context.Context, pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
 	p.logG(ctx).Infof("Synchronized state with the runtime (%d pods, %d containers)...",
 		len(pods), len(containers))
-	select {
-	case <-p.synchronized:
-	default:
+	p.synchronizeOnce.Do(func() {
 		close(p.synchronized)
-	}
+	})
 	return nil, nil
 }
 


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/52601
- Follow up to: https://github.com/moby/moby/pull/52589

## Summary

`builtinPlugin.Synchronize` in `integration/daemon/nri/plugin.go` closed the `synchronized` channel inside a `select { case <-p.synchronized: default: close(p.synchronized) }` block. The pattern is not safe under concurrent invocation: two goroutines can both observe the channel as still open in `default` and panic when the second one calls `close` on an already-closed channel.

This was flagged in the Copilot review of #52589 (line 90), and @vvoland opened #52601 to track the fix.

Replace the racy select with `sync.Once.Do(func() { close(p.synchronized) })` so the channel is closed exactly once regardless of concurrency.

The timeout/hang concern raised in the same Copilot review on `startBuiltinPlugin`'s wait is intentionally left for a follow-up PR to keep this change focused on the race fix tracked by #52601.

## Release notes (optional)

<!-- Integration-test-only change; no user-facing changelog entry. -->

```markdown changelog

```

Created with: Claude Code (Opus 4.7)
