### PR TITLE
daemon: join detached netns when inspecting sysinfo

### DIFF
--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -10,7 +10,11 @@ import (
 func (daemon *Daemon) saveAppArmorConfig(container *container.Container) error {
 	container.AppArmorProfile = "" // reset; parseSecurityOpt re-derives it from HostConfig.SecurityOpt.
 
-	if !daemon.RawSysInfo().AppArmor {
+	sysInfo, err := daemon.RawSysInfo()
+	if err != nil {
+		return errdefs.System(err)
+	}
+	if !sysInfo.AppArmor {
 		return nil // if apparmor is disabled there is nothing to do here.
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -115,6 +115,7 @@ type Daemon struct {
 	root              string
 	sysInfoOnce       sync.Once
 	sysInfo           *sysinfo.SysInfo
+	sysInfoErr        error
 	shutdown          bool
 	idMapping         user.IdentityMapping
 	PluginStore       *plugin.Store // TODO: remove
@@ -1877,11 +1878,14 @@ func (daemon *Daemon) RawSysInfo() (*sysinfo.SysInfo, error) {
 		// We check if sysInfo is not set here, to allow some test to
 		// override the actual sysInfo.
 		if daemon.sysInfo == nil {
-			daemon.sysInfo = getSysInfo(&daemon.config().Config)
+			daemon.sysInfoErr = daemon.runInNetNS(func() error {
+				daemon.sysInfo = getSysInfo(&daemon.config().Config)
+				return nil
+			})
 		}
 	})
 
-	return daemon.sysInfo, nil
+	return daemon.sysInfo, daemon.sysInfoErr
 }
 
 // imageBackend is used to satisfy the [executorpkg.ImageBackend] and

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1872,7 +1872,7 @@ func (daemon *Daemon) BuilderBackend() builder.Backend {
 }
 
 // RawSysInfo returns *sysinfo.SysInfo .
-func (daemon *Daemon) RawSysInfo() *sysinfo.SysInfo {
+func (daemon *Daemon) RawSysInfo() (*sysinfo.SysInfo, error) {
 	daemon.sysInfoOnce.Do(func() {
 		// We check if sysInfo is not set here, to allow some test to
 		// override the actual sysInfo.
@@ -1881,7 +1881,7 @@ func (daemon *Daemon) RawSysInfo() *sysinfo.SysInfo {
 		}
 	})
 
-	return daemon.sysInfo
+	return daemon.sysInfo, nil
 }
 
 // imageBackend is used to satisfy the [executorpkg.ImageBackend] and

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -631,7 +631,10 @@ func verifyPlatformContainerSettings(daemon *Daemon, daemonCfg *configStore, hos
 	if hostConfig == nil {
 		return nil, nil
 	}
-	sysInfo := daemon.RawSysInfo()
+	sysInfo, err := daemon.RawSysInfo()
+	if err != nil {
+		return nil, err
+	}
 
 	w, err := verifyPlatformContainerResources(&hostConfig.Resources, sysInfo, update)
 

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -44,7 +44,10 @@ func doWithTrace[T any](ctx context.Context, name string, f func() T) T {
 func (daemon *Daemon) SystemInfo(ctx context.Context) (*system.Info, error) {
 	defer metrics.StartTimer(metrics.HostInfoFunctions.WithValues("system_info"))()
 
-	sysInfo := daemon.RawSysInfo()
+	sysInfo, err := daemon.RawSysInfo()
+	if err != nil {
+		return nil, err
+	}
 	cfg := daemon.config()
 
 	v := &system.Info{

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -272,7 +272,11 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 
 		// Remove time-namespace if not supported. We can remove this once we
 		// drop support for kernel < 5.6.
-		if !daemon.RawSysInfo().TimeNamespaces {
+		sysInfo, err := daemon.RawSysInfo()
+		if err != nil {
+			return errdefs.System(err)
+		}
+		if !sysInfo.TimeNamespaces {
 			oci.RemoveNamespace(s, specs.TimeNamespace)
 		}
 

--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -28,7 +28,11 @@ func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 			}
 			return err
 		}
-		if !daemon.RawSysInfo().Seccomp {
+		sysInfo, err := daemon.RawSysInfo()
+		if err != nil {
+			return err
+		}
+		if !sysInfo.Seccomp {
 			if c.SeccompProfile != "" && c.SeccompProfile != dconfig.SeccompProfileDefault {
 				return errors.New("seccomp is not enabled in your kernel, cannot run a custom seccomp profile")
 			}
@@ -39,7 +43,6 @@ func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		if s.Linux == nil {
 			s.Linux = &specs.Linux{}
 		}
-		var err error
 		switch {
 		case c.SeccompProfile == dconfig.SeccompProfileDefault:
 			s.Linux.Seccomp, err = seccomp.GetDefaultProfile(s)

--- a/daemon/server/router/container/backend.go
+++ b/daemon/server/router/container/backend.go
@@ -71,7 +71,7 @@ type commitBackend interface {
 }
 
 type sysInfoProvider interface {
-	RawSysInfo() *sysinfo.SysInfo
+	RawSysInfo() (*sysinfo.SysInfo, error)
 }
 
 // Backend is all the methods that need to be implemented to provide container specific functionality.

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -557,7 +557,11 @@ func (c *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 	rdr := io.TeeReader(r.Body, &requestBody)
 
 	// TODO(thaJeztah): do we prefer [backend.ContainerCreateConfig] here?
-	req, err := runconfig.DecodeCreateRequest(rdr, c.backend.RawSysInfo())
+	sysInfo, err := c.backend.RawSysInfo()
+	if err != nil {
+		return err
+	}
+	req, err := runconfig.DecodeCreateRequest(rdr, sysInfo)
 	if err != nil {
 		return err
 	}
@@ -598,7 +602,7 @@ func (c *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 
 	if versions.LessThan(version, "1.41") {
 		// Older clients expect the default to be "host" on cgroup v1 hosts
-		if hostConfig.CgroupnsMode.IsEmpty() && !c.backend.RawSysInfo().CgroupUnified {
+		if hostConfig.CgroupnsMode.IsEmpty() && !sysInfo.CgroupUnified {
 			hostConfig.CgroupnsMode = container.CgroupnsModeHost
 		}
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- Fixes: #52737

## Summary

Join `$ROOTLESSKIT_STATE_DIR/netns` when inspecting `net.ipv4.ip_forward`, to silence the bogus warning "IPv4 forwarding is disabled".

Test:
- `sudo sysctl -w net.ipv4.ip_forward=0`
- `systemctl --user start docker`.  This enables `net.ipv4.ip_forward=1` in `$ROOTLESSKIT_STATE_DIR/netns`.
- `docker info` no longer shows "IPv4 forwarding is disabled"

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Silence the spurious warning "IPv4 forwarding is disabled"
```

## A picture of a cute animal (not mandatory but encouraged)
