### PR TITLE
api: return HTTP 400 for invalid image references in image GET endpoints

### DIFF
--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -171,6 +171,12 @@ func (i *ImageService) ExportImage(ctx context.Context, names []string, platform
 			if _, ok := ref.(reference.Digested); ok {
 				specificDigestResolved = true
 			}
+		} else if resolveErr != nil {
+			// Both reference parsing and image resolution failed,
+			// so the name is not a valid image reference. Return
+			// the format error so the API gives a 400 instead of
+			// a misleading "not found" response.
+			return errdefs.InvalidParameter(refErr)
 		}
 
 		if resolveErr != nil || !specificDigestResolved {
@@ -189,7 +195,7 @@ func (i *ImageService) ExportImage(ctx context.Context, names []string, platform
 			return resolveErr
 		}
 		if refErr != nil {
-			return refErr
+			return errdefs.InvalidParameter(refErr)
 		}
 
 		// If user exports a specific digest, it shouldn't have a tag.

--- a/daemon/internal/image/tarexport/save.go
+++ b/daemon/internal/image/tarexport/save.go
@@ -116,7 +116,7 @@ func (l *tarexporter) parseNames(ctx context.Context, names []string) (desc map[
 				}
 				continue
 			}
-			return nil, errors.Errorf("invalid reference: %v", name)
+			return nil, errdefs.InvalidParameter(errors.Errorf("invalid reference: %v", name))
 		}
 
 		if reference.FamiliarName(namedRef) == string(digest.Canonical) {


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/48408

## Summary

Return HTTP 400 for invalid image references in `GET /images/get` and `GET /images/{name}/get` instead of HTTP 500.

### daemon/internal/image/tarexport/save.go

In `parseNames()`, wrap the untyped `invalid reference` error with `errdefs.InvalidParameter` so that the image export API returns HTTP 400 for invalid image references instead of HTTP 500.

### daemon/containerd/image_exporter.go

In `ExportImage()`, when both `refErr` (from `ParseNormalizedNamed`, format validation failure) and `resolveErr` (from `resolveImage`, image not found) are non-nil, prefer `refErr` wrapped with `errdefs.InvalidParameter`. Previously `resolveErr` was returned first, which produced a misleading `No such image` message with HTTP 404 instead of the format validation error with HTTP 400.

## Release notes

```markdown changelog
Return HTTP 400 instead of HTTP 500 when an invalid image reference is provided to GET /images/get and GET /images/{name}/get.
```