### PR TITLE
fix: suppress IPv4 forwarding warning in rootless mode (fixes #52737)

### DIFF
--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -150,7 +150,7 @@ func (daemon *Daemon) fillPlatformInfo(ctx context.Context, v *system.Info, sysI
 	if v.CgroupVersion == "1" {
 		v.Warnings = append(v.Warnings, "WARNING: Support for cgroup v1 is deprecated and planned to be removed by no later than May 2029 (https://github.com/moby/moby/issues/51111)")
 	}
-	if !v.IPv4Forwarding {
+	if !v.IPv4Forwarding && !cfg.Config.Rootless {
 		v.Warnings = append(v.Warnings, "WARNING: IPv4 forwarding is disabled")
 	}
 	// Env-var belonging to the bridge driver, disables use of the iptables "raw" table.


### PR DESCRIPTION
fixes #52737

## Summary

In rootless mode, IPv4 forwarding is handled within the network namespace
and the host-level sysctl check is not relevant. This change prevents the
misleading \"WARNING: IPv4 forwarding is disabled\" message from appearing
when running `docker info` on rootless instances.

## Changes

- Modified: `daemon/info_unix.go`
- Added `!cfg.Config.Rootless` check before appending the IPv4 forwarding warning

## Testing

- [x] Code compiles for Linux (`GOOS=linux go build ./daemon/...`)
- [ ] Unit tests pass
- [ ] Integration tests pass

## Checklist

- [x] Code follows project style guidelines
- [x] No breaking changes introduced