### PR TITLE
docs: document --firewall-backend option in dockerd.8.md (fixes #52695)

### DIFF
--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -32,6 +32,7 @@ dockerd - Enable daemon mode
 [**--exec-root**[=*/var/run/docker*]]
 [**--experimental**[=**false**]]
 [**--feature**[=*NAME*[=**true**|**false**]]
+[**--firewall-backend**[=*iptables*]]
 [**--fixed-cidr**[=*FIXED-CIDR*]]
 [**--fixed-cidr-v6**[=*FIXED-CIDR-V6*]]
 [**-G**|**--group**[=*docker*]]
@@ -222,6 +223,10 @@ Bridge networks will accept packets with this firewall mark/mask.
   file produces an error. The feature option can be specified multiple times
   to configure multiple features.
   Usage example: `--feature containerd-snapshotter` or `--feature containerd-snapshotter=true`.
+
+**--firewall-backend**="**iptables**|**nftables**"
+  Set the firewall backend to use for managing network rules. Supported
+  values are **iptables** and **nftables**. Default is **iptables**.
 
 **--fixed-cidr**=""
   IPv4 subnet for the default bridge network (e.g., 10.20.0.0/16); this


### PR DESCRIPTION
fixes #52695

## Summary

The `--firewall-backend` daemon option was not documented in the dockerd(8) man page.
This PR adds it to both the SYNOPSIS and OPTIONS sections.

## Changes

- Added `[**--firewall-backend**[=*iptables*]]` to SYNOPSIS
- Added description explaining the option accepts `iptables` or `nftables`, defaulting to `iptables`

## Checklist

- [x] Documentation follows existing man page style
- [x] No code changes introduced