### PR TITLE
fix: handle port ranges in image EXPOSE config (fixes #52553)

### DIFF
--- a/daemon/containerd/imagespec.go
+++ b/daemon/containerd/imagespec.go
@@ -96,8 +96,10 @@ func containerConfigToDockerOCIImageConfig(cfg *container.Config) dockerspec.Doc
 func dockerOCIImageConfigToContainerConfig(cfg dockerspec.DockerOCIImageConfig) *container.Config {
 	exposedPorts := make(network.PortSet, len(cfg.ExposedPorts))
 	for k := range cfg.ExposedPorts {
-		if p, err := network.ParsePort(k); err == nil {
-			exposedPorts[p] = struct{}{}
+		if pr, err := network.ParsePortRange(k); err == nil {
+			for p := range pr.All() {
+				exposedPorts[p] = struct{}{}
+			}
 		}
 	}
 


### PR DESCRIPTION
fixes #52553

## Summary

Images with port ranges in `EXPOSE` (e.g. `EXPOSE 33060-33061`) were failing
to pull with 'invalid port: 33060-33061: invalid syntax' since v29.

The regression was caused by `dockerOCIImageConfigToContainerConfig` using
`network.ParsePort()` which only handles single ports, not ranges.

## Changes

- `daemon/containerd/imagespec.go`: Use `ParsePortRange` instead of `ParsePort`
- Iterate over all ports in the range and add them individually to `ExposedPorts`

## Testing

- [x] Compiles for Linux (`GOOS=linux go build ./daemon/containerd/...`)
- [ ] Unit tests pass
- [ ] Integration tests pass

## Checklist

- [x] Code follows project style guidelines
- [x] No breaking changes introduced