### PR TITLE
fix: conditionally set ulimit in sysv

### DIFF
--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -58,8 +58,13 @@ case "$1" in
 		touch "$DOCKER_LOGFILE"
 		chgrp docker "$DOCKER_LOGFILE"
 
-		# Only set the hard limit (soft limit should remain as the system default of 1024):
-		ulimit -Hn 524288
+		# Only set the hard limit if the current hard limit below desired and soft limit is also below desired.
+		desired_hard_limit=524288
+		current_hard_limit=$(ulimit -Hn)
+		current_soft_limit=$(ulimit -Sn)
+		if [ "$current_hard_limit" -lt "$desired_hard_limit" ] && [ "$current_soft_limit" -lt "$desired_hard_limit" ]; then
+			ulimit -Hn $desired_hard_limit
+		fi
 
 		# Having non-zero limits causes performance problems due to accounting overhead
 		# in the kernel. We recommend using cgroups to do container-local accounting.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

The SysV init script is setting hard file descriptor limit.

This is evidently fine in most use cases as it's existed for 2 years; however, in the use case where running docker within the ubuntu:24.04 image in a k8s cluster (where the ulimits are high on the node). What I was seeing was the soft limit was higher than the hard limit that was trying to get set, which resulted in `/etc/init.d/docker: 62: ulimit: error setting limit (Invalid argument)`.

- In the case where the hard limit is already above where we're trying to bump to, it should be left as is.
- In the case where setting the hard limit would violate the soft > hard constraint, it should be left as is.

Repro:

```bash
NOFILE=1048576
docker run --rm --privileged --ulimit "nofile=${NOFILE}:${NOFILE}" \
  "$IMAGE:$TAG" sh -c "
  set -u
  echo \"container nofile: soft=\$(ulimit -Sn) hard=\$(ulimit -Hn)\"
  service docker start; echo \"service exit=\$?\"
  if timeout 20 sh -c 'until docker info >/dev/null 2>&1; do sleep 0.5; done'; then
    echo 'started'
  else
    echo 'failed'
  fi
"
```

A simple work-around is possible:

```bash
sed -i '/ulimit -Hn/d' /etc/init.d/docker
```