### PR TITLE
contrib/busybox: Use 64-bit binary

### DIFF
--- a/contrib/busybox/Dockerfile
+++ b/contrib/busybox/Dockerfile
@@ -1,7 +1,7 @@
 # Source: https://frippery.org/busybox/
-# This Dockerfile builds a (32-bit) busybox images which is suitable for
+# This Dockerfile builds a (64-bit) busybox images which is suitable for
 # running many of the integration-cli tests for Docker against a Windows
-# daemon. It will not run on nanoserver as that is 64-bit only.
+# daemon.
 #
 # Based on https://github.com/jhowardmsft/busybox
 # John Howard (IRC jhowardmsft, Email john.howard@microsoft.com)
@@ -13,13 +13,13 @@ ARG WINDOWS_BASE_IMAGE_TAG=ltsc2022
 ARG BUSYBOX_VERSION=FRP-5007-g82accfc19
 
 # Checksum taken from https://frippery.org/files/busybox/SHA256SUM
-ARG BUSYBOX_SHA256SUM=2d6fff0b2de5c034c92990d696c0d85a677b8a75931fa1ec30694fbf1f1df5c9
+ARG BUSYBOX_SHA256SUM=8263abc2aee6b6f3b3c41aa704bee98987bf7b1ea9bce833f75c7bce89ec1602
 
 FROM ${WINDOWS_BASE_IMAGE}:${WINDOWS_BASE_IMAGE_TAG}
 RUN mkdir C:\tmp && mkdir C:\bin
 ARG BUSYBOX_VERSION
 ARG BUSYBOX_SHA256SUM
-ADD https://github.com/moby/busybox/releases/download/${BUSYBOX_VERSION}/busybox-w32-${BUSYBOX_VERSION}.exe /bin/busybox.exe
+ADD https://github.com/moby/busybox/releases/download/${BUSYBOX_VERSION}/busybox-w64-${BUSYBOX_VERSION}.exe /bin/busybox.exe
 RUN powershell \
     if ((Get-FileHash -Path /bin/busybox.exe -Algorithm SHA256).Hash -ne $Env:BUSYBOX_SHA256SUM) { \
         Throw \"Checksum validation failed\" \


### PR DESCRIPTION
Switch Windows image busybox to use the 64 bit busybox binary to avoid depending on 32-bit Windows process support which is not available in nanoserver images.