### PR TITLE
update to go1.26.4

### DIFF
--- a/.github/workflows/.test-unit.yml
+++ b/.github/workflows/.test-unit.yml
@@ -13,7 +13,7 @@ on:
         required: false
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   SETUP_BUILDX_VERSION: edge

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -18,7 +18,7 @@ on:
         required: false
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   ITG_CLI_MATRIX_SIZE: 6

--- a/.github/workflows/.vm.yml
+++ b/.github/workflows/.vm.yml
@@ -19,7 +19,7 @@ on:
         default: ""
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
   TESTSTAT_VERSION: v0.1.25
   TEMPLATE_NAME: ${{ inputs.template }}
 

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -25,7 +25,7 @@ on:
         required: false
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   WINDOWS_BASE_IMAGE: mcr.microsoft.com/windows/servercore

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -17,7 +17,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
   TESTSTAT_VERSION: v0.1.25
   DESTDIR: ./build
   SETUP_BUILDX_VERSION: edge

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -17,7 +17,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
   DESTDIR: ./build
   SETUP_BUILDX_VERSION: edge
   SETUP_BUILDKIT_IMAGE: moby/buildkit:latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ on:
     - cron: '0 9 * * 4'
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
 
 jobs:
   codeql:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
   GIT_PAGER: "cat"
   PAGER: "cat"
   SETUP_BUILDX_VERSION: edge

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ version: "2"
 
 run:
   # prevent golangci-lint from deducting the go version to lint for through go.mod,
-  go: "1.26.3"
+  go: "1.26.4"
   # Only supported with go modules enabled (build flag -mod=vendor only valid when using modules)
   # modules-download-mode: vendor
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"
 

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -161,7 +161,7 @@ FROM ${WINDOWS_BASE_IMAGE}:${WINDOWS_BASE_IMAGE_TAG}
 # Use PowerShell as the default shell
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 
 # GOTESTSUM_VERSION is the version of gotest.tools/gotestsum to install.
 ARG GOTESTSUM_VERSION=v1.13.0

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 
 FROM golang:${GO_VERSION}-alpine AS base
 RUN apk add --no-cache bash make yamllint

--- a/hack/dockerfiles/generate-files.Dockerfile
+++ b/hack/dockerfiles/generate-files.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG PROTOC_VERSION=3.11.4
 

--- a/hack/dockerfiles/govulncheck.Dockerfile
+++ b/hack/dockerfiles/govulncheck.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 ARG GOVULNCHECK_VERSION=v1.1.4
 ARG FORMAT=text
 


### PR DESCRIPTION
- https://github.com/golang/go/issues?q=milestone%3AGo1.26.4+label%3ACherryPickApproved
- full diff: https://github.com/golang/go/compare/go1.26.3...go1.26.4


  This release include 3 security fixes following the security policy:

  - mime: quadratic complexity in WordDecoder.DecodeHeader

      Decoding a maliciously-crafted MIME header containing many invalid
     encoded-words could consume excessive CPU.
     The MIME decoder now better handles this case.

      Thanks to p4p3r (https://hackerone.com/p4p3r_hak) for reporting this issue.

      This is CVE-2026-42504 and Go issue https://go.dev/issue/79217.

  - net/textproto: arbitrary input are included in errors without any escaping

      When returning errors, functions in the net/textproto package would
     include its input as part of the error, without any escaping. Note that
     said input is often controlled by external parties when using this
     package naturally. For example, a net/http client uses ReadMIMEHeader
     when parsing the headers it receive from a server.

      As a result, an attacker could inject arbitrary content into the error.
     Practically, this can result in an attacker injecting misleading
     content, terminal control bytes, etc. into a victim's output or logs.

      This is CVE-2026-42507 and Go issue https://go.dev/issue/79346

  - crypto/x509: split candidate hostname only once

      (*x509.Certificate).VerifyHostname previously called matchHostnames in a loop
     over all DNS Subject Alternative Name (SAN) entries. This caused
     strings.Split(host, ".") to execute repeatedly on the same input hostname.

      With a large DNS SAN list, verification costs scaled quadratically based on the
     number of SAN entries multiplied by the hostname's label count. Because
     x509.Verify validates hostnames before building the certificate chain, this
     overhead occurred even for untrusted certificates.

      Thanks to Jakub Ciolek (https://ciolek.dev) for reporting this issue.

      This is CVE-2026-27145 and https://go.dev/issue/79694.

  View the release notes for more information: https://go.dev/doc/devel/release#go1.26.4



```markdown changelog
Update Go runtime to [1.26.4](https://go.dev/doc/devel/release#go1.26.4)
```

