### PR TITLE
test/docker-py: re-enable test_run_with_networking_config

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -24,9 +24,6 @@ PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_container_tes
 # TODO re-enable test_run_container_reading_socket_ws. It's reported in https://github.com/docker/docker-py/issues/1478, and we're getting that error in our tests.
 PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_container_test.py::AttachContainerTest::test_run_container_reading_socket_ws"
 
-# TODO re-enable test_run_with_networking_config once this issue is fixed: https://github.com/moby/moby/pull/46853#issuecomment-1864679942.
-PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/models_containers_test.py::ContainerCollectionTest::test_run_with_networking_config"
-
 # Legacy links are deprecated since a long time, and starting with v29.0, the Engine won't set legacy links env vars
 # automatically in linking containers. Thus, this test is expected to fail — skip it. See https://github.com/moby/moby/pull/50719
 PY_TEST_OPTIONS="${PY_TEST_OPTIONS} --deselect=tests/integration/api_container_test.py::CreateContainerTest::test_create_with_links"


### PR DESCRIPTION
## Summary

Re-enable `test_run_with_networking_config` in the docker-py integration suite. The test was deselected in #46853 because `Container.run()` returned stale container state — the Aliases field reflected the value at `ContainerCreate` time, before the container short ID was appended at run-time. That docker-py behaviour has since been corrected and the test passes cleanly against the current pinned commit (`059d371`, v7.2.0-dev).

The remaining two deselected tests are untouched:
- `test_attach_no_stream` — upstream docker/docker-py#2513 still open
- `test_run_container_reading_socket_ws` — websocket `http+docker` scheme bug still present (docker/docker-py#1478)

## Release notes (optional)

```markdown changelog

```

Addresses #52754