### PR TITLE
contrib: fix dockerize-disk qemu-nbd partition mount

### DIFF
--- a/contrib/dockerize-disk.sh
+++ b/contrib/dockerize-disk.sh
@@ -44,9 +44,37 @@ trap cleanup EXIT
 
 # Mount disk image
 modprobe nbd max_part=63
-qemu-nbd -rc ${block_device} -P 1 "$disk_image_file"
+# qemu-nbd -P was removed in QEMU 5.0.
+# Mount the first kernel partition instead.
+qemu-nbd -rc $block_device "$disk_image_file"
+partition_device=${block_device}p1
+if command -v partprobe &> /dev/null; then
+	partprobe $block_device || true
+fi
+if command -v blockdev &> /dev/null; then
+	blockdev --rereadpt $block_device || true
+fi
+# Some environments expose the partition in sysfs before devtmpfs creates it.
+for _ in $(seq 1 30); do
+	if [ -b "$partition_device" ]; then
+		break
+	fi
+	partition_devno="/sys/class/block/${partition_device##*/}/dev"
+	if [ -r "$partition_devno" ]; then
+		IFS=: read -r major minor < "$partition_devno"
+		mknod "$partition_device" b "$major" "$minor" 2>/dev/null || true
+		if [ -b "$partition_device" ]; then
+			break
+		fi
+	fi
+	sleep 0.1
+done
+if [ ! -b "$partition_device" ]; then
+	echo >&2 "error: partition device $partition_device was not created"
+	exit 1
+fi
 mkdir "$builddir/disk_image"
-mount -o ro ${block_device} "$builddir/disk_image"
+mount -o ro $partition_device "$builddir/disk_image"
 
 mkdir "$builddir/workdir"
 mkdir "$builddir/diff"

--- a/contrib/dockerize-disk.sh
+++ b/contrib/dockerize-disk.sh
@@ -62,7 +62,7 @@ for _ in $(seq 1 30); do
 	partition_devno="/sys/class/block/${partition_device##*/}/dev"
 	if [ -r "$partition_devno" ]; then
 		IFS=: read -r major minor < "$partition_devno"
-		mknod "$partition_device" b "$major" "$minor" 2>/dev/null || true
+		mknod "$partition_device" b "$major" "$minor" 2> /dev/null || true
 		if [ -b "$partition_device" ]; then
 			break
 		fi


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/51014
Follow up to: https://github.com/moby/moby/pull/52448

## Summary

This updates `contrib/dockerize-disk.sh` for current `qemu-nbd` releases, where `-P` / `--partition` is no longer available.

The script now connects the whole disk image, refreshes the partition table, and mounts the first kernel partition device (`/dev/nbd0p1`) instead. It also has a small fallback for minimal environments where the partition appears in sysfs before the device node is created.

## Release notes (optional)

```markdown changelog

```

## Testing

- `bash -n contrib/dockerize-disk.sh`
- `git diff --check`
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.8.0 -d -bn -ci -sr contrib/dockerize-disk.sh`
- `docker run --rm -v "$PWD":/src -w /src koalaman/shellcheck:v0.10.0 contrib/dockerize-disk.sh`
  - ShellCheck still reports existing warnings in older, untouched parts of this script, but none in the updated NBD handling.
- Focused privileged Debian trixie smoke test with `qemu-nbd 10.0.8`:
  - created a 64 MiB raw disk image with one MBR/ext4 partition
  - confirmed `qemu-nbd --help` does not expose `--partition`
  - connected the image to `/dev/nbd0`
  - refreshed partitions and verified `/dev/nbd0p1`
  - mounted `/dev/nbd0p1` read-only, unmounted it, and disconnected `/dev/nbd0`

I did not run the full legacy script end-to-end locally because the Docker Desktop environment does not provide the host kernel/module/aufs setup this old contrib helper expects.

Created with: Codex
