### PR TITLE
test: print docker-py deselection reasons

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -13,25 +13,45 @@ source hack/make/.integration-test-helpers
 # --deselect=tests/integration/api_container_test.py::AttachContainerTest::test_attach_no_stream
 : "${PY_TEST_OPTIONS:=--junitxml=${DEST}/junit-report.xml}"
 
+docker_py_deselects=()
+docker_py_deselect_reasons=()
+
+deselect_docker_py_test() {
+	local selector="$1"
+	local reason="$2"
+
+	docker_py_deselects+=("${selector}")
+	docker_py_deselect_reasons+=("${reason}")
+}
+
 # build --squash is not supported with containerd integration.
 if [ -z "$TEST_INTEGRATION_USE_GRAPHDRIVER" ]; then
-	PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_build_test.py::BuildTest::test_build_squash"
+	deselect_docker_py_test "tests/integration/api_build_test.py::BuildTest::test_build_squash" \
+		"build --squash is not supported with containerd integration"
 fi
 
 # TODO re-enable test_attach_no_stream after https://github.com/docker/docker-py/issues/2513 is resolved
-PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_container_test.py::AttachContainerTest::test_attach_no_stream"
+deselect_docker_py_test "tests/integration/api_container_test.py::AttachContainerTest::test_attach_no_stream" \
+	"pending upstream docker-py issue docker/docker-py#2513"
 
 # TODO re-enable test_run_container_reading_socket_ws. It's reported in https://github.com/docker/docker-py/issues/1478, and we're getting that error in our tests.
-PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_container_test.py::AttachContainerTest::test_run_container_reading_socket_ws"
+deselect_docker_py_test "tests/integration/api_container_test.py::AttachContainerTest::test_run_container_reading_socket_ws" \
+	"pending upstream docker-py issue docker/docker-py#1478"
 
 # Legacy links are deprecated since a long time, and starting with v29.0, the Engine won't set legacy links env vars
 # automatically in linking containers. Thus, this test is expected to fail — skip it. See https://github.com/moby/moby/pull/50719
-PY_TEST_OPTIONS="${PY_TEST_OPTIONS} --deselect=tests/integration/api_container_test.py::CreateContainerTest::test_create_with_links"
+deselect_docker_py_test "tests/integration/api_container_test.py::CreateContainerTest::test_create_with_links" \
+	"legacy link environment variables are intentionally no longer set"
 
 # The NetworkSettings.MacAddress field has been deprecated since Docker 1.9, and starting with v29.0, the Engine won't
 # include it in API respoonses. Thus, this test is expected to fail — skip it.
 # See https://github.com/moby/moby/pull/50846 and https://github.com/moby/moby/pull/50957
-PY_TEST_OPTIONS="${PY_TEST_OPTIONS} --deselect=tests/integration/api_container_test.py::CreateContainerTest::test_create_with_mac_address"
+deselect_docker_py_test "tests/integration/api_container_test.py::CreateContainerTest::test_create_with_mac_address" \
+	"deprecated NetworkSettings.MacAddress is intentionally omitted from API responses"
+
+for docker_py_deselect in "${docker_py_deselects[@]}"; do
+	PY_TEST_OPTIONS="${PY_TEST_OPTIONS} --deselect=${docker_py_deselect}"
+done
 
 (
 	bundle .integration-daemon-start
@@ -69,6 +89,9 @@ PY_TEST_OPTIONS="${PY_TEST_OPTIONS} --deselect=tests/integration/api_container_t
 		)
 	fi
 
+	for docker_py_deselect_index in "${!docker_py_deselects[@]}"; do
+		echo "INFO: Deselecting docker-py test ${docker_py_deselects[$docker_py_deselect_index]}: ${docker_py_deselect_reasons[$docker_py_deselect_index]}"
+	done
 	echo INFO: Starting docker-py tests...
 	(
 		[ -n "${TESTDEBUG}" ] && set -x


### PR DESCRIPTION
Related to: https://github.com/moby/moby/issues/46742

## Summary

- Keep the existing docker-py deselection behavior unchanged.
- Collect docker-py deselection selectors with short reason text.
- Print the selector/reason list before pytest starts so CI logs show why each integration test was deselected.

## Release notes (optional)

```markdown changelog

```

## Testing

- `bash -n hack/make/test-docker-py`
- `git diff --check`
## A picture of a cute animal - Our Mascot! Scarab (not mandatory but encouraged)

<img src="https://raw.githubusercontent.com/scarab-systems/scarab-field-lab/main/assets/scarab-mascot.png" alt="Scarab Systems mascot" width="140">
