### PR TITLE
docs: clarify swarm join required fields

### DIFF
--- a/api/docs/v1.54.yaml
+++ b/api/docs/v1.54.yaml
@@ -12556,7 +12556,9 @@ paths:
                 description: |
                   Listen address used for inter-manager communication if the node
                   gets promoted to manager, as well as determining the networking
-                  interface used for the VXLAN Tunnel Endpoint (VTEP).
+                  interface used for the VXLAN Tunnel Endpoint (VTEP). This is
+                  required for joining a swarm. If the port number is omitted,
+                  the default swarm listening port is used.
                 type: "string"
               AdvertiseAddr:
                 description: |
@@ -12590,6 +12592,7 @@ paths:
               JoinToken:
                 description: "Secret token for joining this swarm."
                 type: "string"
+            required: [ListenAddr, RemoteAddrs, JoinToken]
             example:
               ListenAddr: "0.0.0.0:2377"
               AdvertiseAddr: "192.168.1.1:2377"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -12556,7 +12556,9 @@ paths:
                 description: |
                   Listen address used for inter-manager communication if the node
                   gets promoted to manager, as well as determining the networking
-                  interface used for the VXLAN Tunnel Endpoint (VTEP).
+                  interface used for the VXLAN Tunnel Endpoint (VTEP). This is
+                  required for joining a swarm. If the port number is omitted,
+                  the default swarm listening port is used.
                 type: "string"
               AdvertiseAddr:
                 description: |
@@ -12590,6 +12592,7 @@ paths:
               JoinToken:
                 description: "Secret token for joining this swarm."
                 type: "string"
+            required: [ListenAddr, RemoteAddrs, JoinToken]
             example:
               ListenAddr: "0.0.0.0:2377"
               AdvertiseAddr: "192.168.1.1:2377"


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/49159

## Summary

This updates the Engine API spec for `/swarm/join` so the required join fields are documented: `ListenAddr`, `RemoteAddrs`, and `JoinToken`.

It also clarifies the current `ListenAddr` behavior: the daemon rejects an empty listen address, but when a listen address is provided without a port, the default swarm listening port is used.

This is API spec/docs-only and does not change daemon behavior.

## Testing

- `git diff --check -- api/swagger.yaml api/docs/v1.54.yaml`
- `make -C api validate-swagger`
- `make -C api validate-swagger-gen`
- `git diff --exit-code -- daemon/cluster/swarm.go client api/types || true`

## Release notes (optional)

```markdown changelog

```
