### PR TITLE
vendor: github.com/moby/sys/sequential v0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/moby/sys/mount v0.3.5-0.20260529155943-fc52b7222d0b
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/moby/sys/reexec v0.1.0
-	github.com/moby/sys/sequential v0.6.0
+	github.com/moby/sys/sequential v0.7.0
 	github.com/moby/sys/signal v0.7.1
 	github.com/moby/sys/symlink v0.3.0
 	github.com/moby/sys/user v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -585,8 +585,8 @@ github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9Kou
 github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
 github.com/moby/sys/reexec v0.1.0 h1:RrBi8e0EBTLEgfruBOFcxtElzRGTEUkeIFaVXgU7wok=
 github.com/moby/sys/reexec v0.1.0/go.mod h1:EqjBg8F3X7iZe5pU6nRZnYCMUTXoxsjiIfHup5wYIN8=
-github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7zgvCU=
-github.com/moby/sys/sequential v0.6.0/go.mod h1:uyv8EUTrca5PnDsdMGXhZe6CCe8U/UiTWd+lL+7b/Ko=
+github.com/moby/sys/sequential v0.7.0 h1:ASQNGNROJSuOO6LL6bPHbKvuZu6NU8P4ldPWk31zj/8=
+github.com/moby/sys/sequential v0.7.0/go.mod h1:NfSTAp6V3fw4tmkD62PEcOKeZKquXT8VKCkf7aVR79o=
 github.com/moby/sys/signal v0.7.1 h1:PrQxdvxcGijdo6UXXo/lU/TvHUWyPhj7UOpSo8tuvk0=
 github.com/moby/sys/signal v0.7.1/go.mod h1:Se1VGehYokAkrSQwL4tDzHvETwUZlnY7S5XtQ50mQp8=
 github.com/moby/sys/symlink v0.3.0 h1:GZX89mEZ9u53f97npBy4Rc3vJKj7JBDj/PN2I22GrNU=

--- a/vendor/github.com/moby/sys/sequential/sequential_unix.go
+++ b/vendor/github.com/moby/sys/sequential/sequential_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package sequential
 

--- a/vendor/github.com/moby/sys/sequential/sequential_windows.go
+++ b/vendor/github.com/moby/sys/sequential/sequential_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package sequential
 
 import (
@@ -6,108 +8,36 @@ import (
 	"strconv"
 	"sync"
 	"time"
-	"unsafe"
-
-	"golang.org/x/sys/windows"
 )
 
 // Create is a copy of [os.Create], modified to use sequential file access.
 //
-// It uses [windows.FILE_FLAG_SEQUENTIAL_SCAN] rather than [windows.FILE_ATTRIBUTE_NORMAL]
-// as implemented in golang. Refer to the [Win32 API documentation] for details
-// on sequential file access.
+// It uses the Windows sequential scan file flag. Refer to the [Win32 API
+// documentation] for details on sequential file access.
 //
 // [Win32 API documentation]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#FILE_FLAG_SEQUENTIAL_SCAN
 func Create(name string) (*os.File, error) {
-	return openFileSequential(name, windows.O_RDWR|windows.O_CREAT|windows.O_TRUNC)
+	return openFileSequential(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o666)
 }
 
 // Open is a copy of [os.Open], modified to use sequential file access.
 //
-// It uses [windows.FILE_FLAG_SEQUENTIAL_SCAN] rather than [windows.FILE_ATTRIBUTE_NORMAL]
-// as implemented in golang. Refer to the [Win32 API documentation] for details
-// on sequential file access.
+// It uses the Windows sequential scan file flag. Refer to the [Win32 API
+// documentation] for details on sequential file access.
 //
 // [Win32 API documentation]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#FILE_FLAG_SEQUENTIAL_SCAN
 func Open(name string) (*os.File, error) {
-	return openFileSequential(name, windows.O_RDONLY)
+	return openFileSequential(name, os.O_RDONLY, 0)
 }
 
 // OpenFile is a copy of [os.OpenFile], modified to use sequential file access.
 //
-// It uses [windows.FILE_FLAG_SEQUENTIAL_SCAN] rather than [windows.FILE_ATTRIBUTE_NORMAL]
-// as implemented in golang. Refer to the [Win32 API documentation] for details
-// on sequential file access.
+// It uses the Windows sequential scan file flag. Refer to the [Win32 API
+// documentation] for details on sequential file access.
 //
 // [Win32 API documentation]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#FILE_FLAG_SEQUENTIAL_SCAN
-func OpenFile(name string, flag int, _ os.FileMode) (*os.File, error) {
-	return openFileSequential(name, flag)
-}
-
-func openFileSequential(name string, flag int) (file *os.File, err error) {
-	if name == "" {
-		return nil, &os.PathError{Op: "open", Path: name, Err: windows.ERROR_FILE_NOT_FOUND}
-	}
-	r, e := openSequential(name, flag|windows.O_CLOEXEC)
-	if e != nil {
-		return nil, &os.PathError{Op: "open", Path: name, Err: e}
-	}
-	return os.NewFile(uintptr(r), name), nil
-}
-
-func makeInheritSa() *windows.SecurityAttributes {
-	var sa windows.SecurityAttributes
-	sa.Length = uint32(unsafe.Sizeof(sa))
-	sa.InheritHandle = 1
-	return &sa
-}
-
-func openSequential(path string, mode int) (fd windows.Handle, err error) {
-	if len(path) == 0 {
-		return windows.InvalidHandle, windows.ERROR_FILE_NOT_FOUND
-	}
-	pathp, err := windows.UTF16PtrFromString(path)
-	if err != nil {
-		return windows.InvalidHandle, err
-	}
-	var access uint32
-	switch mode & (windows.O_RDONLY | windows.O_WRONLY | windows.O_RDWR) {
-	case windows.O_RDONLY:
-		access = windows.GENERIC_READ
-	case windows.O_WRONLY:
-		access = windows.GENERIC_WRITE
-	case windows.O_RDWR:
-		access = windows.GENERIC_READ | windows.GENERIC_WRITE
-	}
-	if mode&windows.O_CREAT != 0 {
-		access |= windows.GENERIC_WRITE
-	}
-	if mode&windows.O_APPEND != 0 {
-		access &^= windows.GENERIC_WRITE
-		access |= windows.FILE_APPEND_DATA
-	}
-	sharemode := uint32(windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE)
-	var sa *windows.SecurityAttributes
-	if mode&windows.O_CLOEXEC == 0 {
-		sa = makeInheritSa()
-	}
-	var createmode uint32
-	switch {
-	case mode&(windows.O_CREAT|windows.O_EXCL) == (windows.O_CREAT | windows.O_EXCL):
-		createmode = windows.CREATE_NEW
-	case mode&(windows.O_CREAT|windows.O_TRUNC) == (windows.O_CREAT | windows.O_TRUNC):
-		createmode = windows.CREATE_ALWAYS
-	case mode&windows.O_CREAT == windows.O_CREAT:
-		createmode = windows.OPEN_ALWAYS
-	case mode&windows.O_TRUNC == windows.O_TRUNC:
-		createmode = windows.TRUNCATE_EXISTING
-	default:
-		createmode = windows.OPEN_EXISTING
-	}
-	// Use FILE_FLAG_SEQUENTIAL_SCAN rather than FILE_ATTRIBUTE_NORMAL as implemented in golang.
-	// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#FILE_FLAG_SEQUENTIAL_SCAN
-	h, e := windows.CreateFile(pathp, access, sharemode, sa, createmode, windows.FILE_FLAG_SEQUENTIAL_SCAN, 0)
-	return h, e
+func OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	return openFileSequential(name, flag, perm)
 }
 
 // Helpers for CreateTemp
@@ -134,9 +64,8 @@ func nextSuffix() string {
 
 // CreateTemp is a copy of [os.CreateTemp], modified to use sequential file access.
 //
-// It uses [windows.FILE_FLAG_SEQUENTIAL_SCAN] rather than [windows.FILE_ATTRIBUTE_NORMAL]
-// as implemented in golang. Refer to the [Win32 API documentation] for details
-// on sequential file access.
+// It uses the Windows sequential scan file flag. Refer to the [Win32 API
+// documentation] for details on sequential file access.
 //
 // [Win32 API documentation]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#FILE_FLAG_SEQUENTIAL_SCAN
 func CreateTemp(dir, prefix string) (f *os.File, err error) {
@@ -145,9 +74,9 @@ func CreateTemp(dir, prefix string) (f *os.File, err error) {
 	}
 
 	nconflict := 0
-	for i := 0; i < 10000; i++ {
+	for range 10000 {
 		name := filepath.Join(dir, prefix+nextSuffix())
-		f, err = openFileSequential(name, windows.O_RDWR|windows.O_CREAT|windows.O_EXCL)
+		f, err = openFileSequential(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
 		if os.IsExist(err) {
 			if nconflict++; nconflict > 10 {
 				randmu.Lock()

--- a/vendor/github.com/moby/sys/sequential/sequential_windows_go126.go
+++ b/vendor/github.com/moby/sys/sequential/sequential_windows_go126.go
@@ -1,0 +1,13 @@
+//go:build windows && go1.26
+
+package sequential
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func openFileSequential(name string, flag int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(name, flag|windows.O_FILE_FLAG_SEQUENTIAL_SCAN, perm)
+}

--- a/vendor/github.com/moby/sys/sequential/sequential_windows_pre126.go
+++ b/vendor/github.com/moby/sys/sequential/sequential_windows_pre126.go
@@ -1,0 +1,76 @@
+//go:build windows && !go1.26
+
+package sequential
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func openFileSequential(name string, flag int, _ os.FileMode) (file *os.File, err error) {
+	if name == "" {
+		return nil, &os.PathError{Op: "open", Path: name, Err: windows.ERROR_FILE_NOT_FOUND}
+	}
+	r, e := openSequential(name, flag|windows.O_CLOEXEC)
+	if e != nil {
+		return nil, &os.PathError{Op: "open", Path: name, Err: e}
+	}
+	return os.NewFile(uintptr(r), name), nil
+}
+
+func makeInheritSa() *windows.SecurityAttributes {
+	var sa windows.SecurityAttributes
+	sa.Length = uint32(unsafe.Sizeof(sa))
+	sa.InheritHandle = 1
+	return &sa
+}
+
+func openSequential(path string, mode int) (fd windows.Handle, err error) {
+	if len(path) == 0 {
+		return windows.InvalidHandle, windows.ERROR_FILE_NOT_FOUND
+	}
+	pathp, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return windows.InvalidHandle, err
+	}
+	var access uint32
+	switch mode & (windows.O_RDONLY | windows.O_WRONLY | windows.O_RDWR) {
+	case windows.O_RDONLY:
+		access = windows.GENERIC_READ
+	case windows.O_WRONLY:
+		access = windows.GENERIC_WRITE
+	case windows.O_RDWR:
+		access = windows.GENERIC_READ | windows.GENERIC_WRITE
+	}
+	if mode&windows.O_CREAT != 0 {
+		access |= windows.GENERIC_WRITE
+	}
+	if mode&windows.O_APPEND != 0 {
+		access &^= windows.GENERIC_WRITE
+		access |= windows.FILE_APPEND_DATA
+	}
+	sharemode := uint32(windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE)
+	var sa *windows.SecurityAttributes
+	if mode&windows.O_CLOEXEC == 0 {
+		sa = makeInheritSa()
+	}
+	var createmode uint32
+	switch {
+	case mode&(windows.O_CREAT|windows.O_EXCL) == (windows.O_CREAT | windows.O_EXCL):
+		createmode = windows.CREATE_NEW
+	case mode&(windows.O_CREAT|windows.O_TRUNC) == (windows.O_CREAT | windows.O_TRUNC):
+		createmode = windows.CREATE_ALWAYS
+	case mode&windows.O_CREAT == windows.O_CREAT:
+		createmode = windows.OPEN_ALWAYS
+	case mode&windows.O_TRUNC == windows.O_TRUNC:
+		createmode = windows.TRUNCATE_EXISTING
+	default:
+		createmode = windows.OPEN_EXISTING
+	}
+	// Use FILE_FLAG_SEQUENTIAL_SCAN rather than FILE_ATTRIBUTE_NORMAL as implemented in golang.
+	// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#FILE_FLAG_SEQUENTIAL_SCAN
+	h, e := windows.CreateFile(pathp, access, sharemode, sa, createmode, windows.FILE_FLAG_SEQUENTIAL_SCAN, 0)
+	return h, e
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1319,8 +1319,8 @@ github.com/moby/sys/mountinfo
 # github.com/moby/sys/reexec v0.1.0
 ## explicit; go 1.18
 github.com/moby/sys/reexec
-# github.com/moby/sys/sequential v0.6.0
-## explicit; go 1.17
+# github.com/moby/sys/sequential v0.7.0
+## explicit; go 1.24.0
 github.com/moby/sys/sequential
 # github.com/moby/sys/signal v0.7.1
 ## explicit; go 1.17


### PR DESCRIPTION
- update minimum go version to 1.24
- use os.OpenFile with O_FILE_FLAG_SEQUENTIAL_SCAN on Go 1.26+

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
