### PR TITLE
daemon: add ability for custom AppArmor profiles

### DIFF
--- a/daemon/apparmor_default.go
+++ b/daemon/apparmor_default.go
@@ -3,8 +3,15 @@
 package daemon
 
 import (
+	"bytes"
+	"context"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
+	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/internal/rootless"
 	aaprofile "github.com/moby/profiles/apparmor"
 )
@@ -23,7 +30,15 @@ func DefaultApparmorProfile() string {
 	return ""
 }
 
-func loadDefaultAppArmorProfileIfMissing() error {
+type appArmorProfileData struct {
+	Abi           string
+	Name          string
+	DaemonProfile string
+	Imports       []string
+	InnerImports  []string
+}
+
+func (daemon *Daemon) loadDefaultAppArmorProfileIfMissing() error {
 	if !defaultAppArmorProfileSupported() {
 		return nil
 	}
@@ -36,17 +51,83 @@ func loadDefaultAppArmorProfileIfMissing() error {
 		return nil
 	}
 
-	return installDefaultAppArmorProfile()
+	return daemon.installDefaultAppArmorProfile()
 }
 
-func installDefaultAppArmorProfile() error {
-	if defaultAppArmorProfileSupported() {
+func (daemon *Daemon) installDefaultAppArmorProfile() error {
+	if !defaultAppArmorProfileSupported() {
+		return nil
+	}
+
+	if daemon.appArmorProfile == nil {
 		if err := aaprofile.InstallDefault(defaultAppArmorProfile); err != nil {
 			return fmt.Errorf("AppArmor enabled on system but the %s profile could not be loaded: %s", defaultAppArmorProfile, err)
 		}
+		return nil
 	}
 
+	if err := daemon.installCustomAppArmorProfile(); err != nil {
+		return fmt.Errorf("AppArmor enabled on system but the %s profile could not be loaded from %s: %s", defaultAppArmorProfile, daemon.appArmorProfilePath, err)
+	}
 	return nil
+}
+
+func (daemon *Daemon) installCustomAppArmorProfile() error {
+	profile, err := daemon.generateCustomAppArmorProfile()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.CommandContext(context.Background(), "apparmor_parser", "-Kr")
+	cmd.Stdin = profile
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("running '%s' failed with output: %s\nerror: %w", cmd, out, err)
+	}
+	return nil
+}
+
+func (daemon *Daemon) generateCustomAppArmorProfile() (*bytes.Buffer, error) {
+	data := appArmorProfileData{
+		Name:          defaultAppArmorProfile,
+		DaemonProfile: daemonAppArmorProfile(),
+	}
+
+	const abi = "abi/3.0"
+	if appArmorMacroExists(abi) {
+		data.Abi = abi
+	}
+	if appArmorMacroExists("tunables/global") {
+		data.Imports = append(data.Imports, "#include <tunables/global>")
+	} else {
+		data.Imports = append(data.Imports, "@{PROC}=/proc/")
+	}
+	if appArmorMacroExists("abstractions/base") {
+		data.InnerImports = append(data.InnerImports, "#include <abstractions/base>")
+	}
+
+	var profile bytes.Buffer
+	if err := daemon.appArmorProfile.Execute(&profile, data); err != nil {
+		return nil, err
+	}
+	return &profile, nil
+}
+
+func daemonAppArmorProfile() string {
+	currentProfile, err := os.ReadFile("/proc/self/attr/current")
+	if err != nil {
+		log.G(context.TODO()).Warnf("Could not get daemon AppArmor profile: %s", err)
+		return "unconfined"
+	}
+	profile, _, _ := strings.Cut(strings.TrimSpace(string(currentProfile)), " (")
+	if profile == "" {
+		return "unconfined"
+	}
+	return profile
+}
+
+func appArmorMacroExists(m string) bool {
+	_, err := os.Stat(filepath.Join("/etc/apparmor.d", m))
+	return err == nil
 }
 
 func defaultAppArmorProfileSupported() bool {

--- a/daemon/apparmor_default_unsupported.go
+++ b/daemon/apparmor_default_unsupported.go
@@ -2,7 +2,9 @@
 
 package daemon
 
-func loadDefaultAppArmorProfileIfMissing() error {
+import "github.com/moby/moby/v2/daemon/config"
+
+func (daemon *Daemon) loadDefaultAppArmorProfileIfMissing() error {
 	return nil
 }
 
@@ -11,6 +13,10 @@ func DefaultApparmorProfile() string {
 	return ""
 }
 
-func installDefaultAppArmorProfile() error {
+func (daemon *Daemon) installDefaultAppArmorProfile() error {
+	return nil
+}
+
+func (daemon *Daemon) setupAppArmorProfile(*config.Config) error {
 	return nil
 }

--- a/daemon/apparmor_profile_linux.go
+++ b/daemon/apparmor_profile_linux.go
@@ -1,0 +1,29 @@
+//go:build linux
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"text/template"
+
+	"github.com/moby/moby/v2/daemon/config"
+)
+
+func (daemon *Daemon) setupAppArmorProfile(cfg *config.Config) error {
+	if cfg.AppArmorProfile == "" {
+		return nil
+	}
+
+	daemon.appArmorProfilePath = cfg.AppArmorProfile
+	b, err := os.ReadFile(daemon.appArmorProfilePath)
+	if err != nil {
+		return fmt.Errorf("opening AppArmor profile (%s) failed: %v", daemon.appArmorProfilePath, err)
+	}
+	tmpl, err := template.New("apparmor_profile").Option("missingkey=error").Parse(string(b))
+	if err != nil {
+		return fmt.Errorf("parsing AppArmor profile (%s) failed: %v", daemon.appArmorProfilePath, err)
+	}
+	daemon.appArmorProfile = tmpl
+	return nil
+}

--- a/daemon/apparmor_profile_linux_test.go
+++ b/daemon/apparmor_profile_linux_test.go
@@ -1,0 +1,61 @@
+//go:build linux
+
+package daemon
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/moby/moby/v2/daemon/config"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+)
+
+func TestSetupAppArmorProfile(t *testing.T) {
+	profile := fs.NewFile(t, "profile", fs.WithContent(`profile "{{.Name}}" {}`))
+
+	d := &Daemon{}
+	err := d.setupAppArmorProfile(&config.Config{AppArmorProfile: profile.Path()})
+	assert.NilError(t, err)
+	assert.Equal(t, d.appArmorProfilePath, profile.Path())
+	assert.Assert(t, d.appArmorProfile != nil)
+}
+
+func TestSetupAppArmorProfileErrors(t *testing.T) {
+	d := &Daemon{}
+	err := d.setupAppArmorProfile(&config.Config{AppArmorProfile: filepath.Join(t.TempDir(), "missing")})
+	assert.ErrorContains(t, err, "opening AppArmor profile")
+
+	profile := fs.NewFile(t, "profile", fs.WithContent(`profile "{{.Name}" {}`))
+	err = d.setupAppArmorProfile(&config.Config{AppArmorProfile: profile.Path()})
+	assert.ErrorContains(t, err, "parsing AppArmor profile")
+}
+
+func TestGenerateCustomAppArmorProfile(t *testing.T) {
+	profile := fs.NewFile(t, "profile", fs.WithContent(`{{range .Imports}}{{.}}
+{{end}}profile "{{.Name}}" {
+  signal (receive) peer="{{.DaemonProfile}}",
+}`))
+
+	d := &Daemon{}
+	err := d.setupAppArmorProfile(&config.Config{AppArmorProfile: profile.Path()})
+	assert.NilError(t, err)
+
+	generated, err := d.generateCustomAppArmorProfile()
+	assert.NilError(t, err)
+	out := generated.String()
+	assert.Assert(t, strings.Contains(out, `profile "docker-default"`))
+	assert.Assert(t, strings.Contains(out, `#include <tunables/global>`) || strings.Contains(out, `@{PROC}=/proc/`))
+}
+
+func TestGenerateCustomAppArmorProfileMissingKey(t *testing.T) {
+	profile := fs.NewFile(t, "profile", fs.WithContent(`profile "{{.Unknown}}" {}`))
+
+	d := &Daemon{}
+	err := d.setupAppArmorProfile(&config.Config{AppArmorProfile: profile.Path()})
+	assert.NilError(t, err)
+
+	_, err = d.generateCustomAppArmorProfile()
+	assert.ErrorContains(t, err, `can't evaluate field Unknown`)
+}

--- a/daemon/command/config_unix.go
+++ b/daemon/command/config_unix.go
@@ -48,6 +48,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.Int64Var(&conf.CPURealtimePeriod, "cpu-rt-period", 0, "Limit the CPU real-time period in microseconds for the parent cgroup for all containers (not supported with cgroups v2)")
 	flags.Int64Var(&conf.CPURealtimeRuntime, "cpu-rt-runtime", 0, "Limit the CPU real-time runtime in microseconds for the parent cgroup for all containers (not supported with cgroups v2)")
 	flags.StringVar(&conf.SeccompProfile, "seccomp-profile", conf.SeccompProfile, `Path to seccomp profile. Set to "unconfined" to disable the default seccomp profile`)
+	flags.StringVar(&conf.AppArmorProfile, "apparmor-profile", conf.AppArmorProfile, "Path to AppArmor profile template")
 	flags.Var(&conf.ShmSize, "default-shm-size", "Default shm size for containers")
 	flags.BoolVar(&conf.NoNewPrivileges, "no-new-privileges", false, "Set no-new-privileges by default for new containers")
 	flags.StringVar(&conf.IpcMode, "default-ipc-mode", conf.IpcMode, `Default mode for containers ipc ("shareable" | "private")`)

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -87,6 +87,7 @@ type Config struct {
 	Init                 bool                         `json:"init,omitempty"`
 	InitPath             string                       `json:"init-path,omitempty"`
 	SeccompProfile       string                       `json:"seccomp-profile,omitempty"`
+	AppArmorProfile      string                       `json:"apparmor-profile,omitempty"`
 	ShmSize              opts.MemBytes                `json:"default-shm-size,omitempty"`
 	NoNewPrivileges      bool                         `json:"no-new-privileges,omitempty"`
 	IpcMode              string                       `json:"default-ipc-mode,omitempty"`

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -89,6 +89,7 @@ type Config struct {
 	Init                 bool                         `json:"init,omitempty"`
 	InitPath             string                       `json:"init-path,omitempty"`
 	SeccompProfile       string                       `json:"seccomp-profile,omitempty"`
+	AppArmorProfile      string                       `json:"apparmor-profile,omitempty"`
 	ShmSize              opts.MemBytes                `json:"default-shm-size,omitempty"`
 	NoNewPrivileges      bool                         `json:"no-new-privileges,omitempty"`
 	IpcMode              string                       `json:"default-ipc-mode,omitempty"`

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"text/template"
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -132,8 +133,10 @@ type Daemon struct {
 
 	machineMemory uint64
 
-	seccompProfile     []byte
-	seccompProfilePath string
+	seccompProfile      []byte
+	seccompProfilePath  string
+	appArmorProfile     *template.Template
+	appArmorProfilePath string
 
 	usageContainers singleflight.Group[bool, *backend.ContainerDiskUsage]
 	usageImages     singleflight.Group[bool, *backend.ImageDiskUsage]
@@ -965,6 +968,9 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	if err := d.setupSeccompProfile(&cfgStore.Config); err != nil {
 		return nil, err
 	}
+	if err := d.setupAppArmorProfile(&cfgStore.Config); err != nil {
+		return nil, err
+	}
 
 	// Set the default isolation mode (only applicable on Windows)
 	if err := d.setDefaultIsolation(&cfgStore.Config); err != nil {
@@ -977,7 +983,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 
 	// Always install the default AppArmor profile at startup to pick up
 	// any changes to the profile template from a daemon upgrade.
-	if err := installDefaultAppArmorProfile(); err != nil {
+	if err := d.installDefaultAppArmorProfile(); err != nil {
 		log.G(ctx).WithError(err).Error("Failed to load default apparmor profile")
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"text/template"
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -139,8 +140,10 @@ type Daemon struct {
 
 	machineMemory uint64
 
-	seccompProfile     []byte
-	seccompProfilePath string
+	seccompProfile      []byte
+	seccompProfilePath  string
+	appArmorProfile     *template.Template
+	appArmorProfilePath string
 
 	usageContainers singleflight.Group[bool, *backend.ContainerDiskUsage]
 	usageImages     singleflight.Group[bool, *backend.ImageDiskUsage]
@@ -972,6 +975,9 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	if err := d.setupSeccompProfile(&cfgStore.Config); err != nil {
 		return nil, err
 	}
+	if err := d.setupAppArmorProfile(&cfgStore.Config); err != nil {
+		return nil, err
+	}
 
 	// Set the default isolation mode (only applicable on Windows)
 	if err := d.setDefaultIsolation(&cfgStore.Config); err != nil {
@@ -984,7 +990,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 
 	// Always install the default AppArmor profile at startup to pick up
 	// any changes to the profile template from a daemon upgrade.
-	if err := installDefaultAppArmorProfile(); err != nil {
+	if err := d.installDefaultAppArmorProfile(); err != nil {
 		log.G(ctx).WithError(err).Error("Failed to load default apparmor profile")
 	}
 

--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -84,7 +84,7 @@ func (daemon *Daemon) execSetPlatformOpt(ctx context.Context, daemonCfg *config.
 			// telling the system to keep our profile loaded, in order to make
 			// sure that we keep the default profile enabled we load it again
 			// if it is missing.
-			if err := loadDefaultAppArmorProfileIfMissing(); err != nil {
+			if err := daemon.loadDefaultAppArmorProfileIfMissing(); err != nil {
 				return err
 			}
 		}

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -198,7 +198,11 @@ func (daemon *Daemon) fillPluginsInfo(ctx context.Context, v *system.Info, cfg *
 func (daemon *Daemon) fillSecurityOptions(v *system.Info, sysInfo *sysinfo.SysInfo, cfg *config.Config) {
 	var securityOptions []string
 	if sysInfo.AppArmor {
-		securityOptions = append(securityOptions, "name=apparmor")
+		profile := daemon.appArmorProfilePath
+		if profile == "" {
+			profile = "default"
+		}
+		securityOptions = append(securityOptions, "name=apparmor,profile="+profile)
 	}
 	if sysInfo.Seccomp && supportsSeccomp {
 		if daemon.seccompProfilePath != config.SeccompProfileDefault {

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -122,7 +122,7 @@ func WithSelinux(c *container.Container) coci.SpecOpts {
 }
 
 // WithApparmor sets the apparmor profile
-func WithApparmor(c *container.Container) coci.SpecOpts {
+func WithApparmor(daemon *Daemon, c *container.Container) coci.SpecOpts {
 	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
 		if appArmorSupported() {
 			var appArmorProfile string
@@ -141,7 +141,7 @@ func WithApparmor(c *container.Container) coci.SpecOpts {
 				// telling the system to keep our profile loaded, in order to make
 				// sure that we keep the default profile enabled we load it again
 				// if it is missing.
-				if err := loadDefaultAppArmorProfileIfMissing(); err != nil {
+				if err := daemon.loadDefaultAppArmorProfileIfMissing(); err != nil {
 					return err
 				}
 			}
@@ -1021,7 +1021,7 @@ func (daemon *Daemon) createSpec(ctx context.Context, daemonCfg *configStore, c 
 		WithCapabilities(c),
 		WithSeccomp(daemon, c),
 		withMounts(daemon, daemonCfg, c, mounts),
-		WithApparmor(c),
+		WithApparmor(daemon, c),
 		WithSelinux(c),
 		WithOOMScore(&c.HostConfig.OomScoreAdj),
 		coci.WithAnnotations(c.HostConfig.Annotations),

--- a/integration-cli/docker_cli_info_unix_test.go
+++ b/integration-cli/docker_cli_info_unix_test.go
@@ -26,7 +26,7 @@ func (s *DockerCLIInfoSuite) TestInfoSecurityOptions(c *testing.T) {
 	info := result.Info
 
 	if Apparmor() {
-		assert.Check(c, is.Contains(info.SecurityOptions, "name=apparmor"))
+		assert.Check(c, is.Contains(info.SecurityOptions, "name=apparmor,profile=default"))
 	}
 	if seccompEnabled() {
 		assert.Check(c, is.Contains(info.SecurityOptions, "name=seccomp,profile="+config.SeccompProfileDefault))

--- a/integration/container/exec_afalg_linux_test.go
+++ b/integration/container/exec_afalg_linux_test.go
@@ -101,7 +101,10 @@ func TestExecSocketDenied(t *testing.T) {
 		// Seccomp cannot filter socketcall arguments (the address family
 		// is behind a userspace pointer). Only an LSM (AppArmor or
 		// SELinux) can deny AF_ALG via the security_socket_create hook.
-		hasLSM := slices.Contains(testEnv.DaemonInfo.SecurityOptions, "name=apparmor") ||
+		hasAppArmor := slices.ContainsFunc(testEnv.DaemonInfo.SecurityOptions, func(option string) bool {
+			return strings.HasPrefix(option, "name=apparmor,")
+		})
+		hasLSM := hasAppArmor ||
 			slices.Contains(testEnv.DaemonInfo.SecurityOptions, "name=selinux")
 		skip.If(t, !hasLSM, "socketcall filtering requires AppArmor or SELinux")
 

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -129,7 +129,49 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
   **Note**: defining runtime arguments via the command line is not supported.
 
 **--apparmor-profile**=""
-  Path to AppArmor profile template for the default container profile.
+  Path to an AppArmor profile definition for Docker's default
+  `docker-default` container profile. This option is only supported on Linux
+  hosts.
+
+  The file may be either a static AppArmor profile or a Go template. A file
+  without Go template actions renders unchanged, so an existing static profile
+  can be used without converting it to a template. A static profile must
+  declare `docker-default` and provide declarations and includes that are valid
+  on the host.
+
+  The equivalent `daemon.json` configuration is:
+
+```json
+{
+	"apparmor-profile": "/etc/docker/apparmor/docker-default"
+}
+```
+
+  Go templates can use the following values to adapt a profile to the host:
+
+  - `.Name` is the required profile name, `docker-default`.
+  - `.Abi` is `abi/3.0` when that AppArmor ABI is available, or an empty string
+    otherwise.
+  - `.Imports` contains global-scope host declarations. It contains
+    `#include <tunables/global>` when available, or `@{PROC}=/proc/` otherwise.
+  - `.InnerImports` contains `#include <abstractions/base>` when that
+    profile-scope abstraction is available.
+  - `.DaemonProfile` is the AppArmor profile applied to the daemon, or
+    `unconfined`.
+
+  Use the [built-in profile template](https://github.com/moby/profiles/blob/main/apparmor/template.go)
+  as the starting point for a portable custom policy.
+
+  The daemon reads and parses the file at startup. If AppArmor is enabled, the
+  daemon renders the file and loads the result with `apparmor_parser`, replacing
+  the loaded `docker-default` profile. Restart the daemon to apply changes to
+  the file. If the file cannot be read or parsed, the daemon fails to start. If
+  `apparmor_parser` rejects the rendered profile, the daemon logs an error and
+  does not update the loaded profile.
+
+  This option changes only Docker's default AppArmor profile. Containers
+  configured with another profile or with `unconfined` continue to use that
+  setting.
 
 **--authorization-plugin**=""
   Set authorization plugins to load

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -6,6 +6,7 @@ dockerd - Enable daemon mode
 # SYNOPSIS
 **dockerd**
 [**--add-runtime**[=*[]*]]
+[**--apparmor-profile**[=*APPARMOR-PROFILE-PATH*]]
 [**--authorization-plugin**[=*[]*]]
 [**-b**|**--bridge**[=*BRIDGE*]]
 [**--bip**[=*BIP*]]
@@ -126,6 +127,9 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 ```
 
   **Note**: defining runtime arguments via the command line is not supported.
+
+**--apparmor-profile**=""
+  Path to AppArmor profile template for the default container profile.
 
 **--authorization-plugin**=""
   Set authorization plugins to load

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -6,6 +6,7 @@ dockerd - Enable daemon mode
 # SYNOPSIS
 **dockerd**
 [**--add-runtime**[=*[]*]]
+[**--apparmor-profile**[=*APPARMOR-PROFILE-PATH*]]
 [**--authorization-plugin**[=*[]*]]
 [**-b**|**--bridge**[=*BRIDGE*]]
 [**--bip**[=*BIP*]]
@@ -127,6 +128,9 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 ```
 
   **Note**: defining runtime arguments via the command line is not supported.
+
+**--apparmor-profile**=""
+  Path to AppArmor profile template for the default container profile.
 
 **--authorization-plugin**=""
   Set authorization plugins to load

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -130,7 +130,49 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
   **Note**: defining runtime arguments via the command line is not supported.
 
 **--apparmor-profile**=""
-  Path to AppArmor profile template for the default container profile.
+  Path to an AppArmor profile definition for Docker's default
+  `docker-default` container profile. This option is only supported on Linux
+  hosts.
+
+  The file may be either a static AppArmor profile or a Go template. A file
+  without Go template actions renders unchanged, so an existing static profile
+  can be used without converting it to a template. A static profile must
+  declare `docker-default` and provide declarations and includes that are valid
+  on the host.
+
+  The equivalent `daemon.json` configuration is:
+
+```json
+{
+	"apparmor-profile": "/etc/docker/apparmor/docker-default"
+}
+```
+
+  Go templates can use the following values to adapt a profile to the host:
+
+  - `.Name` is the required profile name, `docker-default`.
+  - `.Abi` is `abi/3.0` when that AppArmor ABI is available, or an empty string
+    otherwise.
+  - `.Imports` contains global-scope host declarations. It contains
+    `#include <tunables/global>` when available, or `@{PROC}=/proc/` otherwise.
+  - `.InnerImports` contains `#include <abstractions/base>` when that
+    profile-scope abstraction is available.
+  - `.DaemonProfile` is the AppArmor profile applied to the daemon, or
+    `unconfined`.
+
+  Use the [built-in profile template](https://github.com/moby/profiles/blob/main/apparmor/template.go)
+  as the starting point for a portable custom policy.
+
+  The daemon reads and parses the file at startup. If AppArmor is enabled, the
+  daemon renders the file and loads the result with `apparmor_parser`, replacing
+  the loaded `docker-default` profile. Restart the daemon to apply changes to
+  the file. If the file cannot be read or parsed, the daemon fails to start. If
+  `apparmor_parser` rejects the rendered profile, the daemon logs an error and
+  does not update the loaded profile.
+
+  This option changes only Docker's default AppArmor profile. Containers
+  configured with another profile or with `unconfined` continue to use that
+  setting.
 
 **--authorization-plugin**=""
   Set authorization plugins to load


### PR DESCRIPTION
- replaces/carries, closes https://github.com/moby/moby/pull/41442

This is a long-requested feature, and it solves several usability problems with the default AppArmor profile:

1. The profile is completely opaque because we don't write to /etc/apparmor.d anymore -- this leads to lots of headaches when trying to run certain semi-privileged programs inside containers. It's much nicer to be able to have a starting point for a custom AppArmor profile.

2. Changes to AppArmor have broken backwards compatibility in the past (leading to containers not working properly) -- the poster-child for this problem was signal mediation. In order to fix this problem, distributions had to patch Docker when it would've been much nicer to provide a hotfix in the form of a custom configuration they could apply to their hosts.

It also bridges the feature gap between the default seccomp profile (which has been configurable for a very long time). This patch also fixes a few minor bugs in the AppArmor profile implementation (notably, Docker would not forcefully load its built-in profile at start time -- meaning a Docker update wouldn't actually update the profile).

This feature should probably be ported to other container runtimes (containerd, podman/cri-o, etc) so that we can continue with the effort to merge all of the disparate AppArmor profile implementations. Ideally they would all use the same template variables too.



---

The above was reapplied from the original commit on top of the current daemon code.

The daemon already force-loads the default AppArmor profile at startup, so this change wires the configured template into that existing reload path instead of introducing the reload behavior itself.

The built-in profile now lives in github.com/moby/profiles/apparmor, so the custom template data follows the current profile variables.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Add daemon support for configuring the default container AppArmor profile template.
  * See https://docker.docker.com/engine/security/apparmor/#customize-the-default-profile
```

## A picture of a cute animal (not mandatory but encouraged)
