### PR TITLE
gha/validate-pr: Reject GitHub references in commit messages

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -67,6 +67,21 @@ jobs:
           echo "This PR will be included in the release notes with the following note:"
           echo "$desc"
 
+  check-commit-references:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Check GitHub references
+        env:
+          VALIDATE_REPO: ${{ github.server_url }}/${{ github.repository }}.git
+          VALIDATE_BRANCH: ${{ github.event.pull_request.base.ref }}
+        run: bash hack/validate/pr-gh-references
+
   check-pr-branch:
     runs-on: ubuntu-24.04
     timeout-minutes: 120 # guardrails timeout for the whole job

--- a/hack/validate/pr-gh-references
+++ b/hack/validate/pr-gh-references
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -Ee -o pipefail
+
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPTDIR}/.validate"
+
+ghShorthandRegex='(^|[^[:alnum:]_])#[0-9]+'
+ghRefPrefixRegex='(^|[^[:alnum:]_./-])'
+ghRepoNameRegex='[[:alnum:]_.-]+'
+ghRepoRefRegex="${ghRefPrefixRegex}${ghRepoNameRegex}#[0-9]+"
+ghOwnerRepoRefRegex="${ghRefPrefixRegex}${ghRepoNameRegex}/${ghRepoNameRegex}#[0-9]+"
+ghURLRegex='https?://(www\.)?github\.com/[^[:space:]/]+/[^[:space:]/]+/(issues|pull)/[0-9]+'
+badReferences=()
+
+check_references() {
+	local source="$1"
+	local content="$2"
+	local matches
+
+	matches=$(grep -En -e "$ghShorthandRegex" -e "$ghRepoRefRegex" -e "$ghOwnerRepoRefRegex" -e "$ghURLRegex" <<< "$content" || true)
+	if [ -n "$matches" ]; then
+		badReferences+=("$source")
+		echo "::error::${source} contains a GitHub issue or PR reference. Reference commit hashes instead."
+	fi
+}
+
+for commit in $(validate_log --format='format:%H%n'); do
+	if [ -z "$(git log -1 --format='format:' --name-status "$commit")" ]; then
+		# no content (ie, Merge commit, etc)
+		continue
+	fi
+	check_references "Commit $commit" "$(git log -1 --format='format:%B' "$commit")"
+done
+
+if [ "${#badReferences[@]}" -ne 0 ]; then
+	printf "\nPlease remove GitHub issue or PR references from commit messages.\n"
+	printf "Reference commit hashes instead.\n"
+	printf "Keep GitHub issue or PR references in GitHub-visible text, such as PR descriptions or comments.\n"
+	exit 1
+fi


### PR DESCRIPTION
GitHub issue and PR references in commit messages become part of persistent history and can create unintended cross-references.

Check commit subjects and bodies for shorthand references such as \#123 and GitHub issue or pull-request URLs.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
