### PR TITLE
contrib/check-config: don't propagate optional feature failures to exit code

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -244,6 +244,10 @@ fi
 
 echo
 
+# Save the results of the required features while running optional feature checks.
+required_features_result=${EXITCODE}
+EXITCODE=0
+
 echo 'Optional Features:'
 {
 	check_flags USER_NS
@@ -352,6 +356,9 @@ if ! is_set EXT4_FS || ! is_set EXT4_FS_POSIX_ACL || ! is_set EXT4_FS_SECURITY; 
 		echo "    $(wrap_color 'enable these ext4 configs if you are using ext4 as backing filesystem' bold black)"
 	fi
 fi
+
+# Restore results of the required features check.
+EXITCODE=${required_features_result}
 
 echo '- Network Drivers:'
 echo "  - \"$(wrap_color 'bridge' blue)\":"


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/49972

## Summary

`contrib/check-config.sh` reported a non-zero exit code whenever any *optional* kernel feature was missing, even when every "Generally Necessary" feature was present. This breaks CI workflows that use the script to gate kernel-config compatibility (see #49972 for a real-world reproduction).

The fix mirrors the existing pattern used for the **Storage Drivers** section (`contrib/check-config.sh` L385-411):

- Save the current `EXITCODE` into `optional_features_exit` before the Optional Features section.
- Reset `EXITCODE=0` so failures inside that section are local.
- Restore `EXITCODE=${optional_features_exit}` right before the Network Drivers section starts.

A dedicated variable name (rather than reusing `CODE`) avoids a collision with the `CODE` variable already used inside the kernel-<5.8 `MEMCG_SWAP` branch (L267-272).

### Verified locally

Compared `upstream/master` and the patched script against four kernel-config scenarios inside an Alpine container (using gzipped configs so BusyBox `zcat` reads them):

| Scenario | Before (master) | After (this PR) |
| --- | --- | --- |
| All flags present | 0 | 0 |
| Only `CONFIG_USER_NS` missing | **1** | **0** ✅ |
| Only `CONFIG_EXT4_FS*` missing | **1** | **0** ✅ |
| `CONFIG_NAMESPACES` missing (Generally Necessary) | 1 | 1 (no regression) |

The `MEMCG_SWAP`-missing scenario from the issue was not reproducible directly on a kernel ≥ 5.8 environment because `check_flags MEMCG_SWAP` is gated to kernels < 5.8, so `USER_NS` and `EXT4_FS` were used as version-independent stand-ins for the same code path.

## Release notes (optional)

```markdown changelog

```