### PR TITLE
vendor: update swarmkit to fix completed job task constraint enforcer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/moby/profiles/apparmor v0.2.1
 	github.com/moby/profiles/seccomp v0.2.3
 	github.com/moby/pubsub v1.0.0
-	github.com/moby/swarmkit/v2 v2.1.2
+	github.com/moby/swarmkit/v2 v2.1.3-0.20260608090550-b0ffe7f2049a
 	github.com/moby/sys/atomicwriter v0.1.0
 	github.com/moby/sys/mount v0.3.5-0.20260529155943-fc52b7222d0b
 	github.com/moby/sys/mountinfo v0.7.2

--- a/go.sum
+++ b/go.sum
@@ -573,8 +573,8 @@ github.com/moby/profiles/seccomp v0.2.3 h1:nrHNSiECQQvq4WjgceCUgJXIXUJBIswVQ133k
 github.com/moby/profiles/seccomp v0.2.3/go.mod h1:8m3qkkWZXrRsMqlUUN2zyccnYmBf3EAdQYPMVJ3NBhk=
 github.com/moby/pubsub v1.0.0 h1:jkp/imWsmJz2f6LyFsk7EkVeN2HxR/HTTOY8kHrsxfA=
 github.com/moby/pubsub v1.0.0/go.mod h1:bXSO+3h5MNXXCaEG+6/NlAIk7MMZbySZlnB+cUQhKKc=
-github.com/moby/swarmkit/v2 v2.1.2 h1:1WDZAI6HVYNKdCG4zlXnTAPyLsLwuhRGWlHoOUf5Z6I=
-github.com/moby/swarmkit/v2 v2.1.2/go.mod h1:GQ6T0ij2oBbWX10OHwpvK449xfXkQMZ8J+B+eQ4mgp4=
+github.com/moby/swarmkit/v2 v2.1.3-0.20260608090550-b0ffe7f2049a h1:oRGNdY+ubG3lg8bhqjBT3tRRtqlLPE0SfUdbgtZRMYI=
+github.com/moby/swarmkit/v2 v2.1.3-0.20260608090550-b0ffe7f2049a/go.mod h1:GQ6T0ij2oBbWX10OHwpvK449xfXkQMZ8J+B+eQ4mgp4=
 github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
 github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
 github.com/moby/sys/capability v0.4.0 h1:4D4mI6KlNtWMCM1Z/K0i7RV1FkX+DBDHKVJpCndZoHk=

--- a/vendor/github.com/moby/swarmkit/v2/manager/dispatcher/dispatcher.go
+++ b/vendor/github.com/moby/swarmkit/v2/manager/dispatcher/dispatcher.go
@@ -1174,6 +1174,9 @@ func (d *Dispatcher) Assignments(r *api.AssignmentsRequest, stream api.Dispatche
 				case api.EventUpdateVolume:
 					d.store.View(func(readTx store.ReadTx) {
 						vol := store.GetVolume(readTx, v.Volume.ID)
+						if vol == nil {
+							return
+						}
 						// check through the PublishStatus to see if there is
 						// one for this node.
 						for _, status := range vol.PublishStatus {

--- a/vendor/github.com/moby/swarmkit/v2/manager/orchestrator/constraintenforcer/constraint_enforcer.go
+++ b/vendor/github.com/moby/swarmkit/v2/manager/orchestrator/constraintenforcer/constraint_enforcer.go
@@ -118,6 +118,12 @@ loop:
 		if t.DesiredState < api.TaskStateAssigned || t.DesiredState > api.TaskStateCompleted {
 			continue
 		}
+		// Completed tasks should not consume node reservations. This is
+		// particularly important for replicated-job services, where tasks may
+		// remain with DesiredState=Completed after they finished.
+		if t.Status.State >= api.TaskStateCompleted {
+			continue
+		}
 
 		// Ensure that the node still satisfies placement constraints.
 		// NOTE: If the task is associacted with a service then we must use the

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1233,7 +1233,7 @@ github.com/moby/profiles/seccomp
 # github.com/moby/pubsub v1.0.0
 ## explicit; go 1.19
 github.com/moby/pubsub
-# github.com/moby/swarmkit/v2 v2.1.2
+# github.com/moby/swarmkit/v2 v2.1.3-0.20260608090550-b0ffe7f2049a
 ## explicit; go 1.24.0
 github.com/moby/swarmkit/v2/agent
 github.com/moby/swarmkit/v2/agent/configs


### PR DESCRIPTION
Updates swarmkit to latest master to include the upstream fix for constraint enforcer counting completed replicated-job tasks against node capacity (moby/swarmkit#3237).

This replaces the closed #52715, which had originally attempted to patch vendored files directly. The correct approach is to pull the merged upstream change through the normal vendor sync workflow.

Fixes #52652

Signed-off-by: Lohit Kolluri <lohitkolluri@gmail.com>