### PR TITLE
d/libn/i/nftables: support general maps, sets

### DIFF
--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/network.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/network.go
@@ -67,31 +67,31 @@ func (n *network) configure(ctx context.Context, table nftables.Table, conf fire
 	tm.Create(nftables.Chain{Name: fwdInChain})
 	tm.Create(nftables.Chain{Name: fwdOutChain})
 
-	tm.Create(nftables.VMapElement{
-		VmapName: filtFwdInVMap,
-		Key:      n.config.IfName,
-		Verdict:  "jump " + fwdInChain,
+	tm.Create(nftables.MapElement{
+		MapName: filtFwdInVMap,
+		Key:     n.config.IfName,
+		Value:   "jump " + fwdInChain,
 	})
-	tm.Create(nftables.VMapElement{
-		VmapName: filtFwdOutVMap,
-		Key:      n.config.IfName,
-		Verdict:  "jump " + fwdOutChain,
+	tm.Create(nftables.MapElement{
+		MapName: filtFwdOutVMap,
+		Key:     n.config.IfName,
+		Value:   "jump " + fwdOutChain,
 	})
 
 	// NAT chain
 
 	tm.Create(nftables.Chain{Name: natPostRtInChain})
-	tm.Create(nftables.VMapElement{
-		VmapName: natPostroutingInVMap,
-		Key:      n.config.IfName,
-		Verdict:  "jump " + natPostRtInChain,
+	tm.Create(nftables.MapElement{
+		MapName: natPostroutingInVMap,
+		Key:     n.config.IfName,
+		Value:   "jump " + natPostRtInChain,
 	})
 
 	tm.Create(nftables.Chain{Name: chainNatPostRtOut(n.config.IfName)})
-	tm.Create(nftables.VMapElement{
-		VmapName: natPostroutingOutVMap,
-		Key:      n.config.IfName,
-		Verdict:  "jump " + chainNatPostRtOut(n.config.IfName),
+	tm.Create(nftables.MapElement{
+		MapName: natPostroutingOutVMap,
+		Key:     n.config.IfName,
+		Value:   "jump " + chainNatPostRtOut(n.config.IfName),
 	})
 
 	// Conntrack

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
@@ -105,9 +105,9 @@ func (nft *Nftabler) init(ctx context.Context, family nftables.Family) (nftables
 		Priority:  nftables.BaseChainPriorityFilter,
 	})
 	// Instantiate the verdict maps and add the jumps.
-	tm.Create(nftables.VMap{
+	tm.Create(nftables.Map{
 		Name:        filtFwdInVMap,
-		ElementType: nftables.NftTypeIfname,
+		ElementType: nftables.Ifname.VMap(),
 	})
 	tm.Create(nftables.Rule{
 		Chain: forwardChain,
@@ -115,9 +115,9 @@ func (nft *Nftabler) init(ctx context.Context, family nftables.Family) (nftables
 		Rule:  []string{"oifname vmap @", filtFwdInVMap},
 	})
 
-	tm.Create(nftables.VMap{
+	tm.Create(nftables.Map{
 		Name:        filtFwdOutVMap,
-		ElementType: nftables.NftTypeIfname,
+		ElementType: nftables.Ifname.VMap(),
 	})
 	tm.Create(nftables.Rule{
 		Chain: forwardChain,
@@ -135,9 +135,9 @@ func (nft *Nftabler) init(ctx context.Context, family nftables.Family) (nftables
 		Priority:  nftables.BaseChainPrioritySrcNAT,
 	})
 
-	tm.Create(nftables.VMap{
+	tm.Create(nftables.Map{
 		Name:        natPostroutingOutVMap,
-		ElementType: nftables.NftTypeIfname,
+		ElementType: nftables.Ifname.VMap(),
 	})
 	tm.Create(nftables.Rule{
 		Chain: postroutingChain,
@@ -145,9 +145,9 @@ func (nft *Nftabler) init(ctx context.Context, family nftables.Family) (nftables
 		Rule:  []string{"iifname vmap @", natPostroutingOutVMap},
 	})
 
-	tm.Create(nftables.VMap{
+	tm.Create(nftables.Map{
 		Name:        natPostroutingInVMap,
-		ElementType: nftables.NftTypeIfname,
+		ElementType: nftables.Ifname.VMap(),
 	})
 	tm.Create(nftables.Rule{
 		Chain: postroutingChain,

--- a/daemon/libnetwork/internal/nftables/nftables_linux.go
+++ b/daemon/libnetwork/internal/nftables/nftables_linux.go
@@ -14,7 +14,7 @@
 //	// Apply the updates with ...
 //	err := tm.Apply(ctx)
 //
-// The objects are any of: [BaseChain], [Chain], [Rule], [VMap], [VMapElement],
+// The objects are any of: [BaseChain], [Chain], [Rule], [Map], [MapElement],
 // [Set], [SetElement]
 //
 // The modifier can be reused to apply the same set of commands again or, more
@@ -128,18 +128,85 @@ const (
 	IPv6 Family = "ip6"
 )
 
-// NftType enumerates nft types that can be used to define maps/sets etc.
-type NftType string
+type SetTyper interface {
+	setType() string
+}
+
+type MapTyper interface {
+	mapType() string
+}
+
+// SetType represents named nft types that can be used to define sets or
+// construct map types.
+type SetType string
 
 const (
-	NftTypeIPv4Addr    NftType = "ipv4_addr"
-	NftTypeIPv6Addr    NftType = "ipv6_addr"
-	NftTypeEtherAddr   NftType = "ether_addr"
-	NftTypeInetProto   NftType = "inet_proto"
-	NftTypeInetService NftType = "inet_service"
-	NftTypeMark        NftType = "mark"
-	NftTypeIfname      NftType = "ifname"
+	IPv4Addr    SetType = "ipv4_addr"
+	IPv6Addr    SetType = "ipv6_addr"
+	EtherAddr   SetType = "ether_addr"
+	InetProto   SetType = "inet_proto"
+	InetService SetType = "inet_service"
+	Mark        SetType = "mark"
+	Ifname      SetType = "ifname"
 )
+
+func (t SetType) setType() string {
+	return "type " + string(t)
+}
+
+// Concat returns the tuple type formed by concatenating t and u.
+func (t SetType) Concat(u SetType) SetType {
+	return SetType(string(t) + " . " + string(u))
+}
+
+// MapType represents the named type of a map element, which is a compound type
+// with a key and a value.
+type MapType string
+
+func (t MapType) mapType() string {
+	return "type " + string(t)
+}
+
+// MapTo returns the map type where t is the key type and v is the value type.
+func (t SetType) MapTo(v SetType) MapType {
+	return MapType(string(t) + " : " + string(v))
+}
+
+// VMap returns the map type whose elements have t as the key type and contain
+// a verdict as the value.
+func (t SetType) VMap() MapType {
+	return MapType(string(t) + " : verdict")
+}
+
+// Typeof represents an nft "typeof" expression.
+type Typeof string
+
+func (t Typeof) setType() string {
+	return "typeof " + string(t)
+}
+
+func (t Typeof) Concat(u Typeof) Typeof {
+	return Typeof(string(t) + " . " + string(u))
+}
+
+// MapTypeof represents the type of a map element defined by a "typeof"
+// expression.
+type MapTypeof string
+
+func (t MapTypeof) mapType() string {
+	return "typeof " + string(t)
+}
+
+// MapTo returns the map type where t is the key type and v is the value type.
+func (t Typeof) MapTo(v Typeof) MapTypeof {
+	return MapTypeof(string(t) + " : " + string(v))
+}
+
+// VMap returns the map type whose elements have t as the key type and contain
+// a verdict as the value.
+func (t Typeof) VMap() MapTypeof {
+	return MapTypeof(string(t) + " : verdict")
+}
 
 // Enable tries once to initialise nftables.
 func Enable() error {
@@ -183,7 +250,7 @@ type table struct {
 	Name   string
 	Family Family
 
-	VMaps  map[string]*vMap
+	Maps   map[string]*nftMap
 	Sets   map[string]*set
 	Chains map[string]*chain
 
@@ -225,7 +292,7 @@ func NewTable(family Family, name string) (Table, error) {
 		t: &table{
 			Name:      name,
 			Family:    family,
-			VMaps:     map[string]*vMap{},
+			Maps:      map[string]*nftMap{},
 			Sets:      map[string]*set{},
 			Chains:    map[string]*chain{},
 			MustFlush: true,
@@ -277,13 +344,13 @@ func (t Table) Family() Family {
 //   - add new map/set elements
 const incrementalUpdateTemplText = `{{$family := .Family}}{{$tableName := .Name}}
 table {{$family}} {{$tableName}} {
-	{{range .VMaps}}map {{.Name}} {
-		type {{.ElementType}} : verdict
+	{{range .Maps}}map {{.Name}} {
+		{{.ElementTypeExpr}}
 		{{if len .Flags}}flags{{range .Flags}} {{.}}{{end}}{{end}}
 	}
 	{{end}}
 	{{range .Sets}}set {{.Name}} {
-		type {{.ElementType}}
+		{{.ElementTypeExpr}}
 		{{if len .Flags}}flags{{range .Flags}} {{.}}{{end}}{{end}}
 	}
 	{{end}}
@@ -292,13 +359,13 @@ table {{$family}} {{$tableName}} {
 	} ; {{end}}{{end}}
 }
 {{if .MustFlush}}flush table {{$family}} {{$tableName}}{{end}}
-{{range .VMaps}}{{if .MustFlush}}flush map {{$family}} {{$tableName}} {{.Name}}
+{{range .Maps}}{{if .MustFlush}}flush map {{$family}} {{$tableName}} {{.Name}}
 {{end}}{{end}}
 {{range .Sets}}{{if .MustFlush}}flush set {{$family}} {{$tableName}} {{.Name}}
 {{end}}{{end}}
 {{range .Chains}}{{if .MustFlush}}flush chain {{$family}} {{$tableName}} {{.Name}}
 {{end}}{{end}}
-{{range .VMaps}}{{if .DeletedElements}}delete element {{$family}} {{$tableName}} {{.Name}} { {{range $k,$v := .DeletedElements}}{{$k}}, {{end}} }
+{{range .Maps}}{{if .DeletedElements}}delete element {{$family}} {{$tableName}} {{.Name}} { {{range $k,$v := .DeletedElements}}{{$k}}, {{end}} }
 {{end}}{{end}}
 {{range .Sets}}{{if .DeletedElements}}delete element {{$family}} {{$tableName}} {{.Name}} { {{range $k,$v := .DeletedElements}}{{$k}}, {{end}} }
 {{end}}{{end}}
@@ -312,7 +379,7 @@ table {{$family}} {{$tableName}} {
 	}
 	{{end}}{{end}}
 }
-{{range .VMaps}}{{if .AddedElements}}add element {{$family}} {{$tableName}} {{.Name}} { {{range $k,$v := .AddedElements}}{{$k}} : {{$v}}, {{end}} }
+{{range .Maps}}{{if .AddedElements}}add element {{$family}} {{$tableName}} {{.Name}} { {{range $k,$v := .AddedElements}}{{$k}} : {{$v}}, {{end}} }
 {{end}}{{end}}
 {{range .Sets}}{{if .AddedElements}}add element {{$family}} {{$tableName}} {{.Name}} { {{range $k,$v := .AddedElements}}{{$k}}, {{end}} }
 {{end}}{{end}}
@@ -327,8 +394,8 @@ const reloadTemplText = `{{$family := .Family}}{{$tableName := .Name}}
 table {{$family}} {{$tableName}} {}
 delete table {{$family}} {{$tableName}}
 table {{$family}} {{$tableName}} {
-	{{range .VMaps}}map {{.Name}} {
-		type {{.ElementType}} : verdict
+	{{range .Maps}}map {{.Name}} {
+		{{.ElementTypeExpr}}
 		{{if len .Flags}}flags{{range .Flags}} {{.}}{{end}}{{end}}
         {{if .Elements}}elements = {
 			{{range $k,$v := .Elements}}{{$k}} : {{$v}},
@@ -337,7 +404,7 @@ table {{$family}} {{$tableName}} {
 	}
 	{{end}}
 	{{range .Sets}}set {{.Name}} {
-		type {{.ElementType}}
+		{{.ElementTypeExpr}}
 		{{if len .Flags}}flags{{range .Flags}} {{.}}{{end}}{{end}}
         {{if .Elements}}elements = {
 			{{range $k,$v := .Elements}}{{$k}},
@@ -736,15 +803,15 @@ func (ru Rule) delete(ctx context.Context, t *table) (bool, error) {
 }
 
 // ////////////////////////////
-// VMaps
+// Maps
 
-// vMap is the internal representation of an nftables verdict map.
+// nftMap is the internal representation of an nftables map (including verdict maps).
 // Its elements need to be exported for use by text/template, but they should only be
 // manipulated via exported methods.
-type vMap struct {
+type nftMap struct {
 	table           *table
 	Name            string
-	ElementType     NftType
+	ElementTypeExpr string
 	Flags           []string
 	Elements        map[string]string
 	AddedElements   map[string]string
@@ -752,120 +819,120 @@ type vMap struct {
 	MustFlush       bool
 }
 
-// VMap implements the [Obj] interface, it can be passed to a
-// [Modifier] to create or delete a verdict map.
-type VMap struct {
+// Map implements the [Obj] interface, it can be passed to a
+// [Modifier] to create or delete a map.
+type Map struct {
 	Name        string
-	ElementType NftType
+	ElementType MapTyper
 	Flags       []string
 }
 
-func (vm VMap) create(ctx context.Context, t *table) (bool, error) {
-	if vm.Name == "" {
-		return false, errors.New("vmap must have a name")
+func (m Map) create(ctx context.Context, t *table) (bool, error) {
+	if m.Name == "" {
+		return false, errors.New("map must have a name")
 	}
-	if _, ok := t.VMaps[vm.Name]; ok {
-		return false, fmt.Errorf("vmap '%s' already exists", vm.Name)
+	if _, ok := t.Maps[m.Name]; ok {
+		return false, fmt.Errorf("map '%s' already exists", m.Name)
 	}
-	if vm.ElementType == "" {
-		return false, fmt.Errorf("vmap '%s' has no element type", vm.Name)
+	if m.ElementType == nil {
+		return false, fmt.Errorf("map '%s' has no element type", m.Name)
 	}
-	v := &vMap{
+	nm := &nftMap{
 		table:           t,
-		Name:            vm.Name,
-		ElementType:     vm.ElementType,
-		Flags:           slices.Clone(vm.Flags),
+		Name:            m.Name,
+		ElementTypeExpr: m.ElementType.mapType(),
+		Flags:           slices.Clone(m.Flags),
 		Elements:        map[string]string{},
 		AddedElements:   map[string]string{},
 		DeletedElements: map[string]string{},
 		MustFlush:       true,
 	}
-	t.VMaps[v.Name] = v
+	t.Maps[nm.Name] = nm
 	log.G(ctx).WithFields(log.Fields{
 		"family": t.Family,
 		"table":  t.Name,
-		"vmap":   v.Name,
-	}).Debug("nftables: created interface vmap")
+		"map":    nm.Name,
+	}).Debug("nftables: created map")
 	return true, nil
 }
 
-func (vm VMap) delete(ctx context.Context, t *table) (bool, error) {
-	v := t.VMaps[vm.Name]
-	if v == nil {
-		return false, fmt.Errorf("cannot delete vmap '%s', it does not exist", vm.Name)
+func (m Map) delete(ctx context.Context, t *table) (bool, error) {
+	nm := t.Maps[m.Name]
+	if nm == nil {
+		return false, fmt.Errorf("cannot delete map '%s', it does not exist", m.Name)
 	}
-	if len(v.Elements) != 0 {
-		return false, fmt.Errorf("cannot delete vmap '%s', it contains %d elements", v.Name, len(v.Elements))
+	if len(nm.Elements) != 0 {
+		return false, fmt.Errorf("cannot delete map '%s', it contains %d elements", nm.Name, len(nm.Elements))
 	}
-	delete(t.VMaps, v.Name)
+	delete(t.Maps, nm.Name)
 	t.DeleteCommands = append(t.DeleteCommands,
-		fmt.Sprintf("delete map %s %s %s", t.Family, t.Name, v.Name))
+		fmt.Sprintf("delete map %s %s %s", t.Family, t.Name, nm.Name))
 	log.G(ctx).WithFields(log.Fields{
 		"family": t.Family,
 		"table":  t.Name,
-		"vmap":   v.Name,
-	}).Debug("nftables: deleted vmap")
+		"map":    nm.Name,
+	}).Debug("nftables: deleted map")
 	return true, nil
 }
 
-// VMapElement implements the [Obj] interface, it can be passed to a
-// [Modifier] to create or delete an entry in a verdict map.
-type VMapElement struct {
-	VmapName string
-	Key      string
-	Verdict  string
+// MapElement implements the [Obj] interface, it can be passed to a
+// [Modifier] to create or delete an entry in a map.
+type MapElement struct {
+	MapName string
+	Key     string
+	Value   string
 }
 
-func (ve VMapElement) create(ctx context.Context, t *table) (bool, error) {
-	if ve.VmapName == "" {
-		return false, errors.New("cannot add element to unnamed vmap")
+func (me MapElement) create(ctx context.Context, t *table) (bool, error) {
+	if me.MapName == "" {
+		return false, errors.New("cannot add element to unnamed map")
 	}
-	v := t.VMaps[ve.VmapName]
-	if v == nil {
-		return false, fmt.Errorf("cannot add to vmap '%s', it does not exist", ve.VmapName)
+	nm := t.Maps[me.MapName]
+	if nm == nil {
+		return false, fmt.Errorf("cannot add to map '%s', it does not exist", me.MapName)
 	}
-	if ve.Key == "" || ve.Verdict == "" {
-		return false, fmt.Errorf("cannot add to vmap '%s', element must have key and verdict", ve.VmapName)
+	if me.Key == "" || me.Value == "" {
+		return false, fmt.Errorf("cannot add to map '%s', element must have key and value", me.MapName)
 	}
-	if _, ok := v.Elements[ve.Key]; ok {
-		return false, fmt.Errorf("verdict map '%s' already contains element '%s'", ve.VmapName, ve.Key)
+	if _, ok := nm.Elements[me.Key]; ok {
+		return false, fmt.Errorf("map '%s' already contains element '%s'", me.MapName, me.Key)
 	}
-	v.Elements[ve.Key] = ve.Verdict
-	v.AddedElements[ve.Key] = ve.Verdict
-	delete(v.DeletedElements, ve.Key)
+	nm.Elements[me.Key] = me.Value
+	nm.AddedElements[me.Key] = me.Value
+	delete(nm.DeletedElements, me.Key)
 	log.G(ctx).WithFields(log.Fields{
-		"family":  t.Family,
-		"table":   t.Name,
-		"vmap":    ve.VmapName,
-		"key":     ve.Key,
-		"verdict": ve.Verdict,
-	}).Debug("nftables: added vmap element")
+		"family": t.Family,
+		"table":  t.Name,
+		"map":    me.MapName,
+		"key":    me.Key,
+		"value":  me.Value,
+	}).Debug("nftables: added map element")
 	return true, nil
 }
 
-func (ve VMapElement) delete(ctx context.Context, t *table) (bool, error) {
-	v := t.VMaps[ve.VmapName]
-	if v == nil {
-		return false, fmt.Errorf("cannot delete from vmap '%s', it does not exist", ve.VmapName)
+func (me MapElement) delete(ctx context.Context, t *table) (bool, error) {
+	nm := t.Maps[me.MapName]
+	if nm == nil {
+		return false, fmt.Errorf("cannot delete from map '%s', it does not exist", me.MapName)
 	}
-	oldVerdict, ok := v.Elements[ve.Key]
+	oldValue, ok := nm.Elements[me.Key]
 	if !ok {
-		return false, fmt.Errorf("verdict map '%s' does not contain element '%s'", ve.VmapName, ve.Key)
+		return false, fmt.Errorf("map '%s' does not contain element '%s'", me.MapName, me.Key)
 	}
-	if oldVerdict != ve.Verdict {
-		return false, fmt.Errorf("cannot delete verdict map '%s' element '%s', verdict was '%s', not '%s'",
-			ve.VmapName, ve.Key, oldVerdict, ve.Verdict)
+	if oldValue != me.Value {
+		return false, fmt.Errorf("cannot delete map '%s' element '%s', value was '%s', not '%s'",
+			me.MapName, me.Key, oldValue, me.Value)
 	}
-	delete(v.Elements, ve.Key)
-	delete(v.AddedElements, ve.Key)
-	v.DeletedElements[ve.Key] = ve.Verdict
+	delete(nm.Elements, me.Key)
+	delete(nm.AddedElements, me.Key)
+	nm.DeletedElements[me.Key] = me.Value
 	log.G(ctx).WithFields(log.Fields{
-		"family":  t.Family,
-		"table":   t.Name,
-		"vmap":    ve.VmapName,
-		"key":     ve.Key,
-		"verdict": ve.Verdict,
-	}).Debug("nftables: deleted vmap element")
+		"family": t.Family,
+		"table":  t.Name,
+		"map":    me.MapName,
+		"key":    me.Key,
+		"value":  me.Value,
+	}).Debug("nftables: deleted map element")
 	return true, nil
 }
 
@@ -878,7 +945,7 @@ func (ve VMapElement) delete(ctx context.Context, t *table) (bool, error) {
 type set struct {
 	table           *table
 	Name            string
-	ElementType     NftType
+	ElementTypeExpr string
 	Flags           []string
 	Elements        map[string]struct{}
 	AddedElements   map[string]struct{}
@@ -890,7 +957,7 @@ type set struct {
 // [Modifier] to create or delete a set.
 type Set struct {
 	Name        string
-	ElementType NftType
+	ElementType SetTyper
 	Flags       []string
 }
 
@@ -902,14 +969,14 @@ func (sd Set) create(ctx context.Context, t *table) (bool, error) {
 	if _, ok := t.Sets[sd.Name]; ok {
 		return false, fmt.Errorf("set '%s' already exists", sd.Name)
 	}
-	if sd.ElementType == "" {
+	if sd.ElementType == nil {
 		return false, fmt.Errorf("set '%s' must have a type", sd.Name)
 	}
 	s := &set{
 		table:           t,
 		Name:            sd.Name,
 		Elements:        map[string]struct{}{},
-		ElementType:     sd.ElementType,
+		ElementTypeExpr: sd.ElementType.setType(),
 		Flags:           slices.Clone(sd.Flags),
 		AddedElements:   map[string]struct{}{},
 		DeletedElements: map[string]struct{}{},
@@ -1041,7 +1108,7 @@ func (t *table) updatesApplied() {
 	for _, c := range t.Chains {
 		c.MustFlush = false
 	}
-	for _, m := range t.VMaps {
+	for _, m := range t.Maps {
 		m.AddedElements = map[string]string{}
 		m.DeletedElements = map[string]string{}
 		m.MustFlush = false

--- a/daemon/libnetwork/internal/nftables/nftables_linux_test.go
+++ b/daemon/libnetwork/internal/nftables/nftables_linux_test.go
@@ -189,9 +189,9 @@ func TestVMap(t *testing.T) {
 
 	// Create a verdict map.
 	const mapName = "this_is_a_vmap"
-	tm.Create(VMap{Name: mapName, ElementType: NftTypeIfname})
-	tm.Create(VMapElement{VmapName: mapName, Key: "eth0", Verdict: "return"})
-	tm.Create(VMapElement{VmapName: mapName, Key: "eth1", Verdict: "drop"})
+	tm.Create(Map{Name: mapName, ElementType: Ifname.VMap()})
+	tm.Create(MapElement{MapName: mapName, Key: "eth0", Value: "return"})
+	tm.Create(MapElement{MapName: mapName, Key: "eth1", Value: "drop"})
 
 	// Update nftables and check what happened.
 	applyAndCheck(t, tbl, tm, t.Name()+"/created.golden")
@@ -217,10 +217,10 @@ func TestSet(t *testing.T) {
 	// Create a set in each table.
 	const set4Name = "set4"
 	tm4 := Modifier{}
-	tm4.Create(Set{Name: set4Name, ElementType: NftTypeIPv4Addr, Flags: []string{"interval"}})
+	tm4.Create(Set{Name: set4Name, ElementType: IPv4Addr, Flags: []string{"interval"}})
 	const set6Name = "set6"
 	tm6 := Modifier{}
-	tm6.Create(Set{Name: set6Name, ElementType: NftTypeIPv6Addr, Flags: []string{"interval"}})
+	tm6.Create(Set{Name: set6Name, ElementType: IPv6Addr, Flags: []string{"interval"}})
 
 	// Add elements to each set.
 	tm4.Create(SetElement{SetName: set4Name, Element: "192.0.2.0/24"})
@@ -256,12 +256,12 @@ func TestReload(t *testing.T) {
 	tm.Create(Rule{Chain: bcName, Group: 0, Rule: []string{"counter"}})
 
 	const vmapName = "this_is_a_vmap"
-	tm.Create(VMap{Name: vmapName, ElementType: NftTypeIfname})
-	tm.Create(VMapElement{VmapName: vmapName, Key: "eth0", Verdict: "return"})
-	tm.Create(VMapElement{VmapName: vmapName, Key: "eth1", Verdict: "return"})
+	tm.Create(Map{Name: vmapName, ElementType: Ifname.VMap()})
+	tm.Create(MapElement{MapName: vmapName, Key: "eth0", Value: "return"})
+	tm.Create(MapElement{MapName: vmapName, Key: "eth1", Value: "return"})
 
 	const setName = "this_is_a_set"
-	tm.Create(Set{Name: setName, ElementType: NftTypeIPv4Addr, Flags: []string{"interval"}})
+	tm.Create(Set{Name: setName, ElementType: IPv4Addr, Flags: []string{"interval"}})
 	tm.Create(SetElement{SetName: setName, Element: "192.0.2.0/24"})
 
 	applyAndCheck(t, tbl, tm, t.Name()+"/created.golden")
@@ -463,110 +463,110 @@ func TestValidation(t *testing.T) {
 			},
 			expErr: "chain 'achain', cannot add empty rule",
 		},
-		// VMap
+		// Map (verdict)
 		{
-			name: "duplicate vmap",
+			name: "duplicate map",
 			cmds: []command{
-				{obj: VMap{Name: "avmap", ElementType: NftTypeIfname}},
-				{obj: VMap{Name: "avmap", ElementType: NftTypeIfname}},
+				{obj: Map{Name: "avmap", ElementType: Ifname.VMap()}},
+				{obj: Map{Name: "avmap", ElementType: Ifname.VMap()}},
 			},
-			expErr: "vmap 'avmap' already exists",
+			expErr: "map 'avmap' already exists",
 		},
 		{
-			name: "delete nonexistent vmap",
+			name: "delete nonexistent map",
 			cmds: []command{
-				{obj: VMap{Name: "avmap", ElementType: NftTypeIfname}, delete: true},
+				{obj: Map{Name: "avmap", ElementType: Ifname.VMap()}, delete: true},
 			},
-			expErr: "cannot delete vmap 'avmap', it does not exist",
+			expErr: "cannot delete map 'avmap', it does not exist",
 		},
 		{
-			name:   "missing vmap name",
-			cmds:   []command{{obj: VMap{ElementType: NftTypeIfname}}},
-			expErr: "vmap must have a name",
+			name:   "missing map name",
+			cmds:   []command{{obj: Map{ElementType: Ifname.VMap()}}},
+			expErr: "map must have a name",
 		},
 		{
-			name:   "missing vmap element type",
-			cmds:   []command{{obj: VMap{Name: "avmap"}}},
-			expErr: "vmap 'avmap' has no element type",
+			name:   "missing map element type",
+			cmds:   []command{{obj: Map{Name: "avmap"}}},
+			expErr: "map 'avmap' has no element type",
 		},
 		{
-			name: "delete non-empty vmap",
+			name: "delete non-empty map",
 			cmds: []command{
-				{obj: VMap{Name: "avmap", ElementType: NftTypeIfname}},
-				{obj: VMapElement{VmapName: "avmap", Key: "eth0", Verdict: "drop"}},
-				{obj: VMap{Name: "avmap", ElementType: NftTypeIfname}, delete: true},
+				{obj: Map{Name: "avmap", ElementType: Ifname.VMap()}},
+				{obj: MapElement{MapName: "avmap", Key: "eth0", Value: "drop"}},
+				{obj: Map{Name: "avmap", ElementType: Ifname.VMap()}, delete: true},
 			},
-			expErr: "cannot delete vmap 'avmap', it contains 1 elements",
+			expErr: "cannot delete map 'avmap', it contains 1 elements",
 		},
-		// VMapElement
+		// MapElement
 		{
-			name: "duplicate vmap element",
+			name: "duplicate map element",
 			cmds: []command{
-				{obj: VMap{Name: "avmap", ElementType: NftTypeIfname}},
-				{obj: VMapElement{VmapName: "avmap", Key: "eth0", Verdict: "drop"}},
-				{obj: VMapElement{VmapName: "avmap", Key: "eth0", Verdict: "drop"}},
+				{obj: Map{Name: "avmap", ElementType: Ifname.VMap()}},
+				{obj: MapElement{MapName: "avmap", Key: "eth0", Value: "drop"}},
+				{obj: MapElement{MapName: "avmap", Key: "eth0", Value: "drop"}},
 			},
-			expErr: "verdict map 'avmap' already contains element 'eth0'",
-		},
-		{
-			name: "add to vmap that does not exist",
-			cmds: []command{
-				{obj: VMapElement{VmapName: "avmap", Key: "eth0", Verdict: "drop"}},
-			},
-			expErr: "cannot add to vmap 'avmap', it does not exist",
+			expErr: "map 'avmap' already contains element 'eth0'",
 		},
 		{
-			name: "delete nonexistent vmap element",
+			name: "add to map that does not exist",
 			cmds: []command{
-				{obj: VMap{Name: "avmap", ElementType: NftTypeIfname}},
-				{obj: VMapElement{VmapName: "avmap", Key: "eth0", Verdict: "drop"}, delete: true},
+				{obj: MapElement{MapName: "avmap", Key: "eth0", Value: "drop"}},
 			},
-			expErr: "verdict map 'avmap' does not contain element 'eth0'",
+			expErr: "cannot add to map 'avmap', it does not exist",
 		},
 		{
-			name: "vmap element with no named vmap",
+			name: "delete nonexistent map element",
 			cmds: []command{
-				{obj: VMap{Name: "avmap", ElementType: NftTypeIfname}},
-				{obj: VMapElement{Key: "eth0", Verdict: "drop"}},
+				{obj: Map{Name: "avmap", ElementType: Ifname.VMap()}},
+				{obj: MapElement{MapName: "avmap", Key: "eth0", Value: "drop"}, delete: true},
 			},
-			expErr: "cannot add element to unnamed vmap",
+			expErr: "map 'avmap' does not contain element 'eth0'",
 		},
 		{
-			name: "vmap element with no key",
+			name: "map element with no named map",
 			cmds: []command{
-				{obj: VMap{Name: "avmap", ElementType: NftTypeIfname}},
-				{obj: VMapElement{VmapName: "avmap", Verdict: "drop"}},
+				{obj: Map{Name: "avmap", ElementType: Ifname.VMap()}},
+				{obj: MapElement{Key: "eth0", Value: "drop"}},
 			},
-			expErr: "cannot add to vmap 'avmap', element must have key and verdict",
+			expErr: "cannot add element to unnamed map",
 		},
 		{
-			name: "vmap element with no verdict",
+			name: "map element with no key",
 			cmds: []command{
-				{obj: VMap{Name: "avmap", ElementType: NftTypeIfname}},
-				{obj: VMapElement{VmapName: "avmap", Key: "eth0"}},
+				{obj: Map{Name: "avmap", ElementType: Ifname.VMap()}},
+				{obj: MapElement{MapName: "avmap", Value: "drop"}},
 			},
-			expErr: "cannot add to vmap 'avmap', element must have key and verdict",
+			expErr: "cannot add to map 'avmap', element must have key and value",
+		},
+		{
+			name: "map element with no value",
+			cmds: []command{
+				{obj: Map{Name: "avmap", ElementType: Ifname.VMap()}},
+				{obj: MapElement{MapName: "avmap", Key: "eth0"}},
+			},
+			expErr: "cannot add to map 'avmap', element must have key and value",
 		},
 		// Set
 		{
 			name: "duplicate set",
 			cmds: []command{
-				{obj: Set{Name: "aset", ElementType: NftTypeIPv4Addr, Flags: []string{"interval"}}},
-				{obj: Set{Name: "aset", ElementType: NftTypeIPv4Addr, Flags: []string{"interval"}}},
+				{obj: Set{Name: "aset", ElementType: IPv4Addr, Flags: []string{"interval"}}},
+				{obj: Set{Name: "aset", ElementType: IPv4Addr, Flags: []string{"interval"}}},
 			},
 			expErr: "set 'aset' already exists",
 		},
 		{
 			name: "delete nonexistent set",
 			cmds: []command{
-				{obj: Set{Name: "aset", ElementType: NftTypeIPv4Addr, Flags: []string{"interval"}}, delete: true},
+				{obj: Set{Name: "aset", ElementType: IPv4Addr, Flags: []string{"interval"}}, delete: true},
 			},
 			expErr: "cannot delete set 'aset', it does not exist",
 		},
 		{
 			name: "missing set name",
 			cmds: []command{
-				{obj: Set{ElementType: NftTypeIPv4Addr, Flags: []string{"interval"}}},
+				{obj: Set{ElementType: IPv4Addr, Flags: []string{"interval"}}},
 			},
 			expErr: "set must have a name",
 		},
@@ -580,9 +580,9 @@ func TestValidation(t *testing.T) {
 		{
 			name: "delete non-empty set",
 			cmds: []command{
-				{obj: Set{Name: "aset", ElementType: NftTypeIPv4Addr, Flags: []string{"interval"}}},
+				{obj: Set{Name: "aset", ElementType: IPv4Addr, Flags: []string{"interval"}}},
 				{obj: SetElement{SetName: "aset", Element: "192.0.2.0/24"}},
-				{obj: Set{Name: "aset", ElementType: NftTypeIPv4Addr, Flags: []string{"interval"}}, delete: true},
+				{obj: Set{Name: "aset", ElementType: IPv4Addr, Flags: []string{"interval"}}, delete: true},
 			},
 			expErr: "cannot delete set 'aset', it contains 1 elements",
 		},
@@ -590,7 +590,7 @@ func TestValidation(t *testing.T) {
 		{
 			name: "duplicate set element",
 			cmds: []command{
-				{obj: Set{Name: "aset", ElementType: NftTypeIPv4Addr, Flags: []string{"interval"}}},
+				{obj: Set{Name: "aset", ElementType: IPv4Addr, Flags: []string{"interval"}}},
 				{obj: SetElement{SetName: "aset", Element: "192.0.2.0/24"}},
 				{obj: SetElement{SetName: "aset", Element: "192.0.2.0/24"}},
 			},
@@ -599,7 +599,7 @@ func TestValidation(t *testing.T) {
 		{
 			name: "delete nonexistent set element",
 			cmds: []command{
-				{obj: Set{Name: "aset", ElementType: NftTypeIPv4Addr, Flags: []string{"interval"}}},
+				{obj: Set{Name: "aset", ElementType: IPv4Addr, Flags: []string{"interval"}}},
 				{obj: SetElement{SetName: "aset", Element: "192.0.2.0/24"}, delete: true},
 			},
 			expErr: "cannot delete '192.0.2.0/24' from set 'aset', it does not exist",
@@ -607,7 +607,7 @@ func TestValidation(t *testing.T) {
 		{
 			name: "add set element to unnamed set",
 			cmds: []command{
-				{obj: Set{Name: "aset", ElementType: NftTypeIPv4Addr, Flags: []string{"interval"}}},
+				{obj: Set{Name: "aset", ElementType: IPv4Addr, Flags: []string{"interval"}}},
 				{obj: SetElement{Element: "192.0.2.0/24"}},
 			},
 			expErr: "cannot add to set '', it does not exist",
@@ -615,7 +615,7 @@ func TestValidation(t *testing.T) {
 		{
 			name: "add set element with no element",
 			cmds: []command{
-				{obj: Set{Name: "aset", ElementType: NftTypeIPv4Addr, Flags: []string{"interval"}}},
+				{obj: Set{Name: "aset", ElementType: IPv4Addr, Flags: []string{"interval"}}},
 				{obj: SetElement{SetName: "aset"}},
 			},
 			expErr: "cannot add to set 'aset', element not specified",
@@ -623,7 +623,7 @@ func TestValidation(t *testing.T) {
 		{
 			name: "mismatched set element type",
 			cmds: []command{
-				{obj: Set{Name: "aset", ElementType: NftTypeIPv4Addr, Flags: []string{"interval"}}},
+				{obj: Set{Name: "aset", ElementType: IPv4Addr, Flags: []string{"interval"}}},
 				{obj: SetElement{SetName: "aset", Element: "2001:db8::/64"}},
 			},
 			expErr: "Address family for hostname not supported",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary
An nftables vmap is just a map whose element values are of type `verdict`. Generalize VMap, VMapElement and Set to support any element type.

Add a fluent API to build arbitrary tuple and mapping types from the composition of other types or the 'typeof' an nftables expression. Block the invalid composition of named types and `typeof` expressions at compile time.

There are only a handful of contexts where the data type needs to be specified: set and map definitions. Modelling set and map types as a singular "nft type" does not align well with the semantics of nftables. Map types are always composite types with a key and a value part. Set types do not have a value part; it is an error to create a map with a set type or vice versa. Encode this distinction into the Go type system so it is a compile-time error to try to use a set type in a map context or a map type in a set context.

Drop the 'NftType' prefix from the primitive set-type constants. The prefix stutters with the package name and, as discussed above, it is not accurate to call them "nft types." Verdicts cannot be used as set elements or map keys. Provide dedicated methods to construct verdict-map types from set types instead of modelling verdicts as types themselves.

Support for creating and populating maps and sets of arbitrary types is needed to implement Swarm networking with nftables.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
