### PR TITLE
libn/d/overlay: add nftables support

### DIFF
--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -130,7 +130,7 @@ func (conf *Config) IsSwarmCompatible() error {
 	}
 	// Swarm has not yet been updated to use nftables. But, if "iptables" is disabled, it
 	// doesn't add rules anyway.
-	if conf.FirewallBackend == "nftables" && conf.EnableIPTables {
+	if conf.FirewallBackend == "nftables" && conf.EnableIPTables && !conf.Features["swarm-nftables"] {
 		return errors.New("--firewall-backend=nftables is incompatible with swarm mode")
 	}
 	return nil

--- a/daemon/libnetwork/drivers/overlay/encryption.go
+++ b/daemon/libnetwork/drivers/overlay/encryption.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/libnetwork/discoverapi"
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/overlay/overlayutils"
+	"github.com/moby/moby/v2/daemon/libnetwork/internal/nftables"
 	"github.com/moby/moby/v2/daemon/libnetwork/iptables"
 	"github.com/moby/moby/v2/daemon/libnetwork/ns"
 	"github.com/moby/moby/v2/daemon/libnetwork/types"
@@ -275,6 +276,22 @@ func (d *driver) programInput(vni uint32, add bool) error {
 	}
 
 	return nil
+}
+
+func (d *driver) programOverlayEncryptionFirewall(ctx context.Context, vni uint32, encrypted bool) error {
+	if nftables.Enabled() {
+		return d.programOverlayEncVNINft(ctx, vni, encrypted)
+	}
+
+	mangleErr := d.programMangle(vni, encrypted)
+	if mangleErr != nil && encrypted {
+		return mangleErr
+	}
+	err := d.programInput(vni, encrypted)
+	if err != nil && encrypted {
+		return errors.Join(err, d.programMangle(vni, false))
+	}
+	return errors.Join(mangleErr, err)
 }
 
 func programSA(localIP, remoteIP net.IP, spi spi, k *key, dir int, add bool) (fSA *netlink.XfrmState, rSA *netlink.XfrmState, lastErr error) {

--- a/daemon/libnetwork/drivers/overlay/encryption_nft_linux.go
+++ b/daemon/libnetwork/drivers/overlay/encryption_nft_linux.go
@@ -1,0 +1,113 @@
+//go:build linux
+
+package overlay
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/moby/moby/v2/daemon/libnetwork/drivers/overlay/overlayutils"
+	"github.com/moby/moby/v2/daemon/libnetwork/internal/nftables"
+)
+
+const (
+	nftOverlayTable    = "docker-overlay"
+	nftEncOutChainName = "enc-out"
+	nftEncInChainName  = "enc-in"
+	nftEncVNSetName    = "encrypted-vnis"
+	nftEncVNIExpr      = "@th,96,24"
+)
+
+// ensureOverlayEncNftTable returns the overlay encryption nft table, running one-time setup on first use.
+func (d *driver) ensureOverlayEncNftTable(ctx context.Context) (nftables.Table, error) {
+	d.overlayEncNftInitMu.Lock()
+	defer d.overlayEncNftInitMu.Unlock()
+	if d.overlayEncNftTable.IsValid() {
+		return d.overlayEncNftTable, nil
+	}
+
+	v6, err := d.isIPv6Transport()
+	if err != nil {
+		return nftables.Table{}, err
+	}
+	fam := nftables.IPv4
+	if v6 {
+		fam = nftables.IPv6
+	}
+	t, err := nftables.NewTable(fam, nftOverlayTable)
+	if err != nil {
+		return nftables.Table{}, err
+	}
+
+	tm := nftables.Modifier{}
+	tm.Create(nftables.Set{
+		Name:        nftEncVNSetName,
+		ElementType: nftables.Typeof(nftEncVNIExpr),
+	})
+	tm.Create(nftables.BaseChain{
+		Name:      nftEncOutChainName,
+		ChainType: nftables.BaseChainTypeRoute,
+		Hook:      nftables.BaseChainHookOutput,
+		Priority:  nftables.BaseChainPriorityMangle,
+		Policy:    nftables.BaseChainPolicyAccept,
+	})
+	tm.Create(nftables.BaseChain{
+		Name:      nftEncInChainName,
+		ChainType: nftables.BaseChainTypeFilter,
+		Hook:      nftables.BaseChainHookInput,
+		Priority:  nftables.BaseChainPriorityRaw,
+		Policy:    nftables.BaseChainPolicyAccept,
+	})
+
+	port := strconv.FormatUint(uint64(overlayutils.VXLANUDPPort()), 10)
+	tm.Create(nftables.Rule{
+		Chain: nftEncOutChainName,
+		Rule: []string{
+			"udp dport", port,
+			nftEncVNIExpr,
+			"@" + nftEncVNSetName,
+			"counter",
+			"meta mark set", fmt.Sprintf("0x%x", mark),
+		},
+	})
+	tm.Create(nftables.Rule{
+		Chain: nftEncInChainName,
+		Rule: []string{
+			"meta secpath missing",
+			"udp dport", port,
+			nftEncVNIExpr,
+			"@" + nftEncVNSetName,
+			"counter",
+			"drop",
+		},
+	})
+
+	if err := t.Apply(ctx, tm); err != nil {
+		_ = t.Close()
+		return nftables.Table{}, err
+	}
+
+	d.overlayEncNftTable = t
+	return t, nil
+}
+
+func (d *driver) programOverlayEncVNINft(ctx context.Context, vni uint32, encrypted bool) error {
+	t, err := d.ensureOverlayEncNftTable(ctx)
+	if err != nil {
+		return err
+	}
+
+	tm := nftables.Modifier{}
+	se := nftables.SetElement{
+		SetName:    nftEncVNSetName,
+		Element:    fmt.Sprintf("0x%06x", vni&0xffffff),
+		Idempotent: true,
+	}
+	if encrypted {
+		tm.Create(se)
+	} else {
+		tm.Delete(se)
+	}
+	return t.Apply(ctx, tm)
+}

--- a/daemon/libnetwork/drivers/overlay/ov_network.go
+++ b/daemon/libnetwork/drivers/overlay/ov_network.go
@@ -182,8 +182,7 @@ func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string
 	// Make sure no rule is on the way from any stale secure network
 	if !n.secure {
 		for _, vni := range vnis {
-			d.programMangle(vni, false)
-			d.programInput(vni, false)
+			_ = d.programOverlayEncryptionFirewall(ctx, vni, false)
 		}
 	}
 
@@ -227,19 +226,12 @@ func (d *driver) DeleteNetwork(nid string) error {
 
 	if n.secure {
 		for _, s := range n.subnets {
-			if err := d.programMangle(s.vni, false); err != nil {
+			if err := d.programOverlayEncryptionFirewall(context.TODO(), s.vni, false); err != nil {
 				log.G(context.TODO()).WithFields(log.Fields{
 					"error":      err,
 					"network_id": n.id,
 					"subnet":     s.subnetIP,
-				}).Warn("Failed to clean up iptables rules during overlay network deletion")
-			}
-			if err := d.programInput(s.vni, false); err != nil {
-				log.G(context.TODO()).WithFields(log.Fields{
-					"error":      err,
-					"network_id": n.id,
-					"subnet":     s.subnetIP,
-				}).Warn("Failed to clean up iptables rules during overlay network deletion")
+				}).Warn("Failed to clean up overlay encryption firewall rules during overlay network deletion")
 			}
 		}
 	}
@@ -529,13 +521,8 @@ func (n *network) initSubnetSandbox(s *subnet) error {
 	// Program iptables rules for mandatory encryption of the secure
 	// network, or clean up leftover rules for a stale secure network which
 	// was previously assigned the same VNI.
-	if err := n.driver.programMangle(s.vni, n.secure); err != nil {
+	if err := n.driver.programOverlayEncryptionFirewall(context.TODO(), s.vni, n.secure); err != nil {
 		return err
-	}
-	if err := n.driver.programInput(s.vni, n.secure); err != nil {
-		if n.secure {
-			return errors.Join(err, n.driver.programMangle(s.vni, false))
-		}
 	}
 
 	if err := n.setupSubnetSandbox(s, brName, vxlanName); err != nil {

--- a/daemon/libnetwork/drivers/overlay/overlay.go
+++ b/daemon/libnetwork/drivers/overlay/overlay.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/moby/moby/v2/daemon/libnetwork/discoverapi"
 	"github.com/moby/moby/v2/daemon/libnetwork/driverapi"
+	"github.com/moby/moby/v2/daemon/libnetwork/internal/nftables"
 	"github.com/moby/moby/v2/daemon/libnetwork/scope"
 )
 
@@ -42,6 +43,9 @@ type driver struct {
 	encrMu sync.Mutex
 	secMap encrMap
 	keys   []*key
+
+	overlayEncNftInitMu sync.Mutex
+	overlayEncNftTable  nftables.Table
 
 	// mu must be held when accessing the fields which follow it
 	// in the struct definition.

--- a/daemon/libnetwork/internal/nftables/nftables_linux.go
+++ b/daemon/libnetwork/internal/nftables/nftables_linux.go
@@ -1056,7 +1056,7 @@ func (se SetElement) delete(ctx context.Context, t *table) (bool, error) {
 		"table":   t.Name,
 		"set":     s.Name,
 		"element": se.Element,
-	}).Debug("nftables: added set element")
+	}).Debug("nftables: deleted set element")
 	return true, nil
 }
 

--- a/daemon/libnetwork/internal/nftables/nftables_linux.go
+++ b/daemon/libnetwork/internal/nftables/nftables_linux.go
@@ -1015,6 +1015,9 @@ func (sd Set) delete(ctx context.Context, t *table) (bool, error) {
 type SetElement struct {
 	SetName string
 	Element string
+	// If true, deleting an element that does not exist or creating an
+	// element that already exists will succeed.
+	Idempotent bool
 }
 
 func (se SetElement) create(ctx context.Context, t *table) (bool, error) {
@@ -1026,6 +1029,9 @@ func (se SetElement) create(ctx context.Context, t *table) (bool, error) {
 		return false, fmt.Errorf("cannot add to set '%s', element not specified", se.SetName)
 	}
 	if _, ok := s.Elements[se.Element]; ok {
+		if se.Idempotent {
+			return false, nil
+		}
 		return false, fmt.Errorf("set '%s' already contains element '%s'", s.Name, se.Element)
 	}
 	s.Elements[se.Element] = struct{}{}
@@ -1046,6 +1052,9 @@ func (se SetElement) delete(ctx context.Context, t *table) (bool, error) {
 		return false, fmt.Errorf("cannot delete from set '%s', it does not exist", se.SetName)
 	}
 	if _, ok := s.Elements[se.Element]; !ok {
+		if se.Idempotent {
+			return false, nil
+		}
 		return false, fmt.Errorf("cannot delete '%s' from set '%s', it does not exist", se.Element, s.Name)
 	}
 	delete(s.Elements, se.Element)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- Related to #49638 

## Summary
Port the firewall ruleset for encrypted overlay networks to nftables. Maximize compatibility with the most distros by only using nftables features that are widely available. Use the deprecated `meta secpath exists` expression instead of the more modern `meta ipsec exists`. Extract the VNI from VXLAN packets using the more widely available `@th` raw payload expressions instead of `@ih` or `vxlan vni` expressions.

Note that this is only one piece of the changes required for the daemon with nftables as the firewall backend to be compatible with swarm mode. The load balancing / service mesh infrastructure is still missing an nftables implementation.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
