### PR TITLE
libnet/rlkclient: don't collapse loopback host IPs to 127.0.0.1

### DIFF
--- a/daemon/libnetwork/internal/rlkclient/rootlesskit_client_linux.go
+++ b/daemon/libnetwork/internal/rlkclient/rootlesskit_client_linux.go
@@ -110,6 +110,13 @@ func (c *PortDriverClient) ChildHostIP(proto string, hostIP netip.Addr) netip.Ad
 	if c.childIP.IsValid() {
 		return c.childIP
 	}
+	// Preserve IPv4 loopback addresses, the child namespace's lo covers all
+	// of 127.0.0.0/8. Mapping them all to 127.0.0.1 makes bindings on the
+	// same port but distinct loopback addresses collide in the child
+	// namespace.
+	if hostIP.Is4() && hostIP.IsLoopback() {
+		return hostIP
+	}
 	if hostIP.Is6() {
 		return netip.IPv6Loopback()
 	}

--- a/daemon/libnetwork/internal/rlkclient/rootlesskit_client_linux_test.go
+++ b/daemon/libnetwork/internal/rlkclient/rootlesskit_client_linux_test.go
@@ -1,0 +1,95 @@
+package rlkclient
+
+import (
+	"net/netip"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestChildHostIP(t *testing.T) {
+	builtin := &PortDriverClient{
+		portDriverName: "builtin",
+		protos:         map[string]struct{}{"tcp4": {}, "tcp6": {}, "udp4": {}, "udp6": {}},
+	}
+	slirp4netns := &PortDriverClient{
+		portDriverName: "slirp4netns",
+		protos:         map[string]struct{}{"tcp4": {}, "udp4": {}},
+		childIP:        netip.MustParseAddr("10.0.2.100"),
+	}
+
+	testcases := []struct {
+		name   string
+		pdc    *PortDriverClient
+		proto  string
+		hostIP netip.Addr
+		want   netip.Addr
+	}{
+		{
+			name:   "nil client",
+			proto:  "tcp",
+			hostIP: netip.MustParseAddr("127.0.1.2"),
+			want:   netip.MustParseAddr("127.0.1.2"),
+		},
+		{
+			name:   "unsupported proto",
+			pdc:    slirp4netns,
+			proto:  "tcp",
+			hostIP: netip.MustParseAddr("::1"),
+		},
+		{
+			name:   "forced child IP",
+			pdc:    slirp4netns,
+			proto:  "tcp",
+			hostIP: netip.MustParseAddr("127.0.1.2"),
+			want:   netip.MustParseAddr("10.0.2.100"),
+		},
+		{
+			name:   "v4 unspecified",
+			pdc:    builtin,
+			proto:  "tcp",
+			hostIP: netip.MustParseAddr("0.0.0.0"),
+			want:   netip.MustParseAddr("127.0.0.1"),
+		},
+		{
+			name:   "v4 non-loopback",
+			pdc:    builtin,
+			proto:  "tcp",
+			hostIP: netip.MustParseAddr("192.0.2.1"),
+			want:   netip.MustParseAddr("127.0.0.1"),
+		},
+		{
+			name:   "v4 default loopback",
+			pdc:    builtin,
+			proto:  "tcp",
+			hostIP: netip.MustParseAddr("127.0.0.1"),
+			want:   netip.MustParseAddr("127.0.0.1"),
+		},
+		{
+			// Distinct loopback addresses must not be collapsed to
+			// 127.0.0.1, or bindings on the same port collide in the
+			// child namespace.
+			// Regression test for https://github.com/moby/moby/issues/52783
+			name:   "v4 non-default loopback",
+			pdc:    builtin,
+			proto:  "tcp",
+			hostIP: netip.MustParseAddr("127.0.1.2"),
+			want:   netip.MustParseAddr("127.0.1.2"),
+		},
+		{
+			name:   "v6 non-loopback",
+			pdc:    builtin,
+			proto:  "tcp",
+			hostIP: netip.MustParseAddr("2001:db8::1"),
+			want:   netip.IPv6Loopback(),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.pdc.ChildHostIP(tc.proto, tc.hostIP)
+			assert.Check(t, is.Equal(got, tc.want))
+		})
+	}
+}

--- a/integration/networking/port_mapping_linux_test.go
+++ b/integration/networking/port_mapping_linux_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/netip"
@@ -1599,5 +1600,65 @@ func TestMixAnyWithSpecificHostAddrs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestPortMappingOnDistinctLoopbackAddrs checks that two containers can
+// publish the same port on distinct host loopback addresses, and that each
+// address is routed to its own container. In rootless mode, loopback host
+// addresses used to be collapsed to 127.0.0.1 in the daemon's network
+// namespace, making the second binding fail with "port is already allocated".
+// Regression test for https://github.com/moby/moby/issues/52783
+func TestPortMappingOnDistinctLoopbackAddrs(t *testing.T) {
+	ctx := setupTest(t)
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	const hostPort = "1716"
+	hostAddrs := []string{"127.0.1.2", "127.0.1.3"}
+	for i, hostAddr := range hostAddrs {
+		ctrID := container.Run(ctx, t, c,
+			container.WithName(sanitizeCtrName(fmt.Sprintf("%s-server%d", t.Name(), i))),
+			container.WithExposedPorts("80/tcp"),
+			container.WithPortMap(networktypes.PortMap{
+				networktypes.MustParsePort("80/tcp"): {{
+					HostIP:   netip.MustParseAddr(hostAddr),
+					HostPort: hostPort,
+				}},
+			}),
+			// Serve the index of the host address the container is published
+			// on, so the response identifies which container handled it.
+			container.WithCmd("sh", "-c",
+				fmt.Sprintf("mkdir -p /www && echo -n %d > /www/index.html && exec httpd -f -h /www", i)),
+		)
+		defer c.ContainerRemove(ctx, ctrID, client.ContainerRemoveOptions{Force: true})
+	}
+
+	for i, hostAddr := range hostAddrs {
+		httpClient := &http.Client{Timeout: 3 * time.Second}
+		url := "http://" + net.JoinHostPort(hostAddr, hostPort)
+		var resp *http.Response
+		var err error
+		// The userland proxy or RootlessKit forwarder may need a moment to
+		// start accepting connections after container start.
+		for attempt := 0; attempt < 5; attempt++ {
+			resp, err = httpClient.Get(url)
+			if err == nil {
+				break
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+		assert.NilError(t, err)
+		defer resp.Body.Close()
+		assert.Check(t, is.Equal(resp.StatusCode, http.StatusOK))
+		body, err := io.ReadAll(resp.Body)
+		assert.NilError(t, err)
+		assert.Check(t, is.Equal(string(body), strconv.Itoa(i)),
+			"%s answered by the wrong container", url)
 	}
 }


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/52783

## Summary

In rootless mode, `ChildHostIP` maps every IPv4 host address to `127.0.0.1` in the child network namespace. Port bindings on the same port but distinct loopback addresses (e.g. `127.0.1.2:8080` and `127.0.1.3:8080`) were therefore both reserved as `127.0.0.1:8080` by the port allocator in the child namespace, and the second binding failed with `Bind for 127.0.0.1:8080 failed: port is already allocated` — matching the `docker-proxy -host-ip 127.0.0.1` observation in the issue. Rootful mode handles these bindings fine.

This change preserves IPv4 loopback host addresses as the child host IP. The child namespace's `lo` covers all of 127.0.0.0/8, so the addresses are bindable as-is, and RootlessKit's builtin port driver listens on the requested parent address (`pkg/port/builtin/parent/tcp`) and dials the requested child address (`pkg/port/builtin/child`) verbatim, so no RootlessKit change is needed. Port drivers that disallow loopback child IPs (slirp4netns) are unaffected: their forced non-loopback `childIP` is selected before the new fallback.

## Verification

Unit test added for `ChildHostIP` (nil client, forced child IP, unspecified, non-loopback, default and non-default loopback, IPv6).

End-to-end on an Ubuntu VM (arm64), rootless with the builtin port driver. Before (also reproduces on 29.5.3 stock):

```
$ docker run -d --name web1 -p 127.0.1.2:8080:80 traefik/whoami   # OK
$ docker run -d --name web2 -p 127.0.1.3:8080:80 traefik/whoami
docker: Error response from daemon: ... Bind for 127.0.0.1:8080 failed: port is already allocated
```

After (dockerd + docker-proxy built from this branch):

```
$ docker run -d --name web1 -p 127.0.1.2:8080:80 traefik/whoami   # OK
$ docker run -d --name web2 -p 127.0.1.3:8080:80 traefik/whoami   # OK
$ curl -s http://127.0.1.2:8080 | grep Hostname    # Hostname: 8bab5be48af8
$ curl -s http://127.0.1.3:8080 | grep Hostname    # Hostname: faefe39d1282
$ ps aux | grep -o 'docker-proxy -proto tcp -host-ip [0-9.]*' | sort -u
docker-proxy -proto tcp -host-ip 127.0.0.1
docker-proxy -proto tcp -host-ip 127.0.1.2
docker-proxy -proto tcp -host-ip 127.0.1.3
```

Wildcard (`-p 8081:80`) and default-loopback (`-p 127.0.0.1:8082:80`) bindings re-verified working on the same daemon. `go test ./daemon/libnetwork/portmappers/... ./daemon/libnetwork/portallocator/... ./daemon/libnetwork/internal/rlkclient/...` passes.

## Release notes (optional)

Fix rootless port bindings on distinct loopback addresses (e.g. `127.0.1.2`) failing with `port is already allocated` when using the same port.

---

Created with: Claude Code