### PR TITLE
daemon: add trust-default-address-pools option

### DIFF
--- a/daemon/command/config_unix.go
+++ b/daemon/command/config_unix.go
@@ -52,6 +52,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.BoolVar(&conf.NoNewPrivileges, "no-new-privileges", false, "Set no-new-privileges by default for new containers")
 	flags.StringVar(&conf.IpcMode, "default-ipc-mode", conf.IpcMode, `Default mode for containers ipc ("shareable" | "private")`)
 	flags.Var(&conf.NetworkConfig.DefaultAddressPools, "default-address-pool", "Default address pools for node specific local networks")
+	flags.BoolVar(&conf.NetworkConfig.TrustDefaultAddressPools, "trust-default-address-pools", false, "Allocate subnets from the configured default address pools even when they overlap routes that appear to be in use (requires default-address-pool)")
 	flags.StringVar(&conf.NetworkConfig.FirewallBackend, "firewall-backend", "", "Firewall backend to use, iptables or nftables")
 	// rootless needs to be explicitly specified for running "rootful" dockerd in rootless dockerd (#38702)
 	// Note that conf.BridgeConfig.UserlandProxyPath and honorXDG are configured according to the value of rootless.RunningWithRootlessKit, not the value of --rootless.

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -156,6 +156,11 @@ type commonBridgeConfig struct {
 type NetworkConfig struct {
 	// Default address pools for docker networks
 	DefaultAddressPools opts.PoolsOpt `json:"default-address-pools"`
+	// TrustDefaultAddressPools disables the heuristics that exclude
+	// subnets overlapping routes that appear to be in use when picking a
+	// subnet from DefaultAddressPools. It is an error to set this option
+	// without configuring DefaultAddressPools explicitly.
+	TrustDefaultAddressPools bool `json:"trust-default-address-pools,omitempty"`
 	// NetworkControlPlaneMTU allows to specify the control plane MTU, this will allow to optimize the network use in some components
 	NetworkControlPlaneMTU int `json:"network-control-plane-mtu,omitempty"`
 	// Default options for newly created networks
@@ -720,6 +725,12 @@ func Validate(config *Config) error {
 	// validate HostGatewayIPs
 	if err := dopts.ValidateHostGatewayIPs(config.HostGatewayIPs); err != nil {
 		return err
+	}
+
+	// trust-default-address-pools opts out of the safety heuristics, so it
+	// must not apply to the built-in default pools.
+	if config.TrustDefaultAddressPools && len(config.DefaultAddressPools.Value()) == 0 {
+		return errors.Errorf("trust-default-address-pools requires default-address-pools to be configured")
 	}
 
 	// validate Labels

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -235,6 +235,17 @@ func TestValidateConfigurationErrors(t *testing.T) {
 			expectedErr: "bad attribute format: one",
 		},
 		{
+			name: "trust-default-address-pools without default-address-pools",
+			config: &Config{
+				CommonConfig: CommonConfig{
+					NetworkConfig: NetworkConfig{
+						TrustDefaultAddressPools: true,
+					},
+				},
+			},
+			expectedErr: "trust-default-address-pools requires default-address-pools to be configured",
+		},
+		{
 			name: "multiple label without value",
 			config: &Config{
 				CommonConfig: CommonConfig{
@@ -593,6 +604,14 @@ func TestValidateConfiguration(t *testing.T) {
 			assert.NilError(t, err)
 		})
 	}
+}
+
+func TestValidateTrustDefaultAddressPools(t *testing.T) {
+	cfg, err := New()
+	assert.NilError(t, err)
+	assert.NilError(t, cfg.DefaultAddressPools.Set("base=10.123.0.0/16,size=24"))
+	cfg.TrustDefaultAddressPools = true
+	assert.NilError(t, Validate(cfg))
 }
 
 func TestValidateMinAPIVersion(t *testing.T) {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1693,6 +1693,7 @@ func (daemon *Daemon) networkOptions(conf *config.Config, pg plugingetter.Plugin
 		nwconfig.OptionDefaultNetwork(network.DefaultNetwork),
 		nwconfig.OptionNetworkControlPlaneMTU(conf.NetworkControlPlaneMTU),
 		nwconfig.OptionFirewallBackend(conf.FirewallBackend),
+		nwconfig.OptionTrustDefaultAddressPools(conf.TrustDefaultAddressPools),
 	}
 
 	options = append(options, networkPlatformOptions(conf)...)

--- a/daemon/libnetwork/config/config.go
+++ b/daemon/libnetwork/config/config.go
@@ -36,13 +36,18 @@ type Config struct {
 	ClusterProvider        cluster.Provider
 	NetworkControlPlaneMTU int
 	DefaultAddressPool     []*ipamutils.NetworkToSplit
-	DatastoreBucket        string
-	ActiveSandboxes        map[string]any
-	PluginGetter           plugingetter.PluginGetter
-	FirewallBackend        string
-	Rootless               bool
-	EnableUserlandProxy    bool
-	UserlandProxyPath      string
+	// TrustDefaultAddressPools disables the reserved-network heuristics
+	// when dynamically selecting a subnet for a local-scope network, so
+	// subnets are picked from the configured default address pools even
+	// when they overlap routes that look like they are in use.
+	TrustDefaultAddressPools bool
+	DatastoreBucket          string
+	ActiveSandboxes          map[string]any
+	PluginGetter             plugingetter.PluginGetter
+	FirewallBackend          string
+	Rootless                 bool
+	EnableUserlandProxy      bool
+	UserlandProxyPath        string
 }
 
 // New creates a new Config and initializes it with the given Options.
@@ -84,6 +89,15 @@ func OptionDefaultDriver(dd string) Option {
 func OptionDefaultAddressPoolConfig(addressPool []*ipamutils.NetworkToSplit) Option {
 	return func(c *Config) {
 		c.DefaultAddressPool = addressPool
+	}
+}
+
+// OptionTrustDefaultAddressPools function returns an option setter to disable
+// the reserved-network heuristics when selecting subnets from the default
+// address pools.
+func OptionTrustDefaultAddressPools(trust bool) Option {
+	return func(c *Config) {
+		c.TrustDefaultAddressPools = trust
 	}
 }
 

--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -1517,7 +1517,7 @@ func (n *Network) ipamAllocateVersion(ipam ipamapi.Ipam, v6 bool, ipamConf []*Ip
 		}
 
 		var reserved []netip.Prefix
-		if n.Scope() != scope.Global {
+		if n.Scope() != scope.Global && !n.getController().Config().TrustDefaultAddressPools {
 			reserved = netutils.InferReservedNetworks(v6)
 		}
 
@@ -1548,6 +1548,9 @@ func (n *Network) ipamAllocateVersion(ipam ipamapi.Ipam, v6 bool, ipamConf []*Ip
 			V6:           v6,
 		})
 		if err != nil {
+			if len(reserved) > 0 && errors.Is(err, ipamapi.ErrNoMoreSubnets) {
+				return nil, fmt.Errorf("%w: pools overlapping routes that appear to be in use are excluded; if the configured default-address-pools are known to be safe, this exclusion can be disabled with trust-default-address-pools", err)
+			}
 			return nil, err
 		}
 		defer func() {


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/51863

## Summary

Implements the approach robmry and corhere agreed on in the issue: a `trust-default-address-pools` daemon option that skips the `InferReservedNetworks` heuristics when dynamically selecting subnets for local-scope networks, valid only when `default-address-pools` is configured explicitly (setting it with the built-in defaults is a startup validation error). The `all predefined address pools have been fully subnetted` error now hints at the option when the heuristics contributed exclusions.

The per-pool flags, route-ignore configuration, and split-default-route coalescing discussed on the call are intentionally left out as future refinements.

## Verification

Unit tests for the config validation (error without pools, valid with pools). End-to-end on an Ubuntu VM, simulating the reported VPN scenario with an on-link route covering the configured pool (`ip route replace 10.100.0.0/16 dev eth0 scope link`, `default-address-pools = [{"base": "10.100.0.0/16", "size": 24}]`):

Without the flag (unchanged behavior, new hint):
```
failed to start daemon: ... all predefined address pools have been fully subnetted: pools overlapping routes that appear to be in use are excluded; if the configured default-address-pools are known to be safe, this exclusion can be disabled with trust-default-address-pools
```

With `"trust-default-address-pools": true`:
```
default bridge subnet: 10.100.0.0/24
dynamic network subnet: 10.100.1.0/24
```

With the flag but built-in default pools:
```
unable to configure the Docker daemon with file /etc/docker-test/daemon.json: ... trust-default-address-pools requires default-address-pools to be configured
```

Happy to rename the option if there's a preferred spelling.

## Release notes (optional)

```markdown changelog
Add a `trust-default-address-pools` daemon option to allocate network subnets from explicitly configured `default-address-pools` even when they overlap routes that appear to be in use (for example, routes installed by VPN clients).
```

Created with: Claude Code