### PR TITLE
gha: Set timeout-minutes on build-dind and labeler jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
 
   build-dind:
     runs-on: ubuntu-24.04
+    timeout-minutes: 120 # guardrails timeout for the whole job
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - validate-dco

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,6 +16,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       -
         name: Labels


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/45233

## Summary

The `build-dind` job in `ci.yml` and the `labeler` job in `labeler.yml` were the only two jobs running directly via `runs-on:` that did not have a `timeout-minutes` guardrail. This adds a 120-minute timeout to both, following the maintainer guidance in the issue to use 120 minutes as a conservative starting point to prevent runaway jobs:

> I think we used the 2-hours to prevent "runaway jobs", and that could be a good start already.

Per-job tuning to each job's usual runtime is left as a follow-up, as also suggested in the issue.

Other workflow files (`bin-image.yml`, `vm.yml`, `zizmor.yml`, `windows-2022.yml`, `windows-2025.yml`) only call reusable workflows via `uses:`, so `timeout-minutes` cannot be set on those caller jobs — the reusable workflows they call (`.dco.yml`, `.vm.yml`, `.windows.yml`) already define their own `timeout-minutes`.

## Release notes (optional)

```markdown changelog

```