### PR TITLE
hack/dockerfiles: simplify install of tools

### DIFF
--- a/hack/dockerfiles/generate-files.Dockerfile
+++ b/hack/dockerfiles/generate-files.Dockerfile
@@ -32,15 +32,11 @@ RUN <<EOT
 EOT
 
 FROM base AS tools
-# go install: versions are pinned in go.mod
 RUN --mount=from=src,source=/out,target=.,rw \
     --mount=type=cache,target=/root/.cache/go-build <<EOT
   set -ex
-  go install -v tool \
-    github.com/gogo/protobuf/protoc-gen-gogo \
-    github.com/gogo/protobuf/protoc-gen-gogofaster \
-    github.com/gogo/protobuf/protoc-gen-gogoslick \
-    google.golang.org/protobuf/cmd/protoc-gen-go
+  # install all tools defined in go.mod
+  go install -v tool
   go build -v \
     -o /usr/bin/pluginrpc-gen \
     ./pkg/plugins/pluginrpc-gen


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/52794

Follow-up to 4210ba07d90e4f484938aef4bec9494723619890, which added the "tool" directive, but kept the existing package references, which means that installation would potentially happen multiple times.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
