### PR TITLE
[DO NOT MERGE] vendor: go-archive path-traversal stack (CI signal)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -306,3 +306,5 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 	tags.cncf.io/container-device-interface/specs-go v1.1.0 // indirect
 )
+
+replace github.com/moby/go-archive => github.com/ctalledo/go-archive v0.2.1-0.20260608184626-9c0f90651199

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/cpuguy83/tar2go v0.3.1 h1:DMWlaIyoh9FBWR4hyfZSOEDA7z8rmCiGF1IJIzlTlR8
 github.com/cpuguy83/tar2go v0.3.1/go.mod h1:2Ys2/Hu+iPHQRa4DjIVJ7UAaKnDhAhNACeK3A0Rr5rM=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+github.com/ctalledo/go-archive v0.2.1-0.20260608184626-9c0f90651199 h1:QcMit0Y/eEtn1OOPO7FBfrg+RhTFVPORP5vVlvQ9qTc=
+github.com/ctalledo/go-archive v0.2.1-0.20260608184626-9c0f90651199/go.mod h1:vCuBoXfcpCoeBrbW5Xf647+70tjiZF95nVFLMaoalAc=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h1:uX1JmpONuD549D73r6cgnxyUu18Zb7yHAy5AYU0Pm4Q=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.6.0 h1:BtGB77njd6SVO6VztOHfPxKitJvd/VPT+OFBFMOi1Is=

--- a/vendor/github.com/moby/go-archive/archive.go
+++ b/vendor/github.com/moby/go-archive/archive.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -402,7 +403,11 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 	return nil
 }
 
-func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, opts *TarOptions) error {
+// createTarFile extracts a single tar entry into the given root. path is the
+// root-relative path of the entry being extracted. dc caches the last-used
+// parent directory fd to avoid repeated path walks for consecutive entries
+// in the same directory.
+func createTarFile(dc *dirCache, root *os.Root, path string, hdr *tar.Header, reader io.Reader, opts *TarOptions) error {
 	var (
 		Lchown                     = true
 		inUserns, bestEffortXattrs bool
@@ -422,20 +427,38 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, o
 	// so use hdrInfo.Mode() (they differ for e.g. setuid bits)
 	hdrInfo := hdr.FileInfo()
 
+	// absPath is computed lazily: most types use dc methods (backed by *at(2)
+	// syscalls) and never need it. It is only required for mknod, xattrs, and
+	// symlink creation (os.Root.Symlink rejects absolute targets like /usr/lib).
+	var (
+		absPath    string
+		absPathErr error
+	)
+
+	needAbsPath := func() (string, error) {
+		if absPath == "" && absPathErr == nil {
+			absPath, absPathErr = safeResolve(root.Name(), path)
+		}
+		return absPath, absPathErr
+	}
+
 	switch hdr.Typeflag {
 	case tar.TypeDir:
-		// Create directory unless it exists as a directory already.
-		// In that case we just want to merge the two
-		if fi, err := os.Lstat(path); err != nil || !fi.IsDir() {
-			if err := os.Mkdir(path, hdrInfo.Mode()); err != nil {
+		// Create directory unless it already exists as one; merge in that case.
+		// Special bits are applied afterward by handleLChmod.
+		isDir, err := dc.isExistingDir(root, path)
+		if err != nil {
+			return err
+		}
+		if !isDir {
+			if err := dc.mkdir(root, path, hdrInfo.Mode()&0o777); err != nil {
 				return err
 			}
 		}
 
 	case tar.TypeReg:
-		// Source is regular file. We use sequential file access to avoid depleting
-		// the standby list on Windows. On Linux, this equates to a regular os.OpenFile.
-		file, err := sequential.OpenFile(path, os.O_CREATE|os.O_WRONLY, hdrInfo.Mode())
+		// Special bits are applied afterward by handleLChmod.
+		file, err := dc.openFile(root, path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, hdrInfo.Mode()&0o777)
 		if err != nil {
 			return err
 		}
@@ -450,16 +473,24 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, o
 			log.G(context.TODO()).WithFields(log.Fields{"path": path, "type": hdr.Typeflag}).Debug("skipping device nodes in a userns")
 			return nil
 		}
-		// Handle this is an OS-specific way
-		if err := handleTarTypeBlockCharFifo(hdr, path); err != nil {
+		// os.Root has no mknod support; use absPath so the path stays bounded.
+		ap, err := needAbsPath()
+		if err != nil {
+			return err
+		}
+		if err := handleTarTypeBlockCharFifo(hdr, ap); err != nil {
 			return err
 		}
 
 	case tar.TypeFifo:
-		// Handle this is an OS-specific way
-		if err := handleTarTypeBlockCharFifo(hdr, path); err != nil {
+		// os.Root has no mknod support; use absPath so the path stays bounded.
+		ap, err := needAbsPath()
+		if err != nil {
+			return err
+		}
+		if err := handleTarTypeBlockCharFifo(hdr, ap); err != nil {
 			if inUserns && errors.Is(err, syscall.EPERM) {
-				// In most cases, cannot create a fifo if running in user namespace
+				// In most cases, cannot create a fifo if running in user namespace.
 				log.G(context.TODO()).WithFields(log.Fields{"error": err, "path": path, "type": hdr.Typeflag}).Debug("creating fifo node in a userns")
 				return nil
 			}
@@ -467,27 +498,24 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, o
 		}
 
 	case tar.TypeLink:
-		// #nosec G305 -- The target path is checked for path traversal.
-		targetPath := filepath.Join(extractDir, hdr.Linkname)
-		// check for hardlink breakout
-		if !strings.HasPrefix(targetPath, extractDir) {
-			return breakoutError(fmt.Errorf("invalid hardlink %q -> %q", targetPath, hdr.Linkname))
+		// Defence in depth: root.Link's containment is limited when
+		// dest is a volume root.
+		if !filepath.IsLocal(hdr.Linkname) {
+			return breakoutError(fmt.Errorf("invalid hardlink target %q", hdr.Linkname))
 		}
-		if err := os.Link(targetPath, path); err != nil {
+		if err := root.Link(hdr.Linkname, path); err != nil {
 			return err
 		}
 
 	case tar.TypeSymlink:
-		// 	path 				-> hdr.Linkname = targetPath
-		// e.g. /extractDir/path/to/symlink 	-> ../2/file	= /extractDir/path/2/file
-		targetPath := filepath.Join(filepath.Dir(path), hdr.Linkname) // #nosec G305 -- The target path is checked for path traversal.
-
-		// the reason we don't need to check symlinks in the path (with FollowSymlinkInScope) is because
-		// that symlink would first have to be created, which would be caught earlier, at this very check:
-		if !strings.HasPrefix(targetPath, extractDir) {
-			return breakoutError(fmt.Errorf("invalid symlink %q -> %q", path, hdr.Linkname))
-		}
-		if err := os.Symlink(hdr.Linkname, path); err != nil {
+		// os.Root.Symlink contains the symlink's location (newname) within
+		// root but stores the target (oldname) verbatim, so absolute targets
+		// such as /usr/lib -- common and legitimate in container images -- are
+		// preserved rather than rejected. The symlink node is therefore always
+		// created within root via openat(2) semantics, without resolving to an
+		// absolute path; containment applies when the symlink is followed, not
+		// at creation.
+		if err := root.Symlink(hdr.Linkname, path); err != nil {
 			return err
 		}
 
@@ -504,12 +532,12 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, o
 		if chownOpts == nil {
 			chownOpts = &ChownOpts{UID: hdr.Uid, GID: hdr.Gid}
 		}
-		if err := os.Lchown(path, chownOpts.UID, chownOpts.GID); err != nil {
+		if err := dc.lchown(root, path, chownOpts.UID, chownOpts.GID); err != nil {
 			var msg string
 			if inUserns && errors.Is(err, syscall.EINVAL) {
 				msg = " (try increasing the number of subordinate IDs in /etc/subuid and /etc/subgid)"
 			}
-			return fmt.Errorf("failed to Lchown %q for UID %d, GID %d%s: %w", path, hdr.Uid, hdr.Gid, msg, err)
+			return fmt.Errorf("failed to lchown %q for UID %d, GID %d%s: %w", path, hdr.Uid, hdr.Gid, msg, err)
 		}
 	}
 
@@ -519,7 +547,13 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, o
 		if !ok {
 			continue
 		}
-		if err := lsetxattr(path, xattr, []byte(value), 0); err != nil {
+		// os.Root has no xattr support; use the absolute path derived from
+		// the root so the path remains bounded.
+		ap, err := needAbsPath()
+		if err != nil {
+			return err
+		}
+		if err := lsetxattr(ap, xattr, []byte(value), 0); err != nil {
 			if bestEffortXattrs && errors.Is(err, syscall.ENOTSUP) || errors.Is(err, syscall.EPERM) {
 				// EPERM occurs if modifying xattrs is not allowed. This can
 				// happen when running in userns with restrictions (ChromeOS).
@@ -537,27 +571,27 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, o
 	}
 
 	// There is no LChmod, so ignore mode for symlink. Also, this
-	// must happen after chown, as that can modify the file mode
-	if err := handleLChmod(hdr, path, hdrInfo); err != nil {
+	// must happen after chown, as that can modify the file mode.
+	if err := handleLChmod(dc, root, path, hdr, hdrInfo); err != nil {
 		return err
 	}
 
 	aTime := boundTime(latestTime(hdr.AccessTime, hdr.ModTime))
 	mTime := boundTime(hdr.ModTime)
 
-	// chtimes doesn't support a NOFOLLOW flag atm
+	// Symlinks use lchtimes (AT_SYMLINK_NOFOLLOW); all other types follow symlinks.
 	if hdr.Typeflag == tar.TypeLink {
-		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
-			if err := chtimes(path, aTime, mTime); err != nil {
+		if fi, err := root.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
+			if err := dc.chtimes(root, path, aTime, mTime); err != nil {
 				return err
 			}
 		}
 	} else if hdr.Typeflag != tar.TypeSymlink {
-		if err := chtimes(path, aTime, mTime); err != nil {
+		if err := dc.chtimes(root, path, aTime, mTime); err != nil {
 			return err
 		}
 	} else {
-		if err := lchtimes(path, aTime, mTime); err != nil {
+		if err := dc.lchtimes(root, path, aTime, mTime); err != nil {
 			return err
 		}
 	}
@@ -803,11 +837,32 @@ func (t *Tarballer) Do() {
 	}
 }
 
+// unpackedDir records a directory whose mtime must be restored after all
+// entries are extracted, along with the root-relative entry name used during
+// extraction.
+type unpackedDir struct {
+	hdr  *tar.Header
+	name string // root-relative entry name
+}
+
 // Unpack unpacks the decompressedArchive to dest with options.
 func Unpack(decompressedArchive io.Reader, dest string, options *TarOptions) error {
+	// Open an os.Root for dest so that all extraction operations are bounded
+	// within dest at the OS level using openat(2) semantics.
+	root, err := os.OpenRoot(dest)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+
 	tr := tar.NewReader(decompressedArchive)
 
-	var dirs []*tar.Header
+	// dc caches the last-opened parent directory fd so that consecutive
+	// entries in the same directory avoid re-walking the full path.
+	var dc dirCache
+	defer dc.close()
+
+	var dirs []unpackedDir
 	whiteoutConverter := getWhiteoutConverter(options.WhiteoutFormat)
 
 	// Iterate through the files in the archive.
@@ -828,10 +883,20 @@ loop:
 			continue
 		}
 
-		// Normalize name, for safety and for a simple is-root check
-		// This keeps "../" as-is, but normalizes "/../" to "/". Or Windows:
-		// This keeps "..\" as-is, but normalizes "\..\" to "\".
-		hdr.Name = filepath.Clean(hdr.Name)
+		// Normalize name: root with "/" to eliminate leading ".."
+		// components, then strip the leading "/" for a root-relative path.
+		hdr.Name = strings.TrimLeft(path.Join("/", hdr.Name), "/")
+		if hdr.Name == "" {
+			hdr.Name = "."
+		}
+		// Defence-in-depth: reject any name that, after normalisation,
+		// would still resolve outside the extraction root (absolute, empty,
+		// or containing ".." components). This should be unreachable after
+		// the normalisation above; it also serves as an explicit sanitiser
+		// that static analysers recognise.
+		if !filepath.IsLocal(hdr.Name) {
+			return breakoutError(fmt.Errorf("invalid entry name %q", hdr.Name))
+		}
 
 		for _, exclude := range options.ExcludePatterns {
 			if strings.HasPrefix(hdr.Name, exclude) {
@@ -840,36 +905,26 @@ loop:
 		}
 
 		// Ensure that the parent directory exists.
-		err = createImpliedDirectories(dest, hdr, options)
+		err = createImpliedDirectories(root, hdr, options)
 		if err != nil {
 			return err
 		}
 
-		// #nosec G305 -- The joined path is checked for path traversal.
-		path := filepath.Join(dest, hdr.Name)
-		rel, err := filepath.Rel(dest, path)
-		if err != nil {
-			return err
-		}
-		if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-			return breakoutError(fmt.Errorf("%q is outside of %q", hdr.Name, dest))
-		}
-
-		// If path exits we almost always just want to remove and replace it
-		// The only exception is when it is a directory *and* the file from
-		// the layer is also a directory. Then we want to merge them (i.e.
-		// just apply the metadata from the layer).
-		if fi, err := os.Lstat(path); err == nil {
+		// If the entry already exists, we almost always want to remove and
+		// replace it. The only exception is when it is a directory *and* the
+		// entry from the archive is also a directory, in which case we merge
+		// (i.e. just apply the metadata from the archive).
+		if fi, err := root.Lstat(hdr.Name); err == nil {
 			if options.NoOverwriteDirNonDir && fi.IsDir() && hdr.Typeflag != tar.TypeDir {
 				// If NoOverwriteDirNonDir is true then we cannot replace
 				// an existing directory with a non-directory from the archive.
-				return fmt.Errorf("cannot overwrite directory %q with non-directory %q", path, dest)
+				return fmt.Errorf("cannot overwrite directory %q with non-directory %q", hdr.Name, dest)
 			}
 
 			if options.NoOverwriteDirNonDir && !fi.IsDir() && hdr.Typeflag == tar.TypeDir {
 				// If NoOverwriteDirNonDir is true then we cannot replace
 				// an existing non-directory with a directory from the archive.
-				return fmt.Errorf("cannot overwrite non-directory %q with directory %q", path, dest)
+				return fmt.Errorf("cannot overwrite non-directory %q with directory %q", hdr.Name, dest)
 			}
 
 			if fi.IsDir() && hdr.Name == "." {
@@ -877,7 +932,7 @@ loop:
 			}
 
 			if !fi.IsDir() || hdr.Typeflag != tar.TypeDir {
-				if err := os.RemoveAll(path); err != nil {
+				if err := root.RemoveAll(hdr.Name); err != nil {
 					return err
 				}
 			}
@@ -888,7 +943,14 @@ loop:
 		}
 
 		if whiteoutConverter != nil {
-			writeFile, err := whiteoutConverter.ConvertRead(hdr, path)
+			// ConvertRead implementations (e.g. overlayWhiteoutConverter)
+			// make direct syscalls with the path, so they need the absolute
+			// path bounded within dest rather than the root-relative name.
+			absPath, err := safeResolve(root.Name(), hdr.Name)
+			if err != nil {
+				return err
+			}
+			writeFile, err := whiteoutConverter.ConvertRead(hdr, absPath)
 			if err != nil {
 				return err
 			}
@@ -897,22 +959,20 @@ loop:
 			}
 		}
 
-		if err := createTarFile(path, dest, hdr, tr, options); err != nil {
+		if err := createTarFile(&dc, root, hdr.Name, hdr, tr, options); err != nil {
 			return err
 		}
 
 		// Directory mtimes must be handled at the end to avoid further
-		// file creation in them to modify the directory mtime
+		// file creation in them to modify the directory mtime.
 		if hdr.Typeflag == tar.TypeDir {
-			dirs = append(dirs, hdr)
+			dirs = append(dirs, unpackedDir{hdr: hdr, name: hdr.Name})
 		}
 	}
 
-	for _, hdr := range dirs {
-		// #nosec G305 -- The header was checked for path traversal before it was appended to the dirs slice.
-		path := filepath.Join(dest, hdr.Name)
-
-		if err := chtimes(path, boundTime(latestTime(hdr.AccessTime, hdr.ModTime)), boundTime(hdr.ModTime)); err != nil {
+	for _, d := range dirs {
+		aTime := boundTime(latestTime(d.hdr.AccessTime, d.hdr.ModTime))
+		if err := root.Chtimes(d.name, aTime, boundTime(d.hdr.ModTime)); err != nil {
 			return err
 		}
 	}
@@ -924,23 +984,53 @@ loop:
 // defined by the paths of files in the tar, but there are no header entries for the directories themselves, and thus
 // we most both create them and choose metadata like permissions.
 //
-// The caller should have performed filepath.Clean(hdr.Name), so hdr.Name will now be in the filepath format for the OS
-// on which the daemon is running. This precondition is required because this function assumes a OS-specific path
-// separator when checking that a path is not the root.
-func createImpliedDirectories(dest string, hdr *tar.Header, options *TarOptions) error {
-	// Not the root directory, ensure that the parent directory exists
+// The caller must have normalized hdr.Name (no leading ".." components).
+// All directory creation is performed via root so it is bounded within the
+// destination at the OS level (openat(2) semantics), preventing escape via
+// symlinks in the destination tree.
+func createImpliedDirectories(root *os.Root, hdr *tar.Header, options *TarOptions) error {
+	// Not the root directory, ensure that the parent directory exists.
 	if !strings.HasSuffix(hdr.Name, string(os.PathSeparator)) {
 		parent := filepath.Dir(hdr.Name)
-		parentPath := filepath.Join(dest, parent)
-		if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
-			// RootPair() is confined inside this loop as most cases will not require a call, so we can spend some
-			// unneeded function calls in the uncommon case to encapsulate logic -- implied directories are a niche
-			// usage that reduces the portability of an image.
-			uid, gid := options.IDMap.RootPair()
-
-			err = user.MkdirAllAndChown(parentPath, ImpliedDirectoryMode, uid, gid, user.WithOnlyNew)
-			if err != nil {
-				return err
+		// Skip when the parent is the root itself; nothing to create.
+		if parent == "." || parent == "" || parent == string(os.PathSeparator) {
+			return nil
+		}
+		if _, err := root.Lstat(parent); err == nil {
+			return nil
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		// RootPair() is confined inside this branch as most cases will not require a call, so we can spend some
+		// unneeded function calls in the uncommon case to encapsulate logic -- implied directories are a niche
+		// usage that reduces the portability of an image.
+		uid, gid := options.IDMap.RootPair()
+		// MkdirAll on *os.Root creates any missing intermediate directories
+		// using the given mode, bounded within root. moby/sys/user does not
+		// yet expose a root-bounded MkdirAllAndChown, so apply ownership
+		// afterwards using Lchown on each newly created component.
+		if err := root.MkdirAll(parent, ImpliedDirectoryMode); err != nil {
+			return err
+		}
+		// Walk each component of parent and chown any whose ownership is
+		// not already the desired uid/gid. This mirrors WithOnlyNew
+		// semantics: existing directories are not re-chowned because they
+		// will already match (we only just created the missing ones).
+		if uid != 0 || gid != 0 {
+			components := strings.Split(parent, string(os.PathSeparator))
+			var cur string
+			for _, c := range components {
+				if c == "" {
+					continue
+				}
+				if cur == "" {
+					cur = c
+				} else {
+					cur = cur + string(os.PathSeparator) + c
+				}
+				if err := root.Lchown(cur, uid, gid); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/vendor/github.com/moby/go-archive/archive_unix.go
+++ b/vendor/github.com/moby/go-archive/archive_unix.go
@@ -70,15 +70,18 @@ func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
 	return mknod(path, mode, unix.Mkdev(uint32(hdr.Devmajor), uint32(hdr.Devminor)))
 }
 
-func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
+// handleLChmod applies the mode from hdrInfo to path within root using dc,
+// skipping symlinks (there is no lchmod). For hardlinks, the mode is applied
+// only when the link target is itself not a symlink.
+func handleLChmod(dc *dirCache, root *os.Root, path string, hdr *tar.Header, hdrInfo os.FileInfo) error {
 	if hdr.Typeflag == tar.TypeLink {
-		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
-			if err := os.Chmod(path, hdrInfo.Mode()); err != nil {
+		if fi, err := root.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
+			if err := dc.chmod(root, path, hdrInfo.Mode()); err != nil {
 				return err
 			}
 		}
 	} else if hdr.Typeflag != tar.TypeSymlink {
-		if err := os.Chmod(path, hdrInfo.Mode()); err != nil {
+		if err := dc.chmod(root, path, hdrInfo.Mode()); err != nil {
 			return err
 		}
 	}

--- a/vendor/github.com/moby/go-archive/archive_windows.go
+++ b/vendor/github.com/moby/go-archive/archive_windows.go
@@ -52,7 +52,8 @@ func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
 	return nil
 }
 
-func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
+// handleLChmod is a no-op on Windows because chmod is not supported.
+func handleLChmod(dc *dirCache, root *os.Root, path string, hdr *tar.Header, hdrInfo os.FileInfo) error {
 	return nil
 }
 

--- a/vendor/github.com/moby/go-archive/diff.go
+++ b/vendor/github.com/moby/go-archive/diff.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -20,9 +21,24 @@ import (
 // compressed or uncompressed.
 // Returns the size in bytes of the contents of the layer.
 func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64, err error) {
+	// Open an os.Root for dest so that all extraction operations are bounded
+	// within dest at the OS level using openat(2) semantics.
+	root, err := os.OpenRoot(dest)
+	if err != nil {
+		return 0, err
+	}
+	defer root.Close()
+
 	tr := tar.NewReader(layer)
 
-	var dirs []*tar.Header
+	// dc caches the last-opened parent directory fd so that consecutive
+	// entries in the same directory avoid re-walking the full path.
+	var dc dirCache
+	defer dc.close()
+
+	var dirs []unpackedDir
+	// unpackedPaths tracks root-relative paths already written in this layer
+	// so that the AUFS opaque-whiteout walk knows which paths to preserve.
 	unpackedPaths := make(map[string]struct{})
 
 	if options == nil {
@@ -48,8 +64,20 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 
 		size += hdr.Size
 
-		// Normalize name, for safety and for a simple is-root check
-		hdr.Name = filepath.Clean(hdr.Name)
+		// Normalize name: root with "/" to eliminate leading ".."
+		// components, then strip the leading "/" for a root-relative path.
+		hdr.Name = strings.TrimLeft(path.Join("/", hdr.Name), "/")
+		if hdr.Name == "" {
+			hdr.Name = "."
+		}
+		// Defence-in-depth: reject any name that, after normalisation,
+		// would still resolve outside the extraction root (absolute, empty,
+		// or containing ".." components). This should be unreachable after
+		// the normalisation above; it also serves as an explicit sanitiser
+		// that static analysers recognise.
+		if !filepath.IsLocal(hdr.Name) {
+			return 0, breakoutError(fmt.Errorf("invalid entry name %q", hdr.Name))
+		}
 
 		// Windows does not support filenames with colons in them. Ignore
 		// these files. This is not a problem though (although it might
@@ -73,14 +101,14 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 		}
 
 		// Ensure that the parent directory exists.
-		err = createImpliedDirectories(dest, hdr, options)
+		err = createImpliedDirectories(root, hdr, options)
 		if err != nil {
 			return 0, err
 		}
 
 		// Skip AUFS metadata dirs
 		if strings.HasPrefix(hdr.Name, WhiteoutMetaPrefix) {
-			// Regular files inside /.wh..wh.plnk can be used as hardlink targets
+			// Regular files inside /.wh..wh.plnk can be used as hardlink targets.
 			// We don't want this directory, but we need the files in them so that
 			// such hardlinks can be resolved.
 			if strings.HasPrefix(hdr.Name, WhiteoutLinkDir) && hdr.Typeflag == tar.TypeReg {
@@ -92,8 +120,17 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 					}
 					defer os.RemoveAll(aufsTempdir)
 				}
-				if err := createTarFile(filepath.Join(aufsTempdir, basename), dest, hdr, tr, options); err != nil {
+				// aufsTempdir is outside dest, so open a separate root for it.
+				aufsRoot, err := os.OpenRoot(aufsTempdir)
+				if err != nil {
 					return 0, err
+				}
+				var aufsDC dirCache
+				cerr := createTarFile(&aufsDC, aufsRoot, basename, hdr, tr, options)
+				aufsDC.close()
+				aufsRoot.Close()
+				if cerr != nil {
+					return 0, cerr
 				}
 			}
 
@@ -101,38 +138,48 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				continue
 			}
 		}
-		// #nosec G305 -- The joined path is guarded against path traversal.
-		path := filepath.Join(dest, hdr.Name)
-		rel, err := filepath.Rel(dest, path)
-		if err != nil {
-			return 0, err
-		}
 
-		// Note as these operations are platform specific, so must the slash be.
-		if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-			return 0, breakoutError(fmt.Errorf("%q is outside of %q", hdr.Name, dest))
-		}
+		// path is the root-relative name of the entry being processed.
+		path := hdr.Name
 		base := filepath.Base(path)
 
 		if strings.HasPrefix(base, WhiteoutPrefix) {
 			dir := filepath.Dir(path)
 			if base == WhiteoutOpaqueDir {
-				_, err := os.Lstat(dir)
+				_, err := root.Lstat(dir)
 				if err != nil {
 					return 0, err
 				}
-				err = filepath.WalkDir(dir, func(path string, info os.DirEntry, err error) error {
+				// Walk the absolute directory so we can call os.RemoveAll on
+				// paths outside the walk callback's reach, then convert each
+				// walked path back to a root-relative name for the
+				// unpackedPaths check.
+				// safeResolve walks each path component and bounds any symlinks
+				// within the root to prevent TOCTOU symlink attacks.
+				absDir, err := safeResolve(root.Name(), dir)
+				if err != nil {
+					return 0, err
+				}
+				err = filepath.WalkDir(absDir, func(p string, info os.DirEntry, err error) error {
 					if err != nil {
 						if os.IsNotExist(err) {
 							err = nil // parent was deleted
 						}
 						return err
 					}
-					if path == dir {
+					if p == absDir {
 						return nil
 					}
-					if _, exists := unpackedPaths[path]; !exists {
-						return os.RemoveAll(path)
+					// unpackedPaths is keyed by the root-relative, forward-slash
+					// form of hdr.Name (the result of path.Join("/", ...) in
+					// the normalisation step above). filepath.WalkDir yields
+					// OS-native separators, so convert to slash form before
+					// looking up so the comparison works on Windows too.
+					rel := filepath.ToSlash(strings.TrimPrefix(
+						p, root.Name()+string(os.PathSeparator),
+					))
+					if _, exists := unpackedPaths[rel]; !exists {
+						return os.RemoveAll(p)
 					}
 					return nil
 				})
@@ -142,18 +189,18 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			} else {
 				originalBase := base[len(WhiteoutPrefix):]
 				originalPath := filepath.Join(dir, originalBase)
-				if err := os.RemoveAll(originalPath); err != nil {
+				if err := root.RemoveAll(originalPath); err != nil {
 					return 0, err
 				}
 			}
 		} else {
-			// If path exits we almost always just want to remove and replace it.
-			// The only exception is when it is a directory *and* the file from
-			// the layer is also a directory. Then we want to merge them (i.e.
-			// just apply the metadata from the layer).
-			if fi, err := os.Lstat(path); err == nil {
+			// If path exists we almost always just want to remove and replace
+			// it. The only exception is when it is a directory *and* the file
+			// from the layer is also a directory. Then we want to merge them
+			// (i.e. just apply the metadata from the layer).
+			if fi, err := root.Lstat(path); err == nil {
 				if !fi.IsDir() || hdr.Typeflag != tar.TypeDir {
-					if err := os.RemoveAll(path); err != nil {
+					if err := root.RemoveAll(path); err != nil {
 						return 0, err
 					}
 				}
@@ -162,8 +209,9 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			srcData := io.Reader(tr)
 			srcHdr := hdr
 
-			// Hard links into /.wh..wh.plnk don't work, as we don't extract that directory, so
-			// we manually retarget these into the temporary files we extracted them into
+			// Hard links into /.wh..wh.plnk don't work, as we don't extract
+			// that directory, so we manually retarget these into the temporary
+			// files we extracted them into.
 			if hdr.Typeflag == tar.TypeLink && strings.HasPrefix(filepath.Clean(hdr.Linkname), WhiteoutLinkDir) {
 				linkBasename := filepath.Base(hdr.Linkname)
 				srcHdr = aufsHardlinks[linkBasename]
@@ -182,23 +230,21 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				return 0, err
 			}
 
-			if err := createTarFile(path, dest, srcHdr, srcData, options); err != nil {
+			if err := createTarFile(&dc, root, path, srcHdr, srcData, options); err != nil {
 				return 0, err
 			}
 
 			// Directory mtimes must be handled at the end to avoid further
-			// file creation in them to modify the directory mtime
+			// file creation in them to modify the directory mtime.
 			if hdr.Typeflag == tar.TypeDir {
-				dirs = append(dirs, hdr)
+				dirs = append(dirs, unpackedDir{hdr: hdr, name: path})
 			}
 			unpackedPaths[path] = struct{}{}
 		}
 	}
 
-	for _, hdr := range dirs {
-		// #nosec G305 -- The header was checked for path traversal before it was appended to the dirs slice.
-		path := filepath.Join(dest, hdr.Name)
-		if err := chtimes(path, hdr.AccessTime, hdr.ModTime); err != nil {
+	for _, d := range dirs {
+		if err := root.Chtimes(d.name, d.hdr.AccessTime, d.hdr.ModTime); err != nil {
 			return 0, err
 		}
 	}

--- a/vendor/github.com/moby/go-archive/dircache_unix.go
+++ b/vendor/github.com/moby/go-archive/dircache_unix.go
@@ -1,0 +1,183 @@
+//go:build !windows
+
+package archive
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// dirCache caches an open *os.File for the most recently accessed parent
+// directory, eliminating repeated doInRoot path walks for consecutive tar
+// entries in the same directory. doInRoot opens every path component on
+// each call; with a cached parent fd, operations on the final component
+// cost a single *at(2) syscall regardless of path depth.
+//
+// The cache is keyed on both the *os.Root and the root-relative directory
+// path, so it invalidates automatically when the root changes (e.g. when a
+// separate root is used for AUFS temporary files).
+type dirCache struct {
+	root *os.Root // root under which the cached dir was opened
+	path string   // root-relative path of the cached directory
+	file *os.File // open directory fd; nil when nothing is cached
+}
+
+// close releases the cached directory fd.
+func (dc *dirCache) close() {
+	if dc.file != nil {
+		dc.file.Close()
+		dc.file = nil
+		dc.path = ""
+		dc.root = nil
+	}
+}
+
+// splitPath returns the parent directory and base name for path.
+func splitPath(path string) (dir, base string) {
+	return filepath.Dir(path), filepath.Base(path)
+}
+
+// openDir returns an open *os.File for dir within root, reusing the cached
+// fd when possible and re-opening via root.OpenFile otherwise.
+func (dc *dirCache) openDir(root *os.Root, dir string) (*os.File, error) {
+	if dc.file != nil && dc.root == root && dc.path == dir {
+		return dc.file, nil
+	}
+	if dc.file != nil {
+		dc.file.Close()
+		dc.file = nil
+	}
+	// Open through root so that path resolution is bounded within the
+	// root's security boundary before we cache the raw fd.
+	f, err := root.OpenFile(dir, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	dc.file = f
+	dc.path = dir
+	dc.root = root
+	return f, nil
+}
+
+// openFile creates or truncates the file at path within root, using
+// openat(2) on the cached parent directory fd.
+func (dc *dirCache) openFile(root *os.Root, path string, flag int, perm os.FileMode) (*os.File, error) {
+	dir, base := splitPath(path)
+	d, err := dc.openDir(root, dir)
+	if err != nil {
+		return nil, err
+	}
+	fd, err := unix.Openat(int(d.Fd()), base, flag|syscall.O_CLOEXEC, uint32(perm))
+	if err != nil {
+		return nil, &os.PathError{Op: "openat", Path: path, Err: err}
+	}
+	return os.NewFile(uintptr(fd), path), nil
+}
+
+// isExistingDir reports whether path within root exists and is a directory.
+// A false return with a nil error means the path does not exist or is not a
+// directory; the caller should attempt to create it.
+func (dc *dirCache) isExistingDir(root *os.Root, path string) (bool, error) {
+	dir, base := splitPath(path)
+	d, err := dc.openDir(root, dir)
+	if err != nil {
+		return false, err
+	}
+	var stat unix.Stat_t
+	if err := unix.Fstatat(int(d.Fd()), base, &stat, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		// Any stat error is treated as "not an existing directory"; the
+		// subsequent mkdir call will produce a real error if needed.
+		return false, nil
+	}
+	return stat.Mode&syscall.S_IFMT == syscall.S_IFDIR, nil
+}
+
+// mkdir creates a directory at path within root.
+func (dc *dirCache) mkdir(root *os.Root, path string, perm os.FileMode) error {
+	dir, base := splitPath(path)
+	d, err := dc.openDir(root, dir)
+	if err != nil {
+		return err
+	}
+	if err := unix.Mkdirat(int(d.Fd()), base, uint32(perm)); err != nil {
+		return &os.PathError{Op: "mkdirat", Path: path, Err: err}
+	}
+	return nil
+}
+
+// lchown sets ownership of path without following symlinks.
+func (dc *dirCache) lchown(root *os.Root, path string, uid, gid int) error {
+	dir, base := splitPath(path)
+	d, err := dc.openDir(root, dir)
+	if err != nil {
+		return err
+	}
+	if err := unix.Fchownat(int(d.Fd()), base, uid, gid, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return &os.PathError{Op: "fchownat", Path: path, Err: err}
+	}
+	return nil
+}
+
+// chmod sets the permission bits of path. It follows symlinks (i.e. acts on
+// the target); callers must not invoke this for TypeSymlink entries.
+func (dc *dirCache) chmod(root *os.Root, path string, mode os.FileMode) error {
+	dir, base := splitPath(path)
+	d, err := dc.openDir(root, dir)
+	if err != nil {
+		return err
+	}
+	if err := unix.Fchmodat(int(d.Fd()), base, fileModeToPerm(mode), 0); err != nil {
+		return &os.PathError{Op: "fchmodat", Path: path, Err: err}
+	}
+	return nil
+}
+
+// chtimes sets access and modification times of path, following symlinks.
+// Callers must not invoke this for TypeSymlink entries.
+func (dc *dirCache) chtimes(root *os.Root, path string, atime, mtime time.Time) error {
+	dir, base := splitPath(path)
+	d, err := dc.openDir(root, dir)
+	if err != nil {
+		return err
+	}
+	utimes := [2]unix.Timespec{timeToTimespec(atime), timeToTimespec(mtime)}
+	if err := unix.UtimesNanoAt(int(d.Fd()), base, utimes[0:], 0); err != nil {
+		return &os.PathError{Op: "utimensat", Path: path, Err: err}
+	}
+	return nil
+}
+
+// lchtimes sets access and modification times of a symlink at path without
+// following the symlink.
+func (dc *dirCache) lchtimes(root *os.Root, path string, atime, mtime time.Time) error {
+	dir, base := splitPath(path)
+	d, err := dc.openDir(root, dir)
+	if err != nil {
+		return err
+	}
+	utimes := [2]unix.Timespec{timeToTimespec(atime), timeToTimespec(mtime)}
+	if err := unix.UtimesNanoAt(int(d.Fd()), base, utimes[0:], unix.AT_SYMLINK_NOFOLLOW); err != nil && err != unix.ENOSYS {
+		return &os.PathError{Op: "utimensat", Path: path, Err: err}
+	}
+	return nil
+}
+
+// fileModeToPerm converts an os.FileMode to the Unix permission and
+// special-bit mask expected by fchmodat(2).
+func fileModeToPerm(m os.FileMode) uint32 {
+	mode := uint32(m.Perm())
+	if m&os.ModeSetuid != 0 {
+		mode |= syscall.S_ISUID
+	}
+	if m&os.ModeSetgid != 0 {
+		mode |= syscall.S_ISGID
+	}
+	if m&os.ModeSticky != 0 {
+		mode |= syscall.S_ISVTX
+	}
+	return mode
+}

--- a/vendor/github.com/moby/go-archive/dircache_windows.go
+++ b/vendor/github.com/moby/go-archive/dircache_windows.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package archive
+
+import (
+	"os"
+	"time"
+)
+
+// dirCache on Windows delegates all operations to os.Root methods. There is
+// no fd caching because the equivalent openat(2)-style optimisation is not
+// available through the current os.Root API on Windows.
+type dirCache struct{}
+
+// close is a no-op on Windows.
+func (dc *dirCache) close() {}
+
+// openFile opens or creates path within root.
+func (dc *dirCache) openFile(root *os.Root, path string, flag int, perm os.FileMode) (*os.File, error) {
+	return root.OpenFile(path, flag, perm)
+}
+
+// isExistingDir reports whether path within root exists and is a directory.
+func (dc *dirCache) isExistingDir(root *os.Root, path string) (bool, error) {
+	fi, err := root.Lstat(path)
+	if err != nil {
+		return false, nil
+	}
+	return fi.IsDir(), nil
+}
+
+// mkdir creates a directory at path within root.
+func (dc *dirCache) mkdir(root *os.Root, path string, perm os.FileMode) error {
+	return root.Mkdir(path, perm)
+}
+
+// lchown sets ownership of path without following symlinks.
+func (dc *dirCache) lchown(root *os.Root, path string, uid, gid int) error {
+	return root.Lchown(path, uid, gid)
+}
+
+// chtimes sets access and modification times of path.
+func (dc *dirCache) chtimes(root *os.Root, path string, atime, mtime time.Time) error {
+	return root.Chtimes(path, atime, mtime)
+}
+
+// lchtimes is a no-op on Windows; symlink timestamps are not supported.
+func (dc *dirCache) lchtimes(root *os.Root, path string, atime, mtime time.Time) error {
+	return nil
+}

--- a/vendor/github.com/moby/go-archive/safepath.go
+++ b/vendor/github.com/moby/go-archive/safepath.go
@@ -1,0 +1,148 @@
+package archive
+
+import (
+	"errors"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+// maxSymlinkDepth is the maximum number of symlinks that safeResolve will
+// follow before returning errTooManyLinks.
+const maxSymlinkDepth = 255
+
+// errTooManyLinks is returned when safeResolve encounters more than
+// maxSymlinkDepth symlinks while resolving a path.
+var errTooManyLinks = errors.New("too many symlinks")
+
+// safeResolve joins p to root, resolving each path component on-disk to
+// detect and bound any symlinks within root. This prevents tar path-traversal
+// attacks where a malicious archive creates a symlink pointing outside root
+// and then writes files through it.
+//
+// Unlike filepath.Join(root, p), safeResolve calls os.Lstat on each path
+// component. When a component is a symlink, its target is resolved relative
+// to root, so absolute symlinks and relative symlinks that escape root are
+// silently redirected to stay within root.
+//
+// Internally safeResolve operates on slash-separated paths so that resolution
+// is consistent across platforms regardless of the input separator. Symlink
+// targets read via os.Readlink are normalised to forward slashes too, and
+// absolute targets — both forward-slash ("/foo") and platform-specific
+// ("C:\foo" on Windows) — are bounded within root.
+//
+// This is ported from github.com/containerd/continuity/fs.RootPath.
+func safeResolve(root, p string) (string, error) {
+	if p == "" {
+		return root, nil
+	}
+	// Normalise the input to forward slashes so that all internal path
+	// operations have consistent semantics on every platform.
+	p = filepath.ToSlash(p)
+	var linksWalked int
+	for {
+		prevLinks := linksWalked
+		newpath, err := walkLinks(root, p, &linksWalked)
+		if err != nil {
+			return "", err
+		}
+		p = newpath
+		if prevLinks == linksWalked {
+			// No new symlinks resolved; bound the path under root and
+			// check for stability.
+			newpath = path.Join("/", newpath)
+			if p == newpath {
+				return filepath.Join(root, filepath.FromSlash(newpath)), nil
+			}
+			p = newpath
+		}
+	}
+}
+
+// walkLinks resolves symlinks in a slash-separated path one component at a
+// time, bounding any symlink targets within root.
+func walkLinks(root, p string, linksWalked *int) (string, error) {
+	dir, file := path.Split(p)
+	switch {
+	case dir == "":
+		newpath, _, err := walkLink(root, file, linksWalked)
+		return newpath, err
+	case file == "":
+		if dir[len(dir)-1] == '/' {
+			if dir == "/" {
+				return dir, nil
+			}
+			// Strip trailing separator and recurse.
+			return walkLinks(root, dir[:len(dir)-1], linksWalked)
+		}
+		newpath, _, err := walkLink(root, dir, linksWalked)
+		return newpath, err
+	default:
+		newdir, err := walkLinks(root, dir, linksWalked)
+		if err != nil {
+			return "", err
+		}
+		newpath, islink, err := walkLink(
+			root, path.Join(newdir, file), linksWalked,
+		)
+		if err != nil {
+			return "", err
+		}
+		if !islink {
+			return newpath, nil
+		}
+		// path.IsAbs only recognises forward-slash absolute paths ("/foo");
+		// filepath.IsAbs additionally catches the platform-specific cases
+		// (e.g. "C:\foo" on Windows). Together they cover both so an
+		// absolute symlink target read on either platform is treated as
+		// absolute regardless of which separator style it uses.
+		if path.IsAbs(newpath) || filepath.IsAbs(newpath) {
+			return newpath, nil
+		}
+		return path.Join(newdir, newpath), nil
+	}
+}
+
+// walkLink checks whether the component at filepath.Join(root, p) is a
+// symlink. If it is, it reads the link target, increments linksWalked, and
+// returns the target. Non-existent components are treated as non-symlinks,
+// which allows safeResolve to be used for paths that do not yet exist.
+//
+// p is a slash-separated path; the returned newpath is also slash-separated.
+func walkLink(root, p string, linksWalked *int) (newpath string, islink bool, err error) {
+	if *linksWalked > maxSymlinkDepth {
+		return "", false, errTooManyLinks
+	}
+
+	// Normalise to a slash-rooted path so that filepath.Join(root, p)
+	// never escapes root regardless of whether p is absolute or relative.
+	p = path.Join("/", p)
+	if p == "/" {
+		return p, false, nil
+	}
+	realPath := filepath.Join(root, filepath.FromSlash(p))
+
+	fi, err := os.Lstat(realPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// The component does not exist yet; treat as a non-symlink so
+			// that safeResolve works for paths being created for the first
+			// time.
+			return p, false, nil
+		}
+		return "", false, err
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return p, false, nil
+	}
+
+	target, err := os.Readlink(realPath)
+	if err != nil {
+		return "", false, err
+	}
+	*linksWalked++
+	// Normalise the link target to forward slashes for consistent internal
+	// processing; on Windows os.Readlink may return backslash-separated
+	// paths.
+	return filepath.ToSlash(target), true, nil
+}

--- a/vendor/github.com/moby/go-archive/time_nonwindows.go
+++ b/vendor/github.com/moby/go-archive/time_nonwindows.go
@@ -27,15 +27,3 @@ func timeToTimespec(time time.Time) unix.Timespec {
 	}
 	return unix.NsecToTimespec(time.UnixNano())
 }
-
-func lchtimes(name string, atime time.Time, mtime time.Time) error {
-	utimes := [2]unix.Timespec{
-		timeToTimespec(atime),
-		timeToTimespec(mtime),
-	}
-	err := unix.UtimesNanoAt(unix.AT_FDCWD, name, utimes[0:], unix.AT_SYMLINK_NOFOLLOW)
-	if err != nil && err != unix.ENOSYS {
-		return err
-	}
-	return err
-}

--- a/vendor/github.com/moby/go-archive/time_windows.go
+++ b/vendor/github.com/moby/go-archive/time_windows.go
@@ -26,7 +26,3 @@ func chtimes(name string, atime time.Time, mtime time.Time) error {
 	c := windows.NsecToFiletime(mtime.UnixNano())
 	return windows.SetFileTime(h, &c, nil, nil)
 }
-
-func lchtimes(name string, atime time.Time, mtime time.Time) error {
-	return nil
-}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1168,8 +1168,8 @@ github.com/moby/buildkit/worker/label
 # github.com/moby/docker-image-spec v1.3.1
 ## explicit; go 1.18
 github.com/moby/docker-image-spec/specs-go/v1
-# github.com/moby/go-archive v0.2.0
-## explicit; go 1.23.0
+# github.com/moby/go-archive v0.2.0 => github.com/ctalledo/go-archive v0.2.1-0.20260608184626-9c0f90651199
+## explicit; go 1.25.0
 github.com/moby/go-archive
 github.com/moby/go-archive/chrootarchive
 github.com/moby/go-archive/compression
@@ -2168,3 +2168,4 @@ tags.cncf.io/container-device-interface/pkg/parser
 # tags.cncf.io/container-device-interface/specs-go v1.1.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
+# github.com/moby/go-archive => github.com/ctalledo/go-archive v0.2.1-0.20260608184626-9c0f90651199


### PR DESCRIPTION
**Do not merge — CI-only.**

Temporarily points `github.com/moby/go-archive` at a personal fork carrying the full tar path-traversal hardening stack, so moby's CI/integration suite exercises the combined changes. Requested by @vvoland.

go-archive PRs under review (stack):
- moby/go-archive#24 — symlink-aware breakout protection
- moby/go-archive#25 — `os.Root`-bounded extraction
- moby/go-archive#26 — dirfd cache (stack tip / "full version")

```
replace github.com/moby/go-archive => github.com/ctalledo/go-archive <pseudo @ 9c0f9065>  // art-227-dirfd-cache
```

Notes:
- Not for merge: the replace directive points at a personal fork.
- Branch is based on a slightly older `master` to work around a token-scope limitation on the push; the vendor delta is just the go-archive bump.