### PR TITLE
builder-next: Fix Buildkit GC filter

### DIFF
--- a/daemon/internal/builder-next/worker/gc.go
+++ b/daemon/internal/builder-next/worker/gc.go
@@ -44,7 +44,7 @@ func DefaultGCPolicy(p string, reservedSpace, maxUsedSpace, minFreeSpace int64) 
 	return []client.PruneInfo{
 		// if build cache uses more than 512MB delete the most easily reproducible data after it has not been used for 2 days
 		{
-			Filter:       []string{"type==source.local,type==exec.cachemount,type==source.git.checkout"},
+			Filter:       []string{"type==source.local", "type==exec.cachemount", "type==source.git.checkout"},
 			KeepDuration: 48 * time.Hour,
 			MaxUsedSpace: tempCacheReservedSpace,
 		},


### PR DESCRIPTION
Match Buildkit fix https://github.com/moby/buildkit/pull/6856

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Fix default BuildKit GC policy to prune reproducible cache types as intended.
```

## A picture of a cute animal (not mandatory but encouraged)
