### PR TITLE
libnetwork: don't depend on `nft` when linked against libnftables

### DIFF
--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/cleaner.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/cleaner.go
@@ -3,9 +3,8 @@
 package nftabler
 
 import (
-	"bytes"
 	"context"
-	"os/exec"
+	"fmt"
 
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge/internal/firewaller"
@@ -25,14 +24,10 @@ func Cleanup(ctx context.Context, config firewaller.Config) {
 }
 
 func tryCleanup(ctx context.Context, family nftables.Family, label string) {
-	cmd := exec.CommandContext(ctx, "nft", "delete", "table", string(family), dockerTable)
-	out, err := cmd.CombinedOutput()
+	err := nftables.RunCmd(ctx, fmt.Appendf(nil, "delete table %s %s", family, dockerTable))
 	if err != nil {
 		// May not exist ("Error: Could not process rule: No such file or directory")
-		log.G(ctx).WithFields(log.Fields{
-			"error":  err,
-			"output": string(bytes.TrimRight(out, "\n ^")), // remove "^^^^^" added in nft's error message.
-		}).Info("Deleting nftables " + label + " rules")
+		log.G(ctx).WithError(err).Info("Deleting nftables " + label + " rules")
 		return
 	}
 

--- a/daemon/libnetwork/internal/nftables/nft_cgo_linux.go
+++ b/daemon/libnetwork/internal/nftables/nft_cgo_linux.go
@@ -20,28 +20,19 @@ import (
 // #include <nftables/libnftables.h>
 import "C"
 
-type nftHandle = *C.struct_nft_ctx
+type nftCtx C.struct_nft_ctx
 
-// nftApply calls libnftables to execute the nftables commands in nftCmd.
-// Acquire t.applyLock before calling this function.
-func (t *table) nftApply(ctx context.Context, nftCmd []byte) error {
+// Apply calls libnftables to execute the nftables commands in nftCmd.
+func (h *nftCtx) Apply(ctx context.Context, nftCmd []byte) error {
 	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".nftApply.cgo")
 	defer span.End()
-
-	if t.nftHandle == nil {
-		handle, err := newNftHandle()
-		if err != nil {
-			return err
-		}
-		t.nftHandle = handle
-	}
 
 	cCmd := C.CString(string(nftCmd))
 	defer C.free(unsafe.Pointer(cCmd))
 
-	ret := C.nft_run_cmd_from_buffer(t.nftHandle, cCmd)
-	stdout := C.GoString(C.nft_ctx_get_output_buffer(t.nftHandle))
-	stderr := C.GoString(C.nft_ctx_get_error_buffer(t.nftHandle))
+	ret := C.nft_run_cmd_from_buffer((*C.struct_nft_ctx)(h), cCmd)
+	stdout := C.GoString(C.nft_ctx_get_output_buffer((*C.struct_nft_ctx)(h)))
+	stderr := C.GoString(C.nft_ctx_get_error_buffer((*C.struct_nft_ctx)(h)))
 	if ret != 0 {
 		return fmt.Errorf("libnftables: failed to apply commands (code %d), stderr: %s", int(ret), stderr)
 	}
@@ -49,7 +40,7 @@ func (t *table) nftApply(ctx context.Context, nftCmd []byte) error {
 	return nil
 }
 
-func newNftHandle() (_ *C.struct_nft_ctx, retErr error) {
+func newNftCtx() (_ *nftCtx, retErr error) {
 	handle := C.nft_ctx_new(C.NFT_CTX_DEFAULT)
 	if handle == nil {
 		return nil, errors.New("libnftables: failed to create new nft handle")
@@ -65,14 +56,9 @@ func newNftHandle() (_ *C.struct_nft_ctx, retErr error) {
 	if ret := C.nft_ctx_buffer_error(handle); ret != 0 {
 		return nil, fmt.Errorf("libnftables: failed to set error buffer (code %d)", int(ret))
 	}
-	return handle, nil
+	return (*nftCtx)(handle), nil
 }
 
-func (t *table) closeNftHandle() {
-	t.applyLock.Lock()
-	defer t.applyLock.Unlock()
-	if t.nftHandle != nil {
-		C.nft_ctx_free(t.nftHandle)
-		t.nftHandle = nil
-	}
+func (h *nftCtx) Close() {
+	C.nft_ctx_free((*C.struct_nft_ctx)(h))
 }

--- a/daemon/libnetwork/internal/nftables/nft_cgo_linux.go
+++ b/daemon/libnetwork/internal/nftables/nft_cgo_linux.go
@@ -20,6 +20,10 @@ import (
 // #include <nftables/libnftables.h>
 import "C"
 
+func preflight() error {
+	return nil
+}
+
 type nftCtx C.struct_nft_ctx
 
 // Apply calls libnftables to execute the nftables commands in nftCmd.

--- a/daemon/libnetwork/internal/nftables/nft_exec_linux.go
+++ b/daemon/libnetwork/internal/nftables/nft_exec_linux.go
@@ -20,17 +20,37 @@ type nftCtx struct{}
 var lookPathNSEnter = sync.OnceValues(func() (string, error) {
 	return exec.LookPath("nsenter")
 })
+var lookPathNft = sync.OnceValues(func() (string, error) {
+	p, err := exec.LookPath("nft")
+	if err != nil {
+		log.G(context.Background()).WithError(err).Warnf("Failed to find nft tool")
+		return "", fmt.Errorf("failed to find nft tool: %w", err)
+	}
+	return p, nil
+})
+
+func preflight() error {
+	_, err := lookPathNft()
+	return err
+}
 
 func newNftCtx() (*nftCtx, error) {
-	return *nftCtx{}, nil
+	_, err := lookPathNft()
+	if err != nil {
+		return nil, err
+	}
+	return &nftCtx{}, nil
 }
 
 func (*nftCtx) Apply(ctx context.Context, nftCmd []byte) error {
 	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".nftApply.exec")
 	defer span.End()
 
-	cmdPath := nftPath
-	cmdArgs := []string{nftPath, "-f", "-"}
+	cmdPath, err := lookPathNft()
+	if err != nil {
+		return err
+	}
+	cmdArgs := []string{cmdPath, "-f", "-"}
 	detachedNetNS, err := rootless.DetachedNetNS()
 	if err != nil {
 		return fmt.Errorf("could not check for detached netns: %w", err)

--- a/daemon/libnetwork/internal/nftables/nft_exec_linux.go
+++ b/daemon/libnetwork/internal/nftables/nft_exec_linux.go
@@ -15,13 +15,17 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-type nftHandle = struct{}
+type nftCtx struct{}
 
 var lookPathNSEnter = sync.OnceValues(func() (string, error) {
 	return exec.LookPath("nsenter")
 })
 
-func (t *table) nftApply(ctx context.Context, nftCmd []byte) error {
+func newNftCtx() (*nftCtx, error) {
+	return *nftCtx{}, nil
+}
+
+func (*nftCtx) Apply(ctx context.Context, nftCmd []byte) error {
 	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".nftApply.exec")
 	defer span.End()
 
@@ -82,5 +86,5 @@ func (t *table) nftApply(ctx context.Context, nftCmd []byte) error {
 	return nil
 }
 
-func (t *table) closeNftHandle() {
+func (*nftCtx) Close() {
 }

--- a/daemon/libnetwork/internal/nftables/nftables_linux.go
+++ b/daemon/libnetwork/internal/nftables/nftables_linux.go
@@ -258,7 +258,20 @@ type table struct {
 	MustFlush      bool
 
 	applyLock sync.Mutex
-	nftHandle nftHandle // applyLock must be held to access
+	nftHandle *nftCtx // applyLock must be held to access
+}
+
+// nftApply executes the nftables commands in nftCmd.
+// Acquire t.applyLock before calling this function.
+func (t *table) nftApply(ctx context.Context, nftCmd []byte) error {
+	if t.nftHandle == nil {
+		h, err := newNftCtx()
+		if err != nil {
+			return err
+		}
+		t.nftHandle = h
+	}
+	return t.nftHandle.Apply(ctx, nftCmd)
 }
 
 // Table is a handle for an nftables table.
@@ -305,7 +318,12 @@ func NewTable(family Family, name string) (Table, error) {
 // the underlying nftables table.
 func (t Table) Close() error {
 	if t.IsValid() {
-		t.t.closeNftHandle()
+		t.t.applyLock.Lock()
+		defer t.t.applyLock.Unlock()
+		if t.t.nftHandle != nil {
+			t.t.nftHandle.Close()
+			t.t.nftHandle = nil
+		}
 		t.t = nil
 	}
 	return nil

--- a/daemon/libnetwork/internal/nftables/nftables_linux.go
+++ b/daemon/libnetwork/internal/nftables/nftables_linux.go
@@ -49,7 +49,6 @@ import (
 	"errors"
 	"fmt"
 	"iter"
-	"os/exec"
 	"runtime"
 	"slices"
 	"strconv"
@@ -64,16 +63,15 @@ import (
 const spanPrefix = "libnetwork.internal.nftables"
 
 var (
-	// nftPath is the path of the "nft" tool, set by [Enable] and left empty if the tool
-	// is not present - in which case, nftables is disabled.
-	nftPath string
+	// enabled is set by [Enable].
+	enabled bool
 	// Error returned by Enable if nftables could not be initialised.
 	nftEnableError error
 	// incrementalUpdateTempl is a parsed text/template, used to apply incremental updates.
 	incrementalUpdateTempl *template.Template
 	// reloadTempl is a parsed text/template, used to apply a whole table.
 	reloadTempl *template.Template
-	// enableOnce is used by [Enable] to avoid checking the path for "nft" more than once.
+	// enableOnce is used by [Enable] to avoid parsing the templates more than once.
 	enableOnce sync.Once
 )
 
@@ -211,10 +209,10 @@ func (t Typeof) VMap() MapTypeof {
 // Enable tries once to initialise nftables.
 func Enable() error {
 	enableOnce.Do(func() {
-		path, err := exec.LookPath("nft")
+		err := preflight()
 		if err != nil {
-			log.G(context.Background()).WithError(err).Warnf("Failed to find nft tool")
-			nftEnableError = fmt.Errorf("failed to find nft tool: %w", err)
+			log.G(context.Background()).WithError(err).Warnf("Failed to initialize nftables")
+			nftEnableError = err
 			return
 		}
 		if err := parseTemplate(); err != nil {
@@ -222,22 +220,36 @@ func Enable() error {
 			nftEnableError = fmt.Errorf("internal error while initialising nftables: %w", err)
 			return
 		}
-		nftPath = path
+		enabled = true
 	})
 	return nftEnableError
 }
 
-// Enabled returns true if the "nft" tool is available and [Enable] has been called.
+// Enabled returns true if [Enable] has been called and nftables was initialized successfully.
 func Enabled() bool {
-	return nftPath != ""
+	return enabled
 }
 
 // Disable undoes Enable. Intended for unit testing.
 func Disable() {
-	nftPath = ""
+	enabled = false
 	incrementalUpdateTempl = nil
 	reloadTempl = nil
 	enableOnce = sync.Once{}
+}
+
+// RunCmd runs arbitrary nftables ruleset commands, like `nft -f`, irrespective
+// of whether nftables is [Enabled].
+//
+// Most users of this package should use [Table] and [Modifier] to manage their
+// nftables ruleset.
+func RunCmd(ctx context.Context, nftCmd []byte) error {
+	h, err := newNftCtx()
+	if err != nil {
+		return err
+	}
+	defer h.Close()
+	return h.Apply(ctx, nftCmd)
 }
 
 //////////////////////////////


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary
When the daemon is linked against libnftables it programs the kernel without invoking the `nft` command. Allow the nftables firewall backend to be enabled when libnftables is used, irrespective of whether `nft` is installed on the host.

Update the bridge network driver to clean up stale nftables tables in iptables mode without depending on the `nft` command.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
- Allow the nftables firewall mode to be used with a daemon that is linked against libnftables when the `nft` command is not installed on the system.
```

## A picture of a cute animal (not mandatory but encouraged)
