### PR TITLE
libnet/rlkclient: simplify ChildHostIP loopback handling

### DIFF
--- a/daemon/libnetwork/internal/rlkclient/rootlesskit_client_linux.go
+++ b/daemon/libnetwork/internal/rlkclient/rootlesskit_client_linux.go
@@ -110,11 +110,12 @@ func (c *PortDriverClient) ChildHostIP(proto string, hostIP netip.Addr) netip.Ad
 	if c.childIP.IsValid() {
 		return c.childIP
 	}
-	// Preserve IPv4 loopback addresses, the child namespace's lo covers all
-	// of 127.0.0.0/8. Mapping them all to 127.0.0.1 makes bindings on the
-	// same port but distinct loopback addresses collide in the child
-	// namespace.
-	if hostIP.Is4() && hostIP.IsLoopback() {
+	// Child namespaces only listen on loopback addresses. Preserve requested
+	// loopback addresses (the child namespace's lo covers all of 127.0.0.0/8,
+	// and collapsing them makes bindings on the same port but distinct
+	// loopback addresses collide); otherwise use the canonical loopback
+	// address for the family.
+	if hostIP.IsLoopback() {
 		return hostIP
 	}
 	if hostIP.Is6() {

--- a/daemon/libnetwork/internal/rlkclient/rootlesskit_client_linux_test.go
+++ b/daemon/libnetwork/internal/rlkclient/rootlesskit_client_linux_test.go
@@ -78,6 +78,13 @@ func TestChildHostIP(t *testing.T) {
 			want:   netip.MustParseAddr("127.0.1.2"),
 		},
 		{
+			name:   "v6 loopback",
+			pdc:    builtin,
+			proto:  "tcp",
+			hostIP: netip.MustParseAddr("::1"),
+			want:   netip.IPv6Loopback(),
+		},
+		{
 			name:   "v6 non-loopback",
 			pdc:    builtin,
 			proto:  "tcp",


### PR DESCRIPTION
- Follow up to: https://github.com/moby/moby/pull/52804

## Summary

Applies @thaJeztah's post-merge suggestion from https://github.com/moby/moby/pull/52804#discussion: check `IsLoopback` first for both address families, drop the redundant `Is4` check, and fall back to the canonical loopback for the family otherwise. No behavior change — `::1` now returns through the loopback-preserving branch instead of the IPv6 fallback, with the same result (covered by a new `v6 loopback` case in `TestChildHostIP`).

## Release notes (optional)

Created with: Claude Code