### PR TITLE
integration-cli: get container id from stdout only

### DIFF
--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -37,8 +37,14 @@ func New(t testing.TB, dockerBinary string, dockerdBinary string, ops ...daemon.
 // Cmd executes a docker CLI command against this daemon.
 // Example: d.Cmd("version") will run docker -H unix://path/to/unix.sock version
 func (d *Daemon) Cmd(args ...string) (string, error) {
-	result := icmd.RunCmd(d.Command(args...))
+	result := d.RunCmd(args...)
 	return result.Combined(), result.Error
+}
+
+// RunCmd executes a docker CLI command against this daemon and returns the result.
+// Example: d.RunCmd("version") will run docker -H unix://path/to/unix.sock version
+func (d *Daemon) RunCmd(args ...string) *icmd.Result {
+	return icmd.RunCmd(d.Command(args...))
 }
 
 // Command creates a docker CLI command against this daemon, to be executed later.

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1238,9 +1238,10 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithNames(c *testing.T) {
 	assert.NilError(c, err, out)
 	test2ID := strings.TrimSpace(out)
 
-	out, err = s.d.Cmd("run", "-d", "--name=test3", "--link", "test2:abc", "busybox", "top")
-	assert.NilError(c, err)
-	test3ID := strings.TrimSpace(out)
+	res := s.d.RunCmd("run", "-d", "--name=test3", "--link", "test2:abc", "busybox", "top")
+	assert.NilError(c, res.Error)
+	// Discard any warnings about legacy links, which are emitted on stderr.
+	test3ID := strings.TrimSpace(res.Stdout())
 
 	s.d.Restart(c)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- Follow up to: #47427 

## Summary
`TestDaemonRestartWithNames` in the `DockerDaemonSuite` has been broken since #47427 was merged. The test takes the combined output of a `docker run` command as the ID of the created container. This works fine so long as the command emits no warnings, otherwise it will corrupt the ID that the test captures. Modify the test to read the ID from the command's stdout to make the test robust to warnings being printed.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
