### PR TITLE
gha: windows: skip "Stop OpenTelemetry Collector" if it wasn't started

### DIFF
--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -329,6 +329,7 @@ jobs:
           cache: false
       -
         name: Set up OpenTelemetry Collector
+        id: setup-otel
         run: |
           New-Item -ItemType Directory -Force -Path bundles -ErrorAction Continue
           Start-Process "msiexec" -ArgumentList "/i",
@@ -548,9 +549,12 @@ jobs:
               Tee-Object -file ".\bundles\daemon.log"
       -
         name: Stop OpenTelemetry Collector
-        if: always()
+        if: ${{ always() && steps.setup-otel.outcome != 'skipped' }}
         run: |
-          (Stop-Service -DisplayName "OpenTelemetry Collector" -PassThru).WaitForStatus('Stopped', (New-TimeSpan -Seconds 30))
+          $svc = Get-Service -DisplayName "OpenTelemetry Collector" -ErrorAction SilentlyContinue
+          if ($svc -and $svc.Status -ne "Stopped") {
+              ($svc | Stop-Service -PassThru).WaitForStatus("Stopped", (New-TimeSpan -Seconds 30))
+          }
       -
         name: Upload reports
         if: always()


### PR DESCRIPTION
example failure: https://github.com/moby/moby/actions/runs/26936742177/job/79497816401


If setup failed or was skipped, this produced an error;

    Run (Stop-Service -DisplayName "OpenTelemetry Collector" -PassThru).WaitForStatus('Stopped', (New-TimeSpan -Seconds 30))
    Stop-Service: D:\a\_temp\f0230cca-e5e4-4a0b-9fe2-0d0a6a5bc60e.ps1:2
    Line |
       2 |  (Stop-Service -DisplayName "OpenTelemetry Collector" -PassThru).WaitF …
         |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         | Cannot find any service with display name 'OpenTelemetry Collector'.
    Error: Process completed with exit code 1.

Skip this step if we skipped "Set up OpenTelemetry Collector", and ignore situations where the service could not be found for other reasons.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
