### PR TITLE
gha: windows: skip "Daemon event logs" if starting daemon was skipped

### DIFF
--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -393,6 +393,7 @@ jobs:
           }
       -
         name: Starting test daemon
+        id: start-daemon
         env:
           INPUT_STORAGE: ${{ inputs.storage }}
           MATRIX_RUNTIME: ${{ matrix.runtime }}
@@ -539,8 +540,9 @@ jobs:
         # as the daemon is registered as a service we have to check the event
         # logs against the docker provider.
         name: Daemon event logs
-        if: always()
+        if: ${{ always() && steps.start-daemon.outcome != 'skipped' }}
         run: |
+          New-Item -ItemType Directory -Force -Path ".\bundles" | Out-Null
           Get-WinEvent -ea SilentlyContinue `
             -FilterHashtable @{ProviderName= "docker"; LogName = "application"} |
               Sort-Object @{Expression="TimeCreated";Descending=$false} |


### PR DESCRIPTION
example failure: https://github.com/moby/moby/actions/runs/26936742177/job/79497816401


This step would fail if the daemon was never started ("Starting test daemon"), or failed to start;

    Run Get-WinEvent -ea SilentlyContinue `
    out-file: D:\a\_temp\2b911acb-4e0e-4684-bf63-606f0da5f7c6.ps1:2
    Line |
       2 |  Get-WinEvent -ea SilentlyContinue `
         |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         | Could not find a part of the path 'D:\a\moby\moby\go\src\github.com\docker\docker\bundles\daemon.log'.
    Error: Process completed with exit code 1.

- Update the step to skip if we never attempted to start the daemon
- Make sure the output directory is created: even if we failed to start the daemon (and thus tests weren't run), the startup itself could potentially contain information that helps debugging the reason for the daemon starting.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
