### PR TITLE
integration/services: migrate TestAPISwarmInvalidAddress to integration

### DIFF
--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -539,25 +539,6 @@ loop0:
 	}
 }
 
-func (s *DockerSwarmSuite) TestAPISwarmInvalidAddress(c *testing.T) {
-	ctx := testutil.GetContext(c)
-	d := s.AddDaemon(ctx, c, false, false)
-	req := swarm.InitRequest{
-		ListenAddr: "",
-	}
-	res, _, err := request.Post(testutil.GetContext(c), "/swarm/init", request.Host(d.Sock()), request.JSONBody(req))
-	assert.NilError(c, err)
-	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-
-	req2 := swarm.JoinRequest{
-		ListenAddr:  "0.0.0.0:2377",
-		RemoteAddrs: []string{""},
-	}
-	res, _, err = request.Post(testutil.GetContext(c), "/swarm/join", request.Host(d.Sock()), request.JSONBody(req2))
-	assert.NilError(c, err)
-	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-}
-
 func (s *DockerSwarmSuite) TestAPISwarmForceNewCluster(c *testing.T) {
 	ctx := testutil.GetContext(c)
 	d1 := s.AddDaemon(ctx, c, true, true)

--- a/integration/service/swarm_test.go
+++ b/integration/service/swarm_test.go
@@ -1,12 +1,15 @@
 package service
 
 import (
+	"net/http"
 	"strings"
 	"testing"
 
+	types "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/swarm"
 	"github.com/moby/moby/v2/internal/testutil/daemon"
+	"github.com/moby/moby/v2/internal/testutil/request"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
 )
@@ -33,4 +36,26 @@ func TestSwarmCAHash(t *testing.T) {
 		RemoteAddrs: []string{d1.SwarmListenAddr()},
 	})
 	assert.ErrorContains(t, err, "remote CA does not match fingerprint")
+}
+
+func TestSwarmInvalidAddress(t *testing.T) {
+	ctx := setupTest(t)
+	d := daemon.New(t)
+	d.Start(t)
+	defer d.Stop(t)
+
+	req := types.InitRequest{
+		ListenAddr: "",
+	}
+	res, _, err := request.Post(ctx, "/swarm/init", request.Host(d.Sock()), request.JSONBody(req))
+	assert.NilError(t, err)
+	assert.Equal(t, res.StatusCode, http.StatusBadRequest)
+
+	req2 := types.JoinRequest{
+		ListenAddr:  "0.0.0.0:2377",
+		RemoteAddrs: []string{""},
+	}
+	res, _, err = request.Post(ctx, "/swarm/join", request.Host(d.Sock()), request.JSONBody(req2))
+	assert.NilError(t, err)
+	assert.Equal(t, res.StatusCode, http.StatusBadRequest)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary
Migrated test `TestAPISwarmInvalidAddress` to `integration/services` in reference to epic https://github.com/moby/moby/issues/50159.

You can verify new test passes using the following command:
```
TESTDIRS='./integration/service/' TESTFLAGS='-test.run TestSwarmInvalidAddress' make test-integration
```
<!--
Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

## A picture of a cute animal (not mandatory but encouraged)
![manatee](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExeWw2dXZnNTlpODA1NHQyZjQ2MnpqbDJubjE5bW4xNzF3Nzg2d3ZrdyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ezoh9WgKB3Drik2tGn/giphy.gif)