### PR TITLE
Set ambient capabilities for non-root cap-add

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -167,8 +167,45 @@ func WithCapabilities(ctr *container.Container) coci.SpecOpts {
 		if err != nil {
 			return err
 		}
-		return coci.WithCapabilities(capabilities)(ctx, client, c, s)
+		if err := coci.WithCapabilities(capabilities)(ctx, client, c, s); err != nil {
+			return err
+		}
+		ambient, err := ambientCapabilities(ctr.HostConfig, s.Process.User, capabilities)
+		if err != nil {
+			return err
+		}
+		if len(ambient) == 0 {
+			return nil
+		}
+		return coci.WithAmbientCapabilities(ambient)(ctx, client, c, s)
 	}
+}
+
+func ambientCapabilities(hostConfig *containertypes.HostConfig, user specs.User, allowed []string) ([]string, error) {
+	if hostConfig == nil || user.UID == 0 || len(hostConfig.CapAdd) == 0 {
+		return nil, nil
+	}
+
+	capAdd, err := caps.NormalizeLegacyCapabilities(hostConfig.CapAdd)
+	if err != nil {
+		return nil, err
+	}
+	if slices.Contains(capAdd, "ALL") {
+		return slices.Clone(allowed), nil
+	}
+
+	capDrop, err := caps.NormalizeLegacyCapabilities(hostConfig.CapDrop)
+	if err != nil {
+		return nil, err
+	}
+	var ambient []string
+	for _, cap := range capAdd {
+		if slices.Contains(capDrop, cap) || !slices.Contains(allowed, cap) || slices.Contains(ambient, cap) {
+			continue
+		}
+		ambient = append(ambient, cap)
+	}
+	return ambient, nil
 }
 
 func resourcePath(c *container.Container, getPath func() (string, error)) (string, error) {

--- a/daemon/oci_linux_test.go
+++ b/daemon/oci_linux_test.go
@@ -116,6 +116,47 @@ devices:
 	assert.Assert(t, slices.Contains(s.Process.User.AdditionalGids, uint32(1234)), "CDI additional GID not present in OCI spec")
 }
 
+func TestCreateSpecWithCapAddForNonRootUserSetsAmbientCapabilities(t *testing.T) {
+	c := &container.Container{
+		Config: &containertypes.Config{
+			User: "2400:2400",
+		},
+		HostConfig: &containertypes.HostConfig{
+			CapAdd: []string{"SYS_NICE"},
+		},
+	}
+	d := setupFakeDaemon(t, c)
+
+	s, err := d.createSpec(t.Context(), &configStore{}, c, nil)
+	assert.NilError(t, err)
+
+	assert.Check(t, is.DeepEqual(s.Process.Capabilities.Ambient, []string{"CAP_SYS_NICE"}))
+	assert.Check(t, is.DeepEqual(s.Process.Capabilities.Inheritable, []string{"CAP_SYS_NICE"}))
+	assert.Assert(t, slices.Contains(s.Process.Capabilities.Effective, "CAP_SYS_NICE"))
+	assert.Assert(t, slices.Contains(s.Process.Capabilities.Permitted, "CAP_SYS_NICE"))
+	assert.Assert(t, !slices.Contains(s.Process.Capabilities.Ambient, "CAP_NET_RAW"))
+}
+
+func TestCreateSpecWithCapAddForRootUserLeavesAmbientCapabilitiesUnset(t *testing.T) {
+	c := &container.Container{
+		Config: &containertypes.Config{
+			User: "0:0",
+		},
+		HostConfig: &containertypes.HostConfig{
+			CapAdd: []string{"SYS_NICE"},
+		},
+	}
+	d := setupFakeDaemon(t, c)
+
+	s, err := d.createSpec(t.Context(), &configStore{}, c, nil)
+	assert.NilError(t, err)
+
+	assert.Check(t, is.Len(s.Process.Capabilities.Ambient, 0))
+	assert.Check(t, is.Len(s.Process.Capabilities.Inheritable, 0))
+	assert.Assert(t, slices.Contains(s.Process.Capabilities.Effective, "CAP_SYS_NICE"))
+	assert.Assert(t, slices.Contains(s.Process.Capabilities.Permitted, "CAP_SYS_NICE"))
+}
+
 // TestTmpfsDevShmNoDupMount checks that a user-specified /dev/shm tmpfs
 // mount (as in "docker run --tmpfs /dev/shm:rw,size=NNN") does not result
 // in "Duplicate mount point" error from the engine.

--- a/integration/capabilities/capabilities_linux_test.go
+++ b/integration/capabilities/capabilities_linux_test.go
@@ -3,6 +3,7 @@ package capabilities
 import (
 	"bytes"
 	"io"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -15,6 +16,40 @@ import (
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/poll"
 )
+
+const capSysNice = 23
+
+func TestCapAddForNonRootUserSetsAmbientCapability(t *testing.T) {
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	result := container.RunAttach(ctx, t, apiClient,
+		container.WithImage("busybox:latest"),
+		container.WithUser("2400:2400"),
+		container.WithCapability("SYS_NICE"),
+		container.WithCmd("sh", "-c", "awk '/^CapEff:|^CapAmb:/ { print $1, $2 }' /proc/self/status"),
+	)
+	assert.Equal(t, result.ExitCode, 0, result.Stderr.String())
+
+	stdout := result.Stdout.String()
+	assert.Check(t, hasCapability(t, stdout, "CapEff", capSysNice), stdout)
+	assert.Check(t, hasCapability(t, stdout, "CapAmb", capSysNice), stdout)
+}
+
+func hasCapability(t *testing.T, status string, field string, capability uint) bool {
+	t.Helper()
+	for _, line := range strings.Split(status, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || strings.TrimSuffix(fields[0], ":") != field {
+			continue
+		}
+		mask, err := strconv.ParseUint(fields[1], 16, 64)
+		assert.NilError(t, err)
+		return mask&(uint64(1)<<capability) != 0
+	}
+	t.Fatalf("missing %s in status output: %s", field, status)
+	return false
+}
 
 func TestNoNewPrivileges(t *testing.T) {
 	ctx := setupTest(t)


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/50083

## Summary

Populate the OCI ambient and inheritable capability sets for non-root containers when a capability is explicitly requested with `--cap-add`.

This keeps root containers unchanged, and it only makes explicitly added capabilities ambient for non-root users instead of making the default capability set ambient.