### PR TITLE
libn/d/overlay: clean up rules from other firewall mode

### DIFF
--- a/daemon/libnetwork/drivers/overlay/encryption_nft_linux.go
+++ b/daemon/libnetwork/drivers/overlay/encryption_nft_linux.go
@@ -4,9 +4,11 @@ package overlay
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
+	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/overlay/overlayutils"
 	"github.com/moby/moby/v2/daemon/libnetwork/internal/nftables"
 )
@@ -93,6 +95,13 @@ func (d *driver) ensureOverlayEncNftTable(ctx context.Context) (nftables.Table, 
 }
 
 func (d *driver) programOverlayEncVNINft(ctx context.Context, vni uint32, encrypted bool) error {
+	// Attempt to clean up stale iptables rules from an old incarnation of
+	// the daemon which could clash with the nftables ruleset.
+	cleanupErr := errors.Join(d.programInput(vni, false), d.programMangle(vni, false))
+	if cleanupErr != nil {
+		log.G(ctx).WithError(cleanupErr).Infof("Failed to clean up stale iptables rules for VNI %d", vni)
+	}
+
 	t, err := d.ensureOverlayEncNftTable(ctx)
 	if err != nil {
 		return err
@@ -110,4 +119,24 @@ func (d *driver) programOverlayEncVNINft(ctx context.Context, vni uint32, encryp
 		tm.Delete(se)
 	}
 	return t.Apply(ctx, tm)
+}
+
+// cleanupNft deletes all nftables rules created by the driver. It's intended to
+// be used during startup, to clean up rules created by an old incarnation of
+// the daemon after switching to a different firewall backend.
+func (d *driver) cleanupNft(ctx context.Context) {
+	v6, err := d.isIPv6Transport()
+	if err != nil {
+		log.G(ctx).WithError(err).Error("Deleting overlay encryption nftables rules")
+		return
+	}
+	fam := nftables.IPv4
+	if v6 {
+		fam = nftables.IPv6
+	}
+	if err := nftables.RunCmd(ctx, fmt.Appendf(nil, "delete table %s %s", fam, nftOverlayTable)); err != nil {
+		log.G(ctx).WithError(err).Info("Deleting overlay encryption nftables rules")
+		return
+	}
+	log.G(ctx).Info("Deleted overlay encryption nftables rules")
 }

--- a/daemon/libnetwork/drivers/overlay/overlay.go
+++ b/daemon/libnetwork/drivers/overlay/overlay.go
@@ -72,7 +72,12 @@ func Register(r driverapi.Registerer) error {
 
 func (d *driver) configure() error {
 	// Apply OS specific kernel configs if needed
-	d.initOS.Do(applyOStweaks)
+	d.initOS.Do(func() {
+		applyOStweaks()
+		if !nftables.Enabled() {
+			d.cleanupNft(context.TODO())
+		}
+	})
 
 	return nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- For #49638 

## Summary
Stale rules in one firewall backend could persist if the daemon's firewall backend is switched without rebooting the host, which could interfere with the rules being programmed for the current firewall backend. Have the overlay network driver delete any stale nftables table when starting in iptables mode, and delete any stale iptables per-VNI encryption rules when programming encryption for the VNI in nftables mode.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
