### PR TITLE
daemon: windows: remove stray error log on service shutdown

### DIFF
--- a/daemon/command/daemon_windows.go
+++ b/daemon/command/daemon_windows.go
@@ -65,8 +65,14 @@ func notifyStopping() {
 }
 
 // notifyShutdown is called after the daemon shuts down but before the process exits.
-func notifyShutdown(err error) {
+func notifyShutdown(ctx context.Context, err error) {
 	if service != nil {
+		// log the error, so that it's sent to the event-log.
+		if err != nil {
+			log.G(ctx).WithError(err).Error("Stopping service")
+		} else {
+			log.G(ctx).Info("Stopping service")
+		}
 		service.stopped(err)
 	}
 }

--- a/daemon/command/docker_windows.go
+++ b/daemon/command/docker_windows.go
@@ -26,12 +26,7 @@ func runDaemon(ctx context.Context, cli *daemonCLI) error {
 	}
 
 	err = cli.start(ctx)
-	if service != nil {
-		// When running as a service, log the error, so that it's sent to
-		// the event-log.
-		log.G(ctx).Error(err)
-	}
-	notifyShutdown(err)
+	notifyShutdown(ctx, err)
 	return err
 }
 

--- a/daemon/command/service_windows.go
+++ b/daemon/command/service_windows.go
@@ -293,7 +293,6 @@ func (h *handler) started() error {
 }
 
 func (h *handler) stopped(err error) {
-	log.G(context.TODO()).Debugf("Stopping service: %v", err)
 	h.tosvc <- err != nil
 	<-h.fromsvc
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/52826#issuecomment-4678717526


runDaemon would unconditionally send an error event if the daemon was running as a system service;

    Run New-Item -ItemType Directory -Force -Path ".\bundles" | Out-Null
    2026-06-08T03:31:52.1865738Z [Information] Starting up
    2026-06-08T03:31:52.3160498Z [Information] OTEL tracing is not configured, using no-op tracer provider
    2026-06-08T03:31:52.5037110Z [Information] Windows default isolation mode: process
    2026-06-08T03:31:52.7212058Z [Information] Loading containers: start.
    2026-06-08T03:31:52.7345902Z [Information] [graphdriver] trying configured driver: windowsfilter
    2026-06-08T03:31:52.8920546Z [Information] Restoring containers: start.
    2026-06-08T03:31:52.9910057Z [Information] Restoring existing overlay networks from HNS into docker
    2026-06-08T03:31:53.8958218Z [Information] Loading containers: done.
    2026-06-08T03:31:53.9093383Z [Information] Docker daemon [storage-driver=windowsfilter containerd-snapshotter=false version=29.1.5 commit=3b01d641]
    2026-06-08T03:31:53.9103431Z [Information] Initializing buildkit
    2026-06-08T03:31:54.3243456Z [Information] Completed buildkit initialization
    2026-06-08T03:31:54.4878293Z [Information] Daemon has completed initialization
    2026-06-08T03:31:54.4881959Z [Information] API listen on //./pipe/docker_engine
    2026-06-08T03:47:45.7182269Z [Information] Processing signal 'terminated'
    2026-06-08T03:47:45.7203206Z [Information] Daemon shutdown complete
    Error: 2026-06-08T03:47:45.7206236Z [Error] <nil>

If debug was enabled, it would log this error twice (once as error, and once as debug).

Let's make this a single log, and only an error if there was one. Note that this may still be redundant, as `daemonCLI.start` also logs this error; https://github.com/moby/moby/blob/4c19a015750813d4a289879e1e387d374d7403cd/daemon/command/daemon.go#L127-L134

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
