### PR TITLE
test/docker-py: Fix swarm encrypted failure

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -4,7 +4,7 @@ set -e
 source hack/make/.integration-test-helpers
 
 # The commit or tag to use for testing
-: "${DOCKER_PY_COMMIT:=059d371b576b9f324a16753e2a775b1f7731b6d0}" # master (v7.2.0-dev)
+: "${DOCKER_PY_COMMIT:=ae5dfe9111b1f4e9fafd4107a8ac4a3fa52644dc}" # master (v7.2.0-dev)
 
 # custom options to pass py.test
 #


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

Includes https://github.com/docker/docker-py/pull/3410

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
