### PR TITLE
logger/awslogs: refresh credentials on ExpiredTokenException

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -63,6 +63,11 @@ const (
 
 	credentialsEndpoint = "http://169.254.170.2" //nolint:gosec // G101: Potential hardcoded credentials
 
+	// expiredTokenCode is the API error code the service returns when the
+	// request was signed with credentials that have expired. The error is
+	// not modeled in the SDK, so it is matched by code.
+	expiredTokenCode = "ExpiredTokenException"
+
 	// See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html
 	logsFormatHeader = "x-amzn-logs-format"
 	jsonEmfLogFormat = "json/emf"
@@ -76,6 +81,7 @@ type logStream struct {
 	forceFlushInterval time.Duration
 	multilinePattern   *regexp.Regexp
 	client             api
+	credentials        credentialsInvalidator
 
 	messages *loggerutils.MessageQueue
 	closed   atomic.Bool
@@ -99,6 +105,12 @@ type api interface {
 	CreateLogGroup(context.Context, *cloudwatchlogs.CreateLogGroupInput, ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.CreateLogGroupOutput, error)
 	CreateLogStream(context.Context, *cloudwatchlogs.CreateLogStreamInput, ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.CreateLogStreamOutput, error)
 	PutLogEvents(context.Context, *cloudwatchlogs.PutLogEventsInput, ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error)
+}
+
+// credentialsInvalidator drops cached AWS credentials so that the next
+// request re-resolves them. *aws.CredentialsCache implements it.
+type credentialsInvalidator interface {
+	Invalidate()
 }
 
 type regionFinder interface {
@@ -138,6 +150,10 @@ func New(info logger.Info) (logger.Logger, error) {
 	if err != nil {
 		return nil, err
 	}
+	var credentials credentialsInvalidator
+	if credCache, ok := client.Options().Credentials.(*aws.CredentialsCache); ok {
+		credentials = credCache
+	}
 
 	logNonBlocking := info.Config["mode"] == "non-blocking"
 
@@ -149,6 +165,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		forceFlushInterval: containerStreamConfig.forceFlushInterval,
 		multilinePattern:   containerStreamConfig.multilinePattern,
 		client:             client,
+		credentials:        credentials,
 		messages:           loggerutils.NewMessageQueue(containerStreamConfig.maxBufferedEvents),
 	}
 
@@ -689,6 +706,19 @@ func (l *logStream) publishBatch(batch *eventBatch) {
 			err = nil
 		} else if apiErr := (*types.InvalidSequenceTokenException)(nil); errors.As(err, &apiErr) {
 			nextSequenceToken, err = l.putLogEvents(cwEvents, apiErr.ExpectedSequenceToken)
+		} else if apiErr := smithy.APIError(nil); errors.As(err, &apiErr) && apiErr.ErrorCode() == expiredTokenCode && l.credentials != nil {
+			// The service rejected cached credentials that have expired, for
+			// example temporary credentials in the shared credentials file
+			// that an external process rotates (the SDK never re-reads the
+			// file because file credentials carry no expiry). Drop the cached
+			// credentials so the next request re-resolves them, and retry the
+			// batch once.
+			log.G(context.TODO()).WithFields(log.Fields{
+				"logGroupName":  l.logGroupName,
+				"logStreamName": l.logStreamName,
+			}).Info("Security token expired, refreshing credentials and retrying")
+			l.credentials.Invalidate()
+			nextSequenceToken, err = l.putLogEvents(cwEvents, l.sequenceToken)
 		}
 	}
 	if err != nil {

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/aws/smithy-go"
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/logger/loggerutils"
 	"github.com/moby/moby/v2/dockerversion"
@@ -464,6 +465,88 @@ func TestPublishBatchError(t *testing.T) {
 	}
 
 	stream.publishBatch(testEventBatch(events))
+	assert.Equal(t, sequenceToken, aws.ToString(stream.sequenceToken))
+}
+
+type fakeCredentialsInvalidator struct {
+	invalidated int
+}
+
+func (f *fakeCredentialsInvalidator) Invalidate() { f.invalidated++ }
+
+func TestPublishBatchExpiredTokenRefreshesCredentials(t *testing.T) {
+	mockClient := &mockClient{}
+	creds := &fakeCredentialsInvalidator{}
+	stream := &logStream{
+		client:        mockClient,
+		credentials:   creds,
+		logGroupName:  groupName,
+		logStreamName: streamName,
+		sequenceToken: aws.String(sequenceToken),
+	}
+	calls := 0
+	mockClient.putLogEventsFunc = func(ctx context.Context, input *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
+		calls++
+		if calls == 1 {
+			// The credentials cache held credentials that have expired,
+			// for example rotated temporary credentials from the shared
+			// credentials file. The error is not modeled in the SDK.
+			return nil, &smithy.GenericAPIError{
+				Code:    "ExpiredTokenException",
+				Message: "The security token included in the request is expired",
+			}
+		}
+		// After the credentials are invalidated and re-resolved, the
+		// retried request succeeds.
+		assert.Assert(t, creds.invalidated == 1, "credentials must be invalidated before the retry")
+		return &cloudwatchlogs.PutLogEventsOutput{
+			NextSequenceToken: aws.String(nextSequenceToken),
+		}, nil
+	}
+
+	events := []wrappedEvent{
+		{
+			inputLogEvent: types.InputLogEvent{
+				Message: aws.String(logline),
+			},
+		},
+	}
+
+	stream.publishBatch(testEventBatch(events))
+	assert.Equal(t, 2, calls)
+	assert.Equal(t, 1, creds.invalidated)
+	assert.Equal(t, nextSequenceToken, aws.ToString(stream.sequenceToken))
+}
+
+func TestPublishBatchExpiredTokenNoInvalidatorKeepsError(t *testing.T) {
+	mockClient := &mockClient{}
+	stream := &logStream{
+		client:        mockClient,
+		logGroupName:  groupName,
+		logStreamName: streamName,
+		sequenceToken: aws.String(sequenceToken),
+	}
+	calls := 0
+	mockClient.putLogEventsFunc = func(ctx context.Context, input *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
+		calls++
+		return nil, &smithy.GenericAPIError{
+			Code:    "ExpiredTokenException",
+			Message: "The security token included in the request is expired",
+		}
+	}
+
+	events := []wrappedEvent{
+		{
+			inputLogEvent: types.InputLogEvent{
+				Message: aws.String(logline),
+			},
+		},
+	}
+
+	stream.publishBatch(testEventBatch(events))
+	// Without a credentials invalidator there is nothing to refresh, so
+	// the batch is not retried.
+	assert.Equal(t, 1, calls)
 	assert.Equal(t, sequenceToken, aws.ToString(stream.sequenceToken))
 }
 


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/52823

## Summary

The awslogs driver resolves AWS credentials once at log stream creation. Credentials read from the shared credentials file carry no expiry, so the SDK's `aws.CredentialsCache` returns them forever and never re-reads the file. When an external process rotates the file (the issue's case: SSM agent hybrid activation, which rotates temporary credentials roughly every 2 hours), `PutLogEvents` starts failing with `ExpiredTokenException` and never recovers. Container logging is silently lost from then on, while `awscli` on the same host keeps working because it re-reads the file on every invocation.

This implements the recovery the issue suggests: detect `ExpiredTokenException` in the batch publish error path, call `aws.CredentialsCache.Invalidate` so the next request re-resolves the full credential chain (re-reading the rotated file), and retry the batch once with fresh credentials, so the failing batch is not lost. The error is not modeled in the SDK, so it is matched by error code, the same one the driver already logs (`errorCode=ExpiredTokenException` in the issue).

Design notes:

- The cache is obtained from `client.Options().Credentials` behind a one-method `credentialsInvalidator` interface, so no signatures change and the behavior is unit-testable.
- Providers that already self-refresh (IMDS role, `awslogs-credentials-endpoint`) set expiry on their credentials, so they refresh inside the cache as before and never hit this path. Static env-var credentials re-resolve to the same values: one extra resolution per failed batch, no behavior change.
- A retry happens at most once per batch; if the refreshed credentials are also expired, the error is logged exactly as today.

## Verification

```
go test ./daemon/logger/awslogs/   # ok, including two new tests
```

New tests: `TestPublishBatchExpiredTokenRefreshesCredentials` (invalidate happens before the retry, batch succeeds, sequence token advances) and `TestPublishBatchExpiredTokenNoInvalidatorKeepsError` (no invalidator, no retry, behavior unchanged).

## Release notes (optional)

```markdown changelog
Fix the awslogs logging driver permanently failing with `ExpiredTokenException` when temporary AWS credentials (for example from the SSM agent) are rotated on disk; the driver now refreshes credentials and retries.
```

Created with: Claude Code