### PR TITLE
awslogs: Refresh credentials on ExpiredTokenException

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -76,6 +76,7 @@ type logStream struct {
 	forceFlushInterval time.Duration
 	multilinePattern   *regexp.Regexp
 	client             api
+	info               logger.Info
 
 	messages *loggerutils.MessageQueue
 	closed   atomic.Bool
@@ -149,6 +150,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		forceFlushInterval: containerStreamConfig.forceFlushInterval,
 		multilinePattern:   containerStreamConfig.multilinePattern,
 		client:             client,
+		info:               info,
 		messages:           loggerutils.NewMessageQueue(containerStreamConfig.maxBufferedEvents),
 	}
 
@@ -320,7 +322,14 @@ var newSDKEndpoint = credentialsEndpoint
 // Customizations to the default client from the SDK include a Docker-specific
 // User-Agent string and automatic region detection using the EC2 Instance
 // Metadata Service when region is otherwise unspecified.
-func newAWSLogsClient(info logger.Info, configOpts ...func(*config.LoadOptions) error) (*cloudwatchlogs.Client, error) {
+//
+// newAWSLogsClient is a variable such that the implementation can be swapped
+// out for unit tests.
+var newAWSLogsClient = func(info logger.Info, configOpts ...func(*config.LoadOptions) error) (api, error) {
+	return createAWSLogsClient(info, configOpts...)
+}
+
+func createAWSLogsClient(info logger.Info, configOpts ...func(*config.LoadOptions) error) (*cloudwatchlogs.Client, error) {
 	ctx := context.TODO()
 	var region, endpoint *string
 	if os.Getenv(regionEnvKey) != "" {
@@ -689,6 +698,18 @@ func (l *logStream) publishBatch(batch *eventBatch) {
 			err = nil
 		} else if apiErr := (*types.InvalidSequenceTokenException)(nil); errors.As(err, &apiErr) {
 			nextSequenceToken, err = l.putLogEvents(cwEvents, apiErr.ExpectedSequenceToken)
+		} else if apiErr := (smithy.APIError)(nil); errors.As(err, &apiErr) && apiErr.ErrorCode() == "ExpiredTokenException" {
+			log.G(context.TODO()).WithFields(log.Fields{
+				"errorCode":     apiErr.ErrorCode(),
+				"message":       apiErr.ErrorMessage(),
+				"logGroupName":  l.logGroupName,
+				"logStreamName": l.logStreamName,
+			}).Info("AWS credentials expired, refreshing")
+			newClient, clientErr := newAWSLogsClient(l.info)
+			if clientErr == nil {
+				l.client = newClient
+				nextSequenceToken, err = l.putLogEvents(cwEvents, l.sequenceToken)
+			}
 		}
 	}
 	if err != nil {

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/aws/smithy-go"
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/logger/loggerutils"
 	"github.com/moby/moby/v2/dockerversion"
@@ -1722,4 +1723,52 @@ func TestNewAWSLogsClientCredentialEndpointDetect(t *testing.T) {
 	assert.Check(t, is.Contains(actualAuthHeader, "AWS4-HMAC-SHA256 Credential=test-access-key-id/"))
 	assert.Check(t, is.Contains(actualAuthHeader, "us-west-2"))
 	assert.Check(t, is.Contains(actualAuthHeader, "Signature="))
+}
+
+func TestPublishBatchExpiredTokenRefresh(t *testing.T) {
+	renewedClient := &mockClient{}
+	stream := &logStream{
+		client:        &mockClient{},
+		logGroupName:  groupName,
+		logStreamName: streamName,
+		sequenceToken: aws.String(sequenceToken),
+		info:          logger.Info{Config: map[string]string{regionKey: "us-east-1"}},
+	}
+
+	// First call fails with ExpiredTokenException
+	calls := 0
+	stream.client.(*mockClient).putLogEventsFunc = func(ctx context.Context, input *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
+		calls++
+		return nil, &smithy.GenericAPIError{
+			Code:    "ExpiredTokenException",
+			Message: "The security token included in the request is expired",
+		}
+	}
+
+	// After refresh, the new client succeeds
+	renewedClient.putLogEventsFunc = func(ctx context.Context, input *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
+		calls++
+		return &cloudwatchlogs.PutLogEventsOutput{
+			NextSequenceToken: aws.String(nextSequenceToken),
+		}, nil
+	}
+
+	// Swap newAWSLogsClient to return the renewed mock client
+	origNewAWSLogsClient := newAWSLogsClient
+	defer func() { newAWSLogsClient = origNewAWSLogsClient }()
+	newAWSLogsClient = func(info logger.Info, configOpts ...func(*config.LoadOptions) error) (api, error) {
+		return renewedClient, nil
+	}
+
+	events := []wrappedEvent{
+		{
+			inputLogEvent: types.InputLogEvent{
+				Message: aws.String(logline),
+			},
+		},
+	}
+
+	stream.publishBatch(testEventBatch(events))
+	assert.Equal(t, 2, calls)
+	assert.Equal(t, nextSequenceToken, aws.ToString(stream.sequenceToken))
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

Fixes: https://github.com/moby/moby/issues/52823

## Summary

The `awslogs` driver loads AWS credentials once during container start and stores the resulting client on the `logStream` struct. When temporary credentials expire and are rotated (e.g., by the SSM agent writing fresh creds to `~/.aws/credentials`), the driver never re-reads them, causing `PutLogEvents()` to fail with `ExpiredTokenException` indefinitely.

This fix adds one more error handling condition to `publishBatch()`. When we detect `ExpiredTokenException`, we rebuild the AWS client from the default credential chain (which re-reads the credentials file) and retry the batch.

Changes:
- Store `logger.Info` on `logStream`: needed to pass back into the client constructor on refresh. Follows the same pattern used by the [GELF driver](https://github.com/moby/moby/blob/master/daemon/logger/gelf/gelf.go#L24).
- Handle `ExpiredTokenException` in `publishBatch()`: detect the error, rebuild client, retry once. Follows the existing recovery pattern for `InvalidSequenceTokenException` in the same function.
- Make `newAWSLogsClient` a package-level var: allows the test to swap in a mock client on refresh. Same pattern as `newTicker` and `newRegionFinder` in this file.
- Unit test `TestPublishBatchExpiredTokenRefresh`: verifies expired token is detected, client is rebuilt, retry
   succeeds.

Unit tests pass locally. Manually verified end-to-end on an AL2023 EC2 instance:
1. Started container with `--log-driver=awslogs` using temporary AWS credentials written to
   `/root/.aws/credentials` (IMDS disabled via `ec2_metadata_disabled = true` to force file-based credential loading).
2. Confirmed logs flowing to CloudWatch.
3. Waited for token expiry.
4. Observed `ExpiredTokenException` errors and the new `"AWS credentials expired, refreshing"` info log firing in journald.
5. Wrote fresh credentials to `/root/.aws/credentials` (simulating SSM agent rotation).
6. Logs resumed on the next flush cycle without container restart.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Fix the awslogs driver to refresh temporary AWS credentials.

```

## A picture of a cute animal (not mandatory but encouraged)
🐳