### PR TITLE
Honor custom ifname for remote network drivers

### DIFF
--- a/daemon/libnetwork/docs/remote.md
+++ b/daemon/libnetwork/docs/remote.md
@@ -232,6 +232,7 @@ The response must have the form
     {
 		"InterfaceName": {
 			SrcName: string,
+			DstName: string,
 			DstPrefix: string
 		},
 		"Gateway": string,
@@ -245,7 +246,7 @@ The response must have the form
 
 `Gateway` is optional and if supplied is an IP address as a string; e.g., `"192.168.0.1"`. `GatewayIPv6` is optional and if supplied is an IPv6 address as a string; e.g., `"fe80::7809:baff:fec6:7744"`.
 
-The entries in `InterfaceName` represent actual OS level interfaces that should be moved by LibNetwork into the sandbox; the `SrcName` is the name of the OS level interface that the remote process created, and the `DstPrefix` is a prefix for the name the OS level interface should have after it has been moved into the sandbox (LibNetwork will append an index to make sure the actual name does not collide with others).
+The entries in `InterfaceName` represent actual OS level interfaces that should be moved by LibNetwork into the sandbox; the `SrcName` is the name of the OS level interface that the remote process created. `DstName` is optional and specifies the exact name the interface should have after it has been moved into the sandbox. If `DstName` is empty, `DstPrefix` is used as a prefix for the interface name, and LibNetwork appends an index to make sure the actual name does not collide with others.
 
 The entries in `"StaticRoutes"` represent routes that should be added to an interface once it has been moved into the sandbox. Since there may be zero or more routes for an interface, unlike the interface name they can be supplied in any order.
 

--- a/daemon/libnetwork/drivers/remote/driver.go
+++ b/daemon/libnetwork/drivers/remote/driver.go
@@ -287,7 +287,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]any, error) {
 }
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, _, options map[string]any) (retErr error) {
+func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, epOpts, options map[string]any) (retErr error) {
 	join := &api.JoinRequest{
 		NetworkID:  nid,
 		EndpointID: eid,
@@ -314,8 +314,18 @@ func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo 
 
 	ifaceName := res.InterfaceName
 	if iface := jinfo.InterfaceName(); iface != nil && ifaceName != nil {
-		if err := iface.SetNames(ifaceName.SrcName, ifaceName.DstPrefix, ""); err != nil {
-			return fmt.Errorf("failed to set interface name: %s", err)
+		// Honor a custom interface name (com.docker.network.endpoint.ifname,
+		// Compose interface_name) for remote drivers too: prefer a DstName
+		// returned by the plugin, otherwise fall back to the endpoint
+		// option, mirroring how the built-in drivers apply it in their Join
+		// paths (netlabel.GetIfname). This previously passed "", silently
+		// dropping both and leaving plugin endpoints named ethN.
+		dstName := ifaceName.DstName
+		if dstName == "" {
+			dstName = netlabel.GetIfname(epOpts)
+		}
+		if err := iface.SetNames(ifaceName.SrcName, ifaceName.DstPrefix, dstName); err != nil {
+			return fmt.Errorf("failed to set interface name: %w", err)
 		}
 	}
 

--- a/daemon/libnetwork/drivers/remote/driver.go
+++ b/daemon/libnetwork/drivers/remote/driver.go
@@ -314,8 +314,12 @@ func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo 
 
 	ifaceName := res.InterfaceName
 	if iface := jinfo.InterfaceName(); iface != nil && ifaceName != nil {
-		if err := iface.SetNames(ifaceName.SrcName, ifaceName.DstPrefix, ""); err != nil {
-			return fmt.Errorf("failed to set interface name: %s", err)
+		// DstName lets the driver pick the exact interface name inside the
+		// container — e.g. to honour the com.docker.network.endpoint.ifname
+		// endpoint option it received in CreateEndpoint. When the driver
+		// leaves it empty, a name is generated from DstPrefix.
+		if err := iface.SetNames(ifaceName.SrcName, ifaceName.DstPrefix, ifaceName.DstName); err != nil {
+			return fmt.Errorf("failed to set interface name: %w", err)
 		}
 	}
 

--- a/daemon/libnetwork/drivers/remote/driver_test.go
+++ b/daemon/libnetwork/drivers/remote/driver_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/moby/moby/v2/daemon/libnetwork/discoverapi"
 	"github.com/moby/moby/v2/daemon/libnetwork/driverapi"
+	"github.com/moby/moby/v2/daemon/libnetwork/netlabel"
 	"github.com/moby/moby/v2/daemon/libnetwork/options"
 	"github.com/moby/moby/v2/daemon/libnetwork/scope"
 	"github.com/moby/moby/v2/daemon/libnetwork/types"
@@ -502,6 +503,83 @@ func TestRemoteDriver(t *testing.T) {
 	}
 	if err = d.DiscoverDelete(discoverapi.NodeDiscovery, data); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestRemoteDriverJoinInterfaceName verifies that a custom interface
+// name reaches the endpoint for remote (plugin) drivers: a DstName the
+// plugin returns in its Join response is applied, and absent that the
+// engine falls back to the com.docker.network.endpoint.ifname endpoint
+// option (Compose interface_name) — mirroring the built-in drivers.
+// Before the fix the remote proxy passed an empty name to SetNames,
+// dropping both sources and leaving plugin endpoints named ethN.
+func TestRemoteDriverJoinInterfaceName(t *testing.T) {
+	const ifname = "myiface0"
+	testcases := []struct {
+		name        string
+		respDstName string         // DstName returned by the plugin's Join
+		epOpts      map[string]any // endpoint options passed to Join
+		wantDstName string         // name SetNames must receive
+	}{
+		{
+			name:        "plugin-returned DstName is applied",
+			respDstName: ifname,
+			wantDstName: ifname,
+		},
+		{
+			name:        "falls back to endpoint ifname option",
+			epOpts:      map[string]any{netlabel.Ifname: ifname},
+			wantDstName: ifname,
+		},
+		{
+			name:        "plugin DstName takes precedence over the option",
+			respDstName: ifname,
+			epOpts:      map[string]any{netlabel.Ifname: "other0"},
+			wantDstName: ifname,
+		},
+		{
+			name:        "neither source set leaves the name empty",
+			wantDstName: "",
+		},
+	}
+
+	for i, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Unique plugin name per subtest: plugins.Get caches by name,
+			// and each subtest stands up its own short-lived HTTP server.
+			plugin := fmt.Sprintf("test-ifname-driver-%d", i)
+			ep := &testEndpoint{
+				t:         t,
+				srcName:   "vethsrc",
+				dstPrefix: "vethdst",
+				dstName:   tc.wantDstName, // SetNames asserts it receives this
+			}
+
+			mux := http.NewServeMux()
+			defer setupPlugin(t, plugin, mux)()
+
+			handle(t, mux, "Join", func(msg map[string]any) any {
+				return map[string]any{
+					"InterfaceName": map[string]any{
+						"SrcName":   ep.srcName,
+						"DstPrefix": ep.dstPrefix,
+						"DstName":   tc.respDstName,
+					},
+				}
+			})
+			handle(t, mux, "Leave", func(msg map[string]any) any {
+				return map[string]string{}
+			})
+
+			p, err := plugins.Get(plugin, driverapi.NetworkPluginEndpointType)
+			assert.NilError(t, err)
+			client, err := getPluginClient(p)
+			assert.NilError(t, err)
+			d := newDriver(plugin, client)
+
+			err = d.Join(context.Background(), "dummy-network", "dummy-endpoint", "sandbox-key", ep, tc.epOpts, map[string]any{})
+			assert.NilError(t, err)
+		})
 	}
 }
 

--- a/daemon/libnetwork/drivers/remote/driver_test.go
+++ b/daemon/libnetwork/drivers/remote/driver_test.go
@@ -505,6 +505,67 @@ func TestRemoteDriver(t *testing.T) {
 	}
 }
 
+// TestRemoteDriverJoinDstName verifies that a DstName the driver returns
+// in its Join response is applied to the endpoint's interface, and that an
+// empty DstName keeps the generated-from-DstPrefix behaviour. DstName is
+// how a remote driver honours a request for a custom interface name
+// (com.docker.network.endpoint.ifname), which it receives in the options
+// of the CreateEndpoint call.
+func TestRemoteDriverJoinDstName(t *testing.T) {
+	testcases := []struct {
+		name        string
+		respDstName string // DstName returned by the driver's Join
+	}{
+		{
+			name:        "driver-returned DstName is applied",
+			respDstName: "myiface0",
+		},
+		{
+			name:        "empty DstName falls back to DstPrefix",
+			respDstName: "",
+		},
+	}
+
+	for i, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Unique plugin name per subtest: plugins.Get caches by name,
+			// and each subtest stands up its own short-lived HTTP server.
+			plugin := fmt.Sprintf("test-dstname-driver-%d", i)
+			ep := &testEndpoint{
+				t:         t,
+				srcName:   "vethsrc",
+				dstPrefix: "vethdst",
+				dstName:   tc.respDstName, // SetNames asserts it receives this
+			}
+
+			mux := http.NewServeMux()
+			defer setupPlugin(t, plugin, mux)()
+
+			handle(t, mux, "Join", func(msg map[string]any) any {
+				return map[string]any{
+					"InterfaceName": map[string]any{
+						"SrcName":   ep.srcName,
+						"DstPrefix": ep.dstPrefix,
+						"DstName":   tc.respDstName,
+					},
+				}
+			})
+			handle(t, mux, "Leave", func(msg map[string]any) any {
+				return map[string]string{}
+			})
+
+			p, err := plugins.Get(plugin, driverapi.NetworkPluginEndpointType)
+			assert.NilError(t, err)
+			client, err := getPluginClient(p)
+			assert.NilError(t, err)
+			d := newDriver(plugin, client)
+
+			err = d.Join(context.Background(), "dummy-network", "dummy-endpoint", "sandbox-key", ep, nil, map[string]any{})
+			assert.NilError(t, err)
+		})
+	}
+}
+
 func TestDriverError(t *testing.T) {
 	plugin := "test-net-driver-error"
 


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/52865

## Summary

The remote driver API has declared a `DstName` field in the `Join` response's `InterfaceName` for years, but the remote proxy always passed `""` to `SetNames`, discarding it. Remote drivers therefore had no way to control the interface name inside the container — in particular no way to honour a request for a custom name (`com.docker.network.endpoint.ifname`), which they already receive in the `Options` of the `/NetworkDriver.CreateEndpoint` call.

This wires the driver-returned `DstName` through to `SetNames`, nothing else. An empty `DstName` keeps today's behaviour (name generated from `DstPrefix`), so existing drivers are unaffected — each driver keeps the final say on whether and how it supports custom interface names.

- `daemon/libnetwork/drivers/remote/driver.go`: pass `res.InterfaceName.DstName` to `SetNames` instead of `""`.
- `daemon/libnetwork/drivers/remote/driver_test.go`: new `TestRemoteDriverJoinDstName` table: a returned `DstName` is applied; an empty one keeps the `DstPrefix` behaviour. Fails before the fix, passes after; `gofmt -s` and `go vet` clean.

## Release notes (optional)

```markdown changelog
Remote network-driver plugins can now set the container-side interface name via the `DstName` field in their `Join` response.
```