### PR TITLE
Pass endpoint name to network drivers

### DIFF
--- a/daemon/libnetwork/docs/remote.md
+++ b/daemon/libnetwork/docs/remote.md
@@ -166,7 +166,14 @@ When the proxy is asked to create an endpoint, the remote process shall receive 
 
 The `NetworkID` is the generated identifier for the network to which the endpoint belongs; the `EndpointID` is a generated identifier for the endpoint.
 
-`Options` is an arbitrary map as supplied to the proxy.
+`Options` is an arbitrary map as supplied to the proxy. LibNetwork adds `com.docker.network.endpoint.name` to it, holding the endpoint (container) name — the same value it already supplies to IPAM drivers in their allocation options. The key is absent for an endpoint created without a name.
+
+The name is offered for drivers that want to key per-endpoint state on something more durable than the `EndpointID`, which is regenerated whenever an endpoint is recreated. It is **not** a stable identity, and LibNetwork guarantees nothing about it:
+
+* it is **reusable** — a container may be removed and an unrelated container created afterwards under the same name, and the driver will be handed the same value;
+* it is **mutable** — `docker rename` changes it, so a container that is renamed and later recreated presents a different value than it did before.
+
+A driver that derives a MAC address, a lease, or any other persistent resource from this value must tolerate both cases: the first hands one container's resource to another, the second silently loses it. Drivers needing a guaranteed-stable address or MAC address should take it from the container creation request instead.
 
 The `Interface` value is of the form given. The fields in the `Interface` may be empty; and the `Interface` itself may be empty. If supplied, `Address` is an IPv4 address and subnet in CIDR notation; e.g., `"192.168.34.12/16"`. If supplied, `AddressIPv6` is an IPv6 address and subnet in CIDR notation. `MacAddress` is a MAC address as a string; e.g., `"6e:75:32:60:44:c9"`.
 

--- a/daemon/libnetwork/libnetwork_internal_test.go
+++ b/daemon/libnetwork/libnetwork_internal_test.go
@@ -390,6 +390,70 @@ func TestEndpointNameLabel(t *testing.T) {
 	defer ep.Delete(context.Background(), false) //nolint:errcheck
 }
 
+// capturingDriver is a minimal network driver that records the options
+// map passed to CreateEndpoint, so a test can assert what the engine
+// forwards to network drivers at endpoint-creation time.
+type capturingDriver struct {
+	createEndpointOptions map[string]any
+}
+
+func capturingDriverRegister(reg driverapi.Registerer, d *capturingDriver) error {
+	return reg.RegisterDriver(capturingDriverName, d, driverapi.Capability{DataScope: scope.Local})
+}
+
+const capturingDriverName = "capturing network driver"
+
+func (d *capturingDriver) CreateNetwork(_ context.Context, _ string, _ map[string]any, _ driverapi.NetworkInfo, _, _ []driverapi.IPAMData) error {
+	return nil
+}
+func (d *capturingDriver) DeleteNetwork(_ string) error { return nil }
+func (d *capturingDriver) CreateEndpoint(_ context.Context, _, _ string, _ driverapi.InterfaceInfo, options map[string]any) error {
+	d.createEndpointOptions = options
+	return nil
+}
+func (d *capturingDriver) DeleteEndpoint(_, _ string) error                     { return nil }
+func (d *capturingDriver) EndpointOperInfo(_, _ string) (map[string]any, error) { return nil, nil }
+func (d *capturingDriver) Join(_ context.Context, _, _ string, _ string, _ driverapi.JoinInfo, _, _ map[string]any) error {
+	return nil
+}
+func (d *capturingDriver) Leave(_, _ string) error { return nil }
+func (d *capturingDriver) Type() string            { return capturingDriverName }
+func (d *capturingDriver) IsBuiltIn() bool         { return false }
+
+// TestEndpointNameNetworkDriver verifies that the endpoint (container)
+// name reaches a network driver's CreateEndpoint via its options map —
+// the network-driver counterpart of the IPAM-side guarantee checked by
+// TestEndpointNameLabel. Drivers that key per-endpoint state on a
+// recreate-stable identity (e.g. a DHCP plugin deriving a deterministic
+// MAC) have no other reliable source for it at endpoint-creation time.
+func TestEndpointNameNetworkDriver(t *testing.T) {
+	skip.If(t, runtime.GOOS == "windows", "test causes sync issue with Windows HNS")
+	defer netnsutils.SetupTestOSContext(t)()
+
+	c, err := New(context.Background(), config.OptionDataDir(t.TempDir()))
+	assert.NilError(t, err)
+	defer c.Stop()
+
+	cd := &capturingDriver{}
+	err = capturingDriverRegister(&c.drvRegistry, cd)
+	assert.NilError(t, err)
+
+	ipamOpt := NetworkOptionIpam(defaultipam.DriverName, "", []*IpamConf{{PreferredPool: "10.36.0.0/16", Gateway: "10.36.255.253"}}, nil, nil)
+	nw, err := c.NewNetwork(context.Background(), capturingDriverName, "epname-netdriver", "",
+		NetworkOptionEnableIPv4(true),
+		ipamOpt,
+	)
+	assert.NilError(t, err)
+	defer func() { assert.NilError(t, nw.Delete()) }()
+
+	ep, err := nw.CreateEndpoint(context.Background(), "ep1")
+	assert.NilError(t, err)
+	defer ep.Delete(context.Background(), false) //nolint:errcheck
+
+	got, _ := cd.createEndpointOptions[netlabel.EndpointName].(string)
+	assert.Check(t, is.Equal(got, "ep1"), "network driver CreateEndpoint should receive the endpoint name; got: %q", got)
+}
+
 func TestUpdateSvcRecord(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "bridge driver and IPv6, only works on linux")
 

--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -1147,7 +1147,22 @@ func (n *Network) addEndpoint(ctx context.Context, ep *Endpoint) error {
 		return fmt.Errorf("failed to add endpoint: %v", err)
 	}
 
-	err = d.CreateEndpoint(ctx, n.id, ep.id, ep.Iface(), ep.generic)
+	// Forward the endpoint (container) name to the network driver — the
+	// same stable identity IPAM drivers already receive via ipamOptions
+	// (#50586). Network drivers that key per-endpoint state on a
+	// recreate-stable identity (e.g. a DHCP plugin issuing a deterministic
+	// MAC) have no other reliable source at CreateEndpoint: the EndpointID
+	// is regenerated per recreate and the container is not yet resolvable
+	// via NetworkInspect mid-creation. Injected at the call boundary so it
+	// is not persisted into ep.generic.
+	epOptions := ep.generic
+	if name := ep.Name(); name != "" {
+		epOptions = make(map[string]any, len(ep.generic)+1)
+		maps.Copy(epOptions, ep.generic)
+		epOptions[netlabel.EndpointName] = name
+	}
+
+	err = d.CreateEndpoint(ctx, n.id, ep.id, ep.Iface(), epOptions)
 	if err != nil {
 		return types.InternalErrorf("failed to create endpoint %s on network %s: %v",
 			ep.Name(), n.Name(), err)


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/52870

## Summary

Forward the endpoint (container) name to network drivers in their `CreateEndpoint` options — the same stable identity IPAM drivers already receive via `ipamOptions` (#50586).

A network driver that keys per-endpoint state on a recreate-stable identity has no usable identity at `CreateEndpoint` today: the `EndpointID` is regenerated on every recreate, and the container is not yet resolvable via `NetworkInspect` mid-creation (libnetwork is still creating the endpoint when it calls the driver). The container name is an in-scope argument at the call site and is already handed to IPAM there; this forwards it to the network driver too.

Injected at the `addEndpoint` call boundary so it is not persisted into `ep.generic`. Additive — built-in drivers ignore unknown option keys.

Motivating case: a DHCP network plugin that issues a deterministic, identity-derived MAC so a container keeps the same lease (and IP) across a `compose up -d` recreate, with no per-container configuration.

Adds `TestEndpointNameNetworkDriver`, the network-driver counterpart of the existing IPAM-side `TestEndpointNameLabel`; it fails before this change (name absent) and passes after.

## Release notes

```markdown changelog
Pass the endpoint (container) name to network-driver plugins in their CreateEndpoint options.
```
