### PR TITLE
daemon: replace minInt helper with builtin min

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -413,7 +413,7 @@ func (b *limitedBuffer) Write(data []byte) (int, error) {
 
 	bufLen := b.buf.Len()
 	dataLen := len(data)
-	keep := minInt(maxOutputLen-bufLen, dataLen)
+	keep := min(maxOutputLen-bufLen, dataLen)
 	if keep > 0 {
 		b.buf.Write(data[:keep])
 	}
@@ -441,13 +441,6 @@ func timeoutWithDefault(configuredValue time.Duration, defaultValue time.Duratio
 		return defaultValue
 	}
 	return configuredValue
-}
-
-func minInt(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
 }
 
 func getShell(cntr *container.Container) []string {


### PR DESCRIPTION
## Summary

Replace the private `minInt()` helper function in `daemon/health.go` with
the built-in `min()` function introduced in Go 1.21. Since the module already
requires Go 1.25, the custom helper is now redundant.

Changes in `daemon/health.go`:
- Replace `minInt(maxOutputLen-bufLen, dataLen)` with `min(maxOutputLen-bufLen, dataLen)`
- Remove the `minInt()` helper function (6 lines)

## Release notes (optional)

```markdown changelog

```

Created with: Antigravity
