### PR TITLE
pkg/ioutils: remove redundant loop in cancelReadCloser

### DIFF
--- a/pkg/ioutils/readers.go
+++ b/pkg/ioutils/readers.go
@@ -73,13 +73,10 @@ func NewCancelReadCloser(ctx context.Context, in io.ReadCloser) io.ReadCloser {
 		in.Close()
 	}()
 	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				p.closeWithError(ctx.Err())
-			case <-doneCtx.Done():
-				return
-			}
+		select {
+		case <-ctx.Done():
+			p.closeWithError(ctx.Err())
+		case <-doneCtx.Done():
 		}
 	}()
 


### PR DESCRIPTION
## Summary

Remove redundant loop in `cancelReadCloser` goroutine to prevent busy-looping / redundant error closure when context is cancelled.

In `NewCancelReadCloser`, the monitoring goroutine loops in a `for` block wrapping a `select`. When `ctx.Done()` is selected, `p.closeWithError()` is called, which calls `p.cancel()` and cancels `doneCtx`. Since both channels are then closed, subsequent loop iterations will select randomly between the two, spinning and calling `closeWithError()` repeatedly before finally selecting `doneCtx.Done()` and returning.

Simplifying this to a single `select` is enough since once either channel is done, the goroutine has completed its job and can safely exit immediately.

## Release notes (optional)

```markdown changelog

```

Created with: Antigravity
