### PR TITLE
daemon: optimize adjustParallelLimit on Windows

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"context"
 	"fmt"
-	"math"
 	"net/http"
 	"path/filepath"
 	"runtime"
@@ -43,7 +42,7 @@ const (
 // Windows containers are much larger than Linux containers and each of them
 // have > 20 system processes which why we use much smaller parallelism value.
 func adjustParallelLimit(n int, limit int) int {
-	return int(math.Max(1, math.Floor(float64(runtime.NumCPU())*.8)))
+	return max(1, int(float64(runtime.NumCPU())*0.8))
 }
 
 // Windows has no concept of an execution state directory. So use config.Root here.


### PR DESCRIPTION
## Summary

Optimize `adjustParallelLimit()` on Windows by using Go's built-in `max()` function instead of `math.Max` and `math.Floor`.

In `daemon_windows.go`, `adjustParallelLimit()` uses `math.Max` and `math.Floor` with extensive `float64` type casting to scale the startup parallelism factor. Since the Go module requires Go 1.25, we can use the built-in `max()` function instead of `math.Max`, and replace `math.Floor` with a direct integer type cast (which truncates positive floats towards zero, mathematically identical).

This also removes the now-unused "math" import from `daemon_windows.go`.

## Release notes (optional)

```markdown changelog

```

Created with: Antigravity
