### PR TITLE
integration/container: Extend Windows container state waits

### DIFF
--- a/integration/container/remove_test.go
+++ b/integration/container/remove_test.go
@@ -36,7 +36,11 @@ func TestRemoveContainerWithRemovedVolume(t *testing.T) {
 	tempDir := fs.NewDir(t, "test-rm-container-with-removed-volume", fs.WithMode(0o755))
 
 	cID := container.Run(ctx, t, apiClient, container.WithCmd("true"), container.WithBind(tempDir.Path(), dPath("/test")))
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, containertypes.StateExited))
+	var pollOps []poll.SettingOp
+	if testEnv.DaemonInfo.OSType == "windows" {
+		pollOps = append(pollOps, poll.WithTimeout(StopContainerWindowsPollTimeout))
+	}
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, containertypes.StateExited), pollOps...)
 
 	err := os.RemoveAll(tempDir.Path())
 	assert.NilError(t, err)

--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -144,7 +144,11 @@ func TestRenameAnonymousContainer(t *testing.T) {
 		}
 		c.HostConfig.NetworkMode = containertypes.NetworkMode(networkName)
 	}, container.WithCmd("ping", count, "1", container1Name))
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, containertypes.StateExited))
+	var pollOps []poll.SettingOp
+	if testEnv.DaemonInfo.OSType == "windows" {
+		pollOps = append(pollOps, poll.WithTimeout(StopContainerWindowsPollTimeout))
+	}
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, containertypes.StateExited), pollOps...)
 
 	inspect, err := apiClient.ContainerInspect(ctx, cID, client.ContainerInspectOptions{})
 	assert.NilError(t, err)

--- a/integration/container/stop_test.go
+++ b/integration/container/stop_test.go
@@ -41,8 +41,13 @@ func TestStopContainerWithRestartPolicyAlways(t *testing.T) {
 		assert.NilError(t, err)
 	}
 
+	var pollOpts []poll.SettingOp
+	if testEnv.DaemonInfo.OSType == "windows" {
+		pollOpts = append(pollOpts, poll.WithTimeout(StopContainerWindowsPollTimeout))
+	}
+
 	for _, name := range names {
-		poll.WaitOn(t, container.IsStopped(ctx, apiClient, name))
+		poll.WaitOn(t, container.IsStopped(ctx, apiClient, name), pollOpts...)
 	}
 }
 


### PR DESCRIPTION

## Summary

  
Some Windows container state transitions can take longer than the default 10 second poll timeout.
Reuse the existing `StopContainerWindowsPollTimeout` pattern in the following tests so they can have a chance to be less flaky:
  
  - `TestRemoveContainerWithRemovedVolume`
  - `TestStopContainerWithRestartPolicyAlways`
  - `TestRenameAnonymousContainer`
  

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
