### PR TITLE
test-integration-flaky: Stress modified tests too

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,8 @@
 Dockerfile* linguist-language=Dockerfile
+
+*.c    diff=cpp
+*.h    diff=cpp
+*.go   diff=golang
+*.md   diff=markdown
+*.py   diff=python
+*.sh   diff=bash

--- a/hack/make/test-integration-flaky
+++ b/hack/make/test-integration-flaky
@@ -3,26 +3,40 @@ set -e -o pipefail
 
 source hack/validate/.validate
 
+added_tests() {
+	validate_diff --diff-filter=ACMR --unified=0 -- 'integration/*_test.go' \
+		| grep -E '^(\+func Test)(.*)(\*testing\.T\))' \
+		| sed -E 's/^\+func (Test[A-Za-z0-9_]*).*/\1/' \
+		|| true
+}
+
+changed_tests() {
+	validate_diff --diff-filter=ACMR --function-context -- 'integration/*_test.go' \
+		| grep -E '^ func Test[A-Za-z0-9_]*\(.*\*testing\.T\)' \
+		| sed -E 's/^ func (Test[A-Za-z0-9_]*).*/\1/' \
+		|| true
+}
+
 run_integration_flaky() {
-	diff=$(
-		validate_diff --diff-filter=ACMR --unified=0 -- 'integration/*_test.go'
-	)
-	new_tests=$(
-		printf '%s\n' "$diff" | grep -E '^(\+func Test)(.*)(\*testing\.T\))' || true
+	tests=$(
+		{
+			added_tests
+			changed_tests
+		} | sort -u
 	)
 
-	if [ -z "$new_tests" ]; then
-		echo 'No new tests added to integration.'
+	if [ -z "$tests" ]; then
+		echo 'No new or modified tests found in integration.'
 		return
 	fi
 
 	echo
-	echo "Found new integrations tests:"
-	echo "$new_tests"
+	echo "Found new or modified integration tests:"
+	echo "$tests"
 	echo "Running stress test for them."
 
 	(
-		TESTARRAY=$(echo "$new_tests" | sed 's/+func //' | awk -F'\\(' '{print $1}' | tr '\n' '|')
+		TESTARRAY=$(echo "$tests" | tr '\n' '|')
 		# Note: TEST_REPEAT will make the test suite run 5 times, restarting the daemon
 		# and each test will run 5 times in a row under the same daemon.
 		# This will make a total of 25 runs for each test in TESTARRAY.


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

Also run `test-integration-flaky` for changed existing tests.

Keep the old added-test detection as-is, and add modified-test detection on top of it to avoid regressing the existing behavior.
## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
