### PR TITLE
integration-cli/container: Rewrite on-failure restart tests

### DIFF
--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -153,21 +153,6 @@ func (s *DockerCLIRestartSuite) TestRestartPolicyOnFailure(c *testing.T) {
 	assert.Equal(c, maxRetry, "0")
 }
 
-// a good container with --restart=on-failure:3
-// MaximumRetryCount!=0; RestartCount=0
-func (s *DockerCLIRestartSuite) TestRestartContainerwithGoodContainer(c *testing.T) {
-	id := cli.DockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "true").Stdout()
-	id = strings.TrimSpace(id)
-	err := waitInspect(id, "{{ .State.Restarting }} {{ .State.Running }}", "false false", 30*time.Second)
-	assert.NilError(c, err)
-
-	count := inspectField(c, id, "RestartCount")
-	assert.Equal(c, count, "0")
-
-	MaximumRetryCount := inspectField(c, id, "HostConfig.RestartPolicy.MaximumRetryCount")
-	assert.Equal(c, MaximumRetryCount, "3")
-}
-
 func (s *DockerCLIRestartSuite) TestRestartContainerSuccess(c *testing.T) {
 	testRequires(c, testEnv.IsLocalDaemon)
 	// Skipped for Hyper-V isolated containers. Test is currently written
@@ -275,37 +260,6 @@ func (s *DockerCLIRestartSuite) TestRestartPolicyAfterRestart(c *testing.T) {
 	assert.NilError(c, err)
 
 	err = waitInspect(id, "{{.State.Status}}", "running", 30*time.Second)
-	assert.NilError(c, err)
-}
-
-func (s *DockerCLIRestartSuite) TestRestartContainerwithRestartPolicy(c *testing.T) {
-	id1 := cli.DockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "false").Stdout()
-	id1 = strings.TrimSpace(id1)
-	id2 := cli.DockerCmd(c, "run", "-d", "--restart=always", "busybox", "false").Stdout()
-	id2 = strings.TrimSpace(id2)
-
-	waitTimeout := 15 * time.Second
-	if testEnv.DaemonInfo.OSType == "windows" {
-		waitTimeout = 150 * time.Second
-	}
-	err := waitInspect(id1, "{{ .State.Restarting }} {{ .State.Running }}", "false false", waitTimeout)
-	assert.NilError(c, err)
-
-	cli.DockerCmd(c, "restart", id1)
-	cli.DockerCmd(c, "restart", id2)
-
-	// Make sure we can stop/start (regression test from a705e166cf3bcca62543150c2b3f9bfeae45ecfa)
-	cli.DockerCmd(c, "stop", id1)
-	cli.DockerCmd(c, "stop", id2)
-	cli.DockerCmd(c, "start", id1)
-	cli.DockerCmd(c, "start", id2)
-
-	// Kill the containers, making sure they are stopped at the end of the test
-	cli.DockerCmd(c, "kill", id1)
-	cli.DockerCmd(c, "kill", id2)
-	err = waitInspect(id1, "{{ .State.Restarting }} {{ .State.Running }}", "false false", waitTimeout)
-	assert.NilError(c, err)
-	err = waitInspect(id2, "{{ .State.Restarting }} {{ .State.Running }}", "false false", waitTimeout)
 	assert.NilError(c, err)
 }
 

--- a/integration/container/restart_test.go
+++ b/integration/container/restart_test.go
@@ -162,6 +162,106 @@ func pollForNewHealthCheck(ctx context.Context, apiClient *client.Client, startT
 	}
 }
 
+func TestContainerRestartPolicyOnFailure(t *testing.T) {
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	waitTimeout := 10 * time.Second
+	if testEnv.DaemonInfo.OSType == "windows" {
+		waitTimeout = StopContainerWindowsPollTimeout
+	}
+
+	t.Run("does-not-restart-on-success", func(t *testing.T) {
+		ctx := testutil.StartSpan(ctx, t)
+
+		resp, err := apiClient.ContainerCreate(ctx, client.ContainerCreateOptions{
+			Config: &container.Config{
+				Image: "busybox",
+				Cmd:   []string{"true"},
+			},
+			HostConfig: &container.HostConfig{
+				RestartPolicy: container.RestartPolicy{
+					Name:              container.RestartPolicyOnFailure,
+					MaximumRetryCount: 3,
+				},
+			},
+		})
+		assert.NilError(t, err)
+		t.Cleanup(func() {
+			apiClient.ContainerRemove(ctx, resp.ID, client.ContainerRemoveOptions{Force: true})
+		})
+
+		waitCtx, cancel := context.WithTimeout(ctx, waitTimeout)
+		defer cancel()
+		wait := apiClient.ContainerWait(waitCtx, resp.ID, client.ContainerWaitOptions{Condition: container.WaitConditionNextExit})
+
+		_, err = apiClient.ContainerStart(ctx, resp.ID, client.ContainerStartOptions{})
+		assert.NilError(t, err)
+
+		select {
+		case err := <-wait.Error:
+			assert.NilError(t, err)
+		case res := <-wait.Result:
+			assert.Check(t, is.Equal(int64(0), res.StatusCode))
+		case <-time.After(waitTimeout):
+			inspect, _ := apiClient.ContainerInspect(ctx, resp.ID, client.ContainerInspectOptions{})
+			t.Fatalf("timeout waiting for container exit: status=%q", inspect.Container.State.Status)
+		}
+
+		inspect, err := apiClient.ContainerInspect(ctx, resp.ID, client.ContainerInspectOptions{})
+		assert.NilError(t, err)
+		assert.Check(t, is.Equal(inspect.Container.State.Status, container.StateExited))
+		assert.Check(t, is.Equal(inspect.Container.RestartCount, 0))
+		assert.Check(t, is.DeepEqual(inspect.Container.HostConfig.RestartPolicy, container.RestartPolicy{
+			Name:              container.RestartPolicyOnFailure,
+			MaximumRetryCount: 3,
+		}))
+	})
+
+	t.Run("can-restart-after-retries", func(t *testing.T) {
+		ctx := testutil.StartSpan(ctx, t)
+
+		resp, err := apiClient.ContainerCreate(ctx, client.ContainerCreateOptions{
+			Config: &container.Config{
+				Image: "busybox",
+				Cmd:   []string{"false"},
+			},
+			HostConfig: &container.HostConfig{
+				RestartPolicy: container.RestartPolicy{
+					Name:              container.RestartPolicyOnFailure,
+					MaximumRetryCount: 3,
+				},
+			},
+		})
+		assert.NilError(t, err)
+		t.Cleanup(func() {
+			apiClient.ContainerRemove(ctx, resp.ID, client.ContainerRemoveOptions{Force: true})
+		})
+
+		_, err = apiClient.ContainerStart(ctx, resp.ID, client.ContainerStartOptions{})
+		assert.NilError(t, err)
+
+		poll.WaitOn(t, containerRestartCountIs(ctx, apiClient, resp.ID, 3), poll.WithTimeout(waitTimeout))
+		poll.WaitOn(t, testContainer.IsInState(ctx, apiClient, resp.ID, container.StateExited), poll.WithTimeout(waitTimeout))
+
+		_, err = apiClient.ContainerRestart(ctx, resp.ID, client.ContainerRestartOptions{})
+		assert.NilError(t, err)
+	})
+}
+
+func containerRestartCountIs(ctx context.Context, apiClient client.APIClient, containerID string, expected int) func(log poll.LogT) poll.Result {
+	return func(log poll.LogT) poll.Result {
+		inspect, err := apiClient.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
+		if err != nil {
+			return poll.Error(err)
+		}
+		if inspect.Container.RestartCount == expected {
+			return poll.Success()
+		}
+		return poll.Continue("waiting for restart count %d, current=%d", expected, inspect.Container.RestartCount)
+	}
+}
+
 // Container started with --rm should be able to be restarted.
 // It should be removed only if killed or stopped
 func TestContainerWithAutoRemoveCanBeRestarted(t *testing.T) {


### PR DESCRIPTION
## Summary


Replace flaky legacy CLI restart-policy tests with container API integration coverage.

The CLI tests poll inspect output after short-lived detached containers exit, which can observe transient daemon monitor state while cleanup or restart-policy handling is still settling.

On Windows this can race a manual restart against an `on-failure:3` container that has not exhausted its automatic retries.

Remove flaky tests:
- TestRestartContainerwithGoodContainer
- TestRestartContainerwithRestartPolicy

Verify TestContainerRestartPolicyOnFailure is not flaky

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
