### PR TITLE
Dockerfile: update runc binary to v1.3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -248,7 +248,7 @@ WORKDIR /usr/src/runc
 # This version should usually match the version that is used by the containerd version
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged.
-ARG RUNC_VERSION=v1.3.5
+ARG RUNC_VERSION=v1.3.6
 ADD https://github.com/opencontainers/runc.git?ref=${RUNC_VERSION}&keep-git-dir=1 .
 
 FROM base AS runc-build


### PR DESCRIPTION
This is the sixth patch release of the 1.3.z series of runc. Among some performance improvements and bugfixes, it includes a fix for a low-severity vulnerability ([CVE-2026-41579]) and users are encouraged to update. As it was a low-severity vulnerability and it was reported by multiple people, we decided to release it publicly with NO EMBARGO.

Security

This release includes a fix for the following low-severity security issue:

- CVE-2026-41579 allowed a malicious image with a /dev symlink to have limited write access to the host filesystem in ways that our analysis indicates was too limited to be problematic in practice. This bug was very similar to those fixed in CVE-2025-31133, CVE-2025-52565, CVE-2025-31133 and was simply missed at the time when we hardened the rootfs preparation code. We have conducted a deeper audit and not found any other problematic cases.

Fixed

- A regression in runc v1.3.0 which can result in a stuck runc exec or runc run when the container process runs for a short time.
- Various integration test improvements.

Changed

- When masking directories with maskPaths, runc will now re-use a single tmpfs instance (which is not writable) to reduce the number tmpfs superblocks that need to be reaped when containers die (in particular, Kubernetes applies masks to per-CPU sysfs directories which get expensive quickly).

[CVE-2026-41579]: https://github.com/opencontainers/runc/security/advisories/GHSA-xjvp-4fhw-gc47

full diff: https://github.com/opencontainers/runc/compare/v1.3.5...v1.3.6

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Update runc (in static binaries) to [v1.3.6](https://github.com/opencontainers/runc/releases/tag/v1.3.6)
```

## A picture of a cute animal (not mandatory but encouraged)
