### PR TITLE
integration/container: Wait for trap setup before signaling

### DIFF
--- a/integration/container/logs_helpers_test.go
+++ b/integration/container/logs_helpers_test.go
@@ -1,0 +1,35 @@
+package container
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+
+	"github.com/moby/moby/api/pkg/stdcopy"
+	"github.com/moby/moby/client"
+	"gotest.tools/v3/poll"
+)
+
+// logsContains verifies the container contains the given text in stdout.
+func logsContains(ctx context.Context, apiClient client.APIClient, containerID string, logString string) func(log poll.LogT) poll.Result {
+	return func(log poll.LogT) poll.Result {
+		logs, err := apiClient.ContainerLogs(ctx, containerID, client.ContainerLogsOptions{
+			ShowStdout: true,
+		})
+		if err != nil {
+			return poll.Error(err)
+		}
+		defer logs.Close()
+
+		var stdout bytes.Buffer
+		_, err = stdcopy.StdCopy(&stdout, io.Discard, logs)
+		if err != nil {
+			return poll.Error(err)
+		}
+		if strings.Contains(stdout.String(), logString) {
+			return poll.Success()
+		}
+		return poll.Continue("waiting for logstring '%s' in container", logString)
+	}
+}

--- a/integration/container/restart_test.go
+++ b/integration/container/restart_test.go
@@ -269,13 +269,14 @@ func testContainerRestartWithCancelledRequest(ctx context.Context, t *testing.T,
 	// the container. We're trying to create the scenario where the "stop" is
 	// handled, but the request was cancelled and therefore the "start" not
 	// taking place.
-	cID := testContainer.Run(ctx, t, apiClient, testContainer.WithCmd("sh", "-c", "trap 'echo received TERM' TERM; while true; do usleep 10; done"))
+	cID := testContainer.Run(ctx, t, apiClient, testContainer.WithCmd("sh", "-c", "trap 'echo received TERM' TERM; echo ready; while true; do usleep 10; done"))
 	defer func() {
 		_, err := apiClient.ContainerRemove(ctx, cID, client.ContainerRemoveOptions{Force: true})
 		if t.Failed() && err != nil {
 			t.Logf("Cleaning up test container failed with error: %v", err)
 		}
 	}()
+	poll.WaitOn(t, logsContains(ctx, apiClient, cID, "ready"))
 
 	// Start listening for events.
 	result := apiClient.Events(ctx, client.EventsListOptions{

--- a/integration/container/stop_linux_test.go
+++ b/integration/container/stop_linux_test.go
@@ -1,15 +1,11 @@
 package container
 
 import (
-	"bytes"
 	"context"
-	"io"
-	"strings"
 	"testing"
 	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
-	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"gotest.tools/v3/assert"
@@ -28,8 +24,9 @@ func TestStopContainerWithTimeoutCancel(t *testing.T) {
 	t.Parallel()
 
 	id := container.Run(ctx, t, apiClient,
-		container.WithCmd("sh", "-c", "trap 'echo received TERM' TERM; while true; do usleep 10; done"),
+		container.WithCmd("sh", "-c", "trap 'echo received TERM' TERM; echo ready; while true; do usleep 10; done"),
 	)
+	poll.WaitOn(t, logsContains(ctx, apiClient, id, "ready"))
 
 	ctxCancel, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
@@ -66,27 +63,4 @@ func TestStopContainerWithTimeoutCancel(t *testing.T) {
 	// Adding 3 seconds to the specified stopTimeout to take this into account,
 	// and add another second margin to try to avoid flakiness.
 	poll.WaitOn(t, container.IsStopped(ctx, apiClient, id), poll.WithTimeout((3+stopTimeout)*time.Second))
-}
-
-// logsContains verifies the container contains the given text in the log's stdout.
-func logsContains(ctx context.Context, apiClient client.APIClient, containerID string, logString string) func(log poll.LogT) poll.Result {
-	return func(log poll.LogT) poll.Result {
-		logs, err := apiClient.ContainerLogs(ctx, containerID, client.ContainerLogsOptions{
-			ShowStdout: true,
-		})
-		if err != nil {
-			return poll.Error(err)
-		}
-		defer logs.Close()
-
-		var stdout bytes.Buffer
-		_, err = stdcopy.StdCopy(&stdout, io.Discard, logs)
-		if err != nil {
-			return poll.Error(err)
-		}
-		if strings.Contains(stdout.String(), logString) {
-			return poll.Success()
-		}
-		return poll.Continue("waiting for logstring '%s' in container", logString)
-	}
 }

--- a/integration/container/wait_test.go
+++ b/integration/container/wait_test.go
@@ -70,12 +70,12 @@ func TestWaitBlocked(t *testing.T) {
 	}{
 		{
 			doc:          "test-wait-blocked-exit-zero",
-			cmd:          "trap 'exit 0' TERM; while true; do usleep 10; done",
+			cmd:          "trap 'exit 0' TERM; echo ready; while true; do usleep 10; done",
 			expectedCode: 0,
 		},
 		{
 			doc:          "test-wait-blocked-exit-random",
-			cmd:          "trap 'exit 99' TERM; while true; do usleep 10; done",
+			cmd:          "trap 'exit 99' TERM; echo ready; while true; do usleep 10; done",
 			expectedCode: 99,
 		},
 	}
@@ -85,6 +85,7 @@ func TestWaitBlocked(t *testing.T) {
 			// t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)
 			containerID := container.Run(ctx, t, cli, container.WithCmd("sh", "-c", tc.cmd))
+			poll.WaitOn(t, logsContains(ctx, cli, containerID, "ready"))
 			wait := cli.ContainerWait(ctx, containerID, client.ContainerWaitOptions{})
 
 			_, err := cli.ContainerStop(ctx, containerID, client.ContainerStopOptions{})
@@ -208,9 +209,10 @@ func TestWaitRestartedContainer(t *testing.T) {
 			// t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)
 			containerID := container.Run(ctx, t, cli,
-				container.WithCmd("sh", "-c", "trap 'exit 5' SIGTERM; while true; do sleep 0.1; done"),
+				container.WithCmd("sh", "-c", "trap 'exit 5' SIGTERM; echo ready; while true; do sleep 0.1; done"),
 			)
 			defer cli.ContainerRemove(ctx, containerID, client.ContainerRemoveOptions{Force: true})
+			poll.WaitOn(t, logsContains(ctx, cli, containerID, "ready"))
 
 			// Container is running now, wait for exit
 			wait := cli.ContainerWait(ctx, containerID, client.ContainerWaitOptions{Condition: tc.waitCond})


### PR DESCRIPTION
Try to deflake:

- TestStopContainerWithTimeoutCancel
- TestContainerRestartWithCancelledRequest
- TestWaitBlocked
- TestWaitRestartedContainer

Several container integration tests rely on shell TERM traps to produce specific stop, restart, or wait behavior.
They issue stop or restart requests immediately after container creation, so dockerd can signal the process before the shell installs its trap.
When that happens, the process uses default signal behavior and tests can miss the expected log line or observe the wrong exit status.

Emit a readiness log after installing each trap and wait for it before issuing stop or restart. Move logsContains into a shared helper so the readiness check can be reused by the affected tests.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
