### PR TITLE
daemon/libnetwork: make libnftables opt-in only

### DIFF
--- a/daemon/libnetwork/internal/nftables/nft_cgo_linux.go
+++ b/daemon/libnetwork/internal/nftables/nft_cgo_linux.go
@@ -1,4 +1,4 @@
-//go:build cgo && !static_build && !no_libnftables
+//go:build cgo && !static_build && libnftables
 
 package nftables
 

--- a/daemon/libnetwork/internal/nftables/nft_exec_linux.go
+++ b/daemon/libnetwork/internal/nftables/nft_exec_linux.go
@@ -1,4 +1,4 @@
-//go:build !cgo || static_build || no_libnftables
+//go:build !cgo || static_build || !libnftables
 
 package nftables
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- Fixes #52873 

## Summary
As libnftables uses `select(2)` on the netlink socket the process is aborted if the socket's file descriptor is >= 1024. A dockerd process could easily exceed 1024 open file descriptors at a time under normal circumstances, so there is a risk of libnftables killing dockerd at a random time through no fault of dockerd. Default to programming nftables rulesets by exec'ing `nft -f` until libnftables is updated to be compatible with processes that open a large number of file descriptors by using `poll(2)` or `epoll(2)` instead of `select(2)`.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
- Mitigate a crash in libnftables when using nftables as the firewall backend by changing the default build option to execute the `nft` command instead. Users building dockerd from source can opt into linking against libnftables by building with the `libnftables` build tag.
```

## A picture of a cute animal (not mandatory but encouraged)
