### PR TITLE
daemon/libnetwork/support: refresh Dockerfile and script

### DIFF
--- a/daemon/libnetwork/support/Dockerfile
+++ b/daemon/libnetwork/support/Dockerfile
@@ -1,8 +1,7 @@
-FROM docker:18-dind
+# syntax=docker/dockerfile:1
 
-RUN set -ex \
-    && echo "http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
-    && echo "http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+FROM docker:29-cli
+
 RUN apk add --no-cache \
     util-linux \
     bridge-utils \
@@ -17,4 +16,4 @@ RUN apk add --no-cache \
 WORKDIR /bin
 COPY *.sh /bin/
 
-CMD /bin/run.sh
+CMD ["/bin/run.sh"]

--- a/daemon/libnetwork/support/README
+++ b/daemon/libnetwork/support/README
@@ -1,1 +1,1 @@
-Usage: docker run -v /var/run:/var/run  --network host --privileged dockereng/network-diagnostic:support.sh
+Usage: docker run --rm -v /var/run:/var/run --network host --privileged dockereng/network-diagnostic:support.sh

--- a/daemon/libnetwork/support/run.sh
+++ b/daemon/libnetwork/support/run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # try to fetch the latest version from github
-wget -O support.sh.new https://raw.githubusercontent.com/docker/libnetwork/master/support/support.sh
+wget -O support.sh.new https://raw.githubusercontent.com/moby/moby/refs/heads/master/daemon/libnetwork/support/support.sh
 
 if [ "$?" -eq "0" ]; then
 	mv support.sh.new support.sh


### PR DESCRIPTION
- supersedes, closes https://github.com/moby/moby/pull/52888


- update the Dockerfile to switch to the cli-variant (as it doesn't require a docker daemon), and update to the latest v29 image
- update the script to not use the deprecated libnetwork repository

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
