### PR TITLE
 api: clarify ImageAttestations error when statement blob read fails

### DIFF
--- a/daemon/containerd/image_attestations.go
+++ b/daemon/containerd/image_attestations.go
@@ -3,6 +3,7 @@ package containerd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"slices"
 
 	"github.com/containerd/containerd/v2/core/content"
@@ -110,7 +111,10 @@ func (i *ImageService) ImageAttestations(ctx context.Context, refOrID string, op
 		if opts.IncludeStatement {
 			data, err := content.ReadBlob(ctx, i.content, layer)
 			if err != nil {
-				return nil, err
+				if cerrdefs.IsNotFound(err) {
+					return nil, fmt.Errorf("attestation statement %s is not available locally: %w", layer.Digest, err)
+				}
+				return nil, fmt.Errorf("failed to read attestation statement %s: %w", layer.Digest, err)
 			}
 			raw := json.RawMessage(data)
 			stmt.Statement = &raw

--- a/daemon/containerd/image_provenance_test.go
+++ b/daemon/containerd/image_provenance_test.go
@@ -416,7 +416,7 @@ func TestImageAttestations(t *testing.T) {
 			Platform:         &linuxAMD64,
 			IncludeStatement: true,
 		})
-		assert.ErrorContains(t, err, "not found")
+		assert.ErrorContains(t, err, "not available locally")
 	})
 
 	t.Run("no_attestations_returns_nil", func(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

When a statement blob cannot be read from the local content store, `GET /images/{name}/attestations?statement=true` returned a generic error with no indication of which statement was missing. This PR wraps the `content.ReadBlob` error so the response body identifies the statement by digest and distinguishes the not-found case from other read failures. The behaviour is unchanged, the wrap only improves the error body.

Follow-up to PR #52636

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
