### PR TITLE
daemon: Set umask to 0000 

### DIFF
--- a/daemon/command/daemon_unix.go
+++ b/daemon/command/daemon_unix.go
@@ -16,6 +16,7 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork/portallocator"
 	"github.com/moby/moby/v2/pkg/homedir"
 	"github.com/pkg/errors"
+	fsutilcopy "github.com/tonistiigi/fsutil/copy" //nolint:depguard // Needed to keep fsutil copy behavior aligned with the daemon umask.
 	"golang.org/x/sys/unix"
 )
 
@@ -41,14 +42,15 @@ func getDefaultDaemonConfigFile() string {
 	return filepath.Join(dir, "daemon.json")
 }
 
-// setDefaultUmask sets the umask to 0022 to avoid problems
+// setDefaultUmask sets the umask to 0 to avoid problems
 // caused by custom umask
 func setDefaultUmask() error {
-	desiredUmask := 0o022
+	desiredUmask := 0
 	unix.Umask(desiredUmask)
 	if umask := unix.Umask(desiredUmask); umask != desiredUmask {
 		return errors.Errorf("failed to set umask: expected %#o, got %#o", desiredUmask, umask)
 	}
+	fsutilcopy.UmaskIsZero = true
 
 	return nil
 }

--- a/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
+++ b/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
@@ -222,7 +222,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) (retErr
 		return err
 	}
 	if lower != "" {
-		if err := os.WriteFile(path.Join(dir, lowerFile), []byte(lower), 0o666); err != nil {
+		if err := os.WriteFile(path.Join(dir, lowerFile), []byte(lower), 0o644); err != nil {
 			return err
 		}
 	}

--- a/daemon/internal/layer/migration.go
+++ b/daemon/internal/layer/migration.go
@@ -21,7 +21,7 @@ func (ls *layerStore) ChecksumForGraphID(id, parent, newTarDataPath string) (dif
 	}
 	defer rawArchive.Close()
 
-	f, err := os.Create(newTarDataPath)
+	f, err := os.OpenFile(newTarDataPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return "", 0, err
 	}

--- a/daemon/internal/libcontainerd/supervisor/remote_daemon.go
+++ b/daemon/internal/libcontainerd/supervisor/remote_daemon.go
@@ -161,6 +161,16 @@ func (r *remote) startContainerd() error {
 	}
 
 	r.logger.WithField("binary", r.daemonPath).Debug("starting containerd binary")
+	// Docker clears its umask on startup.
+	// Managed containerd inherits that umask, so paths it creates use the
+	// literal modes requested by containerd instead of being masked by the
+	// historical 0o022 process umask.
+	//
+	// This can make internal containerd paths more permissive than older
+	// installs.
+	// Under the default layout those paths remain below daemon-managed root
+	// and state directories that deny access to "other", so they are reachable
+	// only by root and the docker group, which is already equivalent to root.
 	cmd := exec.Command(r.daemonPath, "--config", cfgFile)
 	// redirect containerd logs to docker logs
 	cmd.Stdout = os.Stdout

--- a/daemon/internal/stack/stackdump.go
+++ b/daemon/internal/stack/stackdump.go
@@ -26,7 +26,7 @@ func DumpToFile(dir string) (string, error) {
 	if dir != "" {
 		path := filepath.Join(dir, fmt.Sprintf(stacksLogNameTemplate, strings.ReplaceAll(time.Now().Format(time.RFC3339), ":", "")))
 		var err error
-		f, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o666)
+		f, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o644)
 		if err != nil {
 			return "", errors.Wrap(err, "failed to open file to write the goroutine stacks")
 		}

--- a/daemon/libnetwork/osl/namespace_linux.go
+++ b/daemon/libnetwork/osl/namespace_linux.go
@@ -223,7 +223,8 @@ func createNamespaceFile(path string) error {
 	// If the path is there unmount it first
 	unmountNamespaceFile(path)
 
-	f, err := os.Create(path)
+	// lgtm[go/path-injection] Ignore CodeQL "path depends on a user-provided value".
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -96,6 +96,7 @@ require (
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	github.com/tonistiigi/fsutil v0.0.0-20260609091201-0257b3308df4
 	github.com/tonistiigi/go-archvariant v1.0.0
 	github.com/vbatts/tar-split v0.12.3
 	github.com/vishvananda/netlink v1.3.1
@@ -264,7 +265,6 @@ require (
 	github.com/theupdateframework/go-tuf/v2 v2.4.2 // indirect
 	github.com/tinylib/msgp v1.3.0 // indirect
 	github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323 // indirect
-	github.com/tonistiigi/fsutil v0.0.0-20260609091201-0257b3308df4 // indirect
 	github.com/tonistiigi/go-actions-cache v0.0.0-20260120203934-54bc28c26fd2 // indirect
 	github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0 // indirect
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- replaces, closes https://github.com/moby/moby/pull/52711
- fixes https://github.com/moby/moby/issues/52739

## Summary

Clear the daemon umask so explicitly requested file modes are preserved instead of being filtered by the previous `0022` umask.
  
This fixes cases such as `COPY --chmod=777` producing `0755` permissions, and adjusts daemon-owned file creation sites that previously relied on the old umask to remove group/other-write bits.
  
Also document that managed containerd inherits the daemon's cleared umask.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Fix explicit file modes being filtered by the daemon umask, including `COPY --chmod` permissions
```

## A picture of a cute animal (not mandatory but encouraged)
