### PR TITLE
Cache squash result to avoid redundant layer work

### DIFF
--- a/daemon/images/image_squash.go
+++ b/daemon/images/image_squash.go
@@ -10,11 +10,28 @@ import (
 	"github.com/pkg/errors"
 )
 
+// squashCacheKey is used to deduplicate squash operations within a daemon session.
+type squashCacheKey struct {
+	imageID  string
+	parentID string
+}
+
 // SquashImage creates a new image with the diff of the specified image and the specified parent.
 // This new image contains only the layers from it's parent + 1 extra layer which contains the diff of all the layers in between.
 // The existing image(s) is not destroyed.
 // If no parent is specified, a new image with the diff of all the specified image's layers merged into a new layer that has no parents.
 func (i *ImageService) SquashImage(id, parent string) (string, error) {
+	// Avoid repeating expensive layer work when nothing has changed.
+	cacheKey := squashCacheKey{imageID: id, parentID: parent}
+	if v, ok := i.squashCache.Load(cacheKey); ok {
+		cachedID := v.(image.ID)
+		if _, err := i.imageStore.Get(cachedID); err == nil {
+			return string(cachedID), nil
+		}
+		// Cached image was removed; evict and recompute.
+		i.squashCache.Delete(cacheKey)
+	}
+
 	var (
 		img *image.Image
 		err error
@@ -90,5 +107,7 @@ func (i *ImageService) SquashImage(id, parent string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "error creating new image after squash")
 	}
+
+	i.squashCache.Store(cacheKey, newImgID)
 	return string(newImgID), nil
 }

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"sync/atomic"
 
 	"github.com/containerd/containerd/v2/core/content"
@@ -85,6 +86,7 @@ type ImageService struct {
 	leases                    leases.Manager
 	content                   content.Store
 	contentNamespace          string
+	squashCache               sync.Map // squashCacheKey → image.ID
 }
 
 // DistributionServices provides daemon image storage services


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/42947

## Summary

When `docker build --squash` is run twice with an unchanged Dockerfile, all build steps hit the cache and produce the same source image ID. Previously the squash step always re-ran regardless, streaming and re-applying the full layer diff each time.

Add an in-memory sync.Map on ImageService keyed by (sourceImageID, parentImageID). SquashImage checks this cache before any layer I/O; on a hit it validates the cached image still exists (handles docker rmi of the squashed image) and returns immediately. The cache is populated after each successful squash. The cache lives for the daemon session; the first build after a daemon restart recomputes once and is cached from then on.

## A picture of a cute animal (not mandatory but encouraged)

 (\_/)
 ( •.•)
 / >♥