### PR TITLE
daemon: add timeout-based lease to prune operations

### DIFF
--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -33,12 +33,45 @@ var imagesAcceptedFilters = map[string]bool{
 // one is in progress
 var errPruneRunning = errdefs.Conflict(errors.New("a prune operation is already running"))
 
+// pruneLeaseTimeout is the maximum duration a prune operation may hold the
+// lease before it is considered stale and may be overridden by a new prune.
+const pruneLeaseTimeout = 5 * time.Minute
+
+// acquirePruneLease attempts to acquire the prune lease. It returns true if the
+// lease was acquired (either because no prune is running or the previous lease
+// has expired). If another prune is actively running within the lease timeout,
+// it returns false.
+func (i *ImageService) acquirePruneLease() bool {
+	now := time.Now().UnixNano()
+	for {
+		current := i.pruneRunning.Load()
+		if current != 0 {
+			// A prune is running. Check if the lease has expired.
+			elapsed := time.Duration(now - current)
+			if elapsed < pruneLeaseTimeout {
+				return false
+			}
+			// Lease expired, try to take over.
+		}
+		if i.pruneRunning.CompareAndSwap(current, now) {
+			return true
+		}
+		// CAS failed, loop and retry.
+	}
+}
+
+// releasePruneLease releases the prune lease so that future prune operations
+// may proceed.
+func (i *ImageService) releasePruneLease() {
+	i.pruneRunning.Store(0)
+}
+
 // ImagePrune removes unused images
 func (i *ImageService) ImagePrune(ctx context.Context, fltrs filters.Args) (*image.PruneReport, error) {
-	if !i.pruneRunning.CompareAndSwap(false, true) {
+	if !i.acquirePruneLease() {
 		return nil, errPruneRunning
 	}
-	defer i.pruneRunning.Store(false)
+	defer i.releasePruneLease()
 
 	err := fltrs.Validate(imagesAcceptedFilters)
 	if err != nil {

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -39,7 +39,7 @@ type ImageService struct {
 	registryHosts       docker.RegistryHosts
 	registryService     distribution.RegistryResolver
 	eventsService       *daemonevents.Events
-	pruneRunning        atomic.Bool
+	pruneRunning        atomic.Int64
 	refCountMounter     snapshotter.Mounter
 	idMapping           user.IdentityMapping
 	policyVerifier      func() (*policyverifier.Verifier, error)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -140,7 +140,7 @@ type Daemon struct {
 	usageVolumes    singleflight.Group[bool, *backend.VolumeDiskUsage]
 	usageLayer      singleflight.Group[struct{}, int64]
 
-	pruneRunning atomic.Bool
+	pruneRunning atomic.Int64
 	hosts        map[string]bool // hosts stores the addresses the daemon is listening on
 	startupDone  chan struct{}
 

--- a/daemon/images/image_prune.go
+++ b/daemon/images/image_prune.go
@@ -32,12 +32,45 @@ var imagesAcceptedFilters = map[string]bool{
 // one is in progress
 var errPruneRunning = errdefs.Conflict(errors.New("a prune operation is already running"))
 
+// pruneLeaseTimeout is the maximum duration a prune operation may hold the
+// lease before it is considered stale and may be overridden by a new prune.
+const pruneLeaseTimeout = 5 * time.Minute
+
+// acquirePruneLease attempts to acquire the prune lease. It returns true if the
+// lease was acquired (either because no prune is running or the previous lease
+// has expired). If another prune is actively running within the lease timeout,
+// it returns false.
+func (i *ImageService) acquirePruneLease() bool {
+	now := time.Now().UnixNano()
+	for {
+		current := i.pruneRunning.Load()
+		if current != 0 {
+			// A prune is running. Check if the lease has expired.
+			elapsed := time.Duration(now - current)
+			if elapsed < pruneLeaseTimeout {
+				return false
+			}
+			// Lease expired, try to take over.
+		}
+		if i.pruneRunning.CompareAndSwap(current, now) {
+			return true
+		}
+		// CAS failed, loop and retry.
+	}
+}
+
+// releasePruneLease releases the prune lease so that future prune operations
+// may proceed.
+func (i *ImageService) releasePruneLease() {
+	i.pruneRunning.Store(0)
+}
+
 // ImagePrune removes unused images
 func (i *ImageService) ImagePrune(ctx context.Context, pruneFilters filters.Args) (*imagetypes.PruneReport, error) {
-	if !i.pruneRunning.CompareAndSwap(false, true) {
+	if !i.acquirePruneLease() {
 		return nil, errPruneRunning
 	}
-	defer i.pruneRunning.Store(false)
+	defer i.releasePruneLease()
 
 	// make sure that only accepted filters have been received
 	err := pruneFilters.Validate(imagesAcceptedFilters)

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -78,7 +78,7 @@ type ImageService struct {
 	eventsService             *daemonevents.Events
 	imageStore                image.Store
 	layerStore                layer.Store
-	pruneRunning              atomic.Bool
+	pruneRunning              atomic.Int64
 	referenceStore            refstore.Store
 	registryService           distribution.RegistryResolver
 	uploadManager             *xfer.LayerUploadManager

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -29,14 +29,47 @@ var (
 		"label!": true,
 		"until":  true,
 	}
+
+	// pruneLeaseTimeout is the maximum duration a prune operation may hold the
+	// lease before it is considered stale and may be overridden by a new prune.
+	pruneLeaseTimeout = 5 * time.Minute
 )
+
+// acquirePruneLease attempts to acquire the prune lease. It returns true if the
+// lease was acquired (either because no prune is running or the previous lease
+// has expired). If another prune is actively running within the lease timeout,
+// it returns false.
+func (daemon *Daemon) acquirePruneLease() bool {
+	now := time.Now().UnixNano()
+	for {
+		current := daemon.pruneRunning.Load()
+		if current != 0 {
+			// A prune is running. Check if the lease has expired.
+			elapsed := time.Duration(now - current)
+			if elapsed < pruneLeaseTimeout {
+				return false
+			}
+			// Lease expired, try to take over.
+		}
+		if daemon.pruneRunning.CompareAndSwap(current, now) {
+			return true
+		}
+		// CAS failed, loop and retry.
+	}
+}
+
+// releasePruneLease releases the prune lease so that future prune operations
+// may proceed.
+func (daemon *Daemon) releasePruneLease() {
+	daemon.pruneRunning.Store(0)
+}
 
 // ContainerPrune removes unused containers
 func (daemon *Daemon) ContainerPrune(ctx context.Context, pruneFilters filters.Args) (*container.PruneReport, error) {
-	if !daemon.pruneRunning.CompareAndSwap(false, true) {
+	if !daemon.acquirePruneLease() {
 		return nil, errPruneRunning
 	}
-	defer daemon.pruneRunning.Store(false)
+	defer daemon.releasePruneLease()
 
 	rep := &container.PruneReport{}
 
@@ -174,10 +207,10 @@ func (daemon *Daemon) clusterNetworkPrune(ctx context.Context, pruneFilters dnet
 
 // NetworkPrune removes unused networks
 func (daemon *Daemon) NetworkPrune(ctx context.Context, filterArgs filters.Args) (*network.PruneReport, error) {
-	if !daemon.pruneRunning.CompareAndSwap(false, true) {
+	if !daemon.acquirePruneLease() {
 		return nil, errPruneRunning
 	}
-	defer daemon.pruneRunning.Store(false)
+	defer daemon.releasePruneLease()
 
 	pruneFilters, err := dnetwork.NewPruneFilter(filterArgs)
 	if err != nil {

--- a/daemon/volume/service/service.go
+++ b/daemon/volume/service/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strconv"
 	"sync/atomic"
+	"time"
 
 	"github.com/containerd/log"
 	"github.com/moby/moby/api/types/events"
@@ -184,6 +185,39 @@ var acceptedPruneFilters = map[string]bool{
 	"all": true,
 }
 
+// pruneLeaseTimeout is the maximum duration a prune operation may hold the
+// lease before it is considered stale and may be overridden by a new prune.
+const pruneLeaseTimeout = 5 * time.Minute
+
+// acquirePruneLease attempts to acquire the prune lease. It returns true if the
+// lease was acquired (either because no prune is running or the previous lease
+// has expired). If another prune is actively running within the lease timeout,
+// it returns false.
+func (s *VolumesService) acquirePruneLease() bool {
+	now := time.Now().UnixNano()
+	for {
+		current := s.pruneRunning.Load()
+		if current != 0 {
+			// A prune is running. Check if the lease has expired.
+			elapsed := time.Duration(now - current)
+			if elapsed < pruneLeaseTimeout {
+				return false
+			}
+			// Lease expired, try to take over.
+		}
+		if s.pruneRunning.CompareAndSwap(current, now) {
+			return true
+		}
+		// CAS failed, loop and retry.
+	}
+}
+
+// releasePruneLease releases the prune lease so that future prune operations
+// may proceed.
+func (s *VolumesService) releasePruneLease() {
+	s.pruneRunning.Store(0)
+}
+
 var acceptedListFilters = map[string]bool{
 	"dangling": true,
 	"name":     true,
@@ -210,10 +244,10 @@ func (s *VolumesService) LocalVolumesSize(ctx context.Context) ([]volumetypes.Vo
 // Note that this intentionally skips volumes with mount options as there would
 // be no space reclaimed in this case.
 func (s *VolumesService) Prune(ctx context.Context, filter filters.Args) (*volumetypes.PruneReport, error) {
-	if !s.pruneRunning.CompareAndSwap(false, true) {
+	if !s.acquirePruneLease() {
 		return nil, errdefs.Conflict(errors.New("a prune operation is already running"))
 	}
-	defer s.pruneRunning.Store(false)
+	defer s.releasePruneLease()
 
 	if err := withPrune(filter); err != nil {
 		return nil, err


### PR DESCRIPTION
The existing prune lock uses an atomic.Bool with CompareAndSwap(false, true). If a prune operation hangs or is extremely slow, the lock stays held forever and all subsequent prune requests are rejected with 'a prune operation is already running'.

Replace the boolean lock with a timestamp-based lease stored in atomic.Int64:

- acquirePruneLease records the current time (UnixNano) in the atomic and returns true when the lease is free or the previous lease has expired.
- releasePruneLease resets the atomic to 0.
- A 5-minute pruneLeaseTimeout prevents a single stuck prune from blocking all future prune calls indefinitely.

This affects all prune paths: ContainerPrune, NetworkPrune, ImagePrune (both graphdriver and containerd backends), and VolumePrune.

Fixes https://github.com/moby/moby/issues/48913
