### PR TITLE
daemon/c8d: Count image usage from their actual snapshots 

### DIFF
--- a/daemon/containerd/image_list_test.go
+++ b/daemon/containerd/image_list_test.go
@@ -202,6 +202,40 @@ func TestImageListCheckTotalSize(t *testing.T) {
 	})
 }
 
+func TestImageDiskUsageWithIndexTarget(t *testing.T) {
+	ctx := namespaces.WithNamespace(t.Context(), "testing-"+t.Name())
+
+	blobsDir := t.TempDir()
+	idx, _, err := specialimage.MultiPlatform(blobsDir, "test:latest", []ocispec.Platform{
+		{OS: "linux", Architecture: "arm64"},
+		{OS: "linux", Architecture: "amd64"},
+	})
+	assert.NilError(t, err)
+
+	cs := &blobsDirContentStore{blobs: filepath.Join(blobsDir, "blobs/sha256")}
+	service := fakeImageService(t, ctx, cs)
+
+	img, err := service.images.Create(ctx, imagesFromIndex(idx)[0])
+	assert.NilError(t, err)
+
+	var expected int64
+	visited := map[digest.Digest]struct{}{}
+	err = service.walkPresentChildren(ctx, img.Target, func(_ context.Context, desc ocispec.Descriptor) error {
+		if _, ok := visited[desc.Digest]; ok {
+			return nil
+		}
+		visited[desc.Digest] = struct{}{}
+
+		expected += desc.Size
+		return nil
+	})
+	assert.NilError(t, err)
+
+	usage, err := service.ImageDiskUsage(ctx)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(usage, expected))
+}
+
 func blobSize(t *testing.T, ctx context.Context, cs content.Store, dgst digest.Digest) int64 {
 	info, err := cs.Info(ctx, dgst)
 	assert.NilError(t, err)

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -24,6 +24,7 @@ import (
 	policyverifier "github.com/moby/policy-helpers"
 	"github.com/moby/sys/user"
 	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -162,19 +163,114 @@ func (i *ImageService) StorageDriver() string {
 // ImageDiskUsage returns the number of bytes used by content and layer stores
 // called from disk_usage.go
 func (i *ImageService) ImageDiskUsage(ctx context.Context) (int64, error) {
-	diskUsage, err := i.layerDiskUsage(ctx)
-	if err != nil {
-		return 0, err
-	}
-
-	// Include the size of content size from the images.
 	imgs, err := i.images.List(ctx)
 	if err != nil {
 		return 0, err
 	}
 
+	var diskUsage int64
+	// TODO(thaJeztah): do we need to take multiple snapshotters into account? See https://github.com/moby/moby/issues/45273
+	snapshotter := i.client.SnapshotService(i.snapshotter)
+	visitedSnapshots := make(map[string]struct{})
 	visitedImages := make(map[digest.Digest]struct{})
 	for _, img := range imgs {
+		if err := i.walkImageManifests(ctx, img, func(platformImg *ImageManifest) error {
+			unpacked, err := platformImg.IsUnpacked(ctx, i.snapshotter)
+			if err != nil {
+				log.G(ctx).WithFields(log.Fields{
+					"error":    err,
+					"image":    img.Name,
+					"target":   img.Target,
+					"manifest": platformImg.Target(),
+				}).Warn("failed to check whether image manifest is unpacked")
+				return nil
+			}
+			if unpacked {
+				diffIDs, err := platformImg.RootFS(ctx)
+				if err != nil {
+					log.G(ctx).WithFields(log.Fields{
+						"error":    err,
+						"image":    img.Name,
+						"target":   img.Target,
+						"manifest": platformImg.Target(),
+					}).Debug("failed to get image rootfs")
+					return nil
+				}
+
+				for snapshot := identity.ChainID(diffIDs).String(); snapshot != ""; {
+					if _, ok := visitedSnapshots[snapshot]; ok {
+						break
+					}
+					visitedSnapshots[snapshot] = struct{}{}
+
+					usage, err := snapshotter.Usage(ctx, snapshot)
+					if err != nil {
+						if cerrdefs.IsNotFound(err) {
+							log.G(ctx).WithFields(log.Fields{
+								"image":    img.Name,
+								"target":   img.Target,
+								"manifest": platformImg.Target(),
+								"snapshot": snapshot,
+							}).Debug("snapshot not found while counting image disk usage")
+							break
+						}
+						log.G(ctx).WithFields(log.Fields{
+							"error":    err,
+							"image":    img.Name,
+							"target":   img.Target,
+							"manifest": platformImg.Target(),
+							"snapshot": snapshot,
+						}).Warn("failed to get snapshot usage for image disk usage")
+						break
+					}
+
+					// Don't accumulate usage.Size just yet
+					// If the Stat below fails with NotFound, it means the
+					// snapshot is already gone at this point.
+					info, err := snapshotter.Stat(ctx, snapshot)
+					if err != nil {
+						if cerrdefs.IsNotFound(err) {
+							log.G(ctx).WithFields(log.Fields{
+								"image":    img.Name,
+								"target":   img.Target,
+								"manifest": platformImg.Target(),
+								"snapshot": snapshot,
+							}).Debug("snapshot not found while counting image disk usage")
+							break
+						}
+						log.G(ctx).WithFields(log.Fields{
+							"error":    err,
+							"image":    img.Name,
+							"target":   img.Target,
+							"manifest": platformImg.Target(),
+							"snapshot": snapshot,
+						}).Warn("failed to get snapshot info for image disk usage")
+						break
+					}
+
+					log.G(ctx).WithFields(log.Fields{
+						"image":    img.Name,
+						"target":   img.Target,
+						"manifest": platformImg.Target(),
+						"snapshot": snapshot,
+						"size":     usage.Size,
+						"inodes":   usage.Inodes,
+					}).Debug("counting snapshot in image disk usage")
+
+					diskUsage += usage.Size
+					snapshot = info.Parent
+				}
+			}
+			return nil
+		}); err != nil {
+			log.G(ctx).WithFields(log.Fields{
+				"error":  err,
+				"image":  img.Name,
+				"target": img.Target,
+			}).Warn("failed to calculate image snapshot disk usage")
+		}
+
+		// Include the size of content size from the images.
 		if err := i.walkPresentChildren(ctx, img.Target, func(ctx context.Context, desc ocispec.Descriptor) error {
 			if _, ok := visitedImages[desc.Digest]; ok {
 				return nil
@@ -188,26 +284,6 @@ func (i *ImageService) ImageDiskUsage(ctx context.Context) (int64, error) {
 		}
 	}
 	return diskUsage, nil
-}
-
-// LayerDiskUsage returns the number of bytes used by layer stores
-// called from disk_usage.go
-func (i *ImageService) layerDiskUsage(ctx context.Context) (allLayersSize int64, err error) {
-	// TODO(thaJeztah): do we need to take multiple snapshotters into account? See https://github.com/moby/moby/issues/45273
-	snapshotter := i.client.SnapshotService(i.snapshotter)
-	err = snapshotter.Walk(ctx, func(ctx context.Context, info snapshots.Info) error {
-		usage, err := snapshotter.Usage(ctx, info.Name)
-		if err != nil {
-			// Snapshot may have been deleted already.
-			if cerrdefs.IsNotFound(err) {
-				return nil
-			}
-			return err
-		}
-		allLayersSize += usage.Size
-		return nil
-	})
-	return allLayersSize, err
 }
 
 // UpdateConfig values

--- a/integration/system/disk_usage_test.go
+++ b/integration/system/disk_usage_test.go
@@ -45,12 +45,10 @@ func TestDiskUsage(t *testing.T) {
 				})
 				assert.NilError(t, err)
 
-				expectedLayersSize := adjustedExpectedUsage(du.Images.TotalSize, 0)
-
 				assert.DeepEqual(t, du, client.DiskUsageResult{
 					Containers: client.ContainersDiskUsage{},
 					Images: client.ImagesDiskUsage{
-						TotalSize: expectedLayersSize,
+						TotalSize: 0,
 					},
 					BuildCache: client.BuildCacheDiskUsage{},
 					Volumes:    client.VolumesDiskUsage{},
@@ -75,16 +73,14 @@ func TestDiskUsage(t *testing.T) {
 				assert.Equal(t, du.Images.ActiveCount, int64(0))
 				assert.Equal(t, du.Images.TotalCount, int64(1))
 
-				expectedTotalSize := adjustedExpectedUsage(du.Images.TotalSize, du.Images.Reclaimable)
-				assert.Equal(t, du.Images.TotalSize, expectedTotalSize)
+				assert.Equal(t, du.Images.TotalSize, du.Images.Reclaimable)
 				assert.Assert(t, du.Images.TotalSize > 0)
 				assert.Equal(t, len(du.Images.Items), 1)
 				assert.Equal(t, len(du.Images.Items[0].RepoTags), 1)
 				assert.Check(t, is.Equal(du.Images.Items[0].RepoTags[0], "busybox:latest"))
 
 				// Image size is layer size + content size. Content size is included in layers size.
-				expectedTotalSize = adjustedExpectedUsage(du.Images.TotalSize, du.Images.Items[0].Size)
-				assert.Equal(t, du.Images.TotalSize, expectedTotalSize)
+				assert.Equal(t, du.Images.TotalSize, du.Images.Items[0].Size)
 
 				return du
 			},
@@ -295,15 +291,4 @@ func TestDiskUsage(t *testing.T) {
 			}
 		})
 	}
-}
-
-// Rootless snapshotter disk usage can drift by one filesystem block.
-// TODO: Investigate why https://github.com/moby/moby/issues/52845
-func adjustedExpectedUsage(actual, expected int64) int64 {
-	if testEnv.UsingSnapshotter() && testEnv.IsRootless() {
-		if actual == expected+4096 {
-			return actual
-		}
-	}
-	return expected
 }

--- a/integration/system/disk_usage_test.go
+++ b/integration/system/disk_usage_test.go
@@ -79,7 +79,7 @@ func TestDiskUsage(t *testing.T) {
 				assert.Equal(t, len(du.Images.Items[0].RepoTags), 1)
 				assert.Check(t, is.Equal(du.Images.Items[0].RepoTags[0], "busybox:latest"))
 
-				// Image size is layer size + content size. Content size is included in layers size.
+				// With a single image, the aggregate image size matches the image item size.
 				assert.Equal(t, du.Images.TotalSize, du.Images.Items[0].Size)
 
 				return du


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

- fix: #47119
- fix: #52845


Image disk usage used to walk every snapshot in the snapshotter and count the result as image storage. That includes container-owned snapshots, such as the container writable snapshot and the Moby init snapshot.

Init snapshots are already represented in container rootfs size. With the containerd snapshotter, GetContainerLayerSize walks the container snapshot parent chain for SizeRootFs, so the init snapshot belongs there. Counting the same snapshot from ImageDiskUsage made it appear as image storage as well.

Before this commit:

Images.TotalSize
 = image content
 + image snapshots
 + all other snapshots walked by snapshotter
 + container init snapshots
 + container RW snapshots

And container size reporting had:

Container.SizeRootFs
 = image snapshots
 + init snapshot
 + RW snapshot

So the init layer was included in:

- Images.TotalSize
- Container.SizeRootFs


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Fix `docker system df` image size reporting to count only snapshots directly used by images.
```

## A picture of a cute animal (not mandatory but encouraged)
