### PR TITLE
c8d/prune: Track removed snapshots

### DIFF
--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -12,10 +12,12 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/v2/daemon/internal/filters"
 	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/moby/moby/v2/daemon/container"
@@ -223,10 +225,39 @@ func (i *ImageService) pruneAll(ctx context.Context, imagesToPrune map[string]c8
 	for _, img := range imagesToPrune {
 		log.G(ctx).WithField("image", img).Debug("pruning image")
 
+		snapshotter := i.snapshotterService(i.snapshotter)
+		snapshotSizes := map[string]int64{}
 		blobs := []ocispec.Descriptor{}
 
-		err := i.walkPresentChildren(ctx, img.Target, func(_ context.Context, desc ocispec.Descriptor) error {
+		err := i.walkPresentChildren(ctx, img.Target, func(ctx context.Context, desc ocispec.Descriptor) error {
 			blobs = append(blobs, desc)
+			if !c8dimages.IsConfigType(desc.MediaType) {
+				return nil
+			}
+
+			var cfg dockerspec.DockerOCIImage
+			if err := readJSON(ctx, i.content, desc, &cfg); err != nil {
+				if cerrdefs.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+
+			for _, chainID := range identity.ChainIDs(cfg.RootFS.DiffIDs) {
+				id := chainID.String()
+				if _, ok := snapshotSizes[id]; ok {
+					continue
+				}
+				usage, err := snapshotter.Usage(ctx, id)
+				if err != nil {
+					if cerrdefs.IsNotFound(err) {
+						snapshotSizes[id] = 0
+						continue
+					}
+					return err
+				}
+				snapshotSizes[id] = usage.Size
+			}
 			return nil
 		})
 		if err != nil {
@@ -236,6 +267,7 @@ func (i *ImageService) pruneAll(ctx context.Context, imagesToPrune map[string]c8
 			}
 			continue
 		}
+
 		err = i.images.Delete(ctx, img.Name, c8dimages.SynchronousDelete())
 		if err != nil && !cerrdefs.IsNotFound(err) {
 			errs = append(errs, err)
@@ -268,6 +300,12 @@ func (i *ImageService) pruneAll(ctx context.Context, imagesToPrune map[string]c8
 					)
 				}
 				report.SpaceReclaimed += uint64(blob.Size)
+			}
+		}
+		for id, size := range snapshotSizes {
+			_, err := snapshotter.Usage(ctx, id)
+			if cerrdefs.IsNotFound(err) {
+				report.SpaceReclaimed += uint64(size)
 			}
 		}
 		if deleted {

--- a/integration/image/prune_test.go
+++ b/integration/image/prune_test.go
@@ -101,6 +101,44 @@ func TestPruneLexographicalOrder(t *testing.T) {
 	}
 }
 
+// When the only image in the daemon is unused, pruning it should report at
+// least that image's TotalSize as reclaimed space.
+func TestPruneReportsUnusedImageTotalSizeReclaimed(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "cannot start multiple daemons on windows")
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+
+	ctx := testutil.StartSpan(t.Context(), t)
+	t.Parallel()
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+
+	apiClient := d.NewClientT(t)
+
+	// Create a container to make sure snapshots were created.
+	// (they _should_ exist on load anyway, but let's make this explicit)
+	cid := container.Create(ctx, t, apiClient, container.WithImage("busybox:latest"))
+	// Remove it before pruning so the image is unused.
+	container.Remove(ctx, t, apiClient, cid, client.ContainerRemoveOptions{Force: true})
+
+	du, err := apiClient.DiskUsage(ctx, client.DiskUsageOptions{Images: true})
+	assert.NilError(t, err)
+	totalSize := uint64(du.Images.TotalSize)
+	assert.Assert(t, totalSize > 0)
+
+	res, err := apiClient.ImagePrune(ctx, client.ImagePruneOptions{
+		Filters: make(client.Filters).Add("dangling", "false"),
+	})
+	assert.NilError(t, err)
+
+	assert.Check(t, is.Equal(res.Report.SpaceReclaimed, totalSize))
+
+	du, err = apiClient.DiskUsage(ctx, client.DiskUsageOptions{Images: true})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(du.Images.TotalSize, int64(0)))
+}
+
 // Regression test for https://github.com/moby/moby/issues/48063
 func TestPruneDontDeleteUsedImage(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "cannot start multiple daemons on windows")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

Unpacked image data wasn't included in the `Total reclaimed space`. This PR fixes it.

### Verification

```diff
$ docker pull ubuntu
...
$ docker images
IMAGE                   ID             DISK USAGE   CONTENT SIZE   EXTRA
ubuntu:latest           f3d28607ddd7        180MB         44.4MB

$ docker system df
TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
Images          1         0         180MB     180MB (100%)
Containers      0         0         0B        0B
Local Volumes   0         0         0B        0B
Build Cache     0         0         0B        0B

$ docker system prune -af
Deleted Images:
untagged: ubuntu:latest
deleted: sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64
deleted: sha256:98ce78d9714d15b1785dd97da22ec7c2506270ff7c910160bc07e393566f7568
deleted: sha256:98e9bec2e99ed8a81fec9634a00d7c1eea6fd8f8689e87dd7d3723383fc8a7e3

-Total reclaimed space: 44.4MB
+Total reclaimed space: 180MB

$ docker system df
TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
Images          0         0         0B        0B
Containers      0         0         0B        0B
Local Volumes   0         0         0B        0B
Build Cache     0         0         0B        0B
```



## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
containerd image store: Fix `docker system prune` to include unpacked image data when reporting reclaimed space.
```

## A picture of a cute animal (not mandatory but encouraged)
