### PR TITLE
TestContainerWithConflictingNoneNetwork: Extend Windows timeout

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3501,7 +3501,9 @@ func (s *DockerCLIRunSuite) TestContainerWithConflictingNoneNetwork(c *testing.T
 
 // #11957 - stdin with no tty does not exit if stdin is not closed even though container exited
 func (s *DockerCLIRunSuite) TestRunStdinBlockedAfterContainerExit(c *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "-i", "--name=test", "busybox", "true")
+	name := "test-stdin-blocked-" + stringid.GenerateRandomID()
+
+	cmd := exec.Command(dockerBinary, "run", "-i", "--name", name, "busybox", "true")
 	in, err := cmd.StdinPipe()
 	assert.NilError(c, err)
 	defer in.Close()
@@ -3509,14 +3511,23 @@ func (s *DockerCLIRunSuite) TestRunStdinBlockedAfterContainerExit(c *testing.T) 
 	cmd.Stdout = stdout
 	cmd.Stderr = stdout
 	assert.NilError(c, cmd.Start())
+	c.Cleanup(func() {
+		dockerCmdWithError("rm", "-f", name)
+	})
 
-	waitChan := make(chan error, 1)
+	exitTimeout := 10 * time.Second
+	if DaemonIsWindows() {
+		exitTimeout = 60 * time.Second
+	}
+	cli.WaitExited(c, name, exitTimeout)
+
+	cmdExited := make(chan error, 1)
 	go func() {
-		waitChan <- cmd.Wait()
+		cmdExited <- cmd.Wait()
 	}()
 
 	select {
-	case err := <-waitChan:
+	case err := <-cmdExited:
 		assert.Assert(c, err == nil, stdout.String())
 	case <-time.After(30 * time.Second):
 		c.Fatal("timeout waiting for command to exit")


### PR DESCRIPTION
Hoping to fix TestContainerWithConflictingNoneNetwork flakiness

Increase stop timeout on Windows and split container and CLI exit waits.

Wait for the container to reach `exited` before timing how long the `docker run -i` process takes to exit with stdin still open.

This keeps the regression check focused on the post-exit CLI behavior instead of combining it with container startup time. Use a unique container name to avoid collisions with leftovers from previous runs.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
