### PR TITLE
Update docker/buildx-bin Docker tag to v0.35.0 (carry 52909)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG DOCKERCLI_INTEGRATION_REPOSITORY="https://github.com/docker/cli.git"
 ARG DOCKERCLI_INTEGRATION_VERSION=v25.0.5
 
 # BUILDX_VERSION is the version of buildx to install in the dev container.
-ARG BUILDX_VERSION=0.34.1
+ARG BUILDX_VERSION=0.35.0
 
 # COMPOSE_VERSION is the version of compose to install in the dev container.
 ARG COMPOSE_VERSION=v5.1.4

--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -541,7 +541,7 @@ Try {
                 Remove-Item -Force "docker.zip"
             }
 
-            if (-not ($buildx = $env:BUILDX_VERSION)) { $buildx = "0.34.1" }
+            if (-not ($buildx = $env:BUILDX_VERSION)) { $buildx = "0.35.0" }
             Write-Host "INFO: Downloading docker/buildx version $buildx..."
             $url = "https://github.com/docker/buildx/releases/download/v${buildx}/buildx-v${buildx}.windows-amd64.exe"
             Invoke-WebRequest $url -OutFile "$PWD\bundles\docker-buildx.exe"


### PR DESCRIPTION
- supersedes, closes https://github.com/moby/moby/pull/52909

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
