### PR TITLE
internal/testutil: cleanup GenerateRandomAlphaOnlyString

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -3161,7 +3161,7 @@ func (s *DockerCLIBuildSuite) TestBuildOnBuildOutput(c *testing.T) {
 
 // FIXME(vdemeester) should be a unit test
 func (s *DockerCLIBuildSuite) TestBuildInvalidTag(c *testing.T) {
-	name := "abcd:" + testutil.GenerateRandomAlphaOnlyString(200)
+	name := "abcd:" + testutil.RandomAlpha(200)
 	cli.Docker(cli.Args("build", "-t", name), build.WithDockerfile("FROM "+minimalBaseImage()+"\nMAINTAINER quux\n")).Assert(c, icmd.Expected{
 		ExitCode: 125,
 		Err:      "invalid reference format",

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1754,7 +1754,7 @@ func testRunWriteSpecialFilesAndNotCommit(t *testing.T, name, path string) {
 }
 
 func eqToBaseDiff(out string, t *testing.T) bool {
-	name := "eqToBaseDiff" + testutil.GenerateRandomAlphaOnlyString(32)
+	name := "eqToBaseDiff" + testutil.RandomAlpha(32)
 	cli.DockerCmd(t, "run", "--name", name, "busybox", "echo", "hello")
 	cID := getIDByName(t, name)
 	baseDiff := cli.DockerCmd(t, "diff", cID).Combined()

--- a/integration-cli/utils_test.go
+++ b/integration-cli/utils_test.go
@@ -51,7 +51,7 @@ func RandomTmpDirPath(s string, platform string) string {
 	if platform == "windows" {
 		tmp = os.Getenv("TEMP")
 	}
-	path := filepath.Join(tmp, fmt.Sprintf("%s.%s", s, testutil.GenerateRandomAlphaOnlyString(10)))
+	path := filepath.Join(tmp, fmt.Sprintf("%s.%s", s, testutil.RandomAlpha(10)))
 	if platform == "windows" {
 		return filepath.FromSlash(path) // Using \
 	}

--- a/internal/testutil/fakestorage/storage.go
+++ b/internal/testutil/fakestorage/storage.go
@@ -133,8 +133,8 @@ func (f *remoteFileServer) Close() error {
 
 func newRemoteFileServer(t testing.TB, ctx *fakecontext.Fake, c client.APIClient) *remoteFileServer {
 	var (
-		imgName = fmt.Sprintf("fileserver-img-%s", strings.ToLower(testutil.GenerateRandomAlphaOnlyString(10)))
-		ctrName = fmt.Sprintf("fileserver-cnt-%s", strings.ToLower(testutil.GenerateRandomAlphaOnlyString(10)))
+		imgName = fmt.Sprintf("fileserver-img-%s", testutil.RandomAlpha(10))
+		ctrName = fmt.Sprintf("fileserver-cnt-%s", testutil.RandomAlpha(10))
 	)
 
 	ensureHTTPServerImage(t)

--- a/internal/testutil/stringutils.go
+++ b/internal/testutil/stringutils.go
@@ -1,14 +1,14 @@
 package testutil
 
-import "math/rand"
+import "math/rand/v2"
 
-// GenerateRandomAlphaOnlyString generates an alphabetical random string with length n.
-func GenerateRandomAlphaOnlyString(n int) string {
-	// make a really long string
-	letters := []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+const letters = "abcdefghijklmnopqrstuvwxyz"
+
+// RandomAlpha generates a lowercase alphabetical random string with length n.
+func RandomAlpha(n int) string {
 	b := make([]byte, n)
 	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))] //nolint: gosec // G404: Use of weak random number generator (math/rand instead of crypto/rand)
+		b[i] = letters[rand.IntN(len(letters))] // #nosec G404 -- ignore "Use of weak random number generator (math/rand or math/rand/v2 instead of crypto/rand)"
 	}
 	return string(b)
 }

--- a/internal/testutil/stringutils_test.go
+++ b/internal/testutil/stringutils_test.go
@@ -7,28 +7,8 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 )
 
-func testLengthHelper(generator func(int) string, t *testing.T) {
+func TestRandomAlphaOnlyString(t *testing.T) {
 	expectedLength := 20
-	s := generator(expectedLength)
-	assert.Check(t, is.Equal(expectedLength, len(s)))
-}
-
-func testUniquenessHelper(generator func(int) string, t *testing.T) {
-	repeats := 25
-	set := make(map[string]struct{}, repeats)
-	for i := 0; i < repeats; i = i + 1 {
-		str := generator(64)
-		assert.Check(t, is.Equal(64, len(str)))
-		_, ok := set[str]
-		assert.Check(t, !ok, "Random number is repeated")
-		set[str] = struct{}{}
-	}
-}
-
-func TestGenerateRandomAlphaOnlyStringLength(t *testing.T) {
-	testLengthHelper(GenerateRandomAlphaOnlyString, t)
-}
-
-func TestGenerateRandomAlphaOnlyStringUniqueness(t *testing.T) {
-	testUniquenessHelper(GenerateRandomAlphaOnlyString, t)
+	s := RandomAlpha(expectedLength)
+	assert.Check(t, is.Equal(len(s), expectedLength))
 }


### PR DESCRIPTION
- use math/rand/v2
- change the util to only produce lowercase; some tests only could use lowercase, and we don't need uppercase here, as long as it's random.
- drop the Uniqueness test; it was effectively just testing stdlib functionality (math/rand/v2 to be random).
- rename to RandomAlpha while we had to update call-sites

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
