### PR TITLE
integration-cli: runSleepingContainerInImage: don't capture stderr

### DIFF
--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -278,7 +278,7 @@ func runSleepingContainerInImage(t *testing.T, image string, extraArgs ...string
 	args = append(args, extraArgs...)
 	args = append(args, image)
 	args = append(args, sleepCommandForDaemonPlatform()...)
-	return strings.TrimSpace(cli.DockerCmd(t, args...).Combined())
+	return strings.TrimSpace(cli.DockerCmd(t, args...).Stdout())
 }
 
 // minimalBaseImage returns the name of the minimal base image for the current


### PR DESCRIPTION
The runSleepingContainerInImage (and runSleepingContainer) utils are expected to return the container's ID (or name). They already assert the command executed successfully, so let's avoid capturing output from stderr (which could be warnings or logs).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
