### PR TITLE
libnetwork/drivers/bridge: configureIPForwarding: fix dropped error message

### DIFF
--- a/daemon/libnetwork/drivers/bridge/setup_ip_forwarding.go
+++ b/daemon/libnetwork/drivers/bridge/setup_ip_forwarding.go
@@ -121,7 +121,7 @@ func setupIPv6Forwarding(ffd filterForwardDropper, wantFilterForwardDrop bool) (
 
 func configureIPForwarding(file string, val byte) (changed bool, _ error) {
 	data, err := os.ReadFile(file)
-	if err != nil || len(data) == 0 {
+	if err != nil {
 		return false, fmt.Errorf("cannot read IP forwarding setup from '%s': %w", file, err)
 	}
 	if len(data) == 0 {


### PR DESCRIPTION
The early return duplicated the length check, making the custom error
path unreachable. As a result, a nil error was wrapped and returned
instead of the intended error message.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

While reading the code, I happened to find some dead code, which will not be executed, so I deleted it.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
