### PR TITLE
classic builder: implement `ADD --unpack`/`--checksum`, predefined platform `ARG`s, error on `# syntax`, and convert silent no-ops to explicit errors

### DIFF
--- a/daemon/builder/dockerfile/builder.go
+++ b/daemon/builder/dockerfile/builder.go
@@ -224,6 +224,22 @@ func emitImageID(aux buildbackend.AuxEmitter, state *dispatchState) error {
 	return aux.Emit("", build.Result{ID: state.imageID})
 }
 
+func injectPredefinedBuildArgs(buildArgs *BuildArgs, targetPlatform *ocispec.Platform) {
+	buildSpec := platforms.DefaultSpec()
+	if targetPlatform == nil {
+		targetPlatform = &buildSpec
+	}
+	strPtr := func(s string) *string { return &s }
+	buildArgs.AddMetaArg("TARGETPLATFORM", strPtr(platforms.Format(*targetPlatform)))
+	buildArgs.AddMetaArg("TARGETOS", strPtr(targetPlatform.OS))
+	buildArgs.AddMetaArg("TARGETARCH", strPtr(targetPlatform.Architecture))
+	buildArgs.AddMetaArg("TARGETVARIANT", strPtr(targetPlatform.Variant))
+	buildArgs.AddMetaArg("BUILDPLATFORM", strPtr(platforms.Format(buildSpec)))
+	buildArgs.AddMetaArg("BUILDOS", strPtr(buildSpec.OS))
+	buildArgs.AddMetaArg("BUILDARCH", strPtr(buildSpec.Architecture))
+	buildArgs.AddMetaArg("BUILDVARIANT", strPtr(buildSpec.Variant))
+}
+
 func processMetaArg(meta instructions.ArgCommand, shlex *shell.Lex, args *BuildArgs) error {
 	// shell.Lex currently only support the concatenated string format
 	envs := shell.EnvsFromSlice(convertMapToEnvList(args.GetAllAllowed()))
@@ -254,6 +270,8 @@ func (b *Builder) dispatchDockerfileWithCancellation(ctx context.Context, parseR
 	for _, stage := range parseResult {
 		totalCommands += len(stage.Commands)
 	}
+	injectPredefinedBuildArgs(buildArgs, b.platform)
+
 	shlex := shell.NewLex(escapeToken)
 	for i := range metaArgs {
 		currentCommandIndex = printCommand(b.Stdout, currentCommandIndex, totalCommands, &metaArgs[i])

--- a/daemon/builder/dockerfile/copy.go
+++ b/daemon/builder/dockerfile/copy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/moby/moby/v2/pkg/longpath"
 	"github.com/moby/sys/symlink"
 	"github.com/moby/sys/user"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -337,6 +338,37 @@ type sourceDownloader func(string) (builder.Source, string, error)
 func newRemoteSourceDownloader(output, stdout io.Writer) sourceDownloader {
 	return func(url string) (builder.Source, string, error) {
 		return downloadSource(output, stdout, url)
+	}
+}
+
+func newChecksummedSourceDownloader(output, stdout io.Writer, checksum string) sourceDownloader {
+	inner := newRemoteSourceDownloader(output, stdout)
+	return func(srcURL string) (builder.Source, string, error) {
+		expected, err := digest.Parse(checksum)
+		if err != nil {
+			return nil, "", errors.Wrapf(err, "invalid --checksum %q", checksum)
+		}
+		remote, path, err := inner(srcURL)
+		if err != nil {
+			return nil, "", err
+		}
+		filename := path
+		if filename == "" {
+			filename = unnamedFilename
+		}
+		f, err := os.Open(filepath.Join(remote.Root(), filename))
+		if err != nil {
+			return nil, "", err
+		}
+		defer f.Close()
+		v := expected.Verifier()
+		if _, err := io.Copy(v, f); err != nil {
+			return nil, "", err
+		}
+		if !v.Verified() {
+			return nil, "", errors.Errorf("checksum mismatch for %s: expected %s", srcURL, checksum)
+		}
+		return remote, path, nil
 	}
 }
 

--- a/daemon/builder/dockerfile/dispatchers.go
+++ b/daemon/builder/dockerfile/dispatchers.go
@@ -96,7 +96,19 @@ func dispatchAdd(ctx context.Context, d dispatchRequest, c *instructions.AddComm
 	if c.Chmod != "" {
 		return errors.New("the --chmod option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled")
 	}
+	if c.KeepGitDir != nil {
+		return errors.New("the --keep-git-dir option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled")
+	}
+	if len(c.ExcludePatterns) > 0 {
+		return errors.New("the --exclude option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled")
+	}
+	if len(c.SourceContents) > 0 {
+		return errors.New("heredoc syntax in ADD requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled")
+	}
 	downloader := newRemoteSourceDownloader(d.builder.Output, d.builder.Stdout)
+	if c.Checksum != "" {
+		downloader = newChecksummedSourceDownloader(d.builder.Output, d.builder.Stdout, c.Checksum)
+	}
 	cpr := copierFromDispatchRequest(d, downloader, nil)
 	defer cpr.Cleanup()
 
@@ -105,7 +117,7 @@ func dispatchAdd(ctx context.Context, d dispatchRequest, c *instructions.AddComm
 		return err
 	}
 	instruction.chownStr = c.Chown
-	instruction.allowLocalDecompression = true
+	instruction.allowLocalDecompression = c.Unpack == nil || *c.Unpack
 
 	return d.builder.performCopy(ctx, d, instruction)
 }
@@ -116,6 +128,18 @@ func dispatchAdd(ctx context.Context, d dispatchRequest, c *instructions.AddComm
 func dispatchCopy(ctx context.Context, d dispatchRequest, c *instructions.CopyCommand) error {
 	if c.Chmod != "" {
 		return errors.New("the --chmod option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled")
+	}
+	if len(c.SourceContents) > 0 {
+		return errors.New("heredoc syntax in COPY requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled")
+	}
+	if c.Link {
+		fmt.Fprintf(d.builder.Stderr, "[Warning] --link is not supported by the classic builder and will be ignored; the copy will proceed normally\n")
+	}
+	if c.Parents {
+		return errors.New("the --parents option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled")
+	}
+	if len(c.ExcludePatterns) > 0 {
+		return errors.New("the --exclude option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled")
 	}
 	var im *imageMount
 	var err error
@@ -343,6 +367,9 @@ func dispatchRun(ctx context.Context, d dispatchRequest, c *instructions.RunComm
 	if len(c.FlagsUsed) > 0 {
 		// classic builder RUN currently does not support any flags, so fail on the first one
 		return errors.Errorf("the --%s option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled", c.FlagsUsed[0])
+	}
+	if len(c.Files) > 0 {
+		return errors.New("heredoc syntax in RUN requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled")
 	}
 
 	stateRunConfig := d.state.runConfig

--- a/daemon/builder/remotecontext/detect.go
+++ b/daemon/builder/remotecontext/detect.go
@@ -141,11 +141,15 @@ func removeDockerfile(c modifiableContext, filesToRemove ...string) error {
 
 func readAndParseDockerfile(name string, rc io.Reader) (*parser.Result, error) {
 	br := bufio.NewReader(rc)
-	if _, err := br.Peek(1); err != nil {
-		if err == io.EOF {
+	peeked, err := br.Peek(512)
+	if len(peeked) == 0 {
+		if errors.Is(err, io.EOF) {
 			return nil, errdefs.InvalidParameter(errors.Errorf("the Dockerfile (%s) cannot be empty", name))
 		}
 		return nil, errors.Wrap(err, "unexpected error reading Dockerfile")
+	}
+	if syntaxImage, _, _, ok := parser.DetectSyntax(peeked); ok {
+		return nil, errdefs.InvalidParameter(errors.Errorf("the Dockerfile uses a custom syntax (%s) which requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled", syntaxImage))
 	}
 
 	dockerfile, err := parser.Parse(br)


### PR DESCRIPTION
- slightly related; https://github.com/moby/moby/issues/4907

The classic builder previously accepted several BuildKit-era Dockerfile flags and heredoc syntax without error but also without effect, leaving users with silently wrong builds.

This change implements previously-ignored features, catches a dangerous directive, and converts the remaining silent no-ops to "requires BuildKit" errors:

- `ADD --unpack`: `allowLocalDecompression` was hardcoded to `true`; now reads `AddCommand.Unpack` with the correct `nil`-means-default semantics.
- `ADD --checksum`: post-download verification using `digest.Parse` from `opencontainers/go-digest`, covering `sha256`, `sha384`, and `sha512`.
- Predefined platform `ARG`s: `injectPredefinedBuildArgs` now populates all eight (`TARGETPLATFORM`, `TARGETOS`, `TARGETARCH`, `TARGETVARIANT`, `BUILDPLATFORM`, `BUILDOS`, `BUILDARCH`, `BUILDVARIANT`) as meta-args before `metaArgs` processing, so `ARG TARGETPLATFORM` in a Dockerfile gets a meaningful value instead of expanding to empty string.
- `# syntax` directive: `readAndParseDockerfile` now peeks the first 512 bytes and calls `parser.DetectSyntax` before proceeding; a Dockerfile with a custom syntax directive is rejected with a clear error naming the requested image.  Previously, the directive was silently ignored and the Dockerfile was parsed by the classic parser regardless.
- Heredocs in `RUN`, `COPY`, and `ADD`; `COPY --parents`; `COPY`/`ADD --exclude`; `ADD --keep-git-dir` -- all now error immediately with a "requires BuildKit" message instead of silently doing nothing.
- `COPY --link`: changed from a hard error to a warning; `--link` is a storage-layer hint that doesn't affect image content, so the copy proceeds normally.

The heredoc case deserves special mention: `RUN <<EOF\ncommands\nEOF` was previously dispatched as `/bin/sh -c '<<EOF'`, which on busybox/bash exits 0 with the body commands never executed -- an empty layer was committed and the build reported success.

Remaining silent behavior not addressed: `# check` directives are still ignored, but `# check` only controls linting rule overrides for warnings, so ignoring it doesn't affect build correctness.