### PR TITLE
libnet/portmappers/nat: retry host-namespace bind on EADDRINUSE in rootless

### DIFF
--- a/daemon/libnetwork/portmappers/nat/mapper_linux.go
+++ b/daemon/libnetwork/portmappers/nat/mapper_linux.go
@@ -8,6 +8,8 @@ import (
 	"net/netip"
 	"slices"
 	"strconv"
+	"strings"
+	"syscall"
 
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/libnetwork/internal/rlkclient"
@@ -18,6 +20,11 @@ import (
 )
 
 const driverName = "nat"
+
+// maxHostBindAttempts bounds how many times MapPorts retries the
+// allocate-and-bind cycle when the rootlesskit host-namespace bind collides
+// with a dynamic port that is already in use in the host namespace.
+const maxHostBindAttempts = 10
 
 type PortDriverClient interface {
 	ChildHostIP(proto string, hostIP netip.Addr) netip.Addr
@@ -88,31 +95,60 @@ func (pm PortMapper) MapPorts(ctx context.Context, cfg []portmapperapi.PortBindi
 	})
 
 	pa := portallocator.NewOSAllocator()
-	allocatedPort, socks, err := pa.RequestPortsInRange(addrs, proto, int(hostPort), int(hostPortEnd))
-	if err != nil {
-		return nil, err
-	}
 
-	for i := range cfg {
-		pb := portmapperapi.PortBinding{
-			PortBinding: cfg[i].PortBinding.Copy(),
-			BoundSocket: socks[i],
-			ChildHostIP: cfg[i].ChildHostIP,
+	// In rootless mode the OS allocator's bind probe runs in the daemon's
+	// (child) network namespace, while the port driver (rootlesskit) binds the
+	// same host port in the host (parent) namespace, which has a separate port
+	// table. A port that is free in the child namespace can therefore still
+	// collide in the host namespace, and the allocator's own retry does not see
+	// that. When the host port is dynamic, retry the whole allocate-and-bind
+	// cycle so a fresh port is chosen; the allocator round-robins, so each
+	// attempt picks a different port (issue #52903).
+	dynamicPort := hostPort == 0 || hostPort != hostPortEnd
+	for attempt := 0; ; attempt++ {
+		allocatedPort, socks, err := pa.RequestPortsInRange(addrs, proto, int(hostPort), int(hostPortEnd))
+		if err != nil {
+			return nil, err
 		}
-		pb.PortBinding.HostPort = uint16(allocatedPort)
-		pb.PortBinding.HostPortEnd = pb.HostPort
 
-		childHIP, _ := netip.AddrFromSlice(cfg[i].ChildHostIP)
-		pb.NAT = netip.AddrPortFrom(childHIP.Unmap(), pb.PortBinding.HostPort)
+		bindings = bindings[:0]
+		for i := range cfg {
+			pb := portmapperapi.PortBinding{
+				PortBinding: cfg[i].PortBinding.Copy(),
+				BoundSocket: socks[i],
+				ChildHostIP: cfg[i].ChildHostIP,
+			}
+			pb.PortBinding.HostPort = uint16(allocatedPort)
+			pb.PortBinding.HostPortEnd = pb.HostPort
 
-		bindings = append(bindings, pb)
+			childHIP, _ := netip.AddrFromSlice(cfg[i].ChildHostIP)
+			pb.NAT = netip.AddrPortFrom(childHIP.Unmap(), pb.PortBinding.HostPort)
+
+			bindings = append(bindings, pb)
+		}
+
+		err = configPortDriver(ctx, bindings, pm.pdc)
+		if err == nil {
+			return bindings, nil
+		}
+		if !dynamicPort || !isAddrInUse(err) || attempt >= maxHostBindAttempts-1 {
+			return nil, err
+		}
+
+		// The host-namespace bind collided on a dynamic port. Release this
+		// attempt's bindings (closing the child-namespace probe sockets and
+		// freeing the allocator reservation) and retry with a new port.
+		if uErr := pm.UnmapPorts(ctx, bindings); uErr != nil {
+			log.G(ctx).WithFields(log.Fields{
+				"pbs":   bindings,
+				"error": uErr,
+			}).Warn("Failed to release port bindings before retry")
+		}
+		log.G(ctx).WithFields(log.Fields{
+			"port":    allocatedPort,
+			"attempt": attempt + 1,
+		}).Debug("Host-namespace port collision in rootless mode, retrying with a new port")
 	}
-
-	if err := configPortDriver(ctx, bindings, pm.pdc); err != nil {
-		return nil, err
-	}
-
-	return bindings, nil
 }
 
 func (pm PortMapper) UnmapPorts(ctx context.Context, pbs []portmapperapi.PortBinding) error {
@@ -155,6 +191,16 @@ func setChildHostIP(pdc PortDriverClient, req portmapperapi.PortBindingReq) (por
 // configPortDriver passes the port binding's details to rootlesskit, and updates the
 // port binding with callbacks to remove the rootlesskit config (or marks the binding as
 // unsupported by rootlesskit).
+// isAddrInUse reports whether err is, or wraps, an EADDRINUSE error. The
+// rootlesskit port driver communicates over IPC and flattens the errno into a
+// string, so errors.Is alone is not sufficient and the message is also matched.
+func isAddrInUse(err error) bool {
+	if errors.Is(err, syscall.EADDRINUSE) {
+		return true
+	}
+	return strings.Contains(err.Error(), "address already in use")
+}
+
 func configPortDriver(ctx context.Context, pbs []portmapperapi.PortBinding, pdc PortDriverClient) error {
 	for i := range pbs {
 		b := pbs[i]

--- a/daemon/libnetwork/portmappers/nat/mapper_linux_test.go
+++ b/daemon/libnetwork/portmappers/nat/mapper_linux_test.go
@@ -2,6 +2,9 @@ package nat
 
 import (
 	"context"
+	"errors"
+	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/moby/moby/v2/daemon/libnetwork/portmapperapi"
@@ -9,6 +12,76 @@ import (
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
+
+// fakePortDriverClient stands in for the rootlesskit port driver. AddPort
+// returns failErr for the first failN calls (simulating a host-namespace bind
+// collision) and records the host port it was asked to bind on each call.
+type fakePortDriverClient struct {
+	childIP netip.Addr
+	failN   int
+	failErr error
+	ports   []int
+}
+
+func (f *fakePortDriverClient) ChildHostIP(_ string, _ netip.Addr) netip.Addr {
+	return f.childIP
+}
+
+func (f *fakePortDriverClient) AddPort(_ context.Context, _ string, _, _ netip.Addr, hostPort int) (func() error, error) {
+	f.ports = append(f.ports, hostPort)
+	if len(f.ports) <= f.failN {
+		return nil, f.failErr
+	}
+	return func() error { return nil }, nil
+}
+
+// addrInUseErr mimics the error rootlesskit surfaces over IPC: the errno is
+// flattened into the message rather than wrapped.
+var addrInUseErr = errors.New("error while calling RootlessKit PortManager.AddPort(): listen tcp 0.0.0.0:0: bind: address already in use")
+
+func TestMapPortsRetriesHostNamespaceCollision(t *testing.T) {
+	f := &fakePortDriverClient{
+		childIP: netip.MustParseAddr("127.0.0.1"),
+		failN:   1,
+		failErr: addrInUseErr,
+	}
+	pm := &PortMapper{pdc: f}
+	// Dynamic host port (HostPort == 0), so a retry is allowed to pick a new one.
+	cfg := []portmapperapi.PortBindingReq{{PortBinding: types.PortBinding{Proto: types.TCP, Port: 80, HostIP: net.IPv4zero}}}
+
+	pbs, err := pm.MapPorts(context.Background(), cfg)
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(pbs, 1))
+	assert.Check(t, is.Len(f.ports, 2)) // failed once, retried once
+	assert.Check(t, f.ports[0] != f.ports[1], "retry should pick a different host port")
+	assert.NilError(t, pm.UnmapPorts(context.Background(), pbs))
+}
+
+func TestMapPortsNoRetryForFixedPort(t *testing.T) {
+	// Grab a free port to use as a fixed (non-dynamic) host port.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NilError(t, err)
+	fixed := l.Addr().(*net.TCPAddr).Port
+	assert.NilError(t, l.Close())
+
+	f := &fakePortDriverClient{
+		childIP: netip.MustParseAddr("127.0.0.1"),
+		failN:   maxHostBindAttempts, // would always fail if retried
+		failErr: addrInUseErr,
+	}
+	pm := &PortMapper{pdc: f}
+	cfg := []portmapperapi.PortBindingReq{{PortBinding: types.PortBinding{
+		Proto:       types.TCP,
+		Port:        80,
+		HostIP:      net.IPv4zero,
+		HostPort:    uint16(fixed),
+		HostPortEnd: uint16(fixed),
+	}}}
+
+	_, err = pm.MapPorts(context.Background(), cfg)
+	assert.Check(t, is.ErrorContains(err, "address already in use"))
+	assert.Check(t, is.Len(f.ports, 1), "a fixed host port must not be retried")
+}
 
 func TestBindHostPortsError(t *testing.T) {
 	cfg := []portmapperapi.PortBindingReq{


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/52903

## Summary

In rootless mode, `MapPorts` binds the same host port twice in two different network namespaces:

1. `OSAllocator.RequestPortsInRange` reserves a port and probes it with `bind(2)` in the daemon's (child) namespace, retrying on EADDRINUSE.
2. `configPortDriver` then asks rootlesskit to bind the same host port in the host (parent) namespace, which has a **separate** port table.

A dynamic port that is free in the child namespace can still be in use in the host namespace, and only step 2 sees that. The child-side retry provides no protection, so concurrent container starts requesting ephemeral host ports intermittently fail with:

```
cannot expose port X: listen tcp 0.0.0.0:X: bind: address already in use
```

(@AkihiroSuda invited a PR on the issue.)

## Approach

Wrap the allocate-and-bind cycle in a retry loop: when the port driver reports EADDRINUSE and the host port is dynamic, release the attempt's bindings (closing the child-namespace probe sockets and freeing the allocator reservation) and try again. The allocator round-robins via its last-allocated pointer, which `ReleasePort` does not reset, so each attempt picks a different port and the retry converges (capped at `maxHostBindAttempts`). Fixed host ports (`HostPort == HostPortEnd != 0`) are not retried, since the allocator would just return the same port.

The errno is flattened into a string across the rootlesskit IPC boundary, so `isAddrInUse` matches the message in addition to `errors.Is(err, syscall.EADDRINUSE)`.

This path is only reached in rootless mode (`pdc != nil`); rootful behavior is unchanged.

## Tests

`go test ./daemon/libnetwork/portmappers/nat/` (Linux):

- `TestMapPortsRetriesHostNamespaceCollision`: a fake port driver returns EADDRINUSE on the first `AddPort` then succeeds; asserts `MapPorts` retries and that the retry binds a **different** host port. This exercises the real `OSAllocator` (only the rootlesskit IPC is faked), so it validates the actual round-robin convergence, not a mocked one.
- `TestMapPortsNoRetryForFixedPort`: a fixed host port that always fails is attempted exactly once (no retry).

Note on validation scope: the underlying failure is a nondeterministic race between concurrent starts, so I validated the fix mechanism (retry occurs, picks a fresh port, converges; fixed ports excluded) deterministically via the unit tests against the real allocator, rather than relying on an inherently flaky concurrent reproduction.

## Release notes

```markdown changelog
Fix rootless mode intermittently failing to start containers with `bind: address already in use` when concurrent starts request ephemeral host ports.
```

Created with: Claude Code