### PR TITLE
vendor: github.com/containerd/containerd/v2 v2.2.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/containerd/cgroups/v3 v3.1.3
 	github.com/containerd/containerd/api v1.10.0
-	github.com/containerd/containerd/v2 v2.2.4
+	github.com/containerd/containerd/v2 v2.2.5
 	github.com/containerd/continuity v0.5.0
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/fifo v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/q
 github.com/containerd/console v1.0.5/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/containerd/containerd/api v1.10.0 h1:5n0oHYVBwN4VhoX9fFykCV9dF1/BvAXeg2F8W6UYq1o=
 github.com/containerd/containerd/api v1.10.0/go.mod h1:NBm1OAk8ZL+LG8R0ceObGxT5hbUYj7CzTmR3xh0DlMM=
-github.com/containerd/containerd/v2 v2.2.4 h1:8x2UdXqww7NYqGNabQ7i1nAgB5LegzjC9KQzO/900iA=
-github.com/containerd/containerd/v2 v2.2.4/go.mod h1:YBcTO8D9149QY9zNmUjy04Mhuc4DlrZQ8FIOwKZEM7o=
+github.com/containerd/containerd/v2 v2.2.5 h1:KTFzB02LviYmmfRmz8r9UFd+n6YlddVFK+5lbgQXUTU=
+github.com/containerd/containerd/v2 v2.2.5/go.mod h1:5t2+xFv2dGd/iDYp9Z8DXB4cmWrWQi1XqxGJPS2gBzU=
 github.com/containerd/continuity v0.5.0 h1:7a85HZpCSs+1Zps0Ee3DPSuAWY+0SJM1JNM51nlEVDg=
 github.com/containerd/continuity v0.5.0/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/vendor/github.com/containerd/containerd/v2/client/container_opts.go
+++ b/vendor/github.com/containerd/containerd/v2/client/container_opts.go
@@ -21,14 +21,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
 	"github.com/opencontainers/image-spec/identity"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -113,6 +116,10 @@ func WithContainerLabels(labels map[string]string) NewContainerOpts {
 // The existing labels are cleared as this is expected to be the first
 // operation in setting up a container's labels. Use WithAdditionalContainerLabels
 // to add/overwrite the existing image config labels.
+//
+// Image config labels in the namespaces reserved for containerd
+// (containerd.io/) and the CRI plugin (io.cri-containerd) are not copied
+// to the container.
 func WithImageConfigLabels(image Image) NewContainerOpts {
 	return func(ctx context.Context, _ *Client, c *containers.Container) error {
 		ic, err := image.Config(ctx)
@@ -138,6 +145,16 @@ func WithImageConfigLabels(image Image) NewContainerOpts {
 		config = ociimage.Config
 
 		c.Labels = config.Labels
+		// Labels in the containerd.io/* namespace are interpreted by containerd
+		// itself, and labels in the io.cri-containerd.* namespace are interpreted
+		// by the CRI plugin, so they are not copied from untrusted image configs.
+		maps.DeleteFunc(c.Labels, func(k, _ string) bool {
+			if labels.IsReserved(k) {
+				log.G(ctx).Warnf("skipping image label %q: the label namespace is reserved for containerd; possible malicious image attempting to alter containerd behavior", k)
+				return true
+			}
+			return false
+		})
 		return nil
 	}
 }

--- a/vendor/github.com/containerd/containerd/v2/pkg/labels/labels.go
+++ b/vendor/github.com/containerd/containerd/v2/pkg/labels/labels.go
@@ -16,6 +16,18 @@
 
 package labels
 
+// ReservedPrefix is the prefix of the label namespace reserved for labels
+// defined and consumed by containerd itself. Labels in this namespace must
+// not be copied from untrusted sources such as image config labels. Use
+// IsReserved to check for such labels.
+const ReservedPrefix = "containerd.io/"
+
+// CRIContainerdPrefix is the prefix of the label namespace reserved for
+// labels defined and consumed by containerd's CRI plugin. Labels in this
+// namespace must not be copied from untrusted sources such as image config
+// labels. Use IsReserved to check for such labels.
+const CRIContainerdPrefix = "io.cri-containerd"
+
 // LabelUncompressed is added to compressed layer contents.
 // The value is digest of the uncompressed content.
 const LabelUncompressed = "containerd.io/uncompressed"

--- a/vendor/github.com/containerd/containerd/v2/pkg/labels/validate.go
+++ b/vendor/github.com/containerd/containerd/v2/pkg/labels/validate.go
@@ -18,6 +18,7 @@ package labels
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/containerd/errdefs"
 )
@@ -38,4 +39,12 @@ func Validate(k, v string) error {
 		return fmt.Errorf("label key and value length (%d bytes) greater than maximum size (%d bytes), key: %s: %w", total, maxSize, k, errdefs.ErrInvalidArgument)
 	}
 	return nil
+}
+
+// IsReserved returns true if the label key is in a namespace reserved for
+// containerd (ReservedPrefix) or its CRI plugin (CRIContainerdPrefix).
+// Reserved labels are interpreted by containerd and must not be copied from
+// untrusted sources such as image config labels.
+func IsReserved(k string) bool {
+	return strings.HasPrefix(k, ReservedPrefix) || strings.HasPrefix(k, CRIContainerdPrefix)
 }

--- a/vendor/github.com/containerd/containerd/v2/pkg/oci/spec_opts.go
+++ b/vendor/github.com/containerd/containerd/v2/pkg/oci/spec_opts.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"math"
 	"os"
@@ -1821,10 +1822,13 @@ type readLinker interface {
 // openUserFile attempts to open a file within the root fs.
 // It handles cases where the file is an absolute symlink (e.g., NixOS /etc/passwd -> /nix/store/...),
 // which triggers "path escapes from parent" errors in Go 1.24+ due to stricter os.DirFS validation.
+//
+// The returned file rejects non-regular sources and returns an error if more
+// than maxUserFileBytes are read from it.
 func openUserFile(root fs.FS, name string) (fs.File, error) {
 	f, err := root.Open(name)
 	if err == nil {
-		return f, nil
+		return wrapUserFile(f, name)
 	}
 
 	// Check if the FS implements our local ReadLink interface.
@@ -1841,7 +1845,11 @@ func openUserFile(root fs.FS, name string) (fs.File, error) {
 				if rerr == nil {
 					// filepath.Rel might return OS-specific separators (backslashes on Windows).
 					// fs.Open strictly expects forward slashes, so we convert it.
-					return root.Open(filepath.ToSlash(rel))
+					f, oerr := root.Open(filepath.ToSlash(rel))
+					if oerr != nil {
+						return nil, oerr
+					}
+					return wrapUserFile(f, name)
 				}
 			}
 		}
@@ -1849,4 +1857,48 @@ func openUserFile(root fs.FS, name string) (fs.File, error) {
 
 	// Return the original error if we couldn't resolve it
 	return nil, err
+}
+
+// maxUserFileBytes caps how much data is read from any user-database file
+// opened via openUserFile. Real systems keep these files well under 1 MiB;
+// 10 MiB is generous headroom while keeping peak memory during
+// user.ParsePasswd/ParseGroup bounded to single-digit MiB.
+const maxUserFileBytes = 10 << 20
+
+// wrapUserFile rejects non-regular sources and returns an fs.File that
+// errors out if more than maxUserFileBytes are read from it.
+func wrapUserFile(f fs.File, name string) (fs.File, error) {
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, fmt.Errorf("stat %s: %w", name, err)
+	}
+	if !info.Mode().IsRegular() {
+		f.Close()
+		return nil, fmt.Errorf("%s is not a regular file", name)
+	}
+	return &limitedFile{
+		File: f,
+		// Allow one byte past the cap so an overflow surfaces as an
+		// error rather than a silent EOF that the parser would treat as
+		// a clean end-of-file (and miss any entries past the cap).
+		r:    &io.LimitedReader{R: f, N: maxUserFileBytes + 1},
+		name: name,
+	}, nil
+}
+
+// limitedFile is an fs.File whose Read returns an error once more than
+// maxUserFileBytes have been read.
+type limitedFile struct {
+	fs.File
+	r    *io.LimitedReader
+	name string
+}
+
+func (l *limitedFile) Read(p []byte) (int, error) {
+	n, err := l.r.Read(p)
+	if l.r.N == 0 {
+		return n, fmt.Errorf("%q exceeds %d bytes", l.name, maxUserFileBytes)
+	}
+	return n, err
 }

--- a/vendor/github.com/containerd/containerd/v2/version/version.go
+++ b/vendor/github.com/containerd/containerd/v2/version/version.go
@@ -24,7 +24,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.2.4+unknown"
+	Version = "2.2.5+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -409,8 +409,8 @@ github.com/containerd/containerd/api/types/runc/options
 github.com/containerd/containerd/api/types/runtimeoptions/v1
 github.com/containerd/containerd/api/types/task
 github.com/containerd/containerd/api/types/transfer
-# github.com/containerd/containerd/v2 v2.2.4
-## explicit; go 1.24.3
+# github.com/containerd/containerd/v2 v2.2.5
+## explicit; go 1.25.0
 github.com/containerd/containerd/v2/client
 github.com/containerd/containerd/v2/cmd/containerd/server/config
 github.com/containerd/containerd/v2/core/containers


### PR DESCRIPTION
- full diff: https://github.com/containerd/containerd/compare/v2.2.4...v2.2.5
- release notes: https://github.com/containerd/containerd/releases/tag/v2.2.5

The fifth patch release for containerd 2.2 contains various fixes and updates including security patches.

-  CVE-2026-50195 / [GHSA-cvxm-645q-p574] CRI: checkpoint import allows local image tag poisoning
-  CVE-2026-53488 / [GHSA-xhf5-7wjv-pqxp] CRI: image-config LABEL flows to host-root command execution from an image pull
-  CVE-2026-53492 / [GHSA-33vj-92qq-66hc] CRI: CDI annotation smuggling during CRI checkpoint restore
-  CVE-2026-53489 / [GHSA-rgh6-rfwx-v388] CRI: Arbitrary host file read via symlink following in CRI checkpoint restore
-  CVE-2026-47262 / [GHSA-jpcc-p29g-p8mq] containerd image-triggered runtime DoS via unbounded group parsing

[GHSA-cvxm-645q-p574]: https://github.com/containerd/containerd/security/advisories/GHSA-cvxm-645q-p574
[GHSA-xhf5-7wjv-pqxp]: https://github.com/containerd/containerd/security/advisories/GHSA-xhf5-7wjv-pqxp
[GHSA-33vj-92qq-66hc]: https://github.com/containerd/containerd/security/advisories/GHSA-33vj-92qq-66hc
[GHSA-rgh6-rfwx-v388]: https://github.com/containerd/containerd/security/advisories/GHSA-rgh6-rfwx-v388
[GHSA-jpcc-p29g-p8mq]: https://github.com/containerd/containerd/security/advisories/GHSA-jpcc-p29g-p8mq

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
