### PR TITLE
libnetwork: add nftables load-balancer prototype

### DIFF
--- a/daemon/libnetwork/docs/nftlb-prototype/.gitignore
+++ b/daemon/libnetwork/docs/nftlb-prototype/.gitignore
@@ -1,0 +1,1 @@
+.nftlb-registry.json

--- a/daemon/libnetwork/docs/nftlb-prototype/README.md
+++ b/daemon/libnetwork/docs/nftlb-prototype/README.md
@@ -1,0 +1,120 @@
+# nftables Load Balancing Prototype
+
+Self-contained shell prototype that simulates Swarm overlay + ingress load balancing on a single host using **nftables only** (no IPVS, no iptables).
+
+## Topology
+
+```
+Host (gwbr0 172.18.0.0/16)
+  └── nft moby-ingress: DNAT published ports → lb-sbox gw (172.18.0.2)
+
+overlay netns (br-overlay 10.255.0.0/24)
+  ├── nftlb-lb-sbox   eth0=10.255.0.2  eth1=172.18.0.2
+  ├── nftlb-nat-backend-{1,2,3}  10.255.0.11-13
+  ├── nftlb-dsr-backend-{1,2}    10.255.0.21-22
+  └── nftlb-client               10.255.0.100
+```
+
+Four services run concurrently (TCP and UDP):
+
+| Service | Mode | Proto | VIP | Published | Target | Backends |
+|---------|------|-------|-----|-----------|--------|----------|
+| A | NAT | TCP | 10.255.0.10 | 8080 | 80 | nat-backend-1..3 |
+| A′ | NAT | UDP | 10.255.0.10 | 8080 | 8123 | nat-backend-1..3 |
+| B | DSR | TCP | 10.255.0.20 | 9000 | 8080 | dsr-backend-1..2 |
+| B′ | DSR | UDP | 10.255.0.20 | 9000 | 8124 | dsr-backend-1..2 |
+
+The demo deliberately publishes **the same port number** for TCP and UDP (8080 and 9000) to different services.
+
+## O(1) ruleset design
+
+Tables, chains, and rule counts are **fixed**. Services, ports, and backends are added by inserting **set/map elements** only (`nft-ctl.sh`), never by generating rules.
+
+Backend selection is random with equal weights. **NAT** flows are persisted using conntrack. **DSR** handles (one-sided) connection tracking using a map updated in the packet path. Soft drain removes a backend from the corresponding map used for backend selection of new flows — established sessions continue to be tracked in conntrack (NAT) or the nftables dynamic map (DSR).
+
+**DSR** uses lb-sbox `netdev` hooks to rewrite **MAC addresses only** (IP headers untouched):
+
+| Path | lb-sbox hook | Host IP SNAT | Backend sees | Return path |
+|------|--------------|--------------|--------------|-------------|
+| Overlay VIP (`10.255.0.20:8080`) | `eth0` ingress | none | real client IP | direct to client (asymmetric) |
+| Published port (host/peers → `:9000`) | `eth1` ip DNAT | yes, onto `gwbr0` | gwbridge IP | lb-sbox ip prerouting; hairpin reply SNAT |
+
+When `publishPort != targetPort`, port translation is performed inside the backend container's network namespace. Only flows from published ports are translated. Flows originating from peers on the overlay network are not translated.
+
+## Prerequisites
+
+- Linux with nftables (kernel ≥ 5.x, `netdev` ingress support)
+- root / `CAP_NET_ADMIN`
+- `docker`, `ip`, `nsenter`, `nft`, `jq`, `curl`
+- `nicolaka/netshoot:latest` (pulled on first `setup.sh`; backends use `socat` for TCP+UDP echo; if pull fails due to a credential helper, use `DOCKER_CONFIG=/tmp/docker-nocreds docker pull <image>` with an empty `config.json`)
+
+## Quick start
+
+```bash
+cd daemon/libnetwork/docs/nftlb-prototype
+sudo ./setup.sh
+sudo ./demo.sh
+sudo ./teardown.sh
+```
+
+### Manual checks
+
+```bash
+# Host ingress (same network namespace as setup.sh)
+curl -s 127.0.0.1:8080   # NAT
+curl -s 127.0.0.1:9000   # DSR (publish 9000 → target 8080)
+
+# From another machine on the same L2/L3 network (replace with setup host IP)
+curl -s <host-ip>:8080
+curl -s <host-ip>:9000
+
+# Overlay VIP from client container
+docker exec nftlb-client curl -s 10.255.0.10:80
+docker exec nftlb-client curl -s 10.255.0.20:8080
+
+# Soft drain (no new flows to backend)
+sudo ./nft-ctl.sh remove-backend svc-nat nftlb-nat-backend-2
+```
+
+### Same-bridge peer access (Moby devcontainer)
+
+Host ingress is programmed in **the network namespace where you run `setup.sh`**. In a Moby devcontainer that is usually `eth0` (for example `172.17.0.2`), not your laptop's LAN address.
+
+From another container on the same bridge, target the devcontainer IP printed by `./setup.sh`:
+
+```bash
+# Quick check (uses inner docker bridge; routed to eth0 in the devcontainer)
+docker run --rm --network bridge nicolaka/netshoot curl -s 172.17.0.2:8080
+docker run --rm --network bridge nicolaka/netshoot curl -s 172.17.0.2:9000
+
+# Automated peer checks (inner docker bridge + ipvlan same-L2 peer on eth0)
+sudo ./lib/bridge-peer-test.sh
+```
+
+Traffic path for a remote peer:
+
+- **NAT overlay VIP** (`10.255.0.10:80`): lb-sbox IP DNAT/SNAT to backend. No port translation.
+- **DSR overlay VIP** (`10.255.0.20:8080`): no host involvement; lb-sbox MAC rewrite on `eth0`; backends see real client IP and return directly.
+- **Published port** (`8080`, `9000`): `eth0` PREROUTING DNAT → forward `eth0`→`gwbr0` (SNAT) → lb-sbox IP DNAT/SNAT to backends → backends REDIRECT to target port. Published-port flows are NAT'ed irrespective of the service mode.
+
+If a peer on the **host** docker bridge (outside the devcontainer) still cannot connect, check that it targets the devcontainer's `eth0` IP and that the outer docker daemon is not filtering inter-container traffic.
+
+### External / LAN access
+
+For a physical machine on your Wi‑Fi/Ethernet, run `setup.sh` in the host root network namespace (`--network host` devcontainer, or bare metal) and use the machine's LAN IP. Inside a normal container without host networking, peers on your LAN cannot reach ingress rules in the devcontainer namespace.
+
+`setup.sh` sets `ip_forward`, `route_localnet` on `gwbr0`, and `rp_filter=0` on `gwbr0` and gwbridge veth ports (matching production's per-interface `route_localnet` on the gateway bridge). Uplink `rp_filter` is left to the host. Bridge netfilter sysctls are left to the bridge driver (see `setup_bridgenetfiltering.go`).
+
+## Files
+
+| File | Role |
+|------|------|
+| `setup.sh` | Topology + load static rulesets + populate via nft-ctl |
+| `teardown.sh` | Cleanup |
+| `demo.sh` | Demo scenarios |
+| `nft-ctl.sh` | Control plane (add-service, add-backend, drain-backend) |
+| `lib/resolve-macs.sh` | DSR MAC resolution from lb-sbox |
+| `lib/bridge-peer-test.sh` | Verify NAT/DSR ingress from bridge / ipvlan peers |
+| `lib/nft/*.nft` | Static O(1) rulesets per netns role |
+
+Demo 9 opens an HTTP keep-alive connection from `nftlb-client` to the NAT VIP, pins it to `nftlb-nat-backend-2`, soft-drains that backend, verifies two further requests on the **same TCP connection** still reach the drained backend, then verifies **new** `docker exec ... curl` flows avoid it. Re-run `./setup.sh` before `./demo.sh` (demo 9 drains a backend in-place).

--- a/daemon/libnetwork/docs/nftlb-prototype/demo.sh
+++ b/daemon/libnetwork/docs/nftlb-prototype/demo.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# Demonstrate load balancing scenarios from the prototype plan.
+
+set -euo pipefail
+
+PROTOTYPE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${PROTOTYPE_DIR}/lib/common.sh"
+
+client_curl() {
+	local url=$1
+	docker exec "$CONTAINER_CLIENT" curl -s --max-time 2 "$url"
+}
+
+# Send one UDP datagram and print the response body.
+udp_probe() {
+	local host=$1 port=$2
+	echo -n probe | docker exec -i "$CONTAINER_CLIENT" nc -u -w2 "$host" "$port" 2>/dev/null || true
+}
+
+host_udp_probe() {
+	local host=$1 port=$2
+	if in_isolated_container_netns; then
+		echo -n probe | docker run --rm -i --network bridge "$CLIENT_IMAGE" \
+			nc -u -w2 "$host" "$port" 2>/dev/null || true
+	else
+		echo -n probe | nc -u -w2 "$host" "$port" 2>/dev/null || true
+	fi
+}
+
+require_cmds curl docker nc
+
+pass=0
+fail=0
+
+check_rr() {
+	local label=$1
+	shift
+	local -a responses=("$@")
+	local -A seen=()
+	local r nonempty=0
+	for r in "${responses[@]}"; do
+		[[ -z $r ]] && continue
+		nonempty=1
+		seen[$r]=1
+	done
+	if [[ $nonempty -eq 0 ]]; then
+		log "FAIL ${label}: no responses (empty)"
+		fail=$((fail + 1))
+		return
+	fi
+	local unique=${#seen[@]}
+	if [[ $unique -ge 2 ]]; then
+		log "PASS ${label}: saw ${unique} distinct backends (${responses[*]})"
+		pass=$((pass + 1))
+	else
+		log "FAIL ${label}: expected multiple backends, got: ${responses[*]}"
+		fail=$((fail + 1))
+	fi
+}
+
+demo_host_nat() {
+	log "=== Demo 1: host ingress NAT TCP (${NAT_PUBLISH_PORT}, target ${NAT_TARGET_PORT}) ==="
+	local -a resp=()
+	local i out
+	for i in $(seq 1 6); do
+		out=$(curl -s --max-time 2 "127.0.0.1:${NAT_PUBLISH_PORT}" || true)
+		resp+=("$out")
+		echo "  request $i -> $out"
+	done
+	check_rr "host NAT RR" "${resp[@]}"
+}
+
+demo_host_dsr() {
+	log "=== Demo 2: host ingress DSR TCP (${DSR_PUBLISH_PORT}, target ${DSR_TARGET_PORT}) ==="
+	log "  (published-port ingress is NAT'ed irrespective of the load-balancer mode)"
+	local -a resp=()
+	local i out
+	for i in $(seq 1 6); do
+		out=$(curl -s --max-time 2 "127.0.0.1:${DSR_PUBLISH_PORT}" || true)
+		resp+=("$out")
+		echo "  request $i -> $out"
+	done
+	check_rr "host DSR RR" "${resp[@]}"
+}
+
+demo_overlay_nat() {
+	log "=== Demo 3: overlay VIP NAT TCP (${NAT_VIP}:${NAT_TARGET_PORT}) ==="
+	local -a resp=()
+	local i out
+	for i in $(seq 1 6); do
+		out=$(client_curl "${NAT_VIP}:${NAT_TARGET_PORT}" || true)
+		resp+=("$out")
+		echo "  request $i -> $out"
+	done
+	check_rr "overlay NAT RR" "${resp[@]}"
+}
+
+demo_overlay_dsr() {
+	log "=== Demo 4: overlay VIP DSR TCP (${DSR_VIP}:${DSR_TARGET_PORT}) ==="
+	local -a resp=()
+	local i out
+	for i in $(seq 1 6); do
+		out=$(client_curl "${DSR_VIP}:${DSR_TARGET_PORT}" || true)
+		resp+=("$out")
+		echo "  request $i -> $out"
+	done
+	check_rr "overlay DSR RR" "${resp[@]}"
+}
+
+demo_host_nat_udp() {
+	log "=== Demo 5: host ingress NAT UDP (${NAT_UDP_PUBLISH_PORT}, target ${NAT_UDP_TARGET_PORT}) ==="
+	local -a resp=()
+	local i out
+	for i in $(seq 1 6); do
+		out=$(echo -n probe | nc -u -w2 127.0.0.1 "$NAT_UDP_PUBLISH_PORT" 2>/dev/null || true)
+		resp+=("$out")
+		echo "  request $i -> $out"
+	done
+	check_rr "host NAT UDP RR" "${resp[@]}"
+}
+
+demo_host_dsr_udp() {
+	log "=== Demo 6: host ingress DSR UDP (${DSR_UDP_PUBLISH_PORT}, target ${DSR_UDP_TARGET_PORT}) ==="
+	local -a resp=()
+	local i out
+	for i in $(seq 1 6); do
+		out=$(echo -n probe | nc -u -w2 127.0.0.1 "$DSR_UDP_PUBLISH_PORT" 2>/dev/null || true)
+		resp+=("$out")
+		echo "  request $i -> $out"
+	done
+	check_rr "host DSR UDP RR" "${resp[@]}"
+}
+
+demo_overlay_nat_udp() {
+	log "=== Demo 7: overlay VIP NAT UDP (${NAT_VIP}:${NAT_UDP_TARGET_PORT}) ==="
+	local -a resp=()
+	local i out
+	for i in $(seq 1 6); do
+		out=$(udp_probe "$NAT_VIP" "$NAT_UDP_TARGET_PORT")
+		resp+=("$out")
+		echo "  request $i -> $out"
+	done
+	check_rr "overlay NAT UDP RR" "${resp[@]}"
+}
+
+demo_overlay_dsr_udp() {
+	log "=== Demo 8: overlay VIP DSR UDP (${DSR_VIP}:${DSR_UDP_TARGET_PORT}) ==="
+	local -a resp=()
+	local i out
+	for i in $(seq 1 6); do
+		out=$(udp_probe "$DSR_VIP" "$DSR_UDP_TARGET_PORT")
+		resp+=("$out")
+		echo "  request $i -> $out"
+	done
+	check_rr "overlay DSR UDP RR" "${resp[@]}"
+}
+
+demo_soft_drain() {
+	log "=== Demo 9: soft drain nat backend ${NAT_BACKEND_IPS[1]} (persistent connection) ==="
+	local target_ip=${NAT_BACKEND_IPS[1]}
+	local target_name=${NAT_BACKENDS[1]}
+	local hold_script="${PROTOTYPE_DIR}/lib/soft-drain-hold.sh"
+	local status_file="/tmp/nftlb-hold-status"
+	local continue_file="/tmp/nftlb-drain-continue"
+	local second third line
+
+	docker exec "$CONTAINER_CLIENT" rm -f "$status_file" "$continue_file"
+	docker cp "$hold_script" "${CONTAINER_CLIENT}:/tmp/soft-drain-hold.sh"
+
+	docker exec -d "$CONTAINER_CLIENT" bash /tmp/soft-drain-hold.sh \
+		"$NAT_VIP" "$NAT_TARGET_PORT" "$target_name" "$status_file" "$continue_file"
+
+	local ready=0 attempt=0
+	while [[ $ready -eq 0 && $attempt -lt 100 ]]; do
+		if docker exec "$CONTAINER_CLIENT" test -f "$status_file" 2>/dev/null; then
+			line=$(docker exec "$CONTAINER_CLIENT" grep '^READY|' "$status_file" 2>/dev/null | head -1 || true)
+			if [[ -n $line ]]; then
+				echo "  hold: $line"
+				ready=1
+				break
+			fi
+			if docker exec "$CONTAINER_CLIENT" grep -q '^ERROR|' "$status_file" 2>/dev/null; then
+				line=$(docker exec "$CONTAINER_CLIENT" grep '^ERROR|' "$status_file" | head -1)
+				log "FAIL soft-drain: ${line#ERROR|}"
+				fail=$((fail + 1))
+				return
+			fi
+		fi
+		attempt=$((attempt + 1))
+		sleep 0.1
+	done
+
+	if [[ $ready -eq 0 ]]; then
+		log "FAIL soft-drain: timed out waiting for persistent connection to ${target_name}"
+		fail=$((fail + 1))
+		return
+	fi
+
+	if [[ ${line#READY|} != "$target_name" ]]; then
+		log "FAIL soft-drain: expected READY from ${target_name}, got: ${line}"
+		fail=$((fail + 1))
+		return
+	fi
+
+	log "draining ${target_name} (${target_ip}) while holding established connection"
+	"${PROTOTYPE_DIR}/nft-ctl.sh" remove-backend svc-nat "$target_name"
+
+	docker exec "$CONTAINER_CLIENT" touch "$continue_file"
+
+	attempt=0
+	second=
+	third=
+	while [[ $attempt -lt 100 ]]; do
+		if docker exec "$CONTAINER_CLIENT" test -f "$status_file" 2>/dev/null; then
+			second=$(docker exec "$CONTAINER_CLIENT" grep '^SECOND|' "$status_file" 2>/dev/null | head -1 | cut -d'|' -f2- || true)
+			third=$(docker exec "$CONTAINER_CLIENT" grep '^THIRD|' "$status_file" 2>/dev/null | head -1 | cut -d'|' -f2- || true)
+			if [[ -n $second && -n $third ]]; then
+				echo "  hold: SECOND|${second}"
+				echo "  hold: THIRD|${third}"
+				break
+			fi
+		fi
+		attempt=$((attempt + 1))
+		sleep 0.1
+	done
+
+	if [[ $second == "$target_name" && $third == "$target_name" ]]; then
+		log "PASS soft-drain: established connection still served by ${target_name} (SECOND/THIRD)"
+	else
+		log "FAIL soft-drain: established connection broken (second='${second}' third='${third}')"
+		fail=$((fail + 1))
+		return
+	fi
+
+	local saw_other=0
+	local i out
+	for i in $(seq 1 12); do
+		out=$(docker exec "$CONTAINER_CLIENT" curl -s --max-time 2 "${NAT_VIP}:${NAT_TARGET_PORT}" || true)
+		echo "  post-drain new-flow request $i -> $out"
+		if [[ $out == *"${target_name}"* ]]; then
+			log "FAIL soft-drain: new flow reached drained backend ${target_name}"
+			fail=$((fail + 1))
+			return
+		fi
+		if [[ -n $out && $out != *"${target_name}"* ]]; then
+			saw_other=1
+		fi
+	done
+
+	if [[ $saw_other -eq 1 ]]; then
+		log "PASS soft-drain: new flows avoid drained backend ${target_name}"
+		pass=$((pass + 1))
+	else
+		log "FAIL soft-drain: no responses from remaining backends on new flows"
+		fail=$((fail + 1))
+	fi
+}
+
+main() {
+	require_root
+	demo_host_nat
+	demo_host_dsr
+	demo_overlay_nat
+	demo_overlay_dsr
+	demo_host_nat_udp
+	demo_host_dsr_udp
+	demo_overlay_nat_udp
+	demo_overlay_dsr_udp
+	demo_soft_drain
+	echo ""
+	log "results: ${pass} passed, ${fail} failed"
+	[[ $fail -eq 0 ]]
+}
+
+main "$@"

--- a/daemon/libnetwork/docs/nftlb-prototype/iptables-notes.md
+++ b/daemon/libnetwork/docs/nftlb-prototype/iptables-notes.md
@@ -1,0 +1,783 @@
+# Observed behaviour with iptables mode
+
+```console
+$ docker network create -d overlay someovl
+$ docker service create --mode global --name foo --network someovl --publish 3000:80 --publish 3001:53/udp nginx
+```
+
+## `docker inspect $servicetask`
+```json
+   {
+       "NetworkSettings": {
+            "SandboxID": "231b9363e169d65d45a93a8707e32f8b5b2f4e13c9099163bbf1ff23f5a525e6",
+            "SandboxKey": "/var/run/docker/netns/231b9363e169",
+            "Ports": {
+                "80/tcp": null
+            },
+            "Networks": {
+                "ingress": {
+                    "IPAMConfig": {
+                        "IPv4Address": "10.0.0.4"
+                    },
+                    "Links": null,
+                    "Aliases": null,
+                    "DriverOpts": null,
+                    "GwPriority": 0,
+                    "NetworkID": "s7wv09h339pg33bwa1x7e94zf",
+                    "EndpointID": "a4a5f3a9b833bd8542b90aa00ee7982276432c1c79dac8f9d468cb55c7201b1f",
+                    "Gateway": "",
+                    "IPAddress": "10.0.0.4",
+                    "MacAddress": "02:42:0a:00:00:04",
+                    "IPPrefixLen": 24,
+                    "IPv6Gateway": "",
+                    "GlobalIPv6Address": "",
+                    "GlobalIPv6PrefixLen": 0,
+                    "DNSNames": [
+                        "foo.b575fhbepobkezwuoxhuu81de.myd389c5xnuj0efizrj4cui4k",
+                        "f2b1465118aa"
+                    ]
+                },
+                "someovl": {
+                    "IPAMConfig": {
+                        "IPv4Address": "10.0.1.3"
+                    },
+                    "Links": null,
+                    "Aliases": null,
+                    "DriverOpts": null,
+                    "GwPriority": 0,
+                    "NetworkID": "0a7kccl4djhyr6mqdo553viir",
+                    "EndpointID": "610eb196f8175ed104ef504ccff22e49cdeb77bfcd9fcdbed70bf14f709d7590",
+                    "Gateway": "",
+                    "IPAddress": "10.0.1.3",
+                    "MacAddress": "02:42:0a:00:01:03",
+                    "IPPrefixLen": 24,
+                    "IPv6Gateway": "",
+                    "GlobalIPv6Address": "",
+                    "GlobalIPv6PrefixLen": 0,
+                    "DNSNames": [
+                        "foo.b575fhbepobkezwuoxhuu81de.myd389c5xnuj0efizrj4cui4k",
+                        "f2b1465118aa"
+                    ]
+                }
+            }
+        }
+    }
+```
+
+## `docker network inspect -v ingress someovl`
+```json
+[
+    {
+        "Name": "ingress",
+        "Id": "s7wv09h339pg33bwa1x7e94zf",
+        "Created": "2026-06-17T15:26:52.277276764Z",
+        "Scope": "swarm",
+        "Driver": "overlay",
+        "EnableIPv4": true,
+        "EnableIPv6": false,
+        "IPAM": {
+            "Driver": "default",
+            "Options": null,
+            "Config": [
+                {
+                    "Subnet": "10.0.0.0/24",
+                    "Gateway": "10.0.0.1"
+                }
+            ]
+        },
+        "Internal": false,
+        "Attachable": false,
+        "Ingress": true,
+        "ConfigFrom": {
+            "Network": ""
+        },
+        "ConfigOnly": false,
+        "Options": {
+            "com.docker.network.driver.overlay.vxlanid_list": "4096"
+        },
+        "Labels": {},
+        "Peers": [
+            {
+                "Name": "dab0d2bf09bf",
+                "IP": "172.17.0.3"
+            }
+        ],
+        "Containers": {
+            "f2b1465118aabe32b1f0be61931890f018adb5b8b22805c689010db91d2017aa": {
+                "Name": "foo.b575fhbepobkezwuoxhuu81de.myd389c5xnuj0efizrj4cui4k",
+                "EndpointID": "a4a5f3a9b833bd8542b90aa00ee7982276432c1c79dac8f9d468cb55c7201b1f",
+                "MacAddress": "02:42:0a:00:00:04",
+                "IPv4Address": "10.0.0.4/24",
+                "IPv6Address": ""
+            },
+            "ingress-sbox": {
+                "Name": "ingress-endpoint",
+                "EndpointID": "012cfd9641daed1b8f5f7f03d88a204a1fc7166472ed698116594d1a025531fe",
+                "MacAddress": "02:42:0a:00:00:02",
+                "IPv4Address": "10.0.0.2/24",
+                "IPv6Address": ""
+            }
+        },
+        "Services": {
+            "foo": {
+                "VIP": "10.0.0.3",
+                "Ports": [
+                    "Target: 80, Publish: 3000",
+                    "Target: 53, Publish: 3001"
+                ],
+                "LocalLBIndex": 256,
+                "Tasks": [
+                    {
+                        "Name": "foo.b575fhbepobkezwuoxhuu81de.myd389c5xnuj0efizrj4cui4k",
+                        "EndpointID": "a4a5f3a9b833bd8542b90aa00ee7982276432c1c79dac8f9d468cb55c7201b1f",
+                        "EndpointIP": "10.0.0.4",
+                        "Info": {
+                            "Host IP": "172.17.0.3"
+                        }
+                    }
+                ]
+            }
+        },
+        "Status": {
+            "IPAM": {
+                "Subnets": {
+                    "10.0.0.0/24": {
+                        "IPsInUse": 6,
+                        "DynamicIPsAvailable": 250
+                    }
+                }
+            }
+        }
+    },
+    {
+        "Name": "someovl",
+        "Id": "0a7kccl4djhyr6mqdo553viir",
+        "Created": "2026-06-17T15:37:07.362104423Z",
+        "Scope": "swarm",
+        "Driver": "overlay",
+        "EnableIPv4": true,
+        "EnableIPv6": false,
+        "IPAM": {
+            "Driver": "default",
+            "Options": null,
+            "Config": [
+                {
+                    "Subnet": "10.0.1.0/24",
+                    "Gateway": "10.0.1.1"
+                }
+            ]
+        },
+        "Internal": false,
+        "Attachable": false,
+        "Ingress": false,
+        "ConfigFrom": {
+            "Network": ""
+        },
+        "ConfigOnly": false,
+        "Options": {
+            "com.docker.network.driver.overlay.vxlanid_list": "4097"
+        },
+        "Labels": {},
+        "Peers": [
+            {
+                "Name": "dab0d2bf09bf",
+                "IP": "172.17.0.3"
+            }
+        ],
+        "Containers": {
+            "f2b1465118aabe32b1f0be61931890f018adb5b8b22805c689010db91d2017aa": {
+                "Name": "foo.b575fhbepobkezwuoxhuu81de.myd389c5xnuj0efizrj4cui4k",
+                "EndpointID": "610eb196f8175ed104ef504ccff22e49cdeb77bfcd9fcdbed70bf14f709d7590",
+                "MacAddress": "02:42:0a:00:01:03",
+                "IPv4Address": "10.0.1.3/24",
+                "IPv6Address": ""
+            },
+            "lb-someovl": {
+                "Name": "someovl-endpoint",
+                "EndpointID": "a44739039ebe1f8169bb8727a9467cef96d3ead8ff381cacf8e9aeb4f279c10e",
+                "MacAddress": "02:42:0a:00:01:04",
+                "IPv4Address": "10.0.1.4/24",
+                "IPv6Address": ""
+            }
+        },
+        "Services": {
+            "foo": {
+                "VIP": "10.0.1.2",
+                "Ports": [],
+                "LocalLBIndex": 257,
+                "Tasks": [
+                    {
+                        "Name": "foo.b575fhbepobkezwuoxhuu81de.myd389c5xnuj0efizrj4cui4k",
+                        "EndpointID": "610eb196f8175ed104ef504ccff22e49cdeb77bfcd9fcdbed70bf14f709d7590",
+                        "EndpointIP": "10.0.1.3",
+                        "Info": {
+                            "Host IP": "172.17.0.3"
+                        }
+                    }
+                ]
+            }
+        },
+        "Status": {
+            "IPAM": {
+                "Subnets": {
+                    "10.0.1.0/24": {
+                        "IPsInUse": 6,
+                        "DynamicIPsAvailable": 250
+                    }
+                }
+            }
+        }
+    }
+]
+```
+
+## Host netns
+
+```console
+$ iptables-save
+# Generated by iptables-save v1.8.9 (nf_tables) on Wed Jun 17 15:37:19 2026
+*raw
+:PREROUTING ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+## Drop incoming packets addressed to a container's gwbridge link
+## except for packets that have been masqueraded and xmit'ed over the bridge link
+## which then presumably re-enters on the input side of netfilter, or something.
+-A PREROUTING -d 172.19.0.2/32 ! -i docker_gwbridge -j DROP
+-A PREROUTING -d 172.19.0.3/32 ! -i docker_gwbridge -j DROP
+COMMIT
+# Completed on Wed Jun 17 15:37:19 2026
+# Generated by iptables-save v1.8.9 (nf_tables) on Wed Jun 17 15:37:19 2026
+*filter
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:DOCKER - [0:0]
+:DOCKER-BRIDGE - [0:0]
+:DOCKER-CT - [0:0]
+:DOCKER-FORWARD - [0:0]
+:DOCKER-INGRESS - [0:0]
+:DOCKER-INTERNAL - [0:0]
+:DOCKER-USER - [0:0]
+-A FORWARD -j DOCKER-USER
+-A FORWARD -j DOCKER-FORWARD
+-A DOCKER ! -i docker0 -o docker0 -j DROP
+-A DOCKER ! -i docker_gwbridge -o docker_gwbridge -j DROP
+-A DOCKER-BRIDGE -o docker0 -j DOCKER
+-A DOCKER-BRIDGE -o docker_gwbridge -j DOCKER
+-A DOCKER-CT -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-CT -o docker_gwbridge -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-INGRESS
+-A DOCKER-FORWARD -j DOCKER-CT
+-A DOCKER-FORWARD -j DOCKER-INTERNAL
+-A DOCKER-FORWARD -j DOCKER-BRIDGE
+-A DOCKER-FORWARD -i docker0 -j ACCEPT
+-A DOCKER-FORWARD -i docker_gwbridge -o docker_gwbridge -j DROP
+-A DOCKER-FORWARD -i docker_gwbridge ! -o docker_gwbridge -j ACCEPT
+-A DOCKER-INGRESS -p udp -m udp --dport 3001 -j ACCEPT
+-A DOCKER-INGRESS -p udp -m udp --sport 3001 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-INGRESS -p tcp -m tcp --dport 3000 -j ACCEPT
+-A DOCKER-INGRESS -p tcp -m tcp --sport 3000 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-INGRESS -j RETURN
+COMMIT
+## Flattened ruleset:
+### DOCKER-INGRESS (don't apply other rules to routed packets addressed to a published port)
+## -A FORWARD -p udp -m udp --dport 3001 -j ACCEPT
+## -A FORWARD -p udp -m udp --sport 3001 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+## -A FORWARD -p tcp -m tcp --dport 3000 -j ACCEPT
+## -A FORWARD -p tcp -m tcp --sport 3000 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+### DOCKER-CT (don't interfere with packets belonging to an existing connection)
+## -A FORWARD -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+## -A FORWARD -o docker_gwbridge -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+### DOCKER-BRIDGE + DOCKER
+### drop packets routed to a bridge that have not been hairpinned from the same bridge
+## -A FORWARD ! -i docker0 -o docker0 -j DROP
+## -A FORWARD ! -i docker_gwbridge -o docker_gwbridge -j DROP
+### accept all packets received on docker0 irrespective of the routing destination
+## -A FORWARD -i docker0 -j ACCEPT
+### drop packets hairpinned thru docker_gwbridge
+## -A FORWARD -i docker_gwbridge -o docker_gwbridge -j DROP
+### accept packets recieved on docker_gwbridge
+## -A FORWARD -i docker_gwbridge ! -o docker_gwbridge -j ACCEPT
+##
+# Completed on Wed Jun 17 15:37:19 2026
+# Generated by iptables-save v1.8.9 (nf_tables) on Wed Jun 17 15:37:19 2026
+*nat
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+:DOCKER - [0:0]
+:DOCKER-INGRESS - [0:0]
+-A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER-INGRESS
+-A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
+-A OUTPUT -m addrtype --dst-type LOCAL -j DOCKER-INGRESS
+-A OUTPUT -m addrtype --dst-type LOCAL -j DOCKER
+### Masquerade locally-xmitted connections addressed to an address behind the gwbridge (why?)
+-A POSTROUTING -o docker_gwbridge -m addrtype --src-type LOCAL -j MASQUERADE
+### Egress: masquerade connections from a container behind the gwbridge
+-A POSTROUTING -s 172.19.0.0/16 ! -o docker_gwbridge -j MASQUERADE
+-A POSTROUTING -o docker0 -m addrtype --src-type LOCAL -j MASQUERADE
+-A POSTROUTING -s 172.18.0.0/16 ! -o docker0 -j MASQUERADE
+### DNAT connections to published ports onto ingress_sbox
+-A DOCKER-INGRESS -p udp -m udp --dport 3001 -j DNAT --to-destination 172.19.0.2:3001
+-A DOCKER-INGRESS -p tcp -m tcp --dport 3000 -j DNAT --to-destination 172.19.0.2:3000
+-A DOCKER-INGRESS -j RETURN
+COMMIT
+# Completed on Wed Jun 17 15:37:19 2026
+```
+
+```console
+$ ip -d a
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00 promiscuity 0  allmulti 0 minmtu 0 maxmtu 0 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host
+       valid_lft forever preferred_lft forever
+[...snip...]
+11: eth0@if82: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 65535 qdisc noqueue state UP group default
+    link/ether ee:2f:8d:9a:52:9b brd ff:ff:ff:ff:ff:ff link-netnsid 0 promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535
+    veth numtxqueues 14 numrxqueues 14 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+    inet 172.17.0.3/16 brd 172.17.255.255 scope global eth0
+       valid_lft forever preferred_lft forever
+12: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default
+    link/ether 5a:df:14:7e:11:c6 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.5a:df:14:7e:11:c6 designated_root 8000.5a:df:14:7e:11:c6 root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  259.14 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536
+    inet 172.18.0.1/16 brd 172.18.255.255 scope global docker0
+       valid_lft forever preferred_lft forever
+16: docker_gwbridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
+    link/ether 32:c7:79:f2:17:e1 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.32:c7:79:f2:17:e1 designated_root 8000.32:c7:79:f2:17:e1 root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  226.37 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+    inet 172.19.0.1/16 brd 172.19.255.255 scope global docker_gwbridge
+       valid_lft forever preferred_lft forever
+    inet6 fe80::30c7:79ff:fef2:17e1/64 scope link
+       valid_lft forever preferred_lft forever
+# ingress-sbox
+18: vethee00f7d@if17: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master docker_gwbridge state UP group default
+    link/ether f6:77:3d:db:00:5a brd ff:ff:ff:ff:ff:ff link-netnsid 2 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535
+    veth
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8001 port_no 0x1 designated_port 32769 designated_cost 0 designated_bridge 8000.32:c7:79:f2:17:e1 designated_root 8000.32:c7:79:f2:17:e1 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off numtxqueues 14 numrxqueues 14 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+    inet6 fe80::f477:3dff:fedb:5a/64 scope link
+       valid_lft forever preferred_lft forever
+# task
+25: veth4928a46@if24: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master docker_gwbridge state UP group default
+    link/ether 4a:93:e6:96:e0:1b brd ff:ff:ff:ff:ff:ff link-netnsid 5 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535
+    veth
+    bridge_slave state forwarding priority 32 cost 2 hairpin on guard off root_block off fastleave off learning on flood on port_id 0x8002 port_no 0x2 designated_port 32770 designated_cost 0 designated_bridge 8000.32:c7:79:f2:17:e1 designated_root 8000.32:c7:79:f2:17:e1 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off numtxqueues 14 numrxqueues 14 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+    inet6 fe80::4893:e6ff:fe96:e01b/64 scope link
+       valid_lft forever preferred_lft forever
+```
+
+```
+$ ip route
+default via 172.17.0.1 dev eth0
+172.17.0.0/16 dev eth0 proto kernel scope link src 172.17.0.3
+172.18.0.0/16 dev docker0 proto kernel scope link src 172.18.0.1 linkdown
+172.19.0.0/16 dev docker_gwbridge proto kernel scope link src 172.19.0.1
+```
+
+```console
+$ ipvsadm -S
+```
+
+## `nsenter --net=1-0a7kccl4dj`
+"Ingress NS" for someovl network (VNI 4097).
+
+```console
+$ iptables-save
+```
+
+```console
+$ ip -d a
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00 promiscuity 0  allmulti 0 minmtu 0 maxmtu 0 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host
+       valid_lft forever preferred_lft forever
+[...snip...]
+11: br0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default
+    link/ether 0e:00:65:fb:13:5d brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.e:0:65:fb:13:5d designated_root 8000.e:0:65:fb:13:5d root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  183.75 vlan_default_pvid 0 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536
+    inet 10.0.1.1/24 brd 10.0.1.255 scope global br0
+       valid_lft forever preferred_lft forever
+19: vxlan0@if19: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master br0 state UNKNOWN group default
+    link/ether 7a:e1:90:98:b8:63 brd ff:ff:ff:ff:ff:ff link-netnsid 0 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535
+    vxlan id 4097 srcport 0 0 dstport 4789 proxy l2miss l3miss ttl auto ageing 300 udpcsum noudp6zerocsumtx noudp6zerocsumrx
+    bridge_slave state forwarding priority 32 cost 100 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8001 port_no 0x1 designated_port 32769 designated_cost 0 designated_bridge 8000.e:0:65:fb:13:5d designated_root 8000.e:0:65:fb:13:5d hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536
+# lb_0a7kccl4d
+21: veth0@if20: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master br0 state UP group default
+    link/ether 62:59:a0:55:4f:96 brd ff:ff:ff:ff:ff:ff link-netnsid 1 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535
+    veth
+    bridge_slave state forwarding priority 32 cost 2 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8002 port_no 0x2 designated_port 32770 designated_cost 0 designated_bridge 8000.e:0:65:fb:13:5d designated_root 8000.e:0:65:fb:13:5d hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off numtxqueues 14 numrxqueues 14 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+# task
+27: veth1@if26: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master br0 state UP group default
+    link/ether 0e:00:65:fb:13:5d brd ff:ff:ff:ff:ff:ff link-netnsid 2 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535
+    veth
+    bridge_slave state forwarding priority 32 cost 2 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8003 port_no 0x3 designated_port 32771 designated_cost 0 designated_bridge 8000.e:0:65:fb:13:5d designated_root 8000.e:0:65:fb:13:5d hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off numtxqueues 14 numrxqueues 14 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+```
+
+```console
+$ ip route
+10.0.1.0/24 dev br0 proto kernel scope link src 10.0.1.1
+```
+
+```console
+$ ipvsadm -S
+```
+
+## `nsenter --net=1-s7wv09h339`
+"Ingress NS" for the network named "ingress"
+
+```console
+$ iptables-save
+```
+
+```console
+$ ip -d a
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00 promiscuity 0  allmulti 0 minmtu 0 maxmtu 0 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host
+       valid_lft forever preferred_lft forever
+[...snip...]
+11: br0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default
+    link/ether 4e:a3:cd:3d:49:66 brd ff:ff:ff:ff:ff:ff promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535
+    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 0 vlan_protocol 802.1Q bridge_id 8000.4e:a3:cd:3d:49:66 designated_root 8000.4e:a3:cd:3d:49:66 root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  183.75 vlan_default_pvid 0 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 no_linklocal_learn 0 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536
+    inet 10.0.0.1/24 brd 10.0.0.255 scope global br0
+       valid_lft forever preferred_lft forever
+13: vxlan0@if13: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master br0 state UNKNOWN group default
+    link/ether 8a:63:bb:13:3b:df brd ff:ff:ff:ff:ff:ff link-netnsid 0 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535
+    vxlan id 4096 srcport 0 0 dstport 4789 proxy l2miss l3miss ttl auto ageing 300 udpcsum noudp6zerocsumtx noudp6zerocsumrx
+    bridge_slave state forwarding priority 32 cost 100 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8001 port_no 0x1 designated_port 32769 designated_cost 0 designated_bridge 8000.4e:a3:cd:3d:49:66 designated_root 8000.4e:a3:cd:3d:49:66 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536
+# ingress_sbox
+15: veth0@if14: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master br0 state UP group default
+    link/ether 4e:a3:cd:3d:49:66 brd ff:ff:ff:ff:ff:ff link-netnsid 1 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535
+    veth
+    bridge_slave state forwarding priority 32 cost 2 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8002 port_no 0x2 designated_port 32770 designated_cost 0 designated_bridge 8000.4e:a3:cd:3d:49:66 designated_root 8000.4e:a3:cd:3d:49:66 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off numtxqueues 14 numrxqueues 14 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+# task
+23: veth1@if22: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue master br0 state UP group default
+    link/ether 9e:e9:6f:2d:9b:c4 brd ff:ff:ff:ff:ff:ff link-netnsid 2 promiscuity 1  allmulti 1 minmtu 68 maxmtu 65535
+    veth
+    bridge_slave state forwarding priority 32 cost 2 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8003 port_no 0x3 designated_port 32771 designated_cost 0 designated_bridge 8000.4e:a3:cd:3d:49:66 designated_root 8000.4e:a3:cd:3d:49:66 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on bcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off locked off numtxqueues 14 numrxqueues 14 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+```
+
+```console
+$ ip route
+10.0.0.0/24 dev br0 proto kernel scope link src 10.0.0.1
+```
+
+```console
+$ ipvsadm -S
+```
+
+## `nsenter --net=231b9363e169`
+```console
+$ iptables-save
+# Generated by iptables-save v1.8.9 (nf_tables) on Wed Jun 17 15:55:30 2026
+*filter
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+### Accept traffic addressed to the container's ingress link iff it's addressed to a published port
+-A INPUT -d 10.0.0.4/32 -p udp -m udp --dport 53 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+-A INPUT -d 10.0.0.4/32 -p tcp -m tcp --dport 80 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+-A INPUT -d 10.0.0.4/32 -p sctp -j DROP
+-A INPUT -d 10.0.0.4/32 -p udp -j DROP
+-A INPUT -d 10.0.0.4/32 -p tcp -j DROP
+### Block outgoing connections from the container to the ingress link but allow replies
+-A OUTPUT -s 10.0.0.4/32 -p udp -m udp --sport 53 -m conntrack --ctstate ESTABLISHED -j ACCEPT
+-A OUTPUT -s 10.0.0.4/32 -p tcp -m tcp --sport 80 -m conntrack --ctstate ESTABLISHED -j ACCEPT
+-A OUTPUT -s 10.0.0.4/32 -p sctp -j DROP
+-A OUTPUT -s 10.0.0.4/32 -p udp -j DROP
+-A OUTPUT -s 10.0.0.4/32 -p tcp -j DROP
+COMMIT
+# Completed on Wed Jun 17 15:55:30 2026
+# Generated by iptables-save v1.8.9 (nf_tables) on Wed Jun 17 15:55:30 2026
+*nat
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+:DOCKER_OUTPUT - [0:0]
+:DOCKER_POSTROUTING - [0:0]
+### DNAT published port -> target port on ingress traffic.
+### This implies that packets traversing the ingress VXLAN will have dport==publishPort.
+### We can't change what goes over the wire because of mixed-version Swarms and Windows nodes.
+### But maybe we can make it transparent to the container by moving the mangling into the ingress NS.
+-A PREROUTING -d 10.0.0.4/32 -p tcp -m tcp --dport 3000 -j REDIRECT --to-ports 80
+-A PREROUTING -d 10.0.0.4/32 -p udp -m udp --dport 3001 -j REDIRECT --to-ports 53
+### Docker DNS resolver stuff
+-A OUTPUT -d 127.0.0.11/32 -j DOCKER_OUTPUT
+-A POSTROUTING -d 127.0.0.11/32 -j DOCKER_POSTROUTING
+-A DOCKER_OUTPUT -d 127.0.0.11/32 -p tcp -m tcp --dport 53 -j DNAT --to-destination 127.0.0.11:43453
+-A DOCKER_OUTPUT -d 127.0.0.11/32 -p udp -m udp --dport 53 -j DNAT --to-destination 127.0.0.11:58069
+-A DOCKER_POSTROUTING -s 127.0.0.11/32 -p tcp -m tcp --sport 43453 -j SNAT --to-source :53
+-A DOCKER_POSTROUTING -s 127.0.0.11/32 -p udp -m udp --sport 58069 -j SNAT --to-source :53
+COMMIT
+# Completed on Wed Jun 17 15:55:30 2026
+```
+
+```console
+$ ip -d a
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00 promiscuity 0  allmulti 0 minmtu 0 maxmtu 0 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host
+       valid_lft forever preferred_lft forever
+[...snip...]
+# 1-s7wv09h339
+22: eth0@if23: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default
+    link/ether 02:42:0a:00:00:04 brd ff:ff:ff:ff:ff:ff link-netnsid 0 promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535
+    veth numtxqueues 14 numrxqueues 14 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+    inet 10.0.0.4/24 brd 10.0.0.255 scope global eth0
+       valid_lft forever preferred_lft forever
+# 1-s7wv09h339 (somehow two separate netns ids inside this netns reference the same netns)
+24: eth1@if25: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
+    link/ether 02:63:10:cc:a6:cd brd ff:ff:ff:ff:ff:ff link-netnsid 1 promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535
+    veth numtxqueues 14 numrxqueues 14 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+    inet 172.19.0.3/16 brd 172.19.255.255 scope global eth1
+       valid_lft forever preferred_lft forever
+# 1-0a7kccl4dj
+26: eth2@if27: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default
+    link/ether 02:42:0a:00:01:03 brd ff:ff:ff:ff:ff:ff link-netnsid 2 promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535
+    veth numtxqueues 14 numrxqueues 14 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+    inet 10.0.1.3/24 brd 10.0.1.255 scope global eth2
+       valid_lft forever preferred_lft forever
+```
+
+```console
+$ ip route
+default via 172.19.0.1 dev eth1
+10.0.0.0/24 dev eth0 proto kernel scope link src 10.0.0.4
+10.0.1.0/24 dev eth2 proto kernel scope link src 10.0.1.3
+172.19.0.0/16 dev eth1 proto kernel scope link src 172.19.0.3
+```
+
+```console
+$ ipvsadm -S
+```
+
+## `nsenter --net=ingress_sbox`
+```console
+$ iptables-save
+# Generated by iptables-save v1.8.9 (nf_tables) on Wed Jun 17 15:55:30 2026
+*mangle
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+-A PREROUTING -p tcp -m tcp --dport 3000 -j MARK --set-xmark 0x100/0xffffffff
+-A PREROUTING -p udp -m udp --dport 3001 -j MARK --set-xmark 0x100/0xffffffff
+### Mark for IPVS incoming packets addressed to the VIP of the service...
+### but nothing DNATs packets to the service VIP on the ingress sandbox AFAICT.
+### Inert rule on the ingress sandbox?
+-A INPUT -d 10.0.0.3/32 -j MARK --set-xmark 0x100/0xffffffff
+COMMIT
+# Completed on Wed Jun 17 15:55:30 2026
+# Generated by iptables-save v1.8.9 (nf_tables) on Wed Jun 17 15:55:30 2026
+*nat
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+:DOCKER_OUTPUT - [0:0]
+:DOCKER_POSTROUTING - [0:0]
+-A OUTPUT -d 127.0.0.11/32 -j DOCKER_OUTPUT
+-A POSTROUTING -d 127.0.0.11/32 -j DOCKER_POSTROUTING
+-A POSTROUTING -d 10.0.0.0/24 -m ipvs --ipvs -j SNAT --to-source 10.0.0.2
+-A DOCKER_OUTPUT -d 127.0.0.11/32 -p tcp -m tcp --dport 53 -j DNAT --to-destination 127.0.0.11:36501
+-A DOCKER_OUTPUT -d 127.0.0.11/32 -p udp -m udp --dport 53 -j DNAT --to-destination 127.0.0.11:35470
+-A DOCKER_POSTROUTING -s 127.0.0.11/32 -p tcp -m tcp --sport 36501 -j SNAT --to-source :53
+-A DOCKER_POSTROUTING -s 127.0.0.11/32 -p udp -m udp --sport 35470 -j SNAT --to-source :53
+### Flattened
+### DNAT DNS requests from container over to engine DNS resolver.
+### Why is this on the ingress_sbox? Inert?
+## -A OUTPUT -d 127.0.0.11/32 -p tcp -m tcp --dport 53 -j DNAT --to-destination 127.0.0.11:36501
+## -A OUTPUT -d 127.0.0.11/32 -p udp -m udp --dport 53 -j DNAT --to-destination 127.0.0.11:35470
+## -A POSTROUTING -s 127.0.0.11/32 -p tcp -m tcp --sport 36501 -j SNAT --to-source :53
+## -A POSTROUTING -s 127.0.0.11/32 -p udp -m udp --sport 35470 -j SNAT --to-source :53
+### SNAT connections that have been routed to a backend via IPVS (IPVS only does DNAT apparently)
+## -A POSTROUTING -d 10.0.0.0/24 -m ipvs --ipvs -j SNAT --to-source 10.0.0.2
+COMMIT
+# Completed on Wed Jun 17 15:55:30 2026
+```
+
+```console
+$ ip -d a
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00 promiscuity 0  allmulti 0 minmtu 0 maxmtu 0 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host
+       valid_lft forever preferred_lft forever
+[...snip...]
+# 1-s7wv09h339
+14: eth0@if15: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default
+    link/ether 02:42:0a:00:00:02 brd ff:ff:ff:ff:ff:ff link-netnsid 0 promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535
+    veth numtxqueues 14 numrxqueues 14 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+    inet 10.0.0.2/24 brd 10.0.0.255 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet 10.0.0.3/32 scope global eth0
+       valid_lft forever preferred_lft forever
+# 1-s7wv09h339 (2nd netns id for same netns)
+17: eth1@if18: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
+    link/ether b6:e5:b0:8f:8a:c9 brd ff:ff:ff:ff:ff:ff link-netnsid 1 promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535
+    veth numtxqueues 14 numrxqueues 14 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+    inet 172.19.0.2/16 brd 172.19.255.255 scope global eth1
+       valid_lft forever preferred_lft forever
+```
+
+```console
+$ ip route
+default via 172.19.0.1 dev eth1
+10.0.0.0/24 dev eth0 proto kernel scope link src 10.0.0.2
+172.19.0.0/16 dev eth1 proto kernel scope link src 172.19.0.2
+```
+
+```console
+$ ipvsadm -S
+-A -f 256 -s rr
+-a -f 256 -r 10.0.0.4:0 -m -w 1
+```
+
+## `nsenter --net=lb_0a7kccl4d`
+```console
+$ iptables-save
+# Generated by iptables-save v1.8.9 (nf_tables) on Wed Jun 17 15:55:30 2026
+*mangle
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+### Mark packets addressed to the service VIP (as resolved from container DNS) for IPVS processing
+-A INPUT -d 10.0.1.2/32 -j MARK --set-xmark 0x101/0xffffffff
+COMMIT
+# Completed on Wed Jun 17 15:55:30 2026
+# Generated by iptables-save v1.8.9 (nf_tables) on Wed Jun 17 15:55:30 2026
+*nat
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+:DOCKER_OUTPUT - [0:0]
+:DOCKER_POSTROUTING - [0:0]
+-A OUTPUT -d 127.0.0.11/32 -j DOCKER_OUTPUT
+-A POSTROUTING -d 127.0.0.11/32 -j DOCKER_POSTROUTING
+-A POSTROUTING -d 10.0.1.0/24 -m ipvs --ipvs -j SNAT --to-source 10.0.1.4
+-A DOCKER_OUTPUT -d 127.0.0.11/32 -p tcp -m tcp --dport 53 -j DNAT --to-destination 127.0.0.11:40003
+-A DOCKER_OUTPUT -d 127.0.0.11/32 -p udp -m udp --dport 53 -j DNAT --to-destination 127.0.0.11:49716
+-A DOCKER_POSTROUTING -s 127.0.0.11/32 -p tcp -m tcp --sport 40003 -j SNAT --to-source :53
+-A DOCKER_POSTROUTING -s 127.0.0.11/32 -p udp -m udp --sport 49716 -j SNAT --to-source :53
+COMMIT
+# Completed on Wed Jun 17 15:55:30 2026
+```
+
+(container) 10.0.1.3 -> 10.0.1.2 (svc VIP)
+routed into lb_0a... via 1-0a...
+IPVS mangling: 10.0.1.3 -> 10.0.1.3
+SNAT: 10.0.1.4 -> 10.0.1.3
+forwarded back into container via 1-0a...
+
+Container reply: 10.0.1.3 -> 10.0.1.4
+back into lb_0a...
+(no IPVS marking, mangling)
+reverse SNAT: 10.0.1.3 -> 10.0.1.3
+reverse DNAT: 10.0.1.2 -> 10.0.1.3
+back to container
+
+So the multi-ns shenanigans are legit? Seems like it's necessary for hairpin lb
+to work with IPVS.
+Is it still necessary with an nftables implementation, though? With nftables
+rules doing all the mangling and nftables' facilities to associate base chains
+with any netfilter hook at any priority it might not be necessary to use a
+separate namespace for lb.
+
+```console
+$ ip -d a
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00 promiscuity 0  allmulti 0 minmtu 0 maxmtu 0 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host
+       valid_lft forever preferred_lft forever
+[...snip...]
+# 1-0a7kccl4dj
+20: eth0@if21: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default
+    link/ether 02:42:0a:00:01:04 brd ff:ff:ff:ff:ff:ff link-netnsid 0 promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535
+    veth numtxqueues 14 numrxqueues 14 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536
+    inet 10.0.1.4/24 brd 10.0.1.255 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet 10.0.1.2/32 scope global eth0
+       valid_lft forever preferred_lft forever
+```
+
+```console
+$ ip route
+10.0.1.0/24 dev eth0 proto kernel scope link src 10.0.1.4
+```
+
+```console
+$ ipvsadm -S
+-A -f 257 -s rr
+-a -f 257 -r 10.0.1.3:0 -m -w 1
+```
+
+## Summary
+
+```mermaid
+graph BT
+    subgraph root
+        vethif18(vethe007fd) --> docker_gwbridge[/"gwbridge\n172.19.0.1/16"\]
+        vethif25(veth4928a46) --> docker_gwbridge
+    end
+    subgraph 1-s7wv09h339
+        1-s7-vxlan0{{"vxlan0\nVNI 4096"}} --> 1-s7-br0[/"br0\n10.0.0.1/24"\]
+        vethif15(veth0) --> 1-s7-br0
+        vethif23(veth1) --> 1-s7-br0
+    end
+    subgraph 1-0a7kccl4dj
+        1-0a-vxlan0{{"vxlan0\nVNI 4097"}} --> 1-0a-br0[/"br0\n10.0.1.1/24"\]
+        vethif21(veth0) --> 1-0a-br0
+        vethif27(veth1) --> 1-0a-br0
+    end
+    subgraph 231b9363e169
+        vethif22("eth0\n10.0.0.4/24") -.-> vethif23
+        vethif24("eth1\n172.19.0.3/16") -.-> vethif25
+        vethif26("eth2\n10.0.1.3/24") -.-> vethif27
+    end
+    subgraph ingress_sbox
+        vethif14("eth0\n10.0.0.2/24\n10.0.0.3/32") -.-> vethif15
+        vethif16("eth1\n172.19.0.2/16") -.-> vethif18
+    end
+    subgraph lb_0a7kccl4d
+        vethif20("eth0\n10.0.1.4/24\n10.0.1.2/32") -.-> vethif21
+    end
+```
+
+### VXLAN traffic over the wire
+
+#### Ingress VNI
+
+- saddr: bastion host ingress_sbox address of the link that's bridged to the VXLAN
+- daddr: backend host ingress_sbox address of the link that's bridged to the VXLAN
+- port: publishPort
+
+#### User-network VNI
+
+Unicast traffic between containers is routed and forwarded without any special sauce.
+
+Load balanced traffic to VIP (NAT):
+- saddr: Endpoint IP of the load balancer for the overlay on the client container's node
+- daddr: Endpoint IP of the chosen backend task instance
+- port: unmangled
+
+Load balanced traffic to VIP (DSR):
+- saddr: Endpoint IP of the client container on the overlay network
+- daddr: VIP
+- port: unmangled
+- dmac: MAC of the endpoint for the chosen backend task instance

--- a/daemon/libnetwork/docs/nftlb-prototype/lib/backend-serve-tcp.sh
+++ b/daemon/libnetwork/docs/nftlb-prototype/lib/backend-serve-tcp.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TEXT=${TEXT:?}
+while true; do
+	while IFS= read -r line; do
+		[[ -z "${line//$'\r'/}" ]] && break
+	done || break
+	printf 'HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nContent-Length: %d\r\n\r\n%s' \
+		"${#TEXT}" "$TEXT"
+done

--- a/daemon/libnetwork/docs/nftlb-prototype/lib/backend-serve.sh
+++ b/daemon/libnetwork/docs/nftlb-prototype/lib/backend-serve.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# TCP (HTTP keep-alive) + UDP echo for prototype backends.
+set -euo pipefail
+
+: "${TEXT:?}"
+: "${TCP_PORT:?}"
+: "${UDP_PORT:?}"
+
+export TEXT
+socat TCP-LISTEN:"${TCP_PORT}",reuseaddr,fork EXEC:"/bin/bash /backend-serve-tcp.sh" &
+# UDP server that sends replies from the IP:PORT which the client addressed the request to.
+socat -u UDP-RECVFROM:"${UDP_PORT}",ip-pktinfo,reuseaddr,reuseport,fork SYSTEM:'"socat -u TEXT:\"${TEXT}\n\" UDP-DATAGRAM:${SOCAT_PEERADDR}:${SOCAT_PEERPORT},reuseaddr,reuseport,bind=${SOCAT_IP_DSTADDR}:${UDP_PORT}"' &
+wait

--- a/daemon/libnetwork/docs/nftlb-prototype/lib/bridge-peer-test.sh
+++ b/daemon/libnetwork/docs/nftlb-prototype/lib/bridge-peer-test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Verify host ingress from a peer on another container (bridge / same-L2).
+
+set -euo pipefail
+
+source "${BASH_SOURCE%/*}/common.sh"
+
+readonly PEER_NETNS="nftlb-peer"
+readonly PEER_IF="ipv1"
+readonly PEER_IP="172.17.0.3"
+
+cleanup_peer() {
+	ip netns del "$PEER_NETNS" 2>/dev/null || true
+	ip link del "$PEER_IF" 2>/dev/null || true
+}
+
+setup_ipvlan_peer() {
+	local ingress_ip=$1
+	[[ $ingress_ip == 172.17.* ]] || return 1
+	cleanup_peer
+	ip netns add "$PEER_NETNS"
+	ip link add "$PEER_IF" link eth0 type ipvlan mode l2
+	ip link set "$PEER_IF" netns "$PEER_NETNS"
+	nsenter --net="/var/run/netns/${PEER_NETNS}" ip addr add "${PEER_IP}/16" dev "$PEER_IF"
+	nsenter --net="/var/run/netns/${PEER_NETNS}" ip link set "$PEER_IF" up
+	nsenter --net="/var/run/netns/${PEER_NETNS}" ip link set lo up
+}
+
+peer_curl() {
+	local runner=$1
+	local url=$2
+	case "$runner" in
+	docker-bridge)
+		docker run --rm --network bridge "$CLIENT_IMAGE" curl -s --max-time 3 "$url"
+		;;
+	ipvlan)
+		nsenter --net="/var/run/netns/${PEER_NETNS}" curl -s --max-time 3 "$url"
+		;;
+	*)
+		die "unknown peer runner: $runner"
+		;;
+	esac
+}
+
+peer_udp_probe() {
+	local runner=$1
+	local port=$2
+	case "$runner" in
+	docker-bridge)
+		echo -n probe | docker run --rm -i --network bridge "$CLIENT_IMAGE" \
+			nc -u -w1 "${INGRESS_IP}" "$port" 2>/dev/null || true
+		;;
+	ipvlan)
+		echo -n probe | nsenter --net="/var/run/netns/${PEER_NETNS}" \
+			nc -u -w1 "${INGRESS_IP}" "$port" 2>/dev/null || true
+		;;
+	*)
+		die "unknown peer runner: $runner"
+		;;
+	esac
+}
+
+check_service() {
+	local runner=$1
+	local port=$2
+	local label=$3
+	local url="http://${INGRESS_IP}:${port}"
+	local out
+	out=$(peer_curl "$runner" "$url" || true)
+	if [[ -n $out ]]; then
+		log "PASS ${label} (${runner}): ${out}"
+		return 0
+	fi
+	log "FAIL ${label} (${runner}): no response from ${url}"
+	return 1
+}
+
+check_udp_service() {
+	local runner=$1
+	local port=$2
+	local label=$3
+	local out
+	out=$(peer_udp_probe "$runner" "$port")
+	if [[ -n $out ]]; then
+		log "PASS ${label} (${runner}): ${out}"
+		return 0
+	fi
+	log "FAIL ${label} (${runner}): no UDP response on port ${port}"
+	return 1
+}
+
+# Published-port DSR ingress is SNAT'd onto gwbr0 (backends see gw IP, not the peer).
+check_ingress_dsr_snat() {
+	local runner=$1
+	local peer_ip=$2
+	local url="http://${INGRESS_IP}:${DSR_PUBLISH_PORT}"
+	local gw="${GWBR_HOST_IP}"
+
+	peer_curl "$runner" "$url" >/dev/null &
+	local pid=$!
+	sleep 0.15
+	local snat=0
+	if grep -E "src=${peer_ip//./\\.} .*dport=${DSR_PUBLISH_PORT} .*dst=${gw//./\\.}" \
+		/proc/net/nf_conntrack 2>/dev/null | grep -q .; then
+		snat=1
+	fi
+	wait "$pid" 2>/dev/null || true
+	if [[ $snat -eq 1 ]]; then
+		log "PASS ingress DSR SNAT (${runner}): host masquerades ${peer_ip} onto gwbr0 (${gw})"
+		return 0
+	fi
+	log "FAIL ingress DSR SNAT (${runner}): expected gw ${gw} in conntrack for ${peer_ip}"
+	return 1
+}
+
+# Overlay VIP DSR: no IP SNAT; client IP preserved (MAC rewrite + port redirect only).
+check_overlay_dsr_client_ip() {
+	local url="http://${DSR_VIP}:${DSR_TARGET_PORT}"
+	local client="${CLIENT_IP}"
+	local ok=0
+	local b
+
+	docker exec "$CONTAINER_CLIENT" curl -s --max-time 3 "$url" >/dev/null &
+	local pid=$!
+	sleep 0.15
+	for b in "${DSR_BACKENDS[@]}"; do
+		if nsenter --net="$(container_netns "$b")" \
+			grep -E "src=${client//./\\.} dst=${DSR_VIP//./\\.} .*dport=${DSR_TARGET_PORT} " \
+			/proc/net/nf_conntrack 2>/dev/null | grep -q .; then
+			ok=1
+			break
+		fi
+	done
+	wait "$pid" 2>/dev/null || true
+	if [[ $ok -eq 1 ]]; then
+		log "PASS overlay DSR client IP: backend conntrack shows ${client} (no IP SNAT)"
+		return 0
+	fi
+	log "FAIL overlay DSR client IP: expected backend to see overlay client ${client}"
+	return 1
+}
+
+main() {
+	require_root
+	require_cmds docker ip nsenter curl nc
+
+	local ingress_ip
+	ingress_ip=$(host_ingress_ip)
+	[[ -n $ingress_ip ]] || die "could not detect ingress IP"
+
+	INGRESS_IP=$ingress_ip
+	log "ingress IP for peer clients: ${INGRESS_IP}"
+	log "NAT published port: ${NAT_PUBLISH_PORT}, DSR published port: ${DSR_PUBLISH_PORT}"
+
+	trap cleanup_peer EXIT
+
+	local pass=0 fail=0
+	local runner peer_ip
+	for runner in docker-bridge; do
+		peer_ip=$(docker run --rm --network bridge "$CLIENT_IMAGE" ip -4 -o addr show eth0 \
+			| awk '{print $4}' | cut -d/ -f1)
+		check_service "$runner" "$NAT_PUBLISH_PORT" "bridge peer NAT" && pass=$((pass + 1)) || fail=$((fail + 1))
+		check_service "$runner" "$DSR_PUBLISH_PORT" "bridge peer DSR" && pass=$((pass + 1)) || fail=$((fail + 1))
+		check_udp_service "$runner" "$NAT_UDP_PUBLISH_PORT" "bridge peer NAT UDP" && pass=$((pass + 1)) || fail=$((fail + 1))
+		check_udp_service "$runner" "$DSR_UDP_PUBLISH_PORT" "bridge peer DSR UDP" && pass=$((pass + 1)) || fail=$((fail + 1))
+		check_ingress_dsr_snat "$runner" "$peer_ip" && pass=$((pass + 1)) || fail=$((fail + 1))
+	done
+
+	if setup_ipvlan_peer "$ingress_ip"; then
+		log "same-L2 ipvlan peer on eth0 (${PEER_IP})"
+		check_service ipvlan "$NAT_PUBLISH_PORT" "ipvlan peer NAT" && pass=$((pass + 1)) || fail=$((fail + 1))
+		check_service ipvlan "$DSR_PUBLISH_PORT" "ipvlan peer DSR" && pass=$((pass + 1)) || fail=$((fail + 1))
+		check_udp_service ipvlan "$NAT_UDP_PUBLISH_PORT" "ipvlan peer NAT UDP" && pass=$((pass + 1)) || fail=$((fail + 1))
+		check_udp_service ipvlan "$DSR_UDP_PUBLISH_PORT" "ipvlan peer DSR UDP" && pass=$((pass + 1)) || fail=$((fail + 1))
+		check_ingress_dsr_snat ipvlan "$PEER_IP" && pass=$((pass + 1)) || fail=$((fail + 1))
+	else
+		log "skip ipvlan peer (ingress IP ${ingress_ip} is not on eth0 172.17.0.0/16)"
+	fi
+
+	check_overlay_dsr_client_ip && pass=$((pass + 1)) || fail=$((fail + 1))
+
+	log "bridge peer results: ${pass} passed, ${fail} failed"
+	[[ $fail -eq 0 ]]
+}
+
+main "$@"

--- a/daemon/libnetwork/docs/nftlb-prototype/lib/common.sh
+++ b/daemon/libnetwork/docs/nftlb-prototype/lib/common.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Shared helpers for the nftables load balancing prototype.
+
+[[ -n "${NFTLB_COMMON_LOADED:-}" ]] && return 0
+NFTLB_COMMON_LOADED=1
+
+set -euo pipefail
+
+PROTOTYPE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Network constants (mirror Swarm address plan)
+readonly GWBR_NAME="gwbr0"
+readonly GWBR_SUBNET="172.18.0.0/16"
+readonly GWBR_HOST_IP="172.18.0.1"
+readonly LB_GW_IP="172.18.0.2"
+readonly OVERLAY_NS="nftlb-overlay"
+readonly OVERLAY_BR="br-overlay"
+readonly OVERLAY_SUBNET="10.255.0.0/24"
+readonly OVERLAY_GW="10.255.0.1"
+readonly LB_OVERLAY_IP="10.255.0.2"
+
+readonly NAT_VIP="10.255.0.10"
+readonly NAT_PUBLISH_PORT="8080"
+readonly NAT_TARGET_PORT="80"
+readonly NAT_UDP_PUBLISH_PORT="8080"
+readonly NAT_UDP_TARGET_PORT="8123"
+
+readonly DSR_VIP="10.255.0.20"
+readonly DSR_PUBLISH_PORT="9000"
+readonly DSR_TARGET_PORT="8080"
+readonly DSR_UDP_PUBLISH_PORT="9000"
+readonly DSR_UDP_TARGET_PORT="8124"
+
+readonly LB_BUCKETS=1024
+
+readonly CONTAINER_LB="nftlb-lb-sbox"
+readonly CONTAINER_CLIENT="nftlb-client"
+readonly CLIENT_IMAGE="nicolaka/netshoot"
+readonly NAT_BACKENDS=(nftlb-nat-backend-1 nftlb-nat-backend-2 nftlb-nat-backend-3)
+readonly NAT_BACKEND_IPS=(10.255.0.11 10.255.0.12 10.255.0.13)
+readonly DSR_BACKENDS=(nftlb-dsr-backend-1 nftlb-dsr-backend-2)
+readonly DSR_BACKEND_IPS=(10.255.0.21 10.255.0.22)
+readonly CLIENT_IP="10.255.0.100"
+
+log() {
+	echo "[nftlb] $*"
+}
+
+warn() {
+	echo "[nftlb] WARNING: $*" >&2
+}
+
+# Primary IPv4 used for routed egress (best-effort host ingress address).
+host_ingress_ip() {
+	ip -4 route get 1.1.1.1 2>/dev/null | awk '{for (i = 1; i <= NF; i++) if ($i == "src") print $(i + 1)}'
+}
+
+# True when setup runs inside a container without host networking.
+in_isolated_container_netns() {
+	[[ -f /.dockerenv ]] || return 1
+	local ingress_ip
+	ingress_ip=$(host_ingress_ip)
+	[[ -n $ingress_ip ]] || return 1
+	# Docker default bridge / custom bridge container IPs are not LAN-routable.
+	[[ $ingress_ip == 172.1[6789].* ]]
+}
+
+die() {
+	echo "[nftlb] ERROR: $*" >&2
+	exit 1
+}
+
+require_root() {
+	[[ ${EUID:-$(id -u)} -eq 0 ]] || die "must run as root"
+}
+
+require_cmds() {
+	local cmd
+	for cmd in "$@"; do
+		command -v "$cmd" >/dev/null 2>&1 || die "required command not found: $cmd"
+	done
+}
+
+container_pid() {
+	local name=$1
+	local pid
+	pid=$(docker inspect -f '{{.State.Pid}}' "$name" 2>/dev/null) || die "container not found: $name"
+	[[ "$pid" != "0" ]] || die "container not running: $name"
+	echo "$pid"
+}
+
+container_netns() {
+	docker inspect --format='{{.NetworkSettings.SandboxKey}}' "$1"
+}
+
+nsenter_net() {
+	local netns=$1
+	shift
+	nsenter --net="$netns" "$@"
+}
+
+nsenter_container() {
+	local name=$1
+	shift
+	nsenter --net="$(container_netns "$name")" "$@"
+}
+
+nft_load() {
+	local netns=$1
+	shift
+	nsenter_net "$netns" nft -f "$@"
+}
+
+nft_run() {
+	local netns=$1
+	shift
+	nsenter_net "$netns" nft "$@"
+}
+
+nft_host() {
+	nft "$@"
+}
+
+registry_file() {
+	echo "${PROTOTYPE_DIR}/.nftlb-registry.json"
+}
+
+ensure_registry() {
+	local f
+	f=$(registry_file)
+	if [[ ! -f $f ]]; then
+		echo '{"services":{},"backends":{},"bucket_state":{}}' >"$f"
+	fi
+}

--- a/daemon/libnetwork/docs/nftlb-prototype/lib/nft/backend.nft
+++ b/daemon/libnetwork/docs/nftlb-prototype/lib/nft/backend.nft
@@ -1,0 +1,41 @@
+#!/usr/sbin/nft -f
+# Backend task sandbox: O(1) redirect + filter ruleset.
+# publishPort != targetPort: local port remap via redirect (TCP and UDP).
+
+# Required parameters: -D ingress_eip=<ingress network endpoint IP>
+
+table ip moby-task-ingress {
+	# Map of publishPort -> targetPort.
+	# Packets with a destination address of $ingress_eip and a destination
+	# port in this map are redirected to the target port.
+	map remap-ports {
+		type inet_proto . inet_service : inet_service
+	}
+
+	# Set of targetPort for published ports on the service.
+	# Packets with destination/source IP $ingress_eip are only allowed
+	# when the destination/source port, respectively, is in this set.
+	set allowed-ports {
+		type inet_proto . inet_service
+	}
+
+	chain prerouting {
+		type nat hook prerouting priority dstnat; policy accept;
+		ip daddr $ingress_eip meta l4proto { tcp, udp, sctp } \
+			counter redirect to meta l4proto . th dport map @remap-ports
+	}
+
+	chain input {
+		type filter hook input priority filter; policy accept;
+		ip daddr != $ingress_eip counter accept
+		meta l4proto . th dport @allowed-ports counter accept
+		counter reject
+	}
+
+	chain output {
+		type filter hook output priority filter; policy accept;
+		ip saddr != $ingress_eip counter accept
+		meta l4proto . th sport @allowed-ports counter accept
+		counter reject
+	}
+}

--- a/daemon/libnetwork/docs/nftlb-prototype/lib/nft/host.nft
+++ b/daemon/libnetwork/docs/nftlb-prototype/lib/nft/host.nft
@@ -1,0 +1,48 @@
+#!/usr/sbin/nft -f
+# Host ingress for published ports.
+#
+# Overlay VIP traffic never hits this table. Traffic addressed to published
+# ports is NAT'd into the ingress network for load balancing onto backend
+# services.
+
+table ip moby-ingress {
+	define gwbr_ifname = "gwbr0"
+	define gwbr_subnet = 172.18.0.0/16
+	define gwbr_dnat_ip = 172.18.0.2
+
+	# Ports in this set are forwarded to the service mesh.
+	set published-port {
+		type inet_proto . inet_service
+	}
+
+	chain prerouting {
+		type nat hook prerouting priority dstnat; policy accept;
+		fib daddr type local meta l4proto { tcp, udp } \
+			meta l4proto . th dport @published-port \
+			counter dnat to $gwbr_dnat_ip
+	}
+
+	chain output {
+		type nat hook output priority -100; policy accept;
+		fib daddr type local meta l4proto { tcp, udp } \
+			meta l4proto . th dport @published-port \
+			counter dnat to $gwbr_dnat_ip
+	}
+
+	chain postrouting {
+		type nat hook postrouting priority srcnat; policy accept;
+		# Published-port ingress (NAT + DSR): LOCAL OUTPUT and remote PREROUTING.
+		meta l4proto . th dport @published-port oifname $gwbr_ifname fib saddr type local counter masquerade
+		meta l4proto . th dport @published-port iifname != $gwbr_ifname oifname $gwbr_ifname \
+			ip daddr $gwbr_subnet counter masquerade
+	}
+
+	chain forward {
+		type filter hook forward priority filter; policy accept;
+		ct state established,related counter accept
+		meta l4proto . th dport @published-port counter accept
+		ip daddr $gwbr_subnet meta l4proto . th dport @published-port counter accept
+		ct state established,related meta l4proto . th sport @published-port counter accept
+		ct state established,related ip saddr $gwbr_subnet meta l4proto . th sport @published-port counter accept
+	}
+}

--- a/daemon/libnetwork/docs/nftlb-prototype/lib/nft/lb-sbox.nft
+++ b/daemon/libnetwork/docs/nftlb-prototype/lib/nft/lb-sbox.nft
@@ -1,0 +1,99 @@
+#!/usr/sbin/nft -f
+# LB sandbox: O(1) static NAT (ip) + DSR (netdev) rulesets.
+# Backend selection is weighted random.
+#
+# NAT flows are persisted using conntrack.
+# DSR flows are persisted using nftables maps that are updated in the
+# packet path (one-sided connection tracking).
+
+table ip moby-lb-nat {
+	# Map of VIP . weight interval : backend IP
+	map nat-service-vip {
+		typeof ip daddr . numgen random mod 1024 : ip daddr
+		counter
+		flags interval
+	}
+
+	# Map of publish port . weight interval : backend IP
+	map nat-publish-port {
+		typeof meta l4proto . th dport . numgen random mod 1024 : ip daddr
+		counter
+		flags interval
+	}
+
+	chain prerouting {
+		type nat hook prerouting priority dstnat; policy accept;
+
+		# NAT hooks only evaluate dnat on ct state new; established flows replay via conntrack.
+		# Inter-container communication inside the overlay: DNAT VIP to backends.
+		dnat to ip daddr . numgen random mod 1024 map @nat-service-vip
+		# Host ingress (eth1): DNAT published ports to backends.
+		dnat to meta l4proto . th dport . numgen random mod 1024 map @nat-publish-port
+	}
+
+	chain postrouting {
+		type nat hook postrouting priority srcnat; policy accept;
+		ct status dnat counter masquerade
+	}
+}
+
+table netdev moby-lb-dsr {
+	set virtual-service {
+		typeof ip daddr . meta l4proto . th dport
+	}
+
+	# Map of VIP . interval : real-server-mac
+	# The relative size of the intervals of each map entry determines the
+	# weight of the real-server in load balancing selection.
+	map real-server {
+		typeof ip daddr . numgen random mod 1024 : ether daddr
+		flags interval
+	}
+
+	# Sticky overlay DSR sessions (4-tuple → backend MAC).
+	# Split by L4 protocol as nftables 1.0.6 crashes when attempting to
+	# compile a ruleset that contains a map update on a 5-tuple key.
+	map dsr-persist-tcp {
+		typeof ip saddr . th sport . ip daddr . th dport : ether daddr
+		flags dynamic
+		size 65535
+		timeout 60s
+	}
+
+	map dsr-persist-udp {
+		typeof ip saddr . th sport . ip daddr . th dport : ether daddr
+		flags dynamic
+		size 65535
+		timeout 60s
+	}
+
+	chain ingress {
+		type filter hook ingress device eth0 priority 0; policy accept;
+
+		ip daddr . meta l4proto . th dport @virtual-service counter goto dsr-fwd
+	}
+
+	chain dsr-fwd {
+		ether saddr set ether daddr
+		# Established session: reuse MAC from persist map.
+		meta l4proto tcp ether daddr set ip saddr . th sport . ip daddr . th dport map @dsr-persist-tcp counter goto dsr-fwd-persist-tcp
+		meta l4proto udp ether daddr set ip saddr . th sport . ip daddr . th dport map @dsr-persist-udp counter goto dsr-fwd-persist-udp
+		# New session: random bucket lookup, record choice in persist map.
+		meta l4proto tcp ether daddr set ip daddr . numgen random mod 1024 map @real-server counter goto dsr-fwd-persist-tcp
+		meta l4proto udp ether daddr set ip daddr . numgen random mod 1024 map @real-server counter goto dsr-fwd-persist-udp
+		# The service is defined but the packet does not correspond to
+		# an established session and no backends are available for a new
+		# session.
+		counter drop
+	}
+
+	chain dsr-fwd-persist-tcp {
+		# Teardown: drop sticky entry so the 4-tuple can be reassigned immediately.
+		tcp flags fin,rst update @dsr-persist-tcp { ip saddr . th sport . ip daddr . th dport : ether daddr timeout 0s } counter fwd to eth0
+		update @dsr-persist-tcp { ip saddr . th sport . ip daddr . th dport : ether daddr } counter fwd to eth0
+	}
+
+	chain dsr-fwd-persist-udp {
+		update @dsr-persist-udp { ip saddr . th sport . ip daddr . th dport : ether daddr } counter fwd to eth0
+	}
+}

--- a/daemon/libnetwork/docs/nftlb-prototype/lib/resolve-macs.sh
+++ b/daemon/libnetwork/docs/nftlb-prototype/lib/resolve-macs.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Resolve overlay MAC addresses for DSR backends.
+
+set -euo pipefail
+
+source "${BASH_SOURCE%/*}/common.sh"
+
+resolve_mac_from_container() {
+	local ip=$1
+	local container
+	for c in "${DSR_BACKENDS[@]}"; do
+		local cip
+		cip=$(nsenter_container "$c" ip -4 -o addr show dev eth0 2>/dev/null | awk '{print $4}' | cut -d/ -f1)
+		if [[ $cip == "$ip" ]]; then
+			nsenter_container "$c" ip link show eth0 | awk '/link\/ether/ {print $2; exit}'
+			return 0
+		fi
+	done
+	return 1
+}
+
+resolve_mac() {
+	local ip=$1
+	local mac
+
+	mac=$(resolve_mac_from_container "$ip" 2>/dev/null || true)
+	if [[ -n $mac ]]; then
+		echo "$mac"
+		return 0
+	fi
+
+	local netns
+	netns=$(container_netns "$CONTAINER_LB")
+	nsenter_net "$netns" ping -c2 -W1 "$ip" >/dev/null 2>&1 || true
+	mac=$(nsenter_net "$netns" ip neigh show "$ip" dev eth0 2>/dev/null | awk '/lladdr/ {print $5; exit}')
+	[[ -n $mac ]] || die "could not resolve MAC for $ip"
+	echo "$mac"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	require_root
+	[[ $# -ge 1 ]] || die "usage: resolve-macs.sh <ip> [ip...]"
+	while [[ $# -gt 0 ]]; do
+		resolve_mac "$1"
+		shift
+	done
+fi

--- a/daemon/libnetwork/docs/nftlb-prototype/lib/soft-drain-hold.sh
+++ b/daemon/libnetwork/docs/nftlb-prototype/lib/soft-drain-hold.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Run inside the client container (netshoot). Holds a keep-alive HTTP connection
+# to the NAT VIP until it lands on the target backend, waits for a drain signal
+# file, then sends further requests on the same TCP socket.
+#
+# Usage: bash -s <vip> <port> <target_backend_name> <status_file> <continue_file>
+
+set -euo pipefail
+
+VIP=${1:?vip required}
+PORT=${2:?port required}
+TARGET=${3:?target backend name required}
+STATUS=${4:?status file required}
+CONTINUE=${5:?continue file required}
+
+: >"$STATUS"
+rm -f "$CONTINUE"
+
+send_http_get() {
+	printf 'GET / HTTP/1.1\r\nHost: %s\r\nConnection: keep-alive\r\n\r\n' "$VIP" >&3
+}
+
+read_http_body() {
+	local line len body
+	while IFS= read -r line <&3; do
+		line=${line//$'\r'/}
+		[[ -z $line ]] && break
+		[[ $line == Content-Length:* ]] && len=${line#Content-Length: }
+	done
+	if [[ -n ${len:-} ]]; then
+		body=$(head -c "$len" <&3)
+	else
+		IFS= read -r body <&3 || true
+		body=${body//$'\r'/}
+	fi
+	printf '%s' "$body"
+}
+
+open_connection() {
+	exec 3<>"/dev/tcp/${VIP}/${PORT}"
+}
+
+close_connection() {
+	exec 3<&-
+	exec 3>&-
+}
+
+attempt=0
+while :; do
+	attempt=$((attempt + 1))
+	if [[ $attempt -gt 200 ]]; then
+		echo "ERROR|could not reach ${TARGET} after 200 attempts" >>"$STATUS"
+		exit 1
+	fi
+	open_connection
+	send_http_get
+	body=$(read_http_body <&3)
+	if [[ $body == "$TARGET" || $body == *"$TARGET"* ]]; then
+		echo "READY|${TARGET}" >>"$STATUS"
+		break
+	fi
+	close_connection
+done
+
+while [[ ! -f $CONTINUE ]]; do
+	sleep 0.1
+done
+
+send_http_get
+second=$(read_http_body <&3)
+echo "SECOND|${second}" >>"$STATUS"
+
+send_http_get
+third=$(read_http_body <&3)
+echo "THIRD|${third}" >>"$STATUS"
+
+close_connection

--- a/daemon/libnetwork/docs/nftlb-prototype/nft-ctl.sh
+++ b/daemon/libnetwork/docs/nftlb-prototype/nft-ctl.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# nftables control plane: mutate sets/maps only (O(1) ruleset).
+
+set -euo pipefail
+
+source "${BASH_SOURCE%/*}/lib/common.sh"
+source "${BASH_SOURCE%/*}/lib/resolve-macs.sh"
+
+require_cmds nft jq docker nsenter
+
+lb_netns() {
+	container_netns "$CONTAINER_LB"
+}
+
+registry_read() {
+	ensure_registry
+	cat "$(registry_file)"
+}
+
+registry_write() {
+	cat > "$(registry_file).tmp"
+	mv "$(registry_file).tmp" "$(registry_file)"
+}
+
+# Partition 0..1023 into N equal intervals; print "lo-hi : backend" lines.
+# Backends are passed as positional args (safe across subshells).
+bucket_intervals() {
+	local -a backends=("$@")
+	local n=${#backends[@]}
+	[[ $n -gt 0 ]] || return 0
+	local per=$((LB_BUCKETS / n))
+	local rem=$((LB_BUCKETS % n))
+	local start=0
+	local i
+	for ((i = 0; i < n; i++)); do
+		local size=$per
+		[[ $i -lt $rem ]] && size=$((size + 1))
+		local end=$((start + size - 1))
+		echo "${start}-${end} : ${backends[$i]}"
+		start=$((end + 1))
+	done
+}
+
+rebalance_service() {
+	local svc_id=$1
+	local json
+	json=$(registry_read)
+	local mode vip port proto
+	mode=$(echo "$json" | jq --arg id "$svc_id" -r '.services[$id].mode')
+	vip=$(echo "$json" | jq --arg id "$svc_id" -r '.services[$id].vip')
+	port=$(echo "$json" | jq --arg id "$svc_id" -r '.services[$id].publish_port')
+	proto=$(echo "$json" | jq --arg id "$svc_id" -r '.services[$id].proto')
+	local netns
+	netns=$(lb_netns)
+
+	local v
+	local old_state=()
+	while IFS= read -r v; do
+		old_state+=("${v}")
+	done < <(echo "$json" | jq --arg id "$svc_id" -r '.bucket_state[$id][]?')
+
+	local new_state=()
+	while IFS= read -r v; do
+		new_state+=("${v}")
+	done < <(bucket_intervals $(echo "$json" | jq --arg id "$svc_id" -r '.backends[$id][]?'))
+
+	{
+		if [[ ${#old_state[@]} -gt 0 ]]; then
+			echo "delete element ip moby-lb-nat nat-publish-port {"
+			for interval in "${old_state[@]}"; do
+				echo " ${proto} . ${port} . ${interval},"
+			done
+			echo "}"
+
+			case $mode in
+			NAT*)
+				echo "delete element ip moby-lb-nat nat-service-vip {"
+				for interval in "${old_state[@]}"; do
+					echo " ${vip} . ${interval},"
+				done
+				echo "}"
+				;;
+			DSR*)
+				echo "delete element netdev moby-lb-dsr real-server {"
+				for interval in "${old_state[@]}"; do
+					local range=$(echo "$interval" | cut -d' ' -f1)
+					local mac=$(resolve_mac $(echo "$interval" | cut -d' ' -f3))
+					echo " ${vip} . ${range} : ${mac},"
+				done
+				echo "}"
+				;;
+			esac
+		fi
+		if [[ ${#new_state[@]} -gt 0 ]]; then
+			# Add entries for NAT'ing from published ports irrespective of the service mode.
+			# DSR services still need to NAT requests from published ports.
+			echo "add element ip moby-lb-nat nat-publish-port {"
+			for interval in "${new_state[@]}"; do
+				echo " ${proto} . ${port} . ${interval},"
+			done
+			echo "}"
+
+			case $mode in
+			NAT*)
+				echo "add element ip moby-lb-nat nat-service-vip {"
+				for interval in "${new_state[@]}"; do
+					echo " ${vip} . ${interval},"
+				done
+				echo "}"
+				;;
+			DSR*)
+				echo "add element netdev moby-lb-dsr real-server {"
+				for interval in "${new_state[@]}"; do
+					local range=$(echo "$interval" | cut -d' ' -f1)
+					local mac=$(resolve_mac $(echo "$interval" | cut -d' ' -f3))
+					echo " ${vip} . ${range} : ${mac},"
+				done
+				echo "}"
+				;;
+			esac
+		fi
+	} | nft_run "$netns" -f -
+
+	echo "$json" | jq '.bucket_state[$id] = $ARGS.positional' \
+		--arg id "$svc_id" --args "${new_state[@]}" | registry_write
+}
+
+cmd_add_service() {
+	local id=$1 mode=${2@U} vip=$3 publish_port=$4 proto=${5@L} target_port=$6
+
+	registry_read | jq --arg id "$id" --arg mode "$mode" --arg vip "$vip" \
+		--arg publish_port "$publish_port" --arg proto "$proto" --arg target_port "$target_port" \
+		'.services[$id] = {$mode, $proto, $vip, publish_port: ($publish_port|tonumber), target_port: ($target_port|tonumber)} |
+		 .backends[$id] //= {} | .bucket_state[$id] //= []' | registry_write
+
+	# L2 target for overlay/client ARP; backends still bind VIP on lo for local delivery.
+	nsenter_container "$CONTAINER_LB" ip addr add "${vip}/32" dev eth0 2>/dev/null || true
+	nft_host add element ip moby-ingress published-port "{ ${proto} . ${publish_port} }"
+	case $mode in
+	NAT*)
+		;;
+	DSR*)
+		nft_run "$(lb_netns)" add element netdev moby-lb-dsr virtual-service "{ ${vip} . ${proto} . ${target_port} }"
+		;;
+	*)
+		die "unknown service mode: $mode"
+		;;
+	esac
+
+	log "add-service ${id} ${mode} vip=${vip} ${publish_port}/${proto} -> ${target_port}"
+}
+
+cmd_add_backend() {
+	local svc_id=$1 container=$2 backend=$3
+
+	local json mode proto pub target
+	json=$(registry_read)
+	mode=$(echo "$json" | jq --arg id "$svc_id" -r '.services[$id].mode')
+	[[ "$mode" != "null" ]] || die "unknown service: $svc_id"
+	proto=$(echo "$json" | jq --arg id "$svc_id" -r '.services[$id].proto')
+	pub=$(echo "$json" | jq --arg id "$svc_id" -r '.services[$id].publish_port')
+	target=$(echo "$json" | jq --arg id "$svc_id" -r '.services[$id].target_port')
+
+	echo "$json" | jq --arg id "$svc_id" --arg container "$container" --arg backend "$backend" \
+		'.backends[$id] += {($container): $backend}' | registry_write
+
+	local netns
+	netns=$(container_netns "$container")
+	nft_run "$netns" add element ip moby-task-ingress allowed-ports "{ ${proto} . ${target} }"
+	if [[ "$pub" != "$target" ]]; then
+		nft_run "$netns" add element ip moby-task-ingress remap-ports \
+			"{ ${proto} . ${pub} : ${target} }"
+	fi
+
+	rebalance_service "$svc_id"
+	log "add-backend ${svc_id} ${container} ${mode} ${pub}/${proto} -> ${target}"
+}
+
+cmd_remove_backend() {
+	local svc_id=$1 container=$2
+	registry_read | jq --arg id "$svc_id" --arg container "$container" \
+		'.backends[$id] |= del(.[$container])' | registry_write
+	rebalance_service "$svc_id"
+	log "remove-backend ${svc_id} ${container}"
+}
+
+usage() {
+	cat <<EOF
+usage: nft-ctl.sh <command> [args]
+
+commands:
+  add-service <svc-id> (NAT|DSR) <vip> <publish-port> (TCP|UDP) [<target-port>]
+  add-backend <svc_id> <container> <ip>
+  remove-backend <svc_id> <container>
+EOF
+}
+
+main() {
+	require_root
+	[[ $# -ge 1 ]] || { usage; exit 1; }
+	case "$1" in
+	add-service)
+		[[ $# -ge 6 ]] || die "add-service <svc-id> (NAT|DSR) <vip> <publish-port> (TCP|UDP) [<target-port>]"
+		cmd_add_service "$2" "$3" "$4" "$5" "$6" "${7:-$5}"
+		;;
+	add-backend)
+		[[ $# -ge 4 ]] || die "add-backend <svc-id> <container> <ip>"
+		cmd_add_backend "$2" "$3" "$4"
+		;;
+	remove-backend)
+		[[ $# -ge 3 ]] || die "remove-backend <svc-id> <container>"
+		cmd_remove_backend "$2" "$3"
+		;;
+	*)
+		usage
+		exit 1
+		;;
+	esac
+}
+
+main "$@"

--- a/daemon/libnetwork/docs/nftlb-prototype/setup.sh
+++ b/daemon/libnetwork/docs/nftlb-prototype/setup.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+# Main setup: topology, static nft rulesets, nft-ctl population.
+
+set -euo pipefail
+
+PROTOTYPE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${PROTOTYPE_DIR}/lib/common.sh"
+
+configure_iface_rp_filter() {
+	local iface=$1
+	# sysctl paths use the netdev name without "@ifindex" suffix.
+	iface="${iface%%@*}"
+	sysctl -w "net.ipv4.conf.${iface}.rp_filter=0" 2>/dev/null || true
+}
+
+# Host sysctls required for ingress forwarding and localhost published-port access.
+configure_host_sysctls() {
+	sysctl -w net.ipv4.ip_forward=1 >/dev/null
+	sysctl -w "net.ipv4.conf.${GWBR_NAME}.route_localnet=1" >/dev/null
+	configure_iface_rp_filter "$GWBR_NAME"
+	ip route replace "${OVERLAY_SUBNET}" dev "${GWBR_NAME}" 2>/dev/null || true
+}
+
+create_host_gwbridge() {
+	if ! ip link show "$GWBR_NAME" >/dev/null 2>&1; then
+		ip link add name "$GWBR_NAME" type bridge
+	fi
+	ip addr flush dev "$GWBR_NAME" 2>/dev/null || true
+	ip addr add "${GWBR_HOST_IP}/16" dev "$GWBR_NAME"
+	ip link set "$GWBR_NAME" up
+	configure_host_sysctls
+}
+
+create_overlay_ns() {
+	if ! ip netns list | grep -qw "$OVERLAY_NS"; then
+		ip netns add "$OVERLAY_NS"
+	fi
+	nsenter --net="/var/run/netns/${OVERLAY_NS}" ip link set lo up
+	if ! nsenter --net="/var/run/netns/${OVERLAY_NS}" ip link show "$OVERLAY_BR" >/dev/null 2>&1; then
+		nsenter --net="/var/run/netns/${OVERLAY_NS}" ip link add name "$OVERLAY_BR" type bridge
+	fi
+	nsenter --net="/var/run/netns/${OVERLAY_NS}" ip addr flush dev "$OVERLAY_BR" 2>/dev/null || true
+	nsenter --net="/var/run/netns/${OVERLAY_NS}" ip addr add "${OVERLAY_GW}/24" dev "$OVERLAY_BR"
+	nsenter --net="/var/run/netns/${OVERLAY_NS}" ip link set "$OVERLAY_BR" up
+}
+
+start_container() {
+	local name=$1
+	local tcp_port=$2
+	local udp_port=$3
+	local text=$4
+
+	if docker ps -a --format '{{.Names}}' | grep -qx "$name"; then
+		docker rm -f "$name" >/dev/null 2>&1 || true
+	fi
+
+	docker run -d --name "$name" --net=none \
+		-v "${PROTOTYPE_DIR}/lib/backend-serve.sh:/backend-serve.sh:ro" \
+		-v "${PROTOTYPE_DIR}/lib/backend-serve-tcp.sh:/backend-serve-tcp.sh:ro" \
+		-e TEXT="$text" -e TCP_PORT="$tcp_port" -e UDP_PORT="$udp_port" \
+		"$CLIENT_IMAGE" bash /backend-serve.sh >/dev/null
+}
+
+start_lb_container() {
+	if docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_LB"; then
+		docker rm -f "$CONTAINER_LB" >/dev/null 2>&1 || true
+	fi
+
+	docker run -d --name "$CONTAINER_LB" --net=none \
+		"$CLIENT_IMAGE" sleep infinity >/dev/null
+}
+
+start_client_container() {
+	if docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_CLIENT"; then
+		docker rm -f "$CONTAINER_CLIENT" >/dev/null 2>&1 || true
+	fi
+
+	docker run -d --name "$CONTAINER_CLIENT" --net=none \
+		"$CLIENT_IMAGE" sleep infinity >/dev/null
+}
+
+start_all_containers() {
+	log "starting containers"
+	start_lb_container
+	for i in "${!NAT_BACKENDS[@]}"; do
+		start_container "${NAT_BACKENDS[$i]}" "$NAT_TARGET_PORT" "$NAT_UDP_TARGET_PORT" \
+			"${NAT_BACKENDS[$i]}"
+	done
+	for i in "${!DSR_BACKENDS[@]}"; do
+		start_container "${DSR_BACKENDS[$i]}" "$DSR_TARGET_PORT" "$DSR_UDP_TARGET_PORT" \
+			"${DSR_BACKENDS[$i]}"
+	done
+	start_client_container
+}
+
+# Create veth: host end name, peer moves to target netns as peer_name, attach host end to bridge
+link_veth_to_bridge() {
+	local host_if=$1
+	local peer_if=$2
+	local bridge=$3
+	local netns=$4
+
+	ip link del "$host_if" 2>/dev/null || true
+	ip link add "$host_if" type veth peer name "$peer_if"
+	ip link set "$peer_if" netns "$netns"
+	ip link set "$host_if" master "$bridge"
+	ip link set "$host_if" up
+	nsenter --net="$netns" ip link set "$peer_if" up
+}
+
+# Link veth into overlay netns bridge from host side
+link_veth_overlay() {
+	local host_if=$1
+	local peer_if=$2
+	local overlay_ip=$3
+
+	link_veth_to_bridge "$host_if" "$peer_if" "$OVERLAY_BR" "/var/run/netns/${OVERLAY_NS}"
+	nsenter --net="/var/run/netns/${OVERLAY_NS}" ip addr add "${overlay_ip}/24" dev "$peer_if"
+}
+
+# Link container overlay iface via veth into overlay bridge
+link_container_overlay() {
+	local container=$1
+	local host_if=$2
+	local peer_if=$3
+	local overlay_ip=$4
+
+	local pid
+	pid=$(container_pid "$container")
+	ip link del "$host_if" 2>/dev/null || true
+	ip link add "$host_if" type veth peer name "$peer_if"
+	ip link set "$host_if" netns "/var/run/netns/${OVERLAY_NS}"
+	ip link set "$peer_if" netns "/proc/${pid}/ns/net"
+	nsenter --net="/var/run/netns/${OVERLAY_NS}" ip link set "$host_if" master "$OVERLAY_BR"
+	nsenter --net="/var/run/netns/${OVERLAY_NS}" ip link set "$host_if" up
+	nsenter --net="/var/run/netns/${OVERLAY_NS}" ip addr add "${overlay_ip}/24" dev "$host_if"
+	nsenter --net="/proc/${pid}/ns/net" ip link set "$peer_if" name eth0
+	nsenter --net="/proc/${pid}/ns/net" ip addr add "${overlay_ip}/24" dev eth0
+	nsenter --net="/proc/${pid}/ns/net" ip link set eth0 up
+	nsenter --net="/proc/${pid}/ns/net" ip route add default via "$OVERLAY_GW"
+}
+
+# Link container gw iface via veth to host gwbridge
+link_container_gw() {
+	local container=$1
+	local host_if=$2
+	local peer_if=$3
+	local gw_ip=$4
+
+	local pid
+	pid=$(container_pid "$container")
+	ip link del "$host_if" 2>/dev/null || true
+	ip link add "$host_if" type veth peer name "$peer_if"
+	ip link set "$host_if" master "$GWBR_NAME"
+	ip link set "$host_if" up
+	configure_iface_rp_filter "$host_if"
+	ip link set "$peer_if" netns "/proc/${pid}/ns/net"
+	nsenter --net="/proc/${pid}/ns/net" ip link set "$peer_if" name eth1
+	nsenter --net="/proc/${pid}/ns/net" ip addr add "${gw_ip}/16" dev eth1
+	nsenter --net="/proc/${pid}/ns/net" ip link set eth1 up
+}
+
+wire_topology() {
+	log "wiring network topology"
+
+	# lb-sbox: eth0 overlay, eth1 gwbridge
+	link_container_overlay "$CONTAINER_LB" veth-lb-o-h veth-lb-o-c "$LB_OVERLAY_IP"
+	link_container_gw "$CONTAINER_LB" veth-lb-g-h veth-lb-g-c "$LB_GW_IP"
+
+	# NAT backends
+	for i in "${!NAT_BACKENDS[@]}"; do
+		local idx=$((i + 1))
+		link_container_overlay "${NAT_BACKENDS[$i]}" "veth-nat${idx}-o-h" "veth-nat${idx}-o-c" "${NAT_BACKEND_IPS[$i]}"
+		link_container_gw "${NAT_BACKENDS[$i]}" "veth-nat${idx}-g-h" "veth-nat${idx}-g-c" "172.18.0.$((10 + idx))"
+	done
+
+	# DSR backends
+	for i in "${!DSR_BACKENDS[@]}"; do
+		local idx=$((i + 1))
+		link_container_overlay "${DSR_BACKENDS[$i]}" "veth-dsr${idx}-o-h" "veth-dsr${idx}-o-c" "${DSR_BACKEND_IPS[$i]}"
+		link_container_gw "${DSR_BACKENDS[$i]}" "veth-dsr${idx}-g-h" "veth-dsr${idx}-g-c" "172.18.0.$((20 + idx))"
+	done
+
+	# Client: overlay only
+	link_container_overlay "$CONTAINER_CLIENT" veth-cli-o-h veth-cli-o-c "$CLIENT_IP"
+}
+
+setup_dsr_backend_sysctls() {
+	local container=$1
+	nsenter_container "$container" sysctl -w net.ipv4.conf.eth0.arp_ignore=1 >/dev/null
+	nsenter_container "$container" sysctl -w net.ipv4.conf.eth0.arp_announce=2 >/dev/null
+	configure_iface_rp_filter_in_netns "$container" eth0
+	configure_iface_rp_filter_in_netns "$container" eth1
+	nsenter_container "$container" ip addr add "${DSR_VIP}/32" dev lo
+}
+
+configure_iface_rp_filter_in_netns() {
+	local container=$1 iface=$2
+	nsenter_container "$container" sysctl -w "net.ipv4.conf.${iface}.rp_filter=0" >/dev/null
+}
+
+# Ingress-published DSR: replies to the SNAT'd gwbr0 host IP hairpin via lb-sbox.
+setup_dsr_backend_routes() {
+	local container=$1
+	nsenter_container "$container" ip route replace "${GWBR_HOST_IP}/32" via "${LB_GW_IP}" dev eth1
+}
+
+setup_topology() {
+	require_root
+	require_cmds docker ip nsenter sysctl
+	create_host_gwbridge
+	create_overlay_ns
+	start_all_containers
+	wire_topology
+	for b in "${DSR_BACKENDS[@]}"; do
+		setup_dsr_backend_sysctls "$b"
+		setup_dsr_backend_routes "$b"
+	done
+	# LB sandbox must forward between gwbridge and overlay
+	nsenter_container "$CONTAINER_LB" sysctl -w net.ipv4.ip_forward=1 >/dev/null
+	configure_iface_rp_filter_in_netns "$CONTAINER_LB" eth0
+	configure_iface_rp_filter_in_netns "$CONTAINER_LB" eth1
+	log "topology ready"
+}
+
+load_rulesets() {
+	log "loading static nft rulesets"
+	nft delete table ip moby-ingress 2>/dev/null || true
+	nft -f "${PROTOTYPE_DIR}/lib/nft/host.nft"
+	local lb_ns
+	lb_ns=$(container_netns "$CONTAINER_LB")
+	nft_run "$lb_ns" delete table ip moby-lb-nat 2>/dev/null || true
+	nft_run "$lb_ns" delete table netdev moby-lb-dsr 2>/dev/null || true
+	nft_load "$lb_ns" "${PROTOTYPE_DIR}/lib/nft/lb-sbox.nft"
+
+	local i bns
+	for i in "${!NAT_BACKENDS[@]}"; do
+		local idx=$((i + 1))
+		bns=$(container_netns "${NAT_BACKENDS[$i]}")
+		nft_run "$bns" delete table ip moby-task-ingress 2>/dev/null || true
+		nft_load "$bns" "${PROTOTYPE_DIR}/lib/nft/backend.nft" -D ingress_eip="${NAT_BACKEND_IPS[$i]}"
+	done
+	for i in "${!DSR_BACKENDS[@]}"; do
+		local idx=$((i + 1))
+		bns=$(container_netns "${DSR_BACKENDS[$i]}")
+		nft_run "$bns" delete table ip moby-task-ingress 2>/dev/null || true
+		nft_load "$bns" "${PROTOTYPE_DIR}/lib/nft/backend.nft" -D ingress_eip="${DSR_BACKEND_IPS[$i]}"
+	done
+}
+
+populate_services() {
+	log "registering services and backends"
+	"${PROTOTYPE_DIR}/nft-ctl.sh" add-service svc-nat NAT "$NAT_VIP" "$NAT_PUBLISH_PORT" TCP "$NAT_TARGET_PORT"
+	"${PROTOTYPE_DIR}/nft-ctl.sh" add-service svc-nat-udp NAT "$NAT_VIP" "$NAT_UDP_PUBLISH_PORT" UDP "$NAT_UDP_TARGET_PORT"
+	"${PROTOTYPE_DIR}/nft-ctl.sh" add-service svc-dsr DSR "$DSR_VIP" "$DSR_PUBLISH_PORT" TCP "$DSR_TARGET_PORT"
+	"${PROTOTYPE_DIR}/nft-ctl.sh" add-service svc-dsr-udp DSR "$DSR_VIP" "$DSR_UDP_PUBLISH_PORT" UDP "$DSR_UDP_TARGET_PORT"
+
+	local i
+	for i in "${!NAT_BACKENDS[@]}"; do
+		"${PROTOTYPE_DIR}/nft-ctl.sh" add-backend svc-nat "${NAT_BACKENDS[$i]}" "${NAT_BACKEND_IPS[$i]}"
+		"${PROTOTYPE_DIR}/nft-ctl.sh" add-backend svc-nat-udp "${NAT_BACKENDS[$i]}" "${NAT_BACKEND_IPS[$i]}"
+	done
+
+	for i in "${!DSR_BACKENDS[@]}"; do
+		"${PROTOTYPE_DIR}/nft-ctl.sh" add-backend svc-dsr "${DSR_BACKENDS[$i]}" "${DSR_BACKEND_IPS[$i]}"
+		"${PROTOTYPE_DIR}/nft-ctl.sh" add-backend svc-dsr-udp "${DSR_BACKENDS[$i]}" "${DSR_BACKEND_IPS[$i]}"
+	done
+}
+
+warn_ingress_scope() {
+	if ! in_isolated_container_netns; then
+		return 0
+	fi
+	local ip
+	ip=$(host_ingress_ip)
+	warn "running inside a container network namespace (/.dockerenv)."
+	warn "Host ingress is programmed here; peers must target ${ip}, not your laptop LAN IP."
+	warn "From another container on the same bridge:"
+	warn "  docker run --rm --network bridge ${CLIENT_IMAGE} curl -s ${ip}:${NAT_PUBLISH_PORT}"
+	warn "Or run: ${PROTOTYPE_DIR}/lib/bridge-peer-test.sh"
+}
+
+print_summary() {
+	local ingress_ip
+	ingress_ip=$(host_ingress_ip)
+	cat <<EOF
+
+nftables LB prototype is ready.
+
+Host ingress (this network namespace):
+  curl -s 127.0.0.1:${NAT_PUBLISH_PORT}    # NAT TCP (VIP ${NAT_VIP})
+  curl -s 127.0.0.1:${DSR_PUBLISH_PORT}    # DSR TCP published port
+  echo probe | nc -u -w1 127.0.0.1 ${NAT_UDP_PUBLISH_PORT}    # NAT UDP
+  echo probe | nc -u -w1 127.0.0.1 ${DSR_UDP_PUBLISH_PORT}    # DSR UDP published port
+  curl -s ${ingress_ip}:${NAT_PUBLISH_PORT}    # NAT TCP (same-bridge / remote peer)
+  curl -s ${ingress_ip}:${DSR_PUBLISH_PORT}    # DSR TCP published port
+  echo probe | nc -u -w1 ${ingress_ip} ${NAT_UDP_PUBLISH_PORT}    # NAT UDP
+  echo probe | nc -u -w1 ${ingress_ip} ${DSR_UDP_PUBLISH_PORT}    # DSR UDP published port
+
+Same-bridge peer test (Moby devcontainer):
+  docker run --rm --network bridge ${CLIENT_IMAGE} curl -s ${ingress_ip}:${NAT_PUBLISH_PORT}
+  ${PROTOTYPE_DIR}/lib/bridge-peer-test.sh
+
+Overlay VIP (from client container):
+  docker exec ${CONTAINER_CLIENT} curl -s ${NAT_VIP}:${NAT_TARGET_PORT}
+  docker exec ${CONTAINER_CLIENT} curl -s ${DSR_VIP}:${DSR_TARGET_PORT}
+  echo probe | docker exec -i ${CONTAINER_CLIENT} nc -u -w1 ${NAT_VIP} ${NAT_UDP_TARGET_PORT}
+  echo probe | docker exec -i ${CONTAINER_CLIENT} nc -u -w1 ${DSR_VIP} ${DSR_UDP_TARGET_PORT}
+
+Soft drain (example):
+  ${PROTOTYPE_DIR}/nft-ctl.sh remove-backend svc-nat ${NAT_BACKENDS[1]}
+
+Run demos:
+  ${PROTOTYPE_DIR}/demo.sh
+
+Teardown:
+  ${PROTOTYPE_DIR}/teardown.sh
+
+EOF
+}
+
+main() {
+	require_root
+	require_cmds docker ip nsenter nft jq sysctl curl
+	"${PROTOTYPE_DIR}/teardown.sh" 2>/dev/null || true
+	setup_topology
+	load_rulesets
+	ensure_registry
+	populate_services
+	warn_ingress_scope
+	print_summary
+}
+
+main "$@"

--- a/daemon/libnetwork/docs/nftlb-prototype/teardown.sh
+++ b/daemon/libnetwork/docs/nftlb-prototype/teardown.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Idempotent cleanup for the nftables load balancing prototype.
+
+set -euo pipefail
+
+PROTOTYPE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${PROTOTYPE_DIR}/lib/common.sh"
+
+require_root
+log "teardown"
+
+nft delete table ip moby-ingress 2>/dev/null || true
+
+for name in "$CONTAINER_LB" "$CONTAINER_CLIENT" "${NAT_BACKENDS[@]}" "${DSR_BACKENDS[@]}"; do
+	docker rm -f "$name" >/dev/null 2>&1 || true
+done
+
+for ifn in \
+	veth-lb-o-h veth-lb-g-h \
+	veth-nat1-o-h veth-nat1-g-h \
+	veth-nat2-o-h veth-nat2-g-h \
+	veth-nat3-o-h veth-nat3-g-h \
+	veth-dsr1-o-h veth-dsr1-g-h \
+	veth-dsr2-o-h veth-dsr2-g-h \
+	veth-cli-o-h
+do ip link del "$ifn" 2>/dev/null || true; done
+
+ip link del "$GWBR_NAME" 2>/dev/null || true
+ip netns del "$OVERLAY_NS" 2>/dev/null || true
+ip netns del nftlb-peer 2>/dev/null || true
+ip link del ipv1 2>/dev/null || true
+
+rm -f "$(registry_file)"
+
+log "done"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- For #49638 

## Summary

Prototype using nftables to implement the load balancer for Swarm services without libnetwork getting in the way. Containers are started with `--net=none` and shell scripts nsenter into the containers' network namespaces to network them together.

The packet path is pure netfilter; IPVS is not involved. Active NAT flows are tracked using the kernel's conntrack infrastructure and active DSR flows are tracked using nftables maps.

This prototype will serve as a sort of executable documentation when nftables load-balancing is implemented in libnetwork.

Cursor Code was used in the development of this prototype.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
