### PR TITLE
api: tolerate invalid default address pool prefix

### DIFF
--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"encoding/json"
 	"net/netip"
 
 	"github.com/moby/moby/api/types/container"
@@ -146,6 +147,40 @@ type Commit struct {
 type NetworkAddressPool struct {
 	Base netip.Prefix
 	Size int
+}
+
+// UnmarshalJSON decodes a NetworkAddressPool as returned by the daemon.
+func (n *NetworkAddressPool) UnmarshalJSON(data []byte) error {
+	type networkAddressPool struct {
+		Base *string
+		Size *int
+	}
+	var pool networkAddressPool
+	if err := json.Unmarshal(data, &pool); err != nil {
+		return err
+	}
+	if pool.Base != nil {
+		if *pool.Base == (netip.Prefix{}).String() && pool.Size != nil && *pool.Size != 0 {
+			_, err := netip.ParsePrefix(*pool.Base)
+			return err
+		}
+		if *pool.Base == "" || *pool.Base == (netip.Prefix{}).String() {
+			n.Base = netip.Prefix{}
+			if pool.Size == nil {
+				n.Size = 0
+			}
+		} else {
+			base, err := netip.ParsePrefix(*pool.Base)
+			if err != nil {
+				return err
+			}
+			n.Base = base
+		}
+	}
+	if pool.Size != nil {
+		n.Size = *pool.Size
+	}
+	return nil
 }
 
 // FirewallInfo describes the firewall backend.

--- a/api/types/system/info_test.go
+++ b/api/types/system/info_test.go
@@ -1,0 +1,75 @@
+package system_test
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"github.com/moby/moby/api/types/system"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestInfoUnmarshalInvalidDefaultAddressPoolPrefix(t *testing.T) {
+	const body = `{
+		"Name": "broken-daemon",
+		"ServerVersion": "28.5.0",
+		"DefaultAddressPools": [
+			{"Base": "invalid Prefix", "Size": 0}
+		]
+	}`
+
+	var info system.Info
+	err := json.Unmarshal([]byte(body), &info)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(info.Name, "broken-daemon"))
+	assert.Check(t, is.Equal(info.ServerVersion, "28.5.0"))
+	assert.Check(t, is.Len(info.DefaultAddressPools, 1))
+	assert.Check(t, !info.DefaultAddressPools[0].Base.IsValid())
+	assert.Check(t, is.Equal(info.DefaultAddressPools[0].Size, 0))
+}
+
+func TestNetworkAddressPoolUnmarshalInvalidPrefixResetsBase(t *testing.T) {
+	pool := system.NetworkAddressPool{
+		Base: netip.MustParsePrefix("10.10.0.0/16"),
+		Size: 24,
+	}
+
+	err := json.Unmarshal([]byte(`{"Base":"invalid Prefix","Size":0}`), &pool)
+	assert.NilError(t, err)
+	assert.Check(t, !pool.Base.IsValid())
+	assert.Check(t, is.Equal(pool.Size, 0))
+}
+
+func TestNetworkAddressPoolUnmarshalInvalidPrefixWithNonZeroSize(t *testing.T) {
+	var pool system.NetworkAddressPool
+	err := json.Unmarshal([]byte(`{"Base":"invalid Prefix","Size":24}`), &pool)
+	assert.Check(t, is.ErrorContains(err, "netip.ParsePrefix"))
+}
+
+func TestInfoUnmarshalDefaultAddressPoolPrefix(t *testing.T) {
+	const body = `{
+		"DefaultAddressPools": [
+			{"Base": "10.10.0.0/16", "Size": 24}
+		]
+	}`
+
+	var info system.Info
+	err := json.Unmarshal([]byte(body), &info)
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(info.DefaultAddressPools, 1))
+	assert.Check(t, is.Equal(info.DefaultAddressPools[0].Base.String(), "10.10.0.0/16"))
+	assert.Check(t, is.Equal(info.DefaultAddressPools[0].Size, 24))
+}
+
+func TestInfoUnmarshalMalformedDefaultAddressPoolPrefix(t *testing.T) {
+	const body = `{
+		"DefaultAddressPools": [
+			{"Base": "not-a-prefix", "Size": 24}
+		]
+	}`
+
+	var info system.Info
+	err := json.Unmarshal([]byte(body), &info)
+	assert.Check(t, is.ErrorContains(err, "netip.ParsePrefix"))
+}

--- a/vendor/github.com/moby/moby/api/types/system/info.go
+++ b/vendor/github.com/moby/moby/api/types/system/info.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"encoding/json"
 	"net/netip"
 
 	"github.com/moby/moby/api/types/container"
@@ -146,6 +147,40 @@ type Commit struct {
 type NetworkAddressPool struct {
 	Base netip.Prefix
 	Size int
+}
+
+// UnmarshalJSON decodes a NetworkAddressPool as returned by the daemon.
+func (n *NetworkAddressPool) UnmarshalJSON(data []byte) error {
+	type networkAddressPool struct {
+		Base *string
+		Size *int
+	}
+	var pool networkAddressPool
+	if err := json.Unmarshal(data, &pool); err != nil {
+		return err
+	}
+	if pool.Base != nil {
+		if *pool.Base == (netip.Prefix{}).String() && pool.Size != nil && *pool.Size != 0 {
+			_, err := netip.ParsePrefix(*pool.Base)
+			return err
+		}
+		if *pool.Base == "" || *pool.Base == (netip.Prefix{}).String() {
+			n.Base = netip.Prefix{}
+			if pool.Size == nil {
+				n.Size = 0
+			}
+		} else {
+			base, err := netip.ParsePrefix(*pool.Base)
+			if err != nil {
+				return err
+			}
+			n.Base = base
+		}
+	}
+	if pool.Size != nil {
+		n.Size = *pool.Size
+	}
+	return nil
 }
 
 // FirewallInfo describes the firewall backend.


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/52728

## Summary
- Add custom JSON decoding for `NetworkAddressPool` so `/info` responses containing the legacy zero-value `"invalid Prefix"` string do not fail the whole response decode.
- Preserve strict decoding for real malformed non-zero default address pool prefixes.
- Keep the vendored API type in sync for the client module.

## Release notes (optional)

```markdown changelog
Fix `docker info` against daemons or proxies that return an invalid empty default address pool prefix.
```

## A picture of a cute animal (not mandatory but encouraged)

Created with: Hermes Agent
