### PR TITLE
docs: clarify image ID with multi-platform store

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1814,12 +1814,14 @@ definitions:
         description: |
           ID is the content-addressable ID of an image.
 
-          This identifier is a content-addressable digest calculated from the
-          image's configuration (which includes the digests of layers used by
-          the image).
+          This identifier is usually a digest calculated from the image's
+          configuration. When the daemon uses a multi-platform image store, and
+          the image record targets a manifest list or OCI index, this identifier
+          may be the digest of the image target instead.
 
-          Note that this digest differs from the `RepoDigests` below, which
-          holds digests of image manifests that reference the image.
+          `Descriptor` describes the image target, and `Manifests` provides
+          details about the platform-specific image manifests and other
+          image-attached data, such as attestations.
         type: "string"
         x-nullable: false
         example: "sha256:ec3f0931a6e6b6855d76b2d7b0be30e81860baccd891b2e243280bf1cd8ad710"
@@ -2216,12 +2218,14 @@ definitions:
         description: |
           ID is the content-addressable ID of an image.
 
-          This identifier is a content-addressable digest calculated from the
-          image's configuration (which includes the digests of layers used by
-          the image).
+          This identifier is usually a digest calculated from the image's
+          configuration. When the daemon uses a multi-platform image store, and
+          the image record targets a manifest list or OCI index, this identifier
+          may be the digest of the image target instead.
 
-          Note that this digest differs from the `RepoDigests` below, which
-          holds digests of image manifests that reference the image.
+          `Descriptor` describes the image target, and `Manifests` provides
+          details about the platform-specific image manifests and other
+          image-attached data, such as attestations.
         type: "string"
         x-nullable: false
         example: "sha256:ec3f0931a6e6b6855d76b2d7b0be30e81860baccd891b2e243280bf1cd8ad710"

--- a/api/types/image/image_inspect.go
+++ b/api/types/image/image_inspect.go
@@ -17,12 +17,14 @@ type RootFS struct {
 type InspectResponse struct {
 	// ID is the content-addressable ID of an image.
 	//
-	// This identifier is a content-addressable digest calculated from the
-	// image's configuration (which includes the digests of layers used by
-	// the image).
+	// This identifier is usually a digest calculated from the image's
+	// configuration. When the daemon uses a multi-platform image store, and the
+	// image record targets a manifest list or OCI index, this identifier may be
+	// the digest of the image target instead.
 	//
-	// Note that this digest differs from the `RepoDigests` below, which
-	// holds digests of image manifests that reference the image.
+	// `Descriptor` describes the image target, and `Manifests` provides details
+	// about the platform-specific image manifests and other image-attached data,
+	// such as attestations.
 	ID string `json:"Id"`
 
 	// RepoTags is a list of image names/tags in the local image cache that

--- a/api/types/image/summary.go
+++ b/api/types/image/summary.go
@@ -20,12 +20,14 @@ type Summary struct {
 
 	// ID is the content-addressable ID of an image.
 	//
-	// This identifier is a content-addressable digest calculated from the
-	// image's configuration (which includes the digests of layers used by
-	// the image).
+	// This identifier is usually a digest calculated from the image's
+	// configuration. When the daemon uses a multi-platform image store, and the
+	// image record targets a manifest list or OCI index, this identifier may be
+	// the digest of the image target instead.
 	//
-	// Note that this digest differs from the `RepoDigests` below, which
-	// holds digests of image manifests that reference the image.
+	// `Descriptor` describes the image target, and `Manifests` provides details
+	// about the platform-specific image manifests and other image-attached data,
+	// such as attestations.
 	//
 	// Required: true
 	ID string `json:"Id"`


### PR DESCRIPTION
Related to: https://github.com/moby/moby/issues/51779

## Summary

- Clarify the API documentation for image `Id` in inspect/list responses.
- Document that daemons using the multi-platform image store may report the image target digest when the image record targets a manifest list or OCI index.
- Point readers at `Descriptor` and `Manifests` for the target and platform-specific manifest details.

This matches the current containerd image-store behavior described in the issue thread: the platform variants are represented as manifests, while the image target may be the multi-platform index.

## Release notes (optional)

```markdown changelog

```

## Verification

- `go test ./types/image` from `api/`
- `git diff --check`
- Second-agent review: `hermes chat -Q`, CLEAN

No regression test was added because this is a documentation/comment-only clarification of existing API behavior, not a behavior change.

## A picture of a cute animal (not mandatory but encouraged)

Created with: Hermes Agent
