### PR TITLE
libnetwork: resolve "<container>.<network>.internal" cross-network DNS names

### DIFF
--- a/daemon/libnetwork/libnetwork_internal_test.go
+++ b/daemon/libnetwork/libnetwork_internal_test.go
@@ -736,7 +736,9 @@ func TestSandboxResolveCrossNetworkInternal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Stop()
+	// Register controller shutdown first so subsequent t.Cleanup registrations
+	// for per-network deletion run before it (Cleanup is LIFO).
+	t.Cleanup(func() { c.Stop() })
 
 	mustNewNetwork := func(name string, opts ...NetworkOption) *Network {
 		opts = append([]NetworkOption{NetworkOptionEnableIPv4(true)}, opts...)
@@ -746,7 +748,7 @@ func TestSandboxResolveCrossNetworkInternal(t *testing.T) {
 		}
 		t.Cleanup(func() {
 			if err := n.Delete(); err != nil {
-				t.Fatal(err)
+				t.Errorf("delete network %s: %v", name, err)
 			}
 		})
 		return n

--- a/daemon/libnetwork/libnetwork_internal_test.go
+++ b/daemon/libnetwork/libnetwork_internal_test.go
@@ -723,6 +723,123 @@ func TestServiceVIPReuse(t *testing.T) {
 	}
 }
 
+// TestSandboxResolveCrossNetworkInternal exercises the "<container>.<network>.internal"
+// resolution path added for https://github.com/moby/moby/issues/49572.
+func TestSandboxResolveCrossNetworkInternal(t *testing.T) {
+	skip.If(t, runtime.GOOS == "windows", "test only works on linux")
+
+	defer netnsutils.SetupTestOSContext(t)()
+
+	ctx := context.Background()
+	c, err := New(ctx, config.OptionDataDir(t.TempDir()),
+		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Stop()
+
+	mustNewNetwork := func(name string, opts ...NetworkOption) *Network {
+		opts = append([]NetworkOption{NetworkOptionEnableIPv4(true)}, opts...)
+		n, err := c.NewNetwork(ctx, "bridge", name, "", opts...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if err := n.Delete(); err != nil {
+				t.Fatal(err)
+			}
+		})
+		return n
+	}
+
+	netA := mustNewNetwork("netA")
+	netB := mustNewNetwork("netB")
+	netInt := mustNewNetwork("netInt", NetworkOptionInternalNetwork())
+	netDotted := mustNewNetwork("my.net")
+	netNamedInternal := mustNewNetwork("internal")
+	netFooInternal := mustNewNetwork("foo.internal")
+	netFoo := mustNewNetwork("foo")
+
+	netA.addSvcRecords("epA", "c1", "svcA", net.ParseIP("10.0.1.10"), nil, true, "test")
+	netB.addSvcRecords("epB", "c2", "svcB", net.ParseIP("10.0.2.20"), net.ParseIP("fd00:b::2"), true, "test")
+	netInt.addSvcRecords("epI", "ci", "svcI", net.ParseIP("10.0.3.30"), nil, true, "test")
+	netDotted.addSvcRecords("epD", "c3", "svcD", net.ParseIP("10.0.4.40"), nil, true, "test")
+	netNamedInternal.addSvcRecords("epN", "db", "svcN", net.ParseIP("10.0.5.50"), net.ParseIP("fd00:5::1"), true, "test")
+	netFoo.addSvcRecords("epFoo", "shadowed", "svcFoo", net.ParseIP("10.0.6.60"), nil, true, "test")
+	netFooInternal.addSvcRecords("epFI", "shadowed", "svcFI", net.ParseIP("10.0.7.70"), net.ParseIP("fd00:7::1"), true, "test")
+
+	epA, err := netA.CreateEndpoint(ctx, "ep-c1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	epN, err := netNamedInternal.CreateEndpoint(ctx, "ep-c1-internal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	epFI, err := netFooInternal.CreateEndpoint(ctx, "ep-c1-foo-internal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sb, err := c.NewSandbox(ctx, "c1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := sb.Delete(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	if err := epA.Join(ctx, sb); err != nil {
+		t.Fatal(err)
+	}
+	if err := epN.Join(ctx, sb); err != nil {
+		t.Fatal(err)
+	}
+	if err := epFI.Join(ctx, sb); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		query  string
+		family types.IPFamily
+		want   string // empty -> expect NXDOMAIN
+	}{
+		{"cross-network", "c2.netB.internal", types.IPv4, "10.0.2.20"},
+		{"cross-network IPv6", "c2.netB.internal", types.IPv6, "fd00:b::2"},
+		{"same-network via .internal", "c1.netA.internal", types.IPv4, "10.0.1.10"},
+		{"internal network is excluded", "ci.netInt.internal", types.IPv4, ""},
+		{"unknown network", "c1.nope.internal", types.IPv4, ""},
+		{"unknown container", "ghost.netB.internal", types.IPv4, ""},
+		{"missing network segment", "noworld.internal", types.IPv4, ""},
+		{"trailing dot before .internal", "name..internal", types.IPv4, ""},
+		{"dotted network name", "c3.my.net.internal", types.IPv4, "10.0.4.40"},
+		{"legacy first: internal-named network", "db.internal", types.IPv4, "10.0.5.50"},
+		{"legacy first: *.internal vs foo", "shadowed.foo.internal", types.IPv4, "10.0.7.70"},
+		{"legacy first IPv6: *.internal vs foo", "shadowed.foo.internal", types.IPv6, "fd00:7::1"},
+		{"legacy first IPv6: internal-named network", "db.internal", types.IPv6, "fd00:5::1"},
+		{"bare name", "c1", types.IPv4, "10.0.1.10"},
+		{"container.network shorthand", "c1.netA", types.IPv4, "10.0.1.10"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := sb.ResolveName(ctx, tc.query, tc.family)
+			if tc.want == "" {
+				if ok || len(got) != 0 {
+					t.Fatalf("expected NXDOMAIN for %q, got %v", tc.query, got)
+				}
+				return
+			}
+			if !ok || len(got) == 0 {
+				t.Fatalf("expected %q to resolve to %s, got NXDOMAIN", tc.query, tc.want)
+			}
+			if got[0].String() != tc.want {
+				t.Fatalf("expected %q -> %s, got %s", tc.query, tc.want, got[0])
+			}
+		})
+	}
+}
+
 func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "test only works on linux")
 

--- a/daemon/libnetwork/sandbox.go
+++ b/daemon/libnetwork/sandbox.go
@@ -444,6 +444,11 @@ func (sb *Sandbox) ResolveService(ctx context.Context, name string) ([]*net.SRV,
 	return nil, nil
 }
 
+// internalDomainSuffix is the pseudo-TLD used to look up a container in a
+// user-defined network the sandbox is not attached to. See
+// https://github.com/moby/moby/issues/49572.
+const internalDomainSuffix = ".internal"
+
 func (sb *Sandbox) ResolveName(ctx context.Context, name string, ipType types.IPFamily) ([]net.IP, bool) {
 	// Embedded server owns the docker network domain. Resolution should work
 	// for both container_name and container_name.network_name
@@ -498,6 +503,13 @@ func (sb *Sandbox) ResolveName(ctx context.Context, name string, ipType types.IP
 			return ip, true
 		}
 	}
+
+	// Try the .internal pseudo-domain only after the in-sandbox path so that
+	// a user-defined network literally named "internal" (or "*.internal") is
+	// still resolved via its attached endpoint first.
+	if base, ok := strings.CutSuffix(name, internalDomainSuffix); ok {
+		return sb.resolveCrossNetwork(ctx, base, ipType)
+	}
 	return nil, false
 }
 
@@ -542,6 +554,31 @@ func (sb *Sandbox) resolveName(ctx context.Context, nameOrAlias string, networkN
 		ip, ok := nw.ResolveName(ctx, name, ipType)
 		if ok {
 			return ip, true
+		}
+	}
+	return nil, false
+}
+
+// resolveCrossNetwork looks up "<container>.<network>" in any non-internal
+// user-defined network, even one the sandbox is not attached to. Network names
+// may contain dots, so every split of base is tried from right to left.
+func (sb *Sandbox) resolveCrossNetwork(ctx context.Context, base string, ipType types.IPFamily) ([]net.IP, bool) {
+	ctx, span := otel.Tracer("").Start(ctx, "Sandbox.resolveCrossNetwork", trace.WithAttributes(
+		attribute.String("libnet.resolver.name", base),
+		attribute.Int("libnet.resolver.ip-family", int(ipType))))
+	defer span.End()
+
+	for i := strings.LastIndex(base, "."); i > 0; i = strings.LastIndex(base[:i], ".") {
+		ctrName, netName := base[:i], base[i+1:]
+		if netName == "" {
+			continue
+		}
+		nw, err := sb.controller.NetworkByName(netName)
+		if err != nil || nw.Internal() {
+			continue
+		}
+		if ips, ok := nw.ResolveName(ctx, ctrName, ipType); ok {
+			return ips, true
 		}
 	}
 	return nil, false

--- a/integration/network/dns_test.go
+++ b/integration/network/dns_test.go
@@ -93,6 +93,96 @@ func TestIntDNSAsExtDNS(t *testing.T) {
 	}
 }
 
+// TestCrossNetworkInternalDomain checks that a container can resolve another
+// container in a separate user-defined network using the
+// "<container>.<network>.internal" pseudo-domain added for
+// https://github.com/moby/moby/issues/49572.
+func TestCrossNetworkInternalDomain(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "test only works on linux")
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot start daemon on remote test run")
+
+	ctx := setupTest(t)
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	const (
+		netA      = "x49572_netA"
+		netB      = "x49572_netB"
+		c1        = "x49572_c1"
+		c2        = "x49572_c2"
+		isolated  = "x49572_isolated"
+		isolated2 = "x49572_isolated_target"
+	)
+
+	network.CreateNoError(ctx, t, c, netA)
+	defer network.RemoveNoError(ctx, t, c, netA)
+	network.CreateNoError(ctx, t, c, netB)
+	defer network.RemoveNoError(ctx, t, c, netB)
+	network.CreateNoError(ctx, t, c, isolated, network.WithInternal())
+	defer network.RemoveNoError(ctx, t, c, isolated)
+
+	c1Id := container.Run(ctx, t, c,
+		container.WithName(c1),
+		container.WithNetworkMode(netA),
+	)
+	defer c.ContainerRemove(ctx, c1Id, client.ContainerRemoveOptions{Force: true})
+
+	c2Id := container.Run(ctx, t, c,
+		container.WithName(c2),
+		container.WithNetworkMode(netB),
+	)
+	defer c.ContainerRemove(ctx, c2Id, client.ContainerRemoveOptions{Force: true})
+
+	isoId := container.Run(ctx, t, c,
+		container.WithName(isolated2),
+		container.WithNetworkMode(isolated),
+	)
+	defer c.ContainerRemove(ctx, isoId, client.ContainerRemoveOptions{Force: true})
+
+	tests := []struct {
+		name      string
+		query     string
+		expectOK  bool
+		expectOut string
+	}{
+		{
+			name:      "cross-network resolves",
+			query:     c2 + "." + netB + ".internal",
+			expectOK:  true,
+			expectOut: "Address",
+		},
+		{
+			name:      "internal network is excluded",
+			query:     isolated2 + "." + isolated + ".internal",
+			expectOK:  false,
+			expectOut: "",
+		},
+		{
+			name:      "unknown network",
+			query:     c2 + ".does-not-exist.internal",
+			expectOK:  false,
+			expectOut: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := container.Exec(ctx, c, c1Id, []string{"nslookup", tc.query})
+			assert.NilError(t, err)
+			if tc.expectOK {
+				assert.Check(t, is.Equal(res.ExitCode, 0), "stdout=%q stderr=%q", res.Stdout(), res.Stderr())
+				assert.Check(t, is.Contains(res.Stdout(), tc.expectOut))
+			} else {
+				assert.Check(t, res.ExitCode != 0, "expected nslookup to fail, stdout=%q", res.Stdout())
+			}
+		})
+	}
+}
+
 // TestExtDNSInIPv6OnlyNw checks that an IPv6-only bridge network has external
 // DNS access.
 func TestExtDNSInIPv6OnlyNw(t *testing.T) {


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/49572

## Summary

Resolve `<container>.<network>.internal` to look up a container in any non-internal user-defined network, even one the requesting sandbox is not attached to. v28 made cross-network reachability work via published ports, but DNS still returned NXDOMAIN for the target's name; this PR fills that gap.

Design choices, following the proposal in #49572:

- The `.internal` pseudo-domain is consulted **after** the existing in-sandbox iterative split, so a user-defined network literally named `internal` or `*.internal` keeps its existing resolution semantics. Existing setups don't regress.
- `Sandbox.resolveCrossNetwork` walks every right-to-left split of the base name, mirroring how the legacy path handles network names that contain dots (e.g. `c1.my.net.internal` → look up `c1` in network `my.net`).
- Networks created with `--internal` are excluded from the cross-network lookup so the network's connectivity policy is also reflected in DNS.

Tests cover cross-network resolution (IPv4/IPv6), the internal-flag exclusion, name collisions (`internal` and `*.internal` networks present), dotted network names, malformed inputs, and existing regression cases.

## Release notes (optional)

<!--
Suggested release note (left for maintainers to enable along with an `impact/*` label):

    Resolve container names in other user-defined networks via the `<container>.<network>.internal` DNS pseudo-domain.
-->

```markdown changelog

```

---
