### PR TITLE
api: add DataPathAddress to GET /swarm response

### DIFF
--- a/api/types/swarm/swarm.go
+++ b/api/types/swarm/swarm.go
@@ -16,6 +16,9 @@ type ClusterInfo struct {
 	DefaultAddrPool        []netip.Prefix
 	SubnetSize             uint32
 	DataPathPort           uint32
+	// DataPathAddress is the address used for data path traffic.
+	// This is the resolved advertise address, not the spec value.
+	DataPathAddress string
 }
 
 // Swarm represents a swarm.

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -224,6 +224,7 @@ func (c *Cluster) Inspect() (types.Swarm, error) {
 			return err
 		}
 		swarm = s
+		swarm.DataPathAddress = c.GetDataPathAddress()
 		return nil
 	}); err != nil {
 		return types.Swarm{}, err


### PR DESCRIPTION
## Summary

Expose the resolved data path (advertise) address in the GET /swarm API response
by adding a DataPathAddress field to ClusterInfo.

GetDataPathAddress() already computes this value at runtime by resolving the
configured advertise address or falling back to the local bind address. This change
makes the resolved value accessible via the API.

This is a prerequisite for fixing misleading docker swarm join-token output
where users cannot see what address the swarm will use for their join command.
The docker/cli side of the fix will follow as a separate PR.

Fixes: moby/moby#51590

## Release notes

```markdown changelog
- Add DataPathAddress field to GET /swarm response to expose the resolved
  advertise address used for data path traffic.
```

Created with: Hermes Agent