### PR TITLE
gha/validate-check: don't run post-merge

### DIFF
--- a/.github/workflows/validate-milestone.yml
+++ b/.github/workflows/validate-milestone.yml
@@ -6,10 +6,11 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, synchronize, milestoned, demilestoned, edited]
+    types: [opened, reopened, edited, synchronize, milestoned, demilestoned]
 
 jobs:
   validate-milestone:
+    if: ${{ github.event.pull_request.state == 'open' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/.github/workflows/validate-milestone.yml
+++ b/.github/workflows/validate-milestone.yml
@@ -1,5 +1,9 @@
 name: validate-milestone
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -9,10 +9,11 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, edited, labeled, unlabeled, synchronize]
+    types: [opened, reopened, edited, synchronize, labeled, unlabeled]
 
 jobs:
   check-labels:
+    if: ${{ github.event.pull_request.state == 'open' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     steps:
@@ -30,6 +31,7 @@ jobs:
         run: exit 0
 
   check-changelog:
+    if: ${{ github.event.pull_request.state == 'open' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     env:
@@ -68,6 +70,7 @@ jobs:
           echo "$desc"
 
   check-commit-references:
+    if: ${{ github.event.pull_request.state == 'open' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -83,6 +86,7 @@ jobs:
         run: bash hack/validate/pr-gh-references
 
   check-pr-branch:
+    if: ${{ github.event.pull_request.state == 'open' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     env:


### PR DESCRIPTION
I noticed that this workflow was running both before, and after merging a pull request. When running after it's merged, it gets confused and the check will be failing (post merge);

    Modified files: .github/workflows/.dco.yml, .github/workflows/.test-unit.yml, .github/workflows/.test.yml, .github/workflows/.vm.yml, .github/workflows/.windows.yml, .github/workflows/buildkit.yml, .github/workflows/ci.yml, .github/workflows/codeql.yml, .github/workflows/test.yml, .github/workflows/validate-pr.yml
    Touches version: false
    Base ref: master
    Error: PR must have a milestone set (expected: 29.7.0)

Add an extra condition so that the check is only triggered while the PR is open, not after it's closed or merged. Also add `reopened` as event, to make sure it's run if someone would close/reopen the PR.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
