### PR TITLE
integration/TestBridgeICC: Retry Bridge ICC ping after reload

### DIFF
--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -33,6 +33,7 @@ import (
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
+	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -206,20 +207,37 @@ func TestBridgeICC(t *testing.T) {
 			pingCmd := []string{"ping", "-c1", "-W3", ipv, pingHost}
 
 			ctr2Name := fmt.Sprintf("ctr-icc-%d-2", tcID)
-			attachCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			defer cancel()
-			res := container.RunAttach(attachCtx, t, c,
+			id2 := container.Run(ctx, t, c,
 				container.WithName(ctr2Name),
 				container.WithImage("busybox:latest"),
-				container.WithCmd(pingCmd...),
+				container.WithCmd("top"),
 				container.WithNetworkMode(bridgeName))
-			defer c.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{
+			defer c.ContainerRemove(ctx, id2, client.ContainerRemoveOptions{
 				Force: true,
 			})
 
+			var res container.ExecResult
+			poll.WaitOn(t, func(_ poll.LogT) poll.Result {
+				execCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				defer cancel()
+
+				var err error
+				res, err = container.Exec(execCtx, c, id2, pingCmd)
+				if err != nil {
+					return poll.Error(err)
+				}
+				if res.ExitCode != 0 {
+					return poll.Continue(
+						"ping failed with exit code %d, stdout: %s, stderr: %s",
+						res.ExitCode, res.Stdout(), res.Stderr(),
+					)
+				}
+				return poll.Success()
+			}, poll.WithTimeout(15*time.Second))
+
 			assert.Check(t, is.Equal(res.ExitCode, 0))
-			assert.Check(t, is.Equal(res.Stderr.Len(), 0))
-			assert.Check(t, is.Contains(res.Stdout.String(), "1 packets transmitted, 1 packets received"))
+			assert.Check(t, is.Equal(res.Stderr(), ""))
+			assert.Check(t, is.Contains(res.Stdout(), "1 packets transmitted, 1 packets received"))
 		})
 	}
 }


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/50595


## Summary

TestBridgeICC was added to verify bridge inter-container communication, including DNS resolution, ARP/NDP, IPv6 SLAAC/link-local addressing, and internal network behavior. A later change added a firewalld reload so the same coverage also verifies that Docker restores bridge firewall rules after firewalld deletes them.

The test is not intended to assert that the first ICMP echo immediately after the reload can never be dropped. In CI, the IPv6 ULA internal-network case can resolve the target name but lose that first packet while the post-reload network path is still converging.

Keep the single-packet ping assertion, but run it from a long-lived peer and poll until it succeeds. Persistent ICC or rule-restoration failures still fail the test, while transient post-reload packet loss no longer flakes it.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
