### PR TITLE
integration/system: Skip flaky disk usage prune test

### DIFF
--- a/integration/system/disk_usage_prune_test.go
+++ b/integration/system/disk_usage_prune_test.go
@@ -20,6 +20,8 @@ import (
 // image removal does not cause an error.
 // Regression test for https://github.com/moby/moby/issues/51978
 func TestDiskUsageConcurrentPrune(t *testing.T) {
+	t.Skip(t, "TODO(https://github.com/moby/moby/issues/52538): unskip once the DiskUsage race is fixed")
+
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "cannot start multiple daemons on windows")
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
 	skip.If(t, !testEnv.UsingSnapshotter(), "only happens with containerd image store")


### PR DESCRIPTION
- related to: https://github.com/moby/moby/issues/52538


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary


TestDiskUsageConcurrentPrune still flakes while DiskUsage races with image removal, so skip it until the race is fixed.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
