### PR TITLE
[docker-29.x backport] Dockerfile: update containerd binary to v2.2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,7 @@ WORKDIR /usr/src/containerd
 # It is used to build containerd binaries, and used for the integration tests.
 # The distributed docker .deb and .rpm packages depend on a separate (containerd.io)
 # package, which may be a different version than specified here.
-ARG CONTAINERD_VERSION=v2.2.4
+ARG CONTAINERD_VERSION=v2.2.5
 ADD https://github.com/containerd/containerd.git?ref=${CONTAINERD_VERSION}&keep-git-dir=1 .
 
 FROM base AS containerd-build

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -170,7 +170,7 @@ ARG GOTESTSUM_VERSION=v1.13.0
 ARG GOWINRES_VERSION=v0.3.3
 
 # CONTAINERD_VERSION is the version of containerd to use for CI.
-ARG CONTAINERD_VERSION=v2.2.4
+ARG CONTAINERD_VERSION=v2.2.5
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/52930

----

- full diff: https://github.com/containerd/containerd/compare/v2.2.4...v2.2.5
- release notes: https://github.com/containerd/containerd/releases/tag/v2.2.5

The fifth patch release for containerd 2.2 contains various fixes and updates including security patches.

-  CVE-2026-50195 / [GHSA-cvxm-645q-p574] CRI: checkpoint import allows local image tag poisoning
-  CVE-2026-53488 / [GHSA-xhf5-7wjv-pqxp] CRI: image-config LABEL flows to host-root command execution from an image pull
-  CVE-2026-53492 / [GHSA-33vj-92qq-66hc] CRI: CDI annotation smuggling during CRI checkpoint restore
-  CVE-2026-53489 / [GHSA-rgh6-rfwx-v388] CRI: Arbitrary host file read via symlink following in CRI checkpoint restore
-  CVE-2026-47262 / [GHSA-jpcc-p29g-p8mq] containerd image-triggered runtime DoS via unbounded group parsing

[GHSA-cvxm-645q-p574]: https://github.com/containerd/containerd/security/advisories/GHSA-cvxm-645q-p574
[GHSA-xhf5-7wjv-pqxp]: https://github.com/containerd/containerd/security/advisories/GHSA-xhf5-7wjv-pqxp
[GHSA-33vj-92qq-66hc]: https://github.com/containerd/containerd/security/advisories/GHSA-33vj-92qq-66hc
[GHSA-rgh6-rfwx-v388]: https://github.com/containerd/containerd/security/advisories/GHSA-rgh6-rfwx-v388
[GHSA-jpcc-p29g-p8mq]: https://github.com/containerd/containerd/security/advisories/GHSA-jpcc-p29g-p8mq


(cherry picked from commit 61a5b5d766cfeda60f2185cb744171469fc91726)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Update containerd (static binaries) to [v2.2.5](https://github.com/containerd/containerd/releases/tag/v2.2.5)
```

## A picture of a cute animal (not mandatory but encouraged)
