### PR TITLE
gha/test: skip pr-gh-references validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,9 @@ jobs:
         name: Create matrix
         id: scripts
         run: |
-          scripts=$(cd ./hack/validate && jq -nc '$ARGS.positional - ["all", "default", "dco"] | map(select(test("[.]")|not)) + ["generate-files"]' --args *)
+          # Select all validate scripts, excluding checks that are already run
+          # elsewhere and/or require pull-request metadata (dco, pr-gh-references).
+          scripts=$(cd ./hack/validate && jq -nc '$ARGS.positional - ["all", "default", "dco", "pr-gh-references"] | map(select(test("[.]")|not)) + ["generate-files"]' --args *)
           echo "matrix=$scripts" >> $GITHUB_OUTPUT
           echo "$scripts"
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/52952#issuecomment-4789958359

This validation is already run elsewhere, but wasn't excluded in this workflow, causing failures on non-default branches (because VALIDATE_BRANCH isn't set, and won't be set when running from a "push" or "workflow_dispatch").

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
