### PR TITLE
[docker-29.x backport] vendor: update buildkit to v0.31.1-dev

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/mistifyio/go-zfs/v4 v4.0.0
 	github.com/mitchellh/copystructure v1.2.0
-	github.com/moby/buildkit v0.31.0
+	github.com/moby/buildkit v0.31.1
 	github.com/moby/docker-image-spec v1.3.1
 	github.com/moby/go-archive v0.2.0
 	github.com/moby/ipvs v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -542,8 +542,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/moby/buildkit v0.31.0 h1:hMUAbQGgjtzJDDOZ6o7MQk5XBZkBTyzLWEvnjguHHQI=
-github.com/moby/buildkit v0.31.0/go.mod h1:YM5iNEbNCc6L1Zt3YWFB/aXNLufvf4Rcu0DPlc9HwQg=
+github.com/moby/buildkit v0.31.1 h1:j3p55abBl4kiXXPZgYX+6zWgB2aefqHXoPown12fIzU=
+github.com/moby/buildkit v0.31.1/go.mod h1:YM5iNEbNCc6L1Zt3YWFB/aXNLufvf4Rcu0DPlc9HwQg=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/go-archive v0.2.0 h1:zg5QDUM2mi0JIM9fdQZWC7U8+2ZfixfTYoHL7rWUcP8=

--- a/vendor/github.com/moby/buildkit/client/llb/exec.go
+++ b/vendor/github.com/moby/buildkit/client/llb/exec.go
@@ -279,8 +279,12 @@ func (e *ExecOp) Marshal(ctx context.Context, c *Constraints) (digest.Digest, []
 		addCap(&e.constraints, pb.CapExecMetaNetwork)
 	}
 
-	if security != SecurityModeSandbox {
+	switch security {
+	case SecurityModeSandbox:
+	case SecurityModeInsecure:
 		addCap(&e.constraints, pb.CapExecMetaSecurity)
+	default:
+		return "", nil, nil, nil, pb.ValidateSecurityMode(security)
 	}
 
 	if p := e.proxyEnv; p != nil {

--- a/vendor/github.com/moby/buildkit/executor/oci/spec_darwin.go
+++ b/vendor/github.com/moby/buildkit/executor/oci/spec_darwin.go
@@ -20,6 +20,9 @@ func generateMountOpts(_, _ string) []oci.SpecOpts {
 }
 
 func generateSecurityOpts(mode pb.SecurityMode, _ string, _ bool) ([]oci.SpecOpts, error) {
+	if err := pb.ValidateSecurityMode(mode); err != nil {
+		return nil, err
+	}
 	return nil, nil
 }
 

--- a/vendor/github.com/moby/buildkit/executor/oci/spec_freebsd.go
+++ b/vendor/github.com/moby/buildkit/executor/oci/spec_freebsd.go
@@ -21,6 +21,9 @@ func generateMountOpts(_, _ string) []oci.SpecOpts {
 
 // generateSecurityOpts may affect mounts, so must be called after generateMountOpts
 func generateSecurityOpts(mode pb.SecurityMode, _ string, _ bool) ([]oci.SpecOpts, error) {
+	if err := pb.ValidateSecurityMode(mode); err != nil {
+		return nil, err
+	}
 	if mode == pb.SecurityMode_INSECURE {
 		return nil, errors.New("no support for running in insecure mode on FreeBSD")
 	}

--- a/vendor/github.com/moby/buildkit/executor/oci/spec_linux.go
+++ b/vendor/github.com/moby/buildkit/executor/oci/spec_linux.go
@@ -53,11 +53,14 @@ func generateMountOpts(resolvConf, hostsFile string) []oci.SpecOpts {
 
 // generateSecurityOpts may affect mounts, so must be called after generateMountOpts
 func generateSecurityOpts(mode pb.SecurityMode, apparmorProfile string, selinuxB bool) (opts []oci.SpecOpts, _ error) {
+	if err := pb.ValidateSecurityMode(mode); err != nil {
+		return nil, err
+	}
 	if selinuxB && !selinux.GetEnabled() {
 		return nil, errors.New("selinux is not available")
 	}
-	switch mode {
-	case pb.SecurityMode_INSECURE:
+
+	if mode == pb.SecurityMode_INSECURE {
 		return []oci.SpecOpts{
 			security.WithInsecureSpec(),
 			oci.WithWriteableCgroupfs,
@@ -70,28 +73,27 @@ func generateSecurityOpts(mode pb.SecurityMode, apparmorProfile string, selinuxB
 				return err
 			},
 		}, nil
-	case pb.SecurityMode_SANDBOX:
-		if cdseccomp.IsEnabled() {
-			opts = append(opts, withDefaultProfile())
-		}
-		if apparmorProfile != "" {
-			// If AppArmor is not supported but a profile was specified, return an error
-			if !apparmor.HostSupports() {
-				return nil, errors.New("AppArmor is not supported on this host, but the profile '" + apparmorProfile + "' was specified")
-			}
-
-			opts = append(opts, oci.WithApparmorProfile(apparmorProfile))
-		}
-		opts = append(opts, func(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
-			var err error
-			if selinuxB {
-				s.Process.SelinuxLabel, s.Linux.MountLabel, err = label.InitLabels(nil)
-			}
-			return err
-		})
-		return opts, nil
 	}
-	return nil, nil
+
+	if cdseccomp.IsEnabled() {
+		opts = append(opts, withDefaultProfile())
+	}
+	if apparmorProfile != "" {
+		// If AppArmor is not supported but a profile was specified, return an error
+		if !apparmor.HostSupports() {
+			return nil, errors.New("AppArmor is not supported on this host, but the profile '" + apparmorProfile + "' was specified")
+		}
+
+		opts = append(opts, oci.WithApparmorProfile(apparmorProfile))
+	}
+	opts = append(opts, func(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
+		var err error
+		if selinuxB {
+			s.Process.SelinuxLabel, s.Linux.MountLabel, err = label.InitLabels(nil)
+		}
+		return err
+	})
+	return opts, nil
 }
 
 // generateProcessModeOpts may affect mounts, so must be called after generateMountOpts

--- a/vendor/github.com/moby/buildkit/executor/oci/spec_windows.go
+++ b/vendor/github.com/moby/buildkit/executor/oci/spec_windows.go
@@ -59,6 +59,9 @@ func generateMountOpts(_, _ string) []oci.SpecOpts {
 
 // generateSecurityOpts may affect mounts, so must be called after generateMountOpts
 func generateSecurityOpts(mode pb.SecurityMode, _ string, _ bool) ([]oci.SpecOpts, error) {
+	if err := pb.ValidateSecurityMode(mode); err != nil {
+		return nil, err
+	}
 	if mode == pb.SecurityMode_INSECURE {
 		return nil, errors.New("no support for running in insecure mode on Windows")
 	}

--- a/vendor/github.com/moby/buildkit/executor/oci/user.go
+++ b/vendor/github.com/moby/buildkit/executor/oci/user.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"io"
 	"os"
 	"slices"
 	"strconv"
@@ -14,6 +15,8 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
+
+const maxUserFileBytes = 10 << 20
 
 func GetUser(root, username string) (uint32, uint32, []uint32, error) {
 	var isDefault bool
@@ -68,12 +71,46 @@ func ParseUIDGID(str string) (uid uint32, gid uint32, err error) {
 	return
 }
 
-func openUserFile(root, p string) (*os.File, error) {
+func openUserFile(root, p string) (io.ReadCloser, error) {
 	p, err := fs.RootPath(root, p)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
-	return os.Open(p)
+
+	f, err := os.Open(p)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, errors.WithStack(err)
+	}
+	if !info.Mode().IsRegular() {
+		f.Close()
+		return nil, errors.Errorf("%s is not a regular file", p)
+	}
+
+	return &limitedReadCloser{
+		ReadCloser: f,
+		r:          &io.LimitedReader{R: f, N: maxUserFileBytes + 1},
+		name:       p,
+	}, nil
+}
+
+type limitedReadCloser struct {
+	io.ReadCloser
+	r    *io.LimitedReader
+	name string
+}
+
+func (l *limitedReadCloser) Read(p []byte) (int, error) {
+	n, err := l.r.Read(p)
+	if l.r.N == 0 {
+		return n, errors.Errorf("%q exceeds %d bytes", l.name, maxUserFileBytes)
+	}
+	return n, err
 }
 
 func parseUID(str string) (uint32, error) {

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/ops/user_linux.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/ops/user_linux.go
@@ -1,6 +1,7 @@
 package ops
 
 import (
+	"io"
 	"os"
 	"syscall"
 
@@ -12,6 +13,8 @@ import (
 	"github.com/pkg/errors"
 	copy "github.com/tonistiigi/fsutil/copy"
 )
+
+const maxUserFileBytes = 10 << 20
 
 func getReadUserFn(_ worker.Worker) func(chopt *pb.ChownOpt, mu, mg snapshot.Mountable) (*copy.User, error) {
 	return readUser
@@ -41,12 +44,7 @@ func readUser(chopt *pb.ChownOpt, mu, mg snapshot.Mountable) (*copy.User, error)
 				return nil, err
 			}
 
-			passwdPath, err = fs.RootPath(dir, passwdPath)
-			if err != nil {
-				return nil, err
-			}
-
-			ufile, err := os.Open(passwdPath)
+			ufile, err := openUserFile(dir, passwdPath)
 			if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTDIR) {
 				// Couldn't open the file. Considering this case as not finding the user in the file.
 				break
@@ -92,12 +90,7 @@ func readUser(chopt *pb.ChownOpt, mu, mg snapshot.Mountable) (*copy.User, error)
 				return nil, err
 			}
 
-			groupPath, err = fs.RootPath(dir, groupPath)
-			if err != nil {
-				return nil, err
-			}
-
-			gfile, err := os.Open(groupPath)
+			gfile, err := openUserFile(dir, groupPath)
 			if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTDIR) {
 				// Couldn't open the file. Considering this case as not finding the group in the file.
 				break
@@ -123,4 +116,46 @@ func readUser(chopt *pb.ChownOpt, mu, mg snapshot.Mountable) (*copy.User, error)
 	}
 
 	return &us, nil
+}
+
+func openUserFile(root, p string) (io.ReadCloser, error) {
+	p, err := fs.RootPath(root, p)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	f, err := os.Open(p)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, errors.WithStack(err)
+	}
+	if !info.Mode().IsRegular() {
+		f.Close()
+		return nil, errors.Errorf("%s is not a regular file", p)
+	}
+
+	return &limitedReadCloser{
+		ReadCloser: f,
+		r:          &io.LimitedReader{R: f, N: maxUserFileBytes + 1},
+		name:       p,
+	}, nil
+}
+
+type limitedReadCloser struct {
+	io.ReadCloser
+	r    *io.LimitedReader
+	name string
+}
+
+func (l *limitedReadCloser) Read(p []byte) (int, error) {
+	n, err := l.r.Read(p)
+	if l.r.N == 0 {
+		return n, errors.Errorf("%q exceeds %d bytes", l.name, maxUserFileBytes)
+	}
+	return n, err
 }

--- a/vendor/github.com/moby/buildkit/solver/pb/securitymode.go
+++ b/vendor/github.com/moby/buildkit/solver/pb/securitymode.go
@@ -1,0 +1,12 @@
+package pb
+
+import "github.com/pkg/errors"
+
+func ValidateSecurityMode(mode SecurityMode) error {
+	switch mode {
+	case SecurityMode_SANDBOX, SecurityMode_INSECURE:
+		return nil
+	default:
+		return errors.Errorf("invalid security mode %d", mode)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -983,7 +983,7 @@ github.com/mitchellh/hashstructure/v2
 # github.com/mitchellh/reflectwalk v1.0.2
 ## explicit
 github.com/mitchellh/reflectwalk
-# github.com/moby/buildkit v0.31.0
+# github.com/moby/buildkit v0.31.1
 ## explicit; go 1.25.9
 github.com/moby/buildkit/api/services/control
 github.com/moby/buildkit/api/types


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/52955

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Update BuildKit to [v0.31.1](https://github.com/moby/buildkit/releases/tag/v0.31.1)
```

## A picture of a cute animal (not mandatory but encouraged)
