### PR TITLE
pkg/plugins: validate plugin names to prevent path traversal

### DIFF
--- a/pkg/plugins/discovery.go
+++ b/pkg/plugins/discovery.go
@@ -95,6 +95,14 @@ func (l *LocalRegistry) Scan() ([]string, error) {
 
 // Plugin returns the plugin registered with the given name (or returns an error).
 func (l *LocalRegistry) Plugin(name string) (*Plugin, error) {
+	// name is used to build filesystem paths for the plugin's socket and spec
+	// files (see pluginPaths). Reject names that are not a single, local path
+	// element so that a crafted name such as "../other" cannot escape the
+	// configured plugin directories and load an out-of-scope spec or socket.
+	if !validName(name) {
+		return nil, errors.Wrapf(ErrNotFound, "invalid v1 plugin name %q", name)
+	}
+
 	socketPaths := pluginPaths(l.socketsPath, name, ".sock")
 	for _, p := range socketPaths {
 		if fi, err := os.Stat(p); err == nil && fi.Mode()&os.ModeSocket != 0 {
@@ -182,4 +190,16 @@ func pluginPaths(base, name, ext string) []string {
 		filepath.Join(base, name+ext),
 		filepath.Join(base, name, name+ext),
 	}
+}
+
+// validName reports whether name is safe to use as a single path element when
+// locating a plugin's socket and spec files. It rejects the "." and ".."
+// directory entries and any non-local name (empty, absolute, containing a path
+// separator, or, on Windows, a reserved device name), all of which could
+// otherwise be joined with a base directory to reference files outside it.
+func validName(name string) bool {
+	if name == "." || name == ".." {
+		return false
+	}
+	return filepath.IsLocal(name)
 }

--- a/pkg/plugins/discovery_test.go
+++ b/pkg/plugins/discovery_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -103,6 +104,57 @@ func TestFileJSONSpecPlugin(t *testing.T) {
 
 	if plugin.TLSConfig.KeyFile != "/usr/shared/docker/certs/example-key.pem" {
 		t.Fatalf("Expected plugin Key `/usr/shared/docker/certs/example-key.pem`, got %s\n", plugin.TLSConfig.KeyFile)
+	}
+}
+
+func TestPluginRejectsTraversalName(t *testing.T) {
+	// Lay out a plugin directory with a sentinel spec one level above it. A name
+	// that escapes the plugin directory via ".." resolves to the sentinel, so a
+	// successful lookup of a crafted name would prove a directory traversal.
+	root := t.TempDir()
+	pluginDir := filepath.Join(root, "plugins")
+	if err := os.Mkdir(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "evil.spec"), []byte("tcp://attacker:9999"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := LocalRegistry{
+		socketsPath: pluginDir,
+		specsPaths:  []string{pluginDir},
+	}
+
+	for _, tc := range []struct {
+		name   string
+		plugin string
+	}{
+		{name: "empty", plugin: ""},
+		{name: "dot", plugin: "."},
+		{name: "dotdot", plugin: ".."},
+		{name: "parent", plugin: "../evil"},
+		{name: "grandparent", plugin: "../../evil"},
+		{name: "embedded traversal", plugin: "foo/../../evil"},
+		{name: "native separator", plugin: filepath.Join("..", "evil")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := r.Plugin(tc.plugin)
+			if !errors.Is(err, ErrNotFound) {
+				t.Fatalf("expected ErrNotFound for name %q, got plugin=%v, err=%v", tc.plugin, p, err)
+			}
+			if p != nil {
+				t.Fatalf("expected no plugin for name %q, got %v", tc.plugin, p)
+			}
+		})
+	}
+
+	// A legitimate, single-element name must still resolve, to guard against
+	// over-rejection.
+	if err := os.WriteFile(filepath.Join(pluginDir, "echo.spec"), []byte("tcp://localhost:8080"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Plugin("echo"); err != nil {
+		t.Fatalf("expected legitimate plugin name to resolve, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

While looking at the v1 plugin loader I noticed `Plugin()` in `pkg/plugins/discovery.go` just takes the plugin name and feeds it into `filepath.Join` to find the `.sock`/`.spec` files. 

Problem is `Join` cleans up `..`, so a name like `../other` jumps out of the plugins dir and the daemon happily reads whatever spec file is sitting there and trusts its contents as the plugin address. The name isn't checked anywhere before this (it comes through the v1 fallback path), so the separators just go straight through.

Fix is just to check the name first — it has to be a single local path element, otherwise we bail out with not-found. Used `filepath.IsLocal` since the volume code already does the same thing. Added a test for the `..` cases and a normal name so we don't accidentally break real plugins.

## Release notes 

​```markdown changelog
Reject v1 plugin names that contain path separators 
​```

