### PR TITLE
builder/git: disable file protocol for submodules

### DIFF
--- a/daemon/builder/remotecontext/git/gitutils.go
+++ b/daemon/builder/remotecontext/git/gitutils.go
@@ -79,9 +79,11 @@ func (repo gitRepo) clone() (checkoutDir string, retErr error) {
 		return "", err
 	}
 
-	cmd := exec.Command("git", "submodule", "update", "--init", "--recursive", "--depth=1")
-	cmd.Dir = root
-	output, err := cmd.CombinedOutput()
+	// Update submodules through gitWithinDir so they use the same protocol
+	// restrictions as the rest of the clone (notably the file protocol
+	// restrictions), keeping submodule fetching independent of the host's
+	// git configuration.
+	output, err := repo.gitWithinDir(root, "submodule", "update", "--init", "--recursive", "--depth=1")
 	if err != nil {
 		return "", errors.Wrapf(err, "error initializing submodules: %s", output)
 	}
@@ -205,13 +207,18 @@ func (repo gitRepo) gitWithinDir(dir string, args ...string) ([]byte, error) {
 	args = append([]string{"-c", "protocol.file.allow=never"}, args...) // Block sneaky repositories from using repos from the filesystem as submodules.
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
-	// Disable unsafe remote protocols.
-	cmd.Env = append(os.Environ(), "GIT_PROTOCOL_FROM_USER=0")
+	cmd.Env = append(os.Environ(),
+		// Disable unsafe remote protocols. The allowlist also covers git
+		// versions without protocol.<name>.allow support (added in git 2.12).
+		"GIT_PROTOCOL_FROM_USER=0",
+		"GIT_ALLOW_PROTOCOL=http:https:git:ssh",
+	)
 
 	if repo.isolateConfig {
 		cmd.Env = append(cmd.Env,
-			"GIT_CONFIG_NOSYSTEM=1", // Disable reading from system gitconfig.
-			"HOME=/dev/null",        // Disable reading from user gitconfig.
+			"GIT_CONFIG_NOSYSTEM=1",         // Disable reading from system gitconfig.
+			"HOME="+os.DevNull,              // Disable reading from user gitconfig.
+			"GIT_CONFIG_GLOBAL="+os.DevNull, // Disable reading from global gitconfig.
 		)
 	}
 

--- a/daemon/builder/remotecontext/git/gitutils_test.go
+++ b/daemon/builder/remotecontext/git/gitutils_test.go
@@ -336,6 +336,77 @@ func TestCheckoutGit(t *testing.T) {
 	}
 }
 
+// TestCloneSubmoduleFileProtocol verifies that clone() fetches submodules with
+// the same config isolation and protocol restrictions as the rest of the
+// clone, so a repository cannot pull a submodule from the daemon host's
+// filesystem when the host's git configuration enables the "file" protocol.
+//
+// The host config below makes a raw "git submodule update" fetch the file://
+// submodule, so without the fix clone() leaks the host repository and the test
+// fails; routing the update through gitWithinDir ignores the host gitconfig
+// and disallows the file protocol, which blocks it.
+func TestCloneSubmoduleFileProtocol(t *testing.T) {
+	gitpath, err := exec.LookPath("git")
+	assert.NilError(t, err)
+
+	root := t.TempDir()
+
+	// Simulate a daemon host whose git configuration enables the file protocol.
+	// Using a global config file (rather than GIT_CONFIG_* env vars) keeps the
+	// test independent of the git version, and also provides a commit identity.
+	home := t.TempDir()
+	gitconfig := "[user]\n\tname = test\n\temail = test@docker.com\n[protocol \"file\"]\n\tallow = always\n"
+	assert.NilError(t, os.WriteFile(filepath.Join(home, ".gitconfig"), []byte(gitconfig), 0o644))
+	t.Setenv("HOME", home)
+
+	// Serve everything under root over Smart HTTP, the way clone() fetches its
+	// remote (the main remote cannot use the file protocol, which gitWithinDir
+	// blocks, so HTTP is required here).
+	server := httptest.NewServer(&cgi.Handler{
+		Path: gitpath,
+		Args: []string{"http-backend"},
+		Dir:  root,
+		Env:  []string{"GIT_PROJECT_ROOT=" + root, "GIT_HTTP_EXPORT_ALL=1"},
+	})
+	defer server.Close()
+
+	// The host-side setup runs git directly; gitWithinDir would block the
+	// file protocol that adding the submodule relies on.
+	git := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		assert.NilError(t, err, "git %s: %s", strings.Join(args, " "), out)
+	}
+
+	// "secret" is a repository on the daemon host that the build must not read.
+	secret := filepath.Join(root, "secret")
+	git(root, "-c", "init.defaultBranch=master", "init", secret)
+	assert.NilError(t, os.WriteFile(filepath.Join(secret, "secret"), []byte("s3cr3t"), 0o644))
+	git(secret, "add", "-A")
+	git(secret, "commit", "-m", "secret")
+
+	// "super" is the attacker-controlled repository, with a file:// submodule
+	// pointing at the host-local "secret" repository.
+	super := filepath.Join(root, "super")
+	git(root, "-c", "init.defaultBranch=master", "init", super)
+	assert.NilError(t, os.WriteFile(filepath.Join(super, "Dockerfile"), []byte("FROM scratch"), 0o644))
+	git(super, "-c", "protocol.file.allow=always", "submodule", "add", "file://"+filepath.ToSlash(secret), "sub")
+	git(super, "add", "-A")
+	git(super, "commit", "-m", "with submodule")
+
+	// Clone with an isolated config, the way the daemon calls Clone().
+	checkoutDir, err := gitRepo{remote: server.URL + "/super", ref: "master", isolateConfig: true}.clone()
+	if checkoutDir != "" {
+		defer os.RemoveAll(checkoutDir)
+	}
+	if err == nil {
+		_, statErr := os.Stat(filepath.Join(checkoutDir, "sub", "secret"))
+		assert.Assert(t, os.IsNotExist(statErr), "file:// submodule was fetched from the host filesystem")
+	}
+}
+
 func TestValidGitTransport(t *testing.T) {
 	gitUrls := []string{
 		"git://github.com/docker/docker",


### PR DESCRIPTION
**What I did**

While reading through the git build-context code I noticed that `git submodule update`
is the only git command run directly with `exec.Command` instead of going through
`gitWithinDir`. That helper forces `protocol.file.allow=never` (and `GIT_PROTOCOL_FROM_USER=0`)
on every other call, so the build doesn't depend on the host's gitconfig.

Because the submodule update skips it, on a host with `protocol.file.allow=always` set
globally a repo's `.gitmodules` can point a submodule at a `file://` path and pull files
off the daemon's filesystem during `docker build <git-url>`. Routing it through
`gitWithinDir` like everything else fixes that and keeps the protocol handling consistent.

**How to verify it**

Added a test that builds a repo with a `file://` submodule under a permissive host
gitconfig. It fails before the change (the submodule gets fetched) and passes after.
