### PR TITLE
gha/vm: Reduce Lima guest size for non-Moby org

### DIFF
--- a/.github/workflows/.vm.yml
+++ b/.github/workflows/.vm.yml
@@ -55,11 +55,21 @@ jobs:
       -
         name: Start the guest VM
         run: |
+          set -eux -o pipefail
+          host_memory_gib=$(awk '/MemTotal/ { print int($2 / 1024 / 1024) }' /proc/meminfo)
+          lima_memory=$((host_memory_gib - 2))
+
+          echo "Lima memory: ${lima_memory} GiB (${host_memory_gib} GiB detected)" >>"${GITHUB_STEP_SUMMARY}"
+
+          if [ $lima_memory -lt 1 ]; then
+            echo "::error::Too little memory!"
+            exit 2
+          fi
+
           # --plain is set because the built-in containerd support conflicts with Docker
           limactl start \
             --name=default \
-            --cpus=4 \
-            --memory=12 \
+            --memory=${lima_memory} \
             --plain \
             ${INPUTS_TEMPLATE}
         env:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

In Docker org, QEMU exits before SSH is available on GitHub-hosted runners because the VM job asks KVM for 12 GiB of guest memory:

```
qemu-system-x86_64: cannot set up guest memory 'pc.ram': Cannot
allocate memory
```

Keep the 12 GiB memory only for the Moby org.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
