### PR TITLE
integration: Deflake TestNetworkInspectWithScope

### DIFF
--- a/integration/network/network_test.go
+++ b/integration/network/network_test.go
@@ -16,6 +16,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/poll"
 )
 
 // TestNetworkInvalidJSON tests that POST endpoints that expect a body return
@@ -160,8 +161,15 @@ func TestNetworkInspectWithScope(t *testing.T) {
 	create, err := cli.NetworkCreate(ctx, name, client.NetworkCreateOptions{Driver: "overlay"})
 	assert.NilError(t, err)
 
-	inspect, err := cli.NetworkInspect(ctx, name, client.NetworkInspectOptions{})
-	assert.NilError(t, err)
+	var inspect client.NetworkInspectResult
+	poll.WaitOn(t, func(_ poll.LogT) poll.Result {
+		var err error
+		inspect, err = cli.NetworkInspect(ctx, name, client.NetworkInspectOptions{})
+		if err != nil {
+			return poll.Continue("waiting for network %s to be inspectable: %v", name, err)
+		}
+		return poll.Success()
+	}, swarm.NetworkPoll)
 	assert.Check(t, is.Equal("swarm", inspect.Network.Scope))
 	assert.Check(t, is.Equal(create.ID, inspect.Network.ID))
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

Poll instead of inspecting once.

Swarm network creation can return before the newly created network is visible to a following inspect by name.

The test asserted immediately and could fail with:


```
Error response from daemon: network test-scoped-network not found
```

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
