### PR TITLE
daemon: prevent path traversal via checkpoint ID

### DIFF
--- a/daemon/checkpoint.go
+++ b/daemon/checkpoint.go
@@ -2,20 +2,33 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/moby/moby/api/types/checkpoint"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/v2/daemon/names"
 	"github.com/moby/moby/v2/daemon/server/backend"
+	"github.com/moby/moby/v2/errdefs"
 )
 
-var (
-	validCheckpointNameChars   = names.RestrictedNameChars
-	validCheckpointNamePattern = names.RestrictedNamePattern
-)
+// validateCheckpointID returns an error if id is not a plain checkpoint name.
+// A checkpoint ID is joined onto the checkpoint directory to build a filesystem
+// path, so it must not be able to traverse outside of it.
+func validateCheckpointID(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errdefs.InvalidParameter(errors.New("invalid checkpoint ID: value is empty"))
+	}
+
+	if !names.RestrictedNamePattern.MatchString(id) {
+		return errdefs.InvalidParameter(fmt.Errorf("invalid checkpoint ID (%s): only %s are allowed", id, names.RestrictedNameChars))
+	}
+	return nil
+}
 
 // getCheckpointDir verifies checkpoint directory for create,remove, list options and checks if checkpoint already exists
 func getCheckpointDir(checkDir, checkpointID, ctrName, ctrID, ctrCheckpointDir string, create bool) (string, error) {
@@ -54,6 +67,10 @@ func getCheckpointDir(checkDir, checkpointID, ctrName, ctrID, ctrCheckpointDir s
 
 // CheckpointCreate checkpoints the process running in a container with CRIU
 func (daemon *Daemon) CheckpointCreate(name string, config checkpoint.CreateRequest) error {
+	if err := validateCheckpointID(config.CheckpointID); err != nil {
+		return err
+	}
+
 	container, err := daemon.GetContainer(name)
 	if err != nil {
 		return err
@@ -64,10 +81,6 @@ func (daemon *Daemon) CheckpointCreate(name string, config checkpoint.CreateRequ
 	container.Unlock()
 	if err != nil {
 		return err
-	}
-
-	if !validCheckpointNamePattern.MatchString(config.CheckpointID) {
-		return fmt.Errorf("Invalid checkpoint ID (%s), only %s are allowed", config.CheckpointID, validCheckpointNameChars)
 	}
 
 	checkpointDir, err := getCheckpointDir(config.CheckpointDir, config.CheckpointID, name, container.ID, container.CheckpointDir(), true)
@@ -88,6 +101,10 @@ func (daemon *Daemon) CheckpointCreate(name string, config checkpoint.CreateRequ
 
 // CheckpointDelete deletes the specified checkpoint
 func (daemon *Daemon) CheckpointDelete(name string, config backend.CheckpointDeleteOptions) error {
+	if err := validateCheckpointID(config.CheckpointID); err != nil {
+		return err
+	}
+
 	container, err := daemon.GetContainer(name)
 	if err != nil {
 		return err

--- a/daemon/checkpoint_test.go
+++ b/daemon/checkpoint_test.go
@@ -1,0 +1,27 @@
+package daemon
+
+import (
+	"testing"
+
+	cerrdefs "github.com/containerd/errdefs"
+)
+
+// TestValidateCheckpointID checks that IDs which could escape the checkpoint
+// directory are rejected, while plain checkpoint names are accepted.
+func TestValidateCheckpointID(t *testing.T) {
+	for _, id := range []string{"..", "../escape", "foo/../..", "/abs", "bad name", "", "   "} {
+		err := validateCheckpointID(id)
+		if err == nil {
+			t.Errorf("checkpoint ID %q: expected error, got nil", id)
+			continue
+		}
+		if !cerrdefs.IsInvalidArgument(err) {
+			t.Errorf("checkpoint ID %q: expected an invalid parameter error, got %v", id, err)
+		}
+	}
+	for _, id := range []string{"good", "good.name", "good-name_1"} {
+		if err := validateCheckpointID(id); err != nil {
+			t.Errorf("checkpoint ID %q: unexpected error: %v", id, err)
+		}
+	}
+}

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -84,6 +84,16 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 		span.End()
 	}()
 
+	if checkpointDir != "" {
+		// TODO(mlaventure): how would we support that?
+		return errdefs.Forbidden(errors.New("custom checkpointdir is not supported"))
+	}
+	if checkpoint != "" {
+		if err := validateCheckpointID(checkpoint); err != nil {
+			return err
+		}
+	}
+
 	start := time.Now()
 	container.Lock()
 	defer container.Unlock()
@@ -94,11 +104,6 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 
 	if container.State.RemovalInProgress || container.State.Dead {
 		return errdefs.Conflict(errors.New("container is marked for removal and cannot be started"))
-	}
-
-	if checkpointDir != "" {
-		// TODO(mlaventure): how would we support that?
-		return errdefs.Forbidden(errors.New("custom checkpointdir is not supported"))
 	}
 
 	// if we encounter an error during start we need to ensure that any other


### PR DESCRIPTION
Checkpoint IDs are joined onto the checkpoint directory to form a real
filesystem path. Create validated the ID, but delete, list, and restore
didn't — so an ID like `..` could point outside the checkpoint dir.

This adds a `validateCheckpointID` helper and calls it from each operation
that takes a caller-supplied ID — create, delete, and restore — before the
path is built, so traversal IDs are rejected up front. `getCheckpointDir`
stays a plain path-construction helper, and listing keeps using the empty
ID internally.

A regression test covers `validateCheckpointID` with traversal and valid IDs.
