### PR TITLE
gha/test/validate: Build dev image on cache miss

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,15 +177,26 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Restore dev image
+        id: restore-dev-image
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: dev-image-amd64-${{ github.run_id }}
           path: /tmp/dev-image-amd64.tar
-          fail-on-cache-miss: true
       -
         name: Load dev image
+        if: steps.restore-dev-image.outputs.cache-hit == 'true'
         run: |
           docker load -i /tmp/dev-image-amd64.tar
+      -
+        # Fall back to building the dev image if the cache could not be
+        # restored (e.g. cache miss or a rate-limited download).
+        name: Build dev image
+        if: steps.restore-dev-image.outputs.cache-hit != 'true'
+        uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584 # v7.2.0
+        with:
+          targets: dev
+          set: |
+            dev.cache-from=type=gha,scope=dev-amd64
       -
         name: Validate
         env:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

Sometimes we get rate limited for cache access.

Drop fail-on-cache-miss and fall back to building the dev image from the GHA buildkit cache (scope=dev-amd64) when the restore doesn't hit, the same way the test and test-unit jobs already build it.

The happy path (cache hit + docker load) is unchanged.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
