### PR TITLE
Mask registry auth tokens in debug request logs

### DIFF
--- a/daemon/server/middleware/debug.go
+++ b/daemon/server/middleware/debug.go
@@ -90,6 +90,13 @@ func maskSecretKeys(inp any) {
 
 	if form, ok := inp.(map[string]any); ok {
 		scrub := []string{
+			// Registry credentials sent in the body of POST /auth requests
+			// (registry.AuthConfig). These field names are only used by
+			// credential-bearing structs, so they are scrubbed unconditionally,
+			// as is the "password" field below.
+			"auth",
+			"identitytoken",
+			"registrytoken",
 			// Note: The Data field contains the base64-encoded secret in 'secret'
 			// and 'config' create and update requests. Currently, no other POST
 			// API endpoints use a data field, so we scrub this field unconditionally.

--- a/daemon/server/middleware/debug_test.go
+++ b/daemon/server/middleware/debug_test.go
@@ -50,6 +50,27 @@ func TestMaskSecretKeys(t *testing.T) {
 			},
 		},
 		{
+			// Credentials from registry.AuthConfig (POST /auth). Matching is
+			// case-insensitive (strings.EqualFold), and only exact credential
+			// field names are scrubbed, so non-secret fields (username,
+			// serveraddress) are preserved.
+			doc: "registry auth credentials (POST /auth)",
+			input: map[string]any{
+				"username":      "user",
+				"serveraddress": "registry.example.test",
+				"auth":          "dXNlcjpwYXNz",
+				"IdEnTiTyToKeN": "id-token",
+				"registrytoken": "reg-token",
+			},
+			expected: map[string]any{
+				"username":      "user",
+				"serveraddress": "registry.example.test",
+				"auth":          "*****",
+				"IdEnTiTyToKeN": "*****",
+				"registrytoken": "*****",
+			},
+		},
+		{
 			doc: "case insensitive field matching",
 			input: map[string]any{
 				"PASSWORD": "pass",


### PR DESCRIPTION
#### What I did

`maskSecretKeys` scrubs credential fields from request bodies before they're
written to the debug log, but misses three fields on `registry.AuthConfig`:
`auth`, `identitytoken`, and `registrytoken`. This adds them.

#### Why

On `POST /auth` (`docker login`) the body is logged at debug level before it's
decoded, so these registry tokens leak into the daemon log in cleartext — even
though the `password` they encode is already masked.

#### How to verify

Added a test that runs the real middleware over an `AuthConfig` body and checks
the credentials never reach the log (fails without the change). These field
names only appear on credential structs, so no benign field is affected.
