### PR TITLE
daemon: do not log full environment on migration

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -922,22 +922,21 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 
 	migrationThreshold := int64(-1)
 	if config.Features["containerd-migration"] {
+		migrationThreshold = 0
 		if ts := os.Getenv("DOCKER_MIGRATE_SNAPSHOTTER_THRESHOLD"); ts != "" {
 			v, err := units.FromHumanSize(ts)
-			if err == nil {
-				migrationThreshold = v
-			} else {
-				log.G(ctx).WithError(err).WithField("size", ts).Warn("Invalid migration threshold value, defaulting to 0")
-				migrationThreshold = 0
+			if err != nil {
+				return nil, fmt.Errorf("invalid migration threshold value (DOCKER_MIGRATE_SNAPSHOTTER_THRESHOLD=%s): %w", ts, err)
 			}
-
-		} else {
-			migrationThreshold = 0
+			if v < 0 {
+				return nil, fmt.Errorf("invalid migration threshold value (DOCKER_MIGRATE_SNAPSHOTTER_THRESHOLD=%s): value must not be negative", ts)
+			}
+			migrationThreshold = v
 		}
 		if migrationThreshold > 0 {
 			log.G(ctx).WithField("max_size", migrationThreshold).Info("(Experimental) Migration to containerd is enabled, driver will be switched to snapshotter after migration is complete")
 		} else {
-			log.G(ctx).WithField("env", os.Environ()).Info("Migration to containerd is enabled, driver will be switched to snapshotter if there are no images or containers")
+			log.G(ctx).Info("Migration to containerd is enabled, driver will be switched to snapshotter if there are no images or containers")
 		}
 	}
 


### PR DESCRIPTION
#### What

While the experimental containerd snapshotter migration is enabled, the daemon
logs its whole process environment at `info` level:

#### go
log.G(ctx).WithField("env", os.Environ()).Info("Migration to containerd is enabled, ...") '''

#### Why it matters
The environment often holds credentials (proxy user:pass, registry/cloud
tokens), so this leaks secrets into the daemon logs. Looks like leftover
debugging — the sibling branch only logs max_size.

#### Change
Log the parsed migration threshold instead of the environment, with the parsing
moved into a small helper. Behaviour is unchanged (empty/invalid → 0), with a
unit test for the parsing.



