### PR TITLE
daemon: scope container working directory creation with os.Root

### DIFF
--- a/daemon/container/container.go
+++ b/daemon/container/container.go
@@ -41,7 +41,6 @@ import (
 	"github.com/moby/sys/atomicwriter"
 	"github.com/moby/sys/signal"
 	"github.com/moby/sys/symlink"
-	"github.com/moby/sys/user"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
@@ -335,15 +334,59 @@ func (container *Container) SetupWorkingDirectory(uid int, gid int) error {
 		return err
 	}
 
-	if err := user.MkdirAllAndChown(pth, 0o755, uid, gid, user.WithOnlyNew); err != nil {
-		pthInfo, err2 := os.Stat(pth)
-		if err2 == nil && pthInfo != nil && !pthInfo.IsDir() {
-			return errors.Errorf("Cannot mkdir: %s is not a directory", container.Config.WorkingDir)
-		}
-
+	// GetResourcePath only guarantees that pth stays inside the container while
+	// none of its components is swapped for a symlink between resolution and use
+	// (see its doc comment). Re-rooting the creation in the container's BaseFS
+	// with [os.Root] makes that guarantee hold for every component on every
+	// operation, the same hardening applied to mount-destination creation in
+	// commit 64a22d80b9.
+	root, err := os.OpenRoot(container.BaseFS)
+	if err != nil {
 		return err
 	}
+	defer root.Close()
 
+	rel, err := filepath.Rel(container.BaseFS, pth)
+	if err != nil {
+		return err
+	}
+	if err := scopedMkdirAllAndChown(root, rel, 0o755, uid, gid); err != nil {
+		if errors.Is(err, syscall.ENOTDIR) {
+			return errors.Errorf("Cannot mkdir: %s is not a directory", container.Config.WorkingDir)
+		}
+		return err
+	}
+	return nil
+}
+
+// scopedMkdirAllAndChown creates path and any missing parent directories inside
+// root, setting ownership of the newly-created directories to uid:gid. It is the
+// [os.Root]-scoped equivalent of user.MkdirAllAndChown(..., user.WithOnlyNew):
+// performing every operation through root ensures that a path component which is
+// (or is swapped for) a symlink cannot redirect the mkdir or chown to a location
+// outside of root. Pre-existing directories are left untouched, and chown is
+// skipped on platforms that do not support it (e.g. Windows), matching the
+// behaviour of the user.MkdirAllAndChown call this replaces.
+func scopedMkdirAllAndChown(root *os.Root, path string, perm os.FileMode, uid, gid int) error {
+	dir := "."
+	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+		if part == "" || part == "." {
+			continue
+		}
+		dir = filepath.Join(dir, part)
+		if fi, err := root.Stat(dir); err == nil {
+			if !fi.IsDir() {
+				return &os.PathError{Op: "mkdir", Path: dir, Err: syscall.ENOTDIR}
+			}
+			continue
+		}
+		if err := root.Mkdir(dir, perm); err != nil {
+			return err
+		}
+		if err := root.Chown(dir, uid, gid); err != nil && runtime.GOOS != "windows" {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/daemon/container/container.go
+++ b/daemon/container/container.go
@@ -368,8 +368,8 @@ func (container *Container) SetupWorkingDirectory(uid int, gid int) error {
 // skipped on platforms that do not support it (e.g. Windows), matching the
 // behaviour of the user.MkdirAllAndChown call this replaces.
 func scopedMkdirAllAndChown(root *os.Root, path string, perm os.FileMode, uid, gid int) error {
-	dir := "."
-	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+	dir := ""
+	for _, part := range strings.Split(filepath.ToSlash(filepath.Clean(path)), "/") {
 		if part == "" || part == "." {
 			continue
 		}

--- a/daemon/container/container_test.go
+++ b/daemon/container/container_test.go
@@ -134,6 +134,18 @@ func TestScopedMkdirAllAndChown(t *testing.T) {
 		_, statErr := os.Stat(filepath.Join(outside, "evil"))
 		assert.Assert(t, os.IsNotExist(statErr), "creation escaped the container root")
 	})
+
+	t.Run("supports relative paths with dots and windows separators", func(t *testing.T) {
+		base := t.TempDir()
+		root, err := os.OpenRoot(base)
+		assert.NilError(t, err)
+		defer root.Close()
+		assert.NilError(t, scopedMkdirAllAndChown(root, filepath.FromSlash("./a/b"), 0o755, uid, gid))
+		assert.NilError(t, scopedMkdirAllAndChown(root, filepath.FromSlash("a\\b/c"), 0o755, uid, gid))
+		fi, err := os.Stat(filepath.Join(base, "a", "b"))
+		assert.NilError(t, err)
+		assert.Assert(t, fi.IsDir())
+	})
 }
 
 func TestContainerSecretReferenceDestTarget(t *testing.T) {

--- a/daemon/container/container_test.go
+++ b/daemon/container/container_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -48,6 +49,91 @@ func TestContainerStopTimeout(t *testing.T) {
 	}
 	s = c.StopTimeout()
 	assert.Equal(t, s, stopTimeout)
+}
+
+func TestSetupWorkingDirectory(t *testing.T) {
+	uid, gid := os.Getuid(), os.Getgid()
+
+	t.Run("creates nested workdir under the container root", func(t *testing.T) {
+		base := t.TempDir()
+		c := &Container{BaseFS: base, Config: &container.Config{WorkingDir: "/a/b/c"}}
+		assert.NilError(t, c.SetupWorkingDirectory(uid, gid))
+		fi, err := os.Stat(filepath.Join(base, "a", "b", "c"))
+		assert.NilError(t, err)
+		assert.Assert(t, fi.IsDir())
+	})
+
+	t.Run("empty workdir is a no-op", func(t *testing.T) {
+		c := &Container{BaseFS: t.TempDir(), Config: &container.Config{}}
+		assert.NilError(t, c.SetupWorkingDirectory(uid, gid))
+	})
+
+	t.Run("workdir over an existing file fails", func(t *testing.T) {
+		base := t.TempDir()
+		assert.NilError(t, os.WriteFile(filepath.Join(base, "file"), nil, 0o644))
+		c := &Container{BaseFS: base, Config: &container.Config{WorkingDir: "/file"}}
+		assert.ErrorContains(t, c.SetupWorkingDirectory(uid, gid), "not a directory")
+	})
+
+	t.Run("symlinked component cannot escape the container root", func(t *testing.T) {
+		base, outside := t.TempDir(), t.TempDir()
+		if err := os.Symlink(outside, filepath.Join(base, "link")); err != nil {
+			t.Skipf("symlinks unsupported: %v", err)
+		}
+		c := &Container{BaseFS: base, Config: &container.Config{WorkingDir: "/link/evil"}}
+		err := c.SetupWorkingDirectory(uid, gid)
+		_, statErr := os.Stat(filepath.Join(outside, "evil"))
+		assert.Assert(t, os.IsNotExist(statErr), "creation escaped the container root (err=%v)", err)
+	})
+}
+
+func TestScopedMkdirAllAndChown(t *testing.T) {
+	uid, gid := os.Getuid(), os.Getgid()
+
+	t.Run("creates missing parents", func(t *testing.T) {
+		base := t.TempDir()
+		root, err := os.OpenRoot(base)
+		assert.NilError(t, err)
+		defer root.Close()
+		assert.NilError(t, scopedMkdirAllAndChown(root, "a/b/c", 0o755, uid, gid))
+		fi, err := os.Stat(filepath.Join(base, "a", "b", "c"))
+		assert.NilError(t, err)
+		assert.Assert(t, fi.IsDir())
+	})
+
+	t.Run("tolerates existing parents", func(t *testing.T) {
+		base := t.TempDir()
+		assert.NilError(t, os.Mkdir(filepath.Join(base, "a"), 0o755))
+		root, err := os.OpenRoot(base)
+		assert.NilError(t, err)
+		defer root.Close()
+		assert.NilError(t, scopedMkdirAllAndChown(root, "a/b", 0o755, uid, gid))
+		fi, err := os.Stat(filepath.Join(base, "a", "b"))
+		assert.NilError(t, err)
+		assert.Assert(t, fi.IsDir())
+	})
+
+	t.Run("errors when a component is not a directory", func(t *testing.T) {
+		base := t.TempDir()
+		assert.NilError(t, os.WriteFile(filepath.Join(base, "f"), nil, 0o644))
+		root, err := os.OpenRoot(base)
+		assert.NilError(t, err)
+		defer root.Close()
+		assert.ErrorIs(t, scopedMkdirAllAndChown(root, "f/x", 0o755, uid, gid), syscall.ENOTDIR)
+	})
+
+	t.Run("does not follow a symlink out of root", func(t *testing.T) {
+		base, outside := t.TempDir(), t.TempDir()
+		if err := os.Symlink(outside, filepath.Join(base, "link")); err != nil {
+			t.Skipf("symlinks unsupported: %v", err)
+		}
+		root, err := os.OpenRoot(base)
+		assert.NilError(t, err)
+		defer root.Close()
+		_ = scopedMkdirAllAndChown(root, "link/evil", 0o755, uid, gid)
+		_, statErr := os.Stat(filepath.Join(outside, "evil"))
+		assert.Assert(t, os.IsNotExist(statErr), "creation escaped the container root")
+	})
 }
 
 func TestContainerSecretReferenceDestTarget(t *testing.T) {

--- a/tmp_root_test/test.go
+++ b/tmp_root_test/test.go
@@ -1,0 +1,15 @@
+package main
+import (
+ "fmt"
+ "os"
+)
+func main() {
+ tmp := os.Args[1]
+ root, err := os.OpenRoot(tmp)
+ if err != nil { panic(err) }
+ defer root.Close()
+ for _, path := range []string{"foo", "foo/bar", "./foo", "./foo/bar", "foo\\bar", "./foo\\bar"} {
+  err := root.Mkdir(path, 0o755)
+  fmt.Printf("path=%q err=%v\n", path, err)
+ }
+}

--- a/tmp_root_test2/test.go
+++ b/tmp_root_test2/test.go
@@ -1,0 +1,12 @@
+package main
+import (
+ "fmt"
+ "path/filepath"
+)
+func main() {
+ fmt.Println(filepath.Join(`C:\base`, `\foo`))
+ fmt.Println(filepath.Join(`C:\base`, `/foo`))
+ fmt.Println(filepath.Join(`C:\base`, `foo`))
+ fmt.Println(filepath.Join(`C:\base`, `//foo`))
+ fmt.Println(filepath.Join(`C:\base`, `C:\foo`))
+}

--- a/tmp_root_test3/test.go
+++ b/tmp_root_test3/test.go
@@ -1,0 +1,14 @@
+package main
+import (
+ "fmt"
+ "os"
+)
+func main() {
+ root, err := os.OpenRoot(os.Args[1])
+ if err != nil { panic(err) }
+ defer root.Close()
+ for _, path := range []string{"tmp", "./tmp", ".\\tmp", "tmp\\sub", "./tmp\\sub"} {
+  err := root.Mkdir(path, 0o755)
+  fmt.Printf("path=%q err=%v\n", path, err)
+ }
+}

--- a/tmp_root_test4/test.go
+++ b/tmp_root_test4/test.go
@@ -1,0 +1,14 @@
+package main
+import (
+ "fmt"
+ "os"
+)
+func main() {
+ root, err := os.OpenRoot(os.Args[1])
+ if err != nil { panic(err) }
+ defer root.Close()
+ for _, path := range []string{".\\tmp","tmp","tmp\\sub","./tmp\\sub","./tmp"} {
+  err := root.Mkdir(path, 0o755)
+  fmt.Printf("path=%q err=%v\n", path, err)
+ }
+}

--- a/tmp_root_test5/test.go
+++ b/tmp_root_test5/test.go
@@ -1,0 +1,17 @@
+package main
+import (
+ "fmt"
+ "os"
+)
+func main() {
+ root, err := os.OpenRoot(os.Args[1])
+ if err != nil { panic(err) }
+ defer root.Close()
+ for _, path := range []string{"foo",".\\foo","foo\\bar",".\\foo\\bar"} {
+  fmt.Printf("test path=%q\n", path)
+  if fi, err := root.Stat(path); err != nil { fmt.Printf(" Stat err=%v\n", err) } else { fmt.Printf(" Stat exists=%v dir=%v\n", true, fi.IsDir()) }
+  err = root.Mkdir(path, 0o755)
+  fmt.Printf(" Mkdir err=%v\n", err)
+  if fi, err := root.Stat(path); err != nil { fmt.Printf(" Stat2 err=%v\n", err) } else { fmt.Printf(" Stat2 exists=%v dir=%v\n", true, fi.IsDir()) }
+ }
+}

--- a/tmp_root_test6/test.go
+++ b/tmp_root_test6/test.go
@@ -1,0 +1,36 @@
+package main
+import (
+ "fmt"
+ "os"
+ "path/filepath"
+ "strings"
+)
+func scopedMkdirAll(root *os.Root, path string) error {
+ dir := ""
+ for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+  if part == "" || part == "." {
+   continue
+  }
+  dir = filepath.Join(dir, part)
+  if fi, err := root.Stat(dir); err == nil {
+   if !fi.IsDir() {
+    return err
+   }
+   continue
+  }
+  if err := root.Mkdir(dir, 0o755); err != nil {
+   return err
+  }
+ }
+ return nil
+}
+func main() {
+ root, err := os.OpenRoot(os.Args[1])
+ if err != nil { panic(err) }
+ defer root.Close()
+ for _, path := range []string{"foo/bar", ".///foo/bar", "./foo/bar", "foo\\bar", "./foo\\bar"} {
+  fmt.Printf("path=%q\n", path)
+  err := scopedMkdirAll(root, path)
+  fmt.Printf(" err=%v\n", err)
+ }
+}


### PR DESCRIPTION
`SetupWorkingDirectory` ran `mkdir`/`chown` on a path from `GetResourcePath`,
which (per its own doc) is only safe while no component is swapped for a symlink
between resolution and use — letting the operation escape the container root.

This scopes the creation to an `os.Root` on the container's `BaseFS`, which
re-checks every component and refuses to follow a symlink out of the root — the
same hardening applied to mount-destination creation in `64a22d80b9`. The
only-new create+chown is factored into a reusable `scopedMkdirAllAndChown`
helper (chown skipped on Windows, as before), with unit and integration tests.