### PR TITLE
progress: propagate Start to enable time-remaining

### DIFF
--- a/client/pkg/progress/progress.go
+++ b/client/pkg/progress/progress.go
@@ -16,6 +16,11 @@ type Progress struct {
 	Current int64
 	Total   int64
 
+	// Start is the Unix timestamp (in seconds) at which the operation began.
+	// When set, renderers use it to estimate the remaining time. It is left
+	// as zero when no meaningful start time is available.
+	Start int64
+
 	// If true, don't show xB/yB
 	HideCounts bool
 	// If not empty, use units instead of bytes for counts

--- a/client/pkg/progress/progressreader.go
+++ b/client/pkg/progress/progressreader.go
@@ -16,6 +16,7 @@ type Reader struct {
 	lastUpdate  int64
 	id          string
 	action      string
+	start       int64 // Unix timestamp (in seconds) at which reading started
 	rateLimiter *rate.Limiter
 }
 
@@ -27,6 +28,7 @@ func NewProgressReader(in io.ReadCloser, out Output, size int64, id, action stri
 		size:        size,
 		id:          id,
 		action:      action,
+		start:       time.Now().Unix(),
 		rateLimiter: rate.NewLimiter(rate.Every(100*time.Millisecond), 1),
 	}
 }
@@ -61,6 +63,6 @@ func (p *Reader) Close() error {
 
 func (p *Reader) updateProgress(last bool) {
 	if last || p.current == p.size || p.rateLimiter.Allow() {
-		p.out.WriteProgress(Progress{ID: p.id, Action: p.action, Current: p.current, Total: p.size, LastUpdate: last})
+		p.out.WriteProgress(Progress{ID: p.id, Action: p.action, Current: p.current, Total: p.size, Start: p.start, LastUpdate: last})
 	}
 }

--- a/client/pkg/progress/progressreader_test.go
+++ b/client/pkg/progress/progressreader_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"testing"
+	"time"
 )
 
 func TestOutputOnPrematureClose(t *testing.T) {
@@ -35,6 +36,43 @@ drainLoop:
 	case <-progressChan:
 	default:
 		t.Fatalf("Expected some output when closing prematurely")
+	}
+}
+
+func TestProgressReaderSetsStart(t *testing.T) {
+	content := []byte("TESTING")
+	reader := io.NopCloser(bytes.NewReader(content))
+	progressChan := make(chan Progress, 10)
+
+	before := time.Now().Unix()
+	pr := NewProgressReader(reader, ChanOutput(progressChan), int64(len(content)), "Test", "Read")
+
+	if _, err := io.ReadAll(pr); err != nil {
+		pr.Close()
+		t.Fatal(err)
+	}
+	pr.Close()
+	close(progressChan)
+
+	var updates int
+	var start int64
+	for p := range progressChan {
+		updates++
+		if p.Start <= 0 {
+			t.Errorf("expected Start to be populated (> 0), got %d", p.Start)
+		}
+		switch {
+		case start == 0:
+			start = p.Start
+		case p.Start != start:
+			t.Errorf("expected a stable Start across updates, got %d and %d", start, p.Start)
+		}
+	}
+	if updates == 0 {
+		t.Fatal("expected at least one progress update")
+	}
+	if start < before {
+		t.Errorf("expected Start (%d) to be >= reader creation time (%d)", start, before)
 	}
 }
 

--- a/client/pkg/streamformatter/streamformatter.go
+++ b/client/pkg/streamformatter/streamformatter.go
@@ -32,6 +32,7 @@ func (sf *jsonProgressFormatter) format(prog progress.Progress) []byte {
 	jsonProgress := jsonstream.Progress{
 		Current:    prog.Current,
 		Total:      prog.Total,
+		Start:      prog.Start,
 		HideCounts: prog.HideCounts,
 		Units:      prog.Units,
 	}
@@ -94,6 +95,7 @@ func (sf *rawProgressFormatter) format(prog progress.Progress) []byte {
 	return sf.formatProgress(prog.Action, &jsonstream.Progress{
 		Current:    prog.Current,
 		Total:      prog.Total,
+		Start:      prog.Start,
 		HideCounts: prog.HideCounts,
 		Units:      prog.Units,
 	})
@@ -143,7 +145,6 @@ func rawProgressString(p *jsonstream.Progress) string {
 		}
 	}
 
-	// FIXME(thaJeztah): p.Start is never set, because progress.Progress doesn't have this field
 	var timeLeftBox string
 	if p.Current > 0 && p.Start > 0 && percentage < 50 {
 		fromStart := time.Since(time.Unix(p.Start, 0))

--- a/client/pkg/streamformatter/streamformatter_test.go
+++ b/client/pkg/streamformatter/streamformatter_test.go
@@ -59,6 +59,20 @@ func TestJSONProgressFormatterFormatProgress(t *testing.T) {
 	assert.Equal(t, buf.String(), expected)
 }
 
+func TestJSONProgressFormatterPassesStart(t *testing.T) {
+	var buf bytes.Buffer
+	err := streamformatter.NewJSONProgressOutput(&buf, false).WriteProgress(progress.Progress{
+		ID:      "id",
+		Action:  "Downloading",
+		Current: 15,
+		Total:   30,
+		Start:   12345,
+	})
+	assert.NilError(t, err)
+	expected := `{"status":"Downloading","progressDetail":{"current":15,"total":30,"start":12345},"id":"id"}` + streamNewline
+	assert.Equal(t, buf.String(), expected)
+}
+
 func TestJSONProgressFormatterFormatStatus(t *testing.T) {
 	var buf bytes.Buffer
 	err := streamformatter.NewJSONProgressOutput(&buf, false).WriteProgress(progress.Progress{

--- a/daemon/containerd/progress.go
+++ b/daemon/containerd/progress.go
@@ -145,11 +145,19 @@ func (p *pullProgress) UpdateProgress(ctx context.Context, ongoing *jobs, out pr
 			if info.Offset == 0 {
 				continue
 			}
+			// Use the per-layer download start (when known) so the estimated
+			// time remaining stays accurate even when layers begin downloading
+			// at different times due to concurrency limits.
+			var layerStart int64
+			if !info.StartedAt.IsZero() {
+				layerStart = info.StartedAt.Unix()
+			}
 			out.WriteProgress(progress.Progress{
 				ID:      stringid.TruncateID(j.Digest.Encoded()),
 				Action:  "Downloading",
 				Current: info.Offset,
 				Total:   info.Total,
+				Start:   layerStart,
 			})
 			continue
 		}
@@ -209,6 +217,7 @@ func (p *pullProgress) UpdateProgress(ctx context.Context, ongoing *jobs, out pr
 					// Start from 1s, because without Total, 0 won't be shown at all.
 					Current: 1 + seconds,
 					Units:   "s",
+					Start:   start.Unix(),
 				})
 		case snapshots.KindCommitted:
 			out.WriteProgress(progress.Progress{

--- a/daemon/internal/progress/progress.go
+++ b/daemon/internal/progress/progress.go
@@ -16,6 +16,11 @@ type Progress struct {
 	Current int64
 	Total   int64
 
+	// Start is the Unix timestamp (in seconds) at which the operation began.
+	// When set, renderers use it to estimate the remaining time. It is left
+	// as zero when no meaningful start time is available.
+	Start int64
+
 	// If true, don't show xB/yB
 	HideCounts bool
 	// If not empty, use units instead of bytes for counts

--- a/daemon/internal/progress/progressreader.go
+++ b/daemon/internal/progress/progressreader.go
@@ -16,6 +16,7 @@ type Reader struct {
 	lastUpdate  int64
 	id          string
 	action      string
+	start       int64 // Unix timestamp (in seconds) at which reading started
 	rateLimiter *rate.Limiter
 }
 
@@ -27,6 +28,7 @@ func NewProgressReader(in io.ReadCloser, out Output, size int64, id, action stri
 		size:        size,
 		id:          id,
 		action:      action,
+		start:       time.Now().Unix(),
 		rateLimiter: rate.NewLimiter(rate.Every(100*time.Millisecond), 1),
 	}
 }
@@ -61,6 +63,6 @@ func (p *Reader) Close() error {
 
 func (p *Reader) updateProgress(last bool) {
 	if last || p.current == p.size || p.rateLimiter.Allow() {
-		p.out.WriteProgress(Progress{ID: p.id, Action: p.action, Current: p.current, Total: p.size, LastUpdate: last})
+		p.out.WriteProgress(Progress{ID: p.id, Action: p.action, Current: p.current, Total: p.size, Start: p.start, LastUpdate: last})
 	}
 }

--- a/daemon/internal/progress/progressreader_test.go
+++ b/daemon/internal/progress/progressreader_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"testing"
+	"time"
 )
 
 func TestOutputOnPrematureClose(t *testing.T) {
@@ -35,6 +36,43 @@ drainLoop:
 	case <-progressChan:
 	default:
 		t.Fatalf("Expected some output when closing prematurely")
+	}
+}
+
+func TestProgressReaderSetsStart(t *testing.T) {
+	content := []byte("TESTING")
+	reader := io.NopCloser(bytes.NewReader(content))
+	progressChan := make(chan Progress, 10)
+
+	before := time.Now().Unix()
+	pr := NewProgressReader(reader, ChanOutput(progressChan), int64(len(content)), "Test", "Read")
+
+	if _, err := io.ReadAll(pr); err != nil {
+		pr.Close()
+		t.Fatal(err)
+	}
+	pr.Close()
+	close(progressChan)
+
+	var updates int
+	var start int64
+	for p := range progressChan {
+		updates++
+		if p.Start <= 0 {
+			t.Errorf("expected Start to be populated (> 0), got %d", p.Start)
+		}
+		switch {
+		case start == 0:
+			start = p.Start
+		case p.Start != start:
+			t.Errorf("expected a stable Start across updates, got %d and %d", start, p.Start)
+		}
+	}
+	if updates == 0 {
+		t.Fatal("expected at least one progress update")
+	}
+	if start < before {
+		t.Errorf("expected Start (%d) to be >= reader creation time (%d)", start, before)
 	}
 }
 

--- a/daemon/internal/streamformatter/streamformatter.go
+++ b/daemon/internal/streamformatter/streamformatter.go
@@ -99,6 +99,7 @@ func (out *progressOutput) WriteProgress(prog progress.Progress) error {
 		jsonProgress := jsonstream.Progress{
 			Current:    prog.Current,
 			Total:      prog.Total,
+			Start:      prog.Start,
 			HideCounts: prog.HideCounts,
 			Units:      prog.Units,
 		}

--- a/daemon/internal/streamformatter/streamformatter_test.go
+++ b/daemon/internal/streamformatter/streamformatter_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/moby/moby/api/types/jsonstream"
+	"github.com/moby/moby/v2/daemon/internal/progress"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -68,6 +69,20 @@ func TestJsonProgressFormatterFormatStatus(t *testing.T) {
 	sf := jsonProgressFormatter{}
 	res := sf.formatStatus("ID", "%s%d", "a", 1)
 	assert.Check(t, is.Equal(`{"status":"a1","id":"ID"}`+streamNewline, string(res)))
+}
+
+func TestJSONProgressOutputPassesStart(t *testing.T) {
+	var buf bytes.Buffer
+	err := NewJSONProgressOutput(&buf, false).WriteProgress(progress.Progress{
+		ID:      "id",
+		Action:  "Downloading",
+		Current: 15,
+		Total:   30,
+		Start:   12345,
+	})
+	assert.NilError(t, err)
+	expected := `{"status":"Downloading","progressDetail":{"current":15,"total":30,"start":12345},"id":"id"}` + streamNewline
+	assert.Check(t, is.Equal(expected, buf.String()))
 }
 
 func TestNewJSONProgressOutput(t *testing.T) {

--- a/daemon/pkg/plugin/backend_linux.go
+++ b/daemon/pkg/plugin/backend_linux.go
@@ -423,7 +423,11 @@ func (pm *Manager) Push(ctx context.Context, name string, metaHeader http.Header
 			}
 
 			for _, s := range statuses {
-				out.WriteProgress(progress.Progress{ID: s.Ref, Current: s.Offset, Total: s.Total, Action: s.Status, LastUpdate: s.Offset == s.Total})
+				var start int64
+				if !s.StartedAt.IsZero() {
+					start = s.StartedAt.Unix()
+				}
+				out.WriteProgress(progress.Progress{ID: s.Ref, Current: s.Offset, Total: s.Total, Start: start, Action: s.Status, LastUpdate: s.Offset == s.Total})
 			}
 		}
 	}()

--- a/daemon/pkg/plugin/fetch_linux.go
+++ b/daemon/pkg/plugin/fetch_linux.go
@@ -230,6 +230,8 @@ func withFetchProgress(cs content.Store, out progress.Output, ref reference.Name
 		key := remotes.MakeRefKey(ctx, desc)
 
 		go func() {
+			start := time.Now().Unix()
+
 			timer := time.NewTimer(100 * time.Millisecond)
 			if !timer.Stop() {
 				<-timer.C
@@ -285,7 +287,7 @@ func withFetchProgress(cs content.Store, out progress.Output, ref reference.Name
 					return
 				}
 
-				out.WriteProgress(progress.Progress{ID: id, Action: "Downloading", Current: s.Offset, Total: s.Total})
+				out.WriteProgress(progress.Progress{ID: id, Action: "Downloading", Current: s.Offset, Total: s.Total, Start: start})
 			}
 		}()
 		return nil, nil


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/52975

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

`jsonstream.Progress` has a `Start` field (a Unix timestamp in seconds) that both the
streamformatter and jsonmessage renderers already use to estimate and display the remaining
time during a transfer. However, the internal `progress.Progress` structs used by the client
and the daemon did not carry a `Start` field, so the conversion to `jsonstream.Progress` never
populated it. As a result `p.Start` was always `0`, the `p.Start > 0` guard was never
satisfied, and the time-remaining display was unreachable dead code (as also noted by a FIXME
in the streamformatter).

Add a `Start` field to both `progress.Progress` structs and thread it through the conversion
layers into `jsonstream.Progress`. Populate it at the source:

- `ProgressReader` records its creation time once and emits it on every update, covering all
  of its callers (downloading, extracting, pushing, importing, loading, ...).
- The containerd pull path uses the per-layer content status `StartedAt` for "Downloading"
  and the operation start time for "Extracting".
- The plugin fetch path captures the download start time, and the plugin push path reuses the
  already-tracked `StartedAt`.

The `start` JSON field keeps its `omitempty` tag, so a zero value produces byte-identical
output and existing rendering is unchanged.

Estimated time-remaining for the containerd "Pushing" status is left out of scope, as it
would require new per-layer start tracking.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Display the estimated time remaining again when pulling images.
```

## A picture of a cute animal (not mandatory but encouraged)
<img width="800" height="740" alt="image" src="https://github.com/user-attachments/assets/eaf13e80-f858-4847-ad10-de917a424cad" />
