### PR TITLE
libnetwork: fix Swarm overlay IPv6 subnet allocation failure

### DIFF
--- a/daemon/libnetwork/cnmallocator/networkallocator.go
+++ b/daemon/libnetwork/cnmallocator/networkallocator.go
@@ -905,6 +905,7 @@ func (na *cnmNetworkAllocator) allocatePools(n *api.Network) (map[netip.Prefix]s
 			Pool:         ic.Subnet,
 			SubPool:      ic.Range,
 			Options:      dOptions,
+			V6:           ic.Family == api.IPAMConfig_IPV6,
 		})
 		if err != nil {
 			// Rollback by releasing all the resources allocated so far.

--- a/daemon/libnetwork/cnmallocator/networkallocator_test.go
+++ b/daemon/libnetwork/cnmallocator/networkallocator_test.go
@@ -790,3 +790,36 @@ func TestCorrectlyPassIPAMOptions(t *testing.T) {
 	assert.Check(t, is.DeepEqual(expectedIpamOptions, ipamDriver.actualIpamOptions))
 	assert.Check(t, err)
 }
+
+func TestAllocateIPv6Subnet(t *testing.T) {
+	na := newNetworkAllocator(t)
+	n := &api.Network{
+		ID: "testIPv6",
+		Spec: api.NetworkSpec{
+			Annotations: api.Annotations{
+				Name: "testIPv6",
+			},
+			DriverConfig: &api.Driver{},
+			IPAM: &api.IPAMOptions{
+				Driver: &api.Driver{},
+				Configs: []*api.IPAMConfig{
+					{
+						Subnet: "10.0.0.0/24",
+						Family: api.IPAMConfig_IPV4,
+					},
+					{
+						Subnet: "fd42:1234:5678:1::/64",
+						Family: api.IPAMConfig_IPV6,
+					},
+				},
+			},
+		},
+	}
+
+	err := na.Allocate(n)
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(len(n.IPAM.Configs), 2))
+	assert.Check(t, is.Equal(n.IPAM.Configs[0].Subnet, "10.0.0.0/24"))
+	assert.Check(t, is.Equal(n.IPAM.Configs[1].Subnet, "fd42:1234:5678:1::/64"))
+}
+


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/52469

## Summary
In `cnmallocator/networkallocator.go`, the network allocator calls `ipam.RequestPool` without setting the `V6` parameter. As a result, the default IPAM allocator registers IPv6 subnets in the IPv4 address space (`global4`/`local4`). When subsequent calls are made to allocate the gateway or request addresses, `RequestAddress` parses the pool ID and looks it up in the IPv6 address space (`global6`/`local6`), causing a lookup failure since the pool is registered under IPv4.

This PR fixes the issue by propagating `V6: ic.Family == api.IPAMConfig_IPV6` to the `PoolRequest` inside `cnmallocator`.

## Note
```markdown changelog
Fix Swarm overlay IPv6 subnet allocation failure by correctly registering IPv6 pools in the IPv6 address space.
