### PR TITLE
d/libn/i/nftables: add fluent chain builder API

### DIFF
--- a/daemon/libnetwork/internal/nftables/fluentapi_linux.go
+++ b/daemon/libnetwork/internal/nftables/fluentapi_linux.go
@@ -1,0 +1,30 @@
+package nftables
+
+type chainBuilder struct {
+	chain string
+	tm    *Modifier
+}
+
+func (b BaseChain) Builder() chainBuilder {
+	tm := &Modifier{}
+	tm.create(b, 1)
+	return chainBuilder{chain: b.Name, tm: tm}
+}
+
+func (c Chain) Builder() chainBuilder {
+	tm := &Modifier{}
+	tm.create(c, 1)
+	return chainBuilder{chain: c.Name, tm: tm}
+}
+
+func (b chainBuilder) Rule(rule ...string) chainBuilder {
+	b.tm.create(Rule{
+		Chain: b.chain,
+		Rule:  rule,
+	}, 1)
+	return b
+}
+
+func (b chainBuilder) Create(tm *Modifier) {
+	tm.cmds = append(tm.cmds, b.tm.cmds...)
+}

--- a/daemon/libnetwork/internal/nftables/nftables_linux.go
+++ b/daemon/libnetwork/internal/nftables/nftables_linux.go
@@ -490,7 +490,11 @@ type Modifier struct {
 
 // Create enqueues creation of object o, to be applied by tm.Apply.
 func (tm *Modifier) Create(o Obj) {
-	_, f, l, _ := runtime.Caller(1)
+	tm.create(o, 1)
+}
+
+func (tm *Modifier) create(o Obj, skipFrames int) {
+	_, f, l, _ := runtime.Caller(skipFrames + 1)
 	tm.cmds = append(tm.cmds, command{
 		obj:        o,
 		callerFile: f,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary
With most of the dynamism of nftables rulesets being powered by named maps and sets, the rules of a chain are often initialized when the chain is added, and never touched again. Add a fluent API for adding the creation of a chain and all its rules to a modifier without having to repeat the chain name for each rule.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
