### PR TITLE
fix(mounts): preserve trailing slash for Windows UNC root paths

### DIFF
--- a/daemon/volume/mounts/windows_parser.go
+++ b/daemon/volume/mounts/windows_parser.go
@@ -402,9 +402,13 @@ func (p *windowsParser) parseMountSpec(cfg mount.Mount, convertTargetToBackslash
 	default:
 		// TODO(thaJeztah): make switch exhaustive: anything to do for mount.TypeTmpfs, mount.TypeCluster, mount.TypeImage ?
 	}
-	// cleanup trailing `\` except for paths like `c:\`
+	// cleanup trailing `\` except for root drives like `c:\` or UNC root drives like `\\?\c:\`
 	if len(mp.Source) > 3 && mp.Source[len(mp.Source)-1] == '\\' {
-		mp.Source = mp.Source[:len(mp.Source)-1]
+		// Verify this is not a UNC root drive (e.g. \\?\c:\) which requires the trailing slash
+		isUNCRoot := len(mp.Source) == 7 && strings.HasPrefix(mp.Source, `\\?\`) && mp.Source[5] == ':'
+		if !isUNCRoot {
+			mp.Source = mp.Source[:len(mp.Source)-1]
+		}
 	}
 	if len(mp.Destination) > 3 && mp.Destination[len(mp.Destination)-1] == '\\' {
 		mp.Destination = mp.Destination[:len(mp.Destination)-1]


### PR DESCRIPTION
Problem:
When evaluating Windows bind mounts, parseMountSpec strips trailing backslashes from the source path. It intentionally skips standard DOS root drives (like C:\) using a naive len > 3 check. However, when users provide Windows long UNC paths (e.g., \\?\C:\) to bypass the 260-character MAX_PATH limit, the 7-character string bypasses this safety check. The engine incorrectly strips the trailing slash, corrupting the UNC prefix into \\?\C:. Because UNC paths do not support relative drive contexts, this invalidates the path and breaks the bind mount before it reaches hcsshim.

Fix:

Injected a specific check inside the trailing slash cleanup block to identify if the source is a 7-character UNC root drive (e.g., starts with \\?\ and ends with :\).

If it is a UNC root, the trailing slash is preserved, ensuring the valid UNC prefix is passed safely to the container runtime.

Verification:

Validated via go test -v ./daemon/volume/mounts/.... All Windows mount parsing tests pass cleanly.
