### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/daemon/internal/cleanups/composite.go
+++ b/daemon/internal/cleanups/composite.go
@@ -2,6 +2,7 @@ package cleanups
 
 import (
 	"context"
+	"slices"
 
 	"github.com/moby/moby/v2/daemon/internal/multierror"
 )
@@ -36,8 +37,8 @@ func (c *Composite) Release() func(context.Context) error {
 
 func call(ctx context.Context, cleanups []func(context.Context) error) error {
 	var errs []error
-	for idx := len(cleanups) - 1; idx >= 0; idx-- {
-		c := cleanups[idx]
+	for _, c := range slices.Backward(cleanups) {
+
 		errs = append(errs, c(ctx))
 	}
 	return multierror.Join(errs...)

--- a/daemon/internal/distribution/push_v2.go
+++ b/daemon/internal/distribution/push_v2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -231,8 +232,8 @@ func (p *pusher) pushTag(ctx context.Context, ref reference.NamedTagged, id dige
 func manifestFromBuilder(ctx context.Context, builder distribution.ManifestBuilder, descriptors []xfer.UploadDescriptor) (distribution.Manifest, error) {
 	// descriptors is in reverse order; iterate backwards to get references
 	// appended in the right order.
-	for i := len(descriptors) - 1; i >= 0; i-- {
-		if err := builder.AppendReference(descriptors[i].(*pushDescriptor)); err != nil {
+	for _, descriptor := range slices.Backward(descriptors) {
+		if err := builder.AppendReference(descriptor.(*pushDescriptor)); err != nil {
 			return nil, err
 		}
 	}

--- a/daemon/libnetwork/internal/resolvconf/resolvconf.go
+++ b/daemon/libnetwork/internal/resolvconf/resolvconf.go
@@ -186,8 +186,8 @@ func (rc *ResolvConf) Options() []string {
 //	Option("ndots") -> ("1", true)
 //	Option("edns0") -> ("", true)
 func (rc *ResolvConf) Option(search string) (string, bool) {
-	for i := len(rc.options) - 1; i >= 0; i-- {
-		k, v, _ := strings.Cut(rc.options[i], ":")
+	for _, v := range slices.Backward(rc.options) {
+		k, v, _ := strings.Cut(v, ":")
 		if k == search {
 			return v, true
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)



<img width="500" height="1000" alt="image" src="https://github.com/user-attachments/assets/10bf351b-ad80-43e8-a3c6-f9ccb33318c0" />

