### PR TITLE
daemon: Create policy trust dir with mode 0o700

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1419,9 +1419,9 @@ func verifierProvider(root string) func() (*policyverifier.Verifier, error) {
 			return verifier, nil
 		}
 
-		confDir := filepath.Join(root, "policy")
-		if err := os.MkdirAll(filepath.Join(confDir, "tuf"), 0o644); err != nil {
-			return nil, errors.Wrapf(err, "failed to create policy verifier config dir")
+		confDir, err := policyStateDir(root)
+		if err != nil {
+			return nil, err
 		}
 
 		v, err := policyverifier.NewVerifier(policyverifier.Config{
@@ -1433,6 +1433,17 @@ func verifierProvider(root string) func() (*policyverifier.Verifier, error) {
 		verifier = v
 		return verifier, nil
 	}
+}
+
+// policyStateDir returns the policy verifier's state directory, created 0o700
+// so the daemon's private TUF trust cache stays owner-only, consistent with the
+// daemon's other state directories.
+func policyStateDir(root string) (string, error) {
+	confDir := filepath.Join(root, "policy")
+	if err := os.MkdirAll(filepath.Join(confDir, "tuf"), 0o700); err != nil {
+		return "", errors.Wrap(err, "failed to create policy verifier config dir")
+	}
+	return confDir, nil
 }
 
 // DistributionServices returns services controlling daemon storage

--- a/daemon/verifier_test.go
+++ b/daemon/verifier_test.go
@@ -1,0 +1,24 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// TestPolicyStateDirPermissions checks that the policy verifier's trust
+// directory is created owner-only (0o700) and not exposed to other users.
+func TestPolicyStateDirPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission bits are not enforced on Windows")
+	}
+	root := t.TempDir()
+	confDir, err := policyStateDir(root)
+	assert.NilError(t, err)
+	fi, err := os.Stat(filepath.Join(confDir, "tuf"))
+	assert.NilError(t, err)
+	assert.Equal(t, fi.Mode().Perm(), os.FileMode(0o700))
+}


### PR DESCRIPTION
While looking through the daemon's state directories I noticed the image
policy verifier creates its trust directory (`<root>/policy/tuf`) with mode
`0o644` — a file mode, missing the execute bit and the only state dir that
isn't created with a proper directory mode.

Every other persistent state directory under the daemon root uses a
restrictive directory mode, `0o700` being the common one (content store,
cluster state, exec-root, image/layer stores, plugin dirs, checkpoints).

This changes the policy trust directory to `0o700` so it's consistent with
its siblings and keeps the daemon's private TUF trust cache owner-only. I
also pulled the directory creation into a small helper so the permissions
are covered by a unit test.
