### PR TITLE
test-integration-flaky: Bump stress multiplier to 10x10 (100 runs)

### DIFF
--- a/hack/make/test-integration-flaky
+++ b/hack/make/test-integration-flaky
@@ -37,10 +37,10 @@ run_integration_flaky() {
 
 	(
 		TESTARRAY=$(echo "$tests" | tr '\n' '|')
-		# Note: TEST_REPEAT will make the test suite run 5 times, restarting the daemon
-		# and each test will run 5 times in a row under the same daemon.
-		# This will make a total of 25 runs for each test in TESTARRAY.
-		export TEST_REPEAT=5
+		# Note: TEST_REPEAT will make the test suite run 10 times, restarting the daemon
+		# and each test will run 10 times in a row under the same daemon.
+		# This will make a total of 100 runs for each test in TESTARRAY.
+		export TEST_REPEAT=10
 		export TESTFLAGS="-test.count ${TEST_REPEAT} -test.run ${TESTARRAY%?}"
 		echo "Using test flags: $TESTFLAGS"
 		source hack/make/test-integration


### PR DESCRIPTION
25 (5x5) is too low for some tests.

It only runs for the added/changed tests so shouldn't be an issue.