### PR TITLE
daemon: Fix container stuck in running state on exit event

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	containerdcli "github.com/containerd/containerd/v2/client"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	containertypes "github.com/moby/moby/api/types/container"
@@ -379,53 +378,37 @@ func (daemon *Daemon) shouldIgnoreExitEventWithLock(c *container.Container, e *l
 		return true
 
 	case containertypes.StateRunning:
-		task, ok := c.State.Task()
-		if !ok {
-			log.G(context.TODO()).WithFields(log.Fields{
-				"container": c.ID,
-			}).Warn("container in running state but no task found while checking for duplicate exit event")
-			return false
-		}
-
-		ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
-		status, err := task.Status(ctx)
-		cancel()
-		if err != nil {
-			// If containerd-shim crashed, the task will be deleted
-			// automatically by containerd, so treat a NotFound
-			// error as meaning the task is not running.
-			log.G(ctx).WithFields(log.Fields{
-				"error":     err,
-				"container": c.ID,
-			}).Warn("failed to get task status while checking for duplicate exit event")
-			return false
-		}
-
-		// If the container is still running, then this exit event must
-		// be a duplicate from a previous run, so ignore it. If the
-		// container is not running, then we should process the exit
-		// event to transition the container to exited.
+		// An exit event for a running container is a duplicate only when
+		// it belongs to a previous run that ended before the current
+		// restart. A previous run will usually have a different PID, but
+		// the kernel may reuse the old PID for the new task. The previous
+		// processed exit timestamp remains in FinishedAt after restart, so
+		// an exact match identifies the delayed duplicate without relying
+		// on wall-clock ordering.
 		//
-		// Timestamp is not reliable for determining whether an exit
-		// event is a duplicate, because CLOCK_REALTIME can jump backwards
-		// (e.g., due to NTP adjustments).
+		// Using task.Status() for this check would require a potentially
+		// blocking RPC while holding the container lock, delaying the
+		// exit transition by up to the RPC timeout. A PID comparison is
+		// instantaneous and sidesteps the NTP-clock concerns that made a
+		// timestamp comparison unreliable.
 		//
 		// See moby/moby#52153 for more details.
-		if status.Status == containerdcli.Running {
+		if !e.ExitedAt.IsZero() && e.ExitedAt.Equal(c.State.FinishedAt) {
 			return true
 		}
-
-		if status.Status == containerdcli.Stopped {
-			if status.ExitStatus != e.ExitCode {
-				log.G(ctx).WithFields(log.Fields{
-					"container": c.ID,
-					"exitCode":  status.ExitStatus,
-					"eventCode": e.ExitCode,
-				}).Warn("container stopped with different exit code than exit event while checking for duplicate exit event")
-				return true
-			}
+		if e.Pid == 0 {
+			log.G(context.TODO()).WithFields(log.Fields{
+				"container": c.ID,
+			}).Warn("exit event has no PID; processing conservatively to avoid dropping a valid exit")
+			return false
 		}
-		return false
+		if uint32(c.State.Pid) == 0 {
+			log.G(context.TODO()).WithFields(log.Fields{
+				"container": c.ID,
+			}).Warn("container in running state has no recorded PID; processing exit event conservatively")
+			return false
+		}
+		return uint32(c.State.Pid) != e.Pid
 
 	case containertypes.StateRestarting:
 		// The restart path acquires and holds the container lock before

--- a/daemon/monitor_test.go
+++ b/daemon/monitor_test.go
@@ -1,0 +1,100 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moby/moby/v2/daemon/container"
+	libcontainerdtypes "github.com/moby/moby/v2/daemon/internal/libcontainerd/types"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+type monitorMockTask struct {
+	libcontainerdtypes.Task
+	pid uint32
+}
+
+func (t *monitorMockTask) Pid() uint32 {
+	return t.pid
+}
+
+func TestShouldIgnoreExitEventWithLockForRunningContainer(t *testing.T) {
+	previousExit := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	currentStart := previousExit.Add(time.Second)
+	currentExit := currentStart.Add(time.Second)
+
+	runningState := func(pid uint32, finishedAt time.Time) *container.State {
+		state := &container.State{FinishedAt: finishedAt}
+		state.SetRunning(nil, &monitorMockTask{pid: pid}, currentStart)
+		return state
+	}
+
+	tests := []struct {
+		name       string
+		state      *container.State
+		event      libcontainerdtypes.EventInfo
+		wantIgnore bool
+	}{
+		{
+			name:  "different event PID ignores event when timestamp cannot identify it",
+			state: runningState(200, previousExit),
+			event: libcontainerdtypes.EventInfo{
+				Pid: 100,
+			},
+			wantIgnore: true,
+		},
+		{
+			name:  "same PID and previous exit timestamp ignores PID reuse duplicate",
+			state: runningState(100, previousExit),
+			event: libcontainerdtypes.EventInfo{
+				Pid:      100,
+				ExitedAt: previousExit,
+			},
+			wantIgnore: true,
+		},
+		{
+			name:  "same PID with later exit timestamp processes current run",
+			state: runningState(100, previousExit),
+			event: libcontainerdtypes.EventInfo{
+				Pid:      100,
+				ExitedAt: currentExit,
+			},
+			wantIgnore: false,
+		},
+		{
+			name:  "zero event PID processes conservatively",
+			state: runningState(100, previousExit),
+			event: libcontainerdtypes.EventInfo{
+				Pid:      0,
+				ExitedAt: currentExit,
+			},
+			wantIgnore: false,
+		},
+		{
+			name:  "zero container PID processes conservatively",
+			state: runningState(0, previousExit),
+			event: libcontainerdtypes.EventInfo{
+				Pid:      100,
+				ExitedAt: currentExit,
+			},
+			wantIgnore: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			daemon := &Daemon{}
+			ctr := &container.Container{
+				ID:    "container_id",
+				State: tc.state,
+			}
+
+			ctr.Lock()
+			got := daemon.shouldIgnoreExitEventWithLock(ctr, &tc.event)
+			ctr.Unlock()
+
+			assert.Check(t, is.Equal(got, tc.wantIgnore))
+		})
+	}
+}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- related: https://github.com/moby/moby/pull/52156
- related: https://github.com/moby/moby/pull/51925
- fixes: https://github.com/moby/moby/issues/39583 (hopefully)

## Summary

shouldIgnoreExitEventWithLock called task.Status() with a 30-second timeout while holding the container lock to detect duplicate exit events.

This caused two failure modes, both manifesting as a flaky TestWaitNonBlocked failure ("timeout hit after 30s: waiting for container State.Status to be 'exited', currently 'running'"):

1. If the RPC stalled (e.g. due to lock contention in embedded- containerd mode), the container lock was held for up to 30 seconds. Since containerInspect also acquires the same lock, ContainerInspect calls blocked for the full duration, leaving the container visibly stuck in "running" state until the RPC timed out.

2. In embedded-containerd mode, the exit event can be delivered before the in-process containerd service commits the task's exit status. In that case task.Status() returns Running, shouldIgnoreExitEventWithLock incorrectly treats the event as a duplicate and discards it, leaving the container permanently stuck in "running" state.

Replace the blocking task.Status() call with an instantaneous PID comparison. A duplicate exit event (from a previous run arriving late after a restart) carries the PID of the old task, which differs from the PID stored in the container state for the current run. If either PID is zero (unavailable), emit a warning and process the event conservatively rather than risk dropping a valid exit.

This sidesteps both the RPC-blocking problem and the NTP clock-skew concern that motivated removing the original timestamp-based check.


/flaky-check=TestWaitNonBlocked

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Fix a bug where containers could get stuck in the "running" state when they exited while the daemon was under load.
```

## A picture of a cute animal (not mandatory but encouraged)
