### PR TITLE
integration/build: Deflake TestBuildWithRemoveAndForceRemove

### DIFF
--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -97,7 +97,6 @@ func TestBuildWithRemoveAndForceRemove(t *testing.T) {
 	apiClient := testEnv.APIClient()
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)
 			dockerfile := []byte(tc.dockerfile)
 


### PR DESCRIPTION
- fix: https://github.com/moby/moby/issues/51112

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

TestBuildWithRemoveAndForceRemove builds several Dockerfiles against the same daemon and then checks for intermediate containers by ID. Running the cases in parallel can make the successful --rm case observe another build's cleanup window and report an unexpected remaining container.

Run the cases serially so each build observes its own final cleanup state.


/flaky-check=TestBuildWithRemoveAndForceRemove

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
