### PR TITLE
daemon: Remove experimental warning for image mount

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/containerd/log"
 	containertypes "github.com/moby/moby/api/types/container"
-	"github.com/moby/moby/api/types/mount"
 	networktypes "github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/daemon/container"
@@ -262,10 +261,6 @@ func validateHostConfig(hostConfig *containertypes.HostConfig) (warnings []strin
 	parser := volumemounts.NewParser()
 	for _, c := range hostConfig.Mounts {
 		cfg := c
-
-		if cfg.Type == mount.TypeImage {
-			warnings = append(warnings, "Image mount is an experimental feature")
-		}
 
 		if err := parser.ValidateMountConfig(&cfg); err != nil {
 			return warnings, err


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

Mount type "image" was introduced in API v1.48.

It has been stable since then, no major issues were reported, and any implementation improvements can be made without breaking the API surface.

It's time to move it out of experimental.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Mount type `image` is no longer experimental.
```

## A picture of a cute animal (not mandatory but encouraged)
