### PR TITLE
daemon: Create policy trust dir with mode 0o700 (carry 52990)

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1420,7 +1420,7 @@ func verifierProvider(root string) func() (*policyverifier.Verifier, error) {
 		}
 
 		confDir := filepath.Join(root, "policy")
-		if err := os.MkdirAll(filepath.Join(confDir, "tuf"), 0o644); err != nil {
+		if err := os.MkdirAll(confDir, 0o700); err != nil {
 			return nil, errors.Wrapf(err, "failed to create policy verifier config dir")
 		}
 


### PR DESCRIPTION
- carries, closes https://github.com/moby/moby/pull/52990
- relates to https://github.com/moby/moby/pull/51737


The image policy verifier creates its trust directory (<root>/policy/tuf) with the wrong mode (0o644) making it non-traversable. Update the permissions to 0o700, matching other persistent state directories under the daemon root.

In addition, there is no need to pre-create the "tuf" subdirectory, which is created (if needed) by policy-helpers/root.NewTrustProvider.

fixes 8890f815ca00fd12fd2c51f8f61a205034a08898

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
