### PR TITLE
d/libn/i/nftables: fix ST1016 (staticcheck)

### DIFF
--- a/daemon/libnetwork/internal/nftables/fluentapi_linux.go
+++ b/daemon/libnetwork/internal/nftables/fluentapi_linux.go
@@ -5,16 +5,16 @@ type chainBuilder struct {
 	tm    *Modifier
 }
 
-func (b BaseChain) Builder() chainBuilder {
+func (cd BaseChain) Builder() chainBuilder {
 	tm := &Modifier{}
-	tm.create(b, 1)
-	return chainBuilder{chain: b.Name, tm: tm}
+	tm.create(cd, 1)
+	return chainBuilder{chain: cd.Name, tm: tm}
 }
 
-func (c Chain) Builder() chainBuilder {
+func (cd Chain) Builder() chainBuilder {
 	tm := &Modifier{}
-	tm.create(c, 1)
-	return chainBuilder{chain: c.Name, tm: tm}
+	tm.create(cd, 1)
+	return chainBuilder{chain: cd.Name, tm: tm}
 }
 
 func (b chainBuilder) Rule(rule ...string) chainBuilder {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/52983

Looks like the linter didn't detect this in de71462b9748458c1ea10ec379288590fe447d28

    daemon/libnetwork/internal/nftables/fluentapi_linux.go:8:20: ST1016: methods on the same type should have the same receiver name (seen 1x "b", 2x "cd") (staticcheck)
    func (b BaseChain) Builder() chainBuilder {
                       ^
    daemon/libnetwork/internal/nftables/fluentapi_linux.go:14:16: ST1016: methods on the same type should have the same receiver name (seen 1x "c", 2x "cd") (staticcheck)
    func (c Chain) Builder() chainBuilder {
                   ^

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
