### PR TITLE
[chore] api/types/network: accept legacy CIDR-prefixed gateway addresses

### DIFF
--- a/api/types/network/ipam.go
+++ b/api/types/network/ipam.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"encoding/json"
 	"net/netip"
 )
 
@@ -17,6 +18,58 @@ type IPAMConfig struct {
 	IPRange    netip.Prefix          `json:"IPRange,omitzero"`
 	Gateway    netip.Addr            `json:"Gateway,omitzero"`
 	AuxAddress map[string]netip.Addr `json:"AuxiliaryAddresses,omitempty"`
+}
+
+// UnmarshalJSON implements [json.Unmarshaler]. It provides lenient parsing for
+// Gateway and AuxiliaryAddresses address fields: older Docker daemons may store
+// gateway addresses with a CIDR prefix notation (e.g. "fd05:d0ca:2::1/112"),
+// which [netip.Addr.UnmarshalText] rejects. To maintain backward compatibility
+// when talking to such daemons, the prefix length is silently stripped.
+func (c *IPAMConfig) UnmarshalJSON(data []byte) error {
+	// Use a shadow type with string fields for the address values so we can
+	// apply lenient parsing ourselves.
+	var raw struct {
+		Subnet     netip.Prefix          `json:"Subnet"`
+		IPRange    netip.Prefix          `json:"IPRange"`
+		Gateway    string                `json:"Gateway"`
+		AuxAddress map[string]string     `json:"AuxiliaryAddresses"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	c.Subnet = raw.Subnet
+	c.IPRange = raw.IPRange
+	c.Gateway = parseAddrLenient(raw.Gateway)
+
+	if len(raw.AuxAddress) > 0 {
+		c.AuxAddress = make(map[string]netip.Addr, len(raw.AuxAddress))
+		for k, v := range raw.AuxAddress {
+			c.AuxAddress[k] = parseAddrLenient(v)
+		}
+	}
+	return nil
+}
+
+// parseAddrLenient parses an IP address string. If the string contains a
+// CIDR prefix (e.g. "192.168.1.1/24"), the prefix length is stripped and the
+// host address is returned. This provides backwards compatibility with Docker
+// daemons that may have stored gateway addresses with prefix notation.
+//
+// An empty or invalid string returns the zero [netip.Addr].
+func parseAddrLenient(s string) netip.Addr {
+	if s == "" {
+		return netip.Addr{}
+	}
+	// Try plain address first (the expected, canonical format).
+	if addr, err := netip.ParseAddr(s); err == nil {
+		return addr.Unmap()
+	}
+	// Fall back: try CIDR notation for older Docker daemon responses.
+	if prefix, err := netip.ParsePrefix(s); err == nil {
+		return prefix.Addr().Unmap()
+	}
+	return netip.Addr{}
 }
 
 type SubnetStatuses = map[netip.Prefix]SubnetStatus

--- a/api/types/network/ipam_test.go
+++ b/api/types/network/ipam_test.go
@@ -1,0 +1,107 @@
+package network_test
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"github.com/moby/moby/api/types/network"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+// TestIPAMConfig_UnmarshalJSON verifies that IPAMConfig.UnmarshalJSON parses
+// normal addresses and, for backwards compatibility with Docker <=26.x daemons
+// that stored gateway addresses with CIDR prefix notation, also accepts
+// addresses such as "fd05:d0ca:2::1/112" by silently stripping the prefix.
+func TestIPAMConfig_UnmarshalJSON(t *testing.T) {
+	t.Run("normal IPv4 gateway", func(t *testing.T) {
+		data := `{"Subnet":"172.19.0.0/24","Gateway":"172.19.0.1"}`
+		var c network.IPAMConfig
+		assert.NilError(t, json.Unmarshal([]byte(data), &c))
+		assert.Check(t, is.Equal(c.Gateway, netip.MustParseAddr("172.19.0.1")))
+		assert.Check(t, is.Equal(c.Subnet, netip.MustParsePrefix("172.19.0.0/24")))
+	})
+
+	t.Run("normal IPv6 gateway", func(t *testing.T) {
+		data := `{"Subnet":"fd05:d0ca:2::/112","Gateway":"fd05:d0ca:2::1"}`
+		var c network.IPAMConfig
+		assert.NilError(t, json.Unmarshal([]byte(data), &c))
+		assert.Check(t, is.Equal(c.Gateway, netip.MustParseAddr("fd05:d0ca:2::1")))
+	})
+
+	// Older Docker daemons (<=26.x) stored gateway addresses with a CIDR prefix.
+	// The client should silently strip the prefix and return just the host address.
+	// See: https://github.com/moby/moby/issues/52991
+	t.Run("legacy IPv6 gateway with prefix (backwards compat)", func(t *testing.T) {
+		data := `{"Subnet":"fd05:d0ca:2::/112","Gateway":"fd05:d0ca:2::1/112"}`
+		var c network.IPAMConfig
+		assert.NilError(t, json.Unmarshal([]byte(data), &c))
+		assert.Check(t, is.Equal(c.Gateway, netip.MustParseAddr("fd05:d0ca:2::1")))
+	})
+
+	t.Run("legacy IPv4 gateway with prefix (backwards compat)", func(t *testing.T) {
+		data := `{"Subnet":"172.19.0.0/24","Gateway":"172.19.0.1/24"}`
+		var c network.IPAMConfig
+		assert.NilError(t, json.Unmarshal([]byte(data), &c))
+		assert.Check(t, is.Equal(c.Gateway, netip.MustParseAddr("172.19.0.1")))
+	})
+
+	t.Run("empty gateway", func(t *testing.T) {
+		data := `{"Subnet":"172.19.0.0/24","Gateway":""}`
+		var c network.IPAMConfig
+		assert.NilError(t, json.Unmarshal([]byte(data), &c))
+		assert.Check(t, !c.Gateway.IsValid())
+	})
+
+	t.Run("omitted gateway", func(t *testing.T) {
+		data := `{"Subnet":"172.19.0.0/24"}`
+		var c network.IPAMConfig
+		assert.NilError(t, json.Unmarshal([]byte(data), &c))
+		assert.Check(t, !c.Gateway.IsValid())
+	})
+
+	t.Run("auxiliary addresses with legacy CIDR prefix (backwards compat)", func(t *testing.T) {
+		data := `{"AuxiliaryAddresses":{"router":"192.168.1.254/24","secondary":"192.168.1.253/24"}}`
+		var c network.IPAMConfig
+		assert.NilError(t, json.Unmarshal([]byte(data), &c))
+		assert.Check(t, is.Equal(c.AuxAddress["router"], netip.MustParseAddr("192.168.1.254")))
+		assert.Check(t, is.Equal(c.AuxAddress["secondary"], netip.MustParseAddr("192.168.1.253")))
+	})
+
+	t.Run("auxiliary addresses without prefix", func(t *testing.T) {
+		data := `{"AuxiliaryAddresses":{"router":"192.168.1.254"}}`
+		var c network.IPAMConfig
+		assert.NilError(t, json.Unmarshal([]byte(data), &c))
+		assert.Check(t, is.Equal(c.AuxAddress["router"], netip.MustParseAddr("192.168.1.254")))
+	})
+
+	t.Run("invalid JSON returns error", func(t *testing.T) {
+		data := `{"Gateway": 12345}`
+		var c network.IPAMConfig
+		assert.Check(t, json.Unmarshal([]byte(data), &c) != nil)
+	})
+
+	// IPv4-mapped IPv6 addresses should be unwrapped to their plain IPv4 form.
+	t.Run("IPv4-mapped IPv6 gateway is unmapped", func(t *testing.T) {
+		data := `{"Gateway":"::ffff:172.19.0.1"}`
+		var c network.IPAMConfig
+		assert.NilError(t, json.Unmarshal([]byte(data), &c))
+		assert.Check(t, is.Equal(c.Gateway, netip.MustParseAddr("172.19.0.1")))
+	})
+
+	// Full round-trip: marshal then unmarshal should preserve Gateway.
+	t.Run("round-trip marshal unmarshal", func(t *testing.T) {
+		orig := network.IPAMConfig{
+			Subnet:  netip.MustParsePrefix("172.19.0.0/24"),
+			Gateway: netip.MustParseAddr("172.19.0.1"),
+		}
+		data, err := json.Marshal(orig)
+		assert.NilError(t, err)
+
+		var got network.IPAMConfig
+		assert.NilError(t, json.Unmarshal(data, &got))
+		assert.Check(t, is.Equal(got.Subnet, orig.Subnet))
+		assert.Check(t, is.Equal(got.Gateway, orig.Gateway))
+	})
+}


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/52991
- Related to: https://github.com/moby/moby/pull/49520

## Summary

Docker ≤26.x stored IPv6 gateway addresses in network IPAM configuration
with a CIDR prefix notation (e.g. `"fd05:d0ca:2::1/112"`). PR #49520 fixed
the daemon so it no longer writes the prefix, but only after a daemon restart.
Until the daemon is restarted, existing in-memory networks continue to report
the legacy format.

The `IPAMConfig.Gateway` field is typed as `netip.Addr`, whose `UnmarshalText`
strictly calls `netip.ParseAddr`, which rejects the `/112` suffix with:

    ParseAddr("fd05:d0ca:2::1/112"): unexpected character, want colon (at "/112")

This breaks `NetworkList` and `NetworkInspect` for any client using moby/moby
v29+ against a Docker ≤26.x daemon that still has IPv6 networks in memory.

### Changes

Add `(*IPAMConfig).UnmarshalJSON` that decodes `Gateway` and
`AuxiliaryAddresses` as raw strings, then uses a new helper
`parseAddrLenient` that:
1. Tries `netip.ParseAddr` (canonical, modern format — no regression)
2. Falls back to `netip.ParsePrefix(...).Addr()` to strip prefix (legacy compat)

No public API types are changed. Serialization (marshal) is unaffected.

## Release notes

```markdown changelog
Fix `NetworkList` and `NetworkInspect` failing when connecting to a Docker 26.x daemon with IPv6 networks whose gateway was stored with CIDR prefix notation.
