### PR TITLE
remove some redundant uses of `fmt.Sprintf`

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -556,7 +556,7 @@ func getConflictFreeConfiguration(configFile string, flags *pflag.FlagSet) (*Con
 			}
 
 			if _, ok := f.Value.(boolValue); ok {
-				f.Value.Set(fmt.Sprintf("%v", value))
+				_ = f.Value.Set(fmt.Sprint(value))
 			}
 		}
 		if len(namedOptions) > 0 {
@@ -566,7 +566,7 @@ func getConflictFreeConfiguration(configFile string, flags *pflag.FlagSet) (*Con
 					v, set := namedOptions[opt.Name()]
 					_, boolean := f.Value.(boolValue)
 					if set && boolean {
-						f.Value.Set(fmt.Sprintf("%v", v))
+						_ = f.Value.Set(fmt.Sprint(v))
 					}
 				}
 			})

--- a/daemon/internal/capabilities/caps_test.go
+++ b/daemon/internal/capabilities/caps_test.go
@@ -51,7 +51,7 @@ func TestMatch(t *testing.T) {
 	}
 
 	for _, m := range testcases {
-		t.Run(fmt.Sprintf("%v", m.caps), func(t *testing.T) {
+		t.Run(fmt.Sprint(m.caps), func(t *testing.T) {
 			selected := set.Match(m.caps)
 			if m.expected == nil || selected == nil {
 				if m.expected == nil && selected == nil {

--- a/daemon/internal/opts/named_iplist_opts.go
+++ b/daemon/internal/opts/named_iplist_opts.go
@@ -24,7 +24,7 @@ func (o *NamedIPListOpts) String() string {
 	if len(*o.ips) == 0 {
 		return ""
 	}
-	return fmt.Sprintf("%v", *o.ips)
+	return fmt.Sprint(*o.ips)
 }
 
 // Set converts value to a netip.Addr and appends it to the underlying []netip.Addr.

--- a/daemon/internal/opts/opts.go
+++ b/daemon/internal/opts/opts.go
@@ -41,7 +41,7 @@ func (opts *SetOpts) GetAll() map[string]bool {
 }
 
 func (opts *SetOpts) String() string {
-	return fmt.Sprintf("%v", opts.values)
+	return fmt.Sprint(opts.values)
 }
 
 // Type returns a string name for this Option type

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -291,7 +291,7 @@ func (daemon *Daemon) reloadFeatures(txn *reloadTxn, newCfg *configStore, conf *
 	newCfg.Features = conf.Features
 
 	// prepare reload event attributes with updatable configurations
-	attributes["features"] = fmt.Sprintf("%v", newCfg.Features)
+	attributes["features"] = fmt.Sprint(newCfg.Features)
 	return nil
 }
 
@@ -315,6 +315,6 @@ func (daemon *Daemon) reloadNRI(txn *reloadTxn, newCfg *configStore, conf *confi
 		txn.OnCommit(commit)
 	}
 
-	attributes["nri-opts"] = fmt.Sprintf("%v", newCfg.NRIOpts)
+	attributes["nri-opts"] = fmt.Sprint(newCfg.NRIOpts)
 	return nil
 }

--- a/integration-cli/daemon/daemon_swarm.go
+++ b/integration-cli/daemon/daemon_swarm.go
@@ -69,7 +69,7 @@ func (d *Daemon) CheckPluginRunning(ctx context.Context, plugin string) func(c *
 		apiclient := d.NewClientT(t)
 		resp, err := apiclient.PluginInspect(ctx, plugin, client.PluginInspectOptions{})
 		if cerrdefs.IsNotFound(err) {
-			return false, fmt.Sprintf("%v", err)
+			return false, err.Error()
 		}
 		assert.NilError(t, err)
 		return resp.Plugin.Enabled, fmt.Sprintf("%+v", resp.Plugin)
@@ -82,7 +82,7 @@ func (d *Daemon) CheckPluginImage(ctx context.Context, plugin string) func(c *te
 		apiclient := d.NewClientT(t)
 		resp, err := apiclient.PluginInspect(ctx, plugin, client.PluginInspectOptions{})
 		if cerrdefs.IsNotFound(err) {
-			return false, fmt.Sprintf("%v", err)
+			return false, err.Error()
 		}
 		assert.NilError(t, err)
 		return resp.Plugin.PluginReference, fmt.Sprintf("%+v", resp.Plugin)

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -47,7 +47,7 @@ func (s *DockerCLIEventSuite) TestEventsTimestampFormats(c *testing.T) {
 	end := daemonTime(c)
 
 	// List of available time formats to --since
-	unixTs := func(t time.Time) string { return fmt.Sprintf("%v", t.Unix()) }
+	unixTs := func(t time.Time) string { return fmt.Sprint(t.Unix()) }
 	rfc3339 := func(t time.Time) string { return t.Format(time.RFC3339) }
 	duration := func(t time.Time) string { return time.Since(t).String() }
 

--- a/integration-cli/docker_cli_external_volume_driver_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_test.go
@@ -466,7 +466,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverList(c *testing.T) {
 	assert.Equal(c, len(ls), 2, fmt.Sprintf("\n%s", out))
 
 	vol := strings.Fields(ls[len(ls)-1])
-	assert.Equal(c, len(vol), 2, fmt.Sprintf("%v", vol))
+	assert.Equal(c, len(vol), 2, fmt.Sprint(vol))
 	assert.Equal(c, vol[0], volumePluginName)
 	assert.Equal(c, vol[1], "abc3")
 
@@ -489,8 +489,8 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverGet(c *testing.T) {
 
 	assert.NilError(c, json.Unmarshal([]byte(out), &st))
 	assert.Equal(c, len(st), 1)
-	assert.Equal(c, len(st[0].Status), 1, fmt.Sprintf("%v", st[0]))
-	assert.Equal(c, st[0].Status["Hello"], "world", fmt.Sprintf("%v", st[0].Status))
+	assert.Equal(c, len(st[0].Status), 1, fmt.Sprint(st[0]))
+	assert.Equal(c, st[0].Status["Hello"], "world", fmt.Sprint(st[0].Status))
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverWithDaemonRestart(c *testing.T) {

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -263,7 +263,7 @@ func (s *DockerCLIInspectSuite) TestInspectLogConfigNoType(c *testing.T) {
 	assert.Assert(c, err == nil, "%v", out)
 
 	assert.Equal(c, logConfig.Type, "json-file")
-	assert.Equal(c, logConfig.Config["max-file"], "42", fmt.Sprintf("%v", logConfig))
+	assert.Equal(c, logConfig.Config["max-file"], "42", fmt.Sprint(logConfig))
 }
 
 func (s *DockerCLIInspectSuite) TestInspectNoSizeFlagContainer(c *testing.T) {

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -398,7 +398,7 @@ func reducedCheck(r reducer, funcs ...checkF) checkF {
 				comments = append(comments, comment)
 			}
 		}
-		return r(values...), fmt.Sprintf("%v", strings.Join(comments, ", "))
+		return r(values...), strings.Join(comments, ", ")
 	}
 }
 


### PR DESCRIPTION
`fmt.Sprintf("%v", something)` is identical to `fmt.Sprint(something)`


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
