### PR TITLE
client: ServiceInspect, ContainerCommit: omit optional query args if not set

### DIFF
--- a/client/container_commit.go
+++ b/client/container_commit.go
@@ -31,8 +31,9 @@ func (cli *Client) ContainerCommit(ctx context.Context, containerID string, opti
 	if err != nil {
 		return ContainerCommitResult{}, err
 	}
+	query := url.Values{}
+	query.Set("container", containerID)
 
-	var repository, tag string
 	if options.Reference != "" {
 		ref, err := reference.ParseNormalizedNamed(options.Reference)
 		if err != nil {
@@ -44,18 +45,18 @@ func (cli *Client) ContainerCommit(ctx context.Context, containerID string, opti
 		}
 		ref = reference.TagNameOnly(ref)
 
+		query.Set("repo", ref.Name())
 		if tagged, ok := ref.(reference.Tagged); ok {
-			tag = tagged.Tag()
+			query.Set("tag", tagged.Tag())
 		}
-		repository = ref.Name()
 	}
 
-	query := url.Values{}
-	query.Set("container", containerID)
-	query.Set("repo", repository)
-	query.Set("tag", tag)
-	query.Set("comment", options.Comment)
-	query.Set("author", options.Author)
+	if options.Comment != "" {
+		query.Set("comment", options.Comment)
+	}
+	if options.Author != "" {
+		query.Set("author", options.Author)
+	}
 	for _, change := range options.Changes {
 		query.Add("changes", change)
 	}

--- a/client/service_inspect.go
+++ b/client/service_inspect.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/url"
 
 	"github.com/moby/moby/api/types/swarm"
@@ -28,7 +27,9 @@ func (cli *Client) ServiceInspect(ctx context.Context, serviceID string, options
 	}
 
 	query := url.Values{}
-	query.Set("insertDefaults", fmt.Sprintf("%v", options.InsertDefaults))
+	if options.InsertDefaults {
+		query.Set("insertDefaults", "1")
+	}
 	resp, err := cli.get(ctx, "/services/"+serviceID, query, nil)
 	if err != nil {
 		return ServiceInspectResult{}, err

--- a/vendor/github.com/moby/moby/client/container_commit.go
+++ b/vendor/github.com/moby/moby/client/container_commit.go
@@ -31,8 +31,9 @@ func (cli *Client) ContainerCommit(ctx context.Context, containerID string, opti
 	if err != nil {
 		return ContainerCommitResult{}, err
 	}
+	query := url.Values{}
+	query.Set("container", containerID)
 
-	var repository, tag string
 	if options.Reference != "" {
 		ref, err := reference.ParseNormalizedNamed(options.Reference)
 		if err != nil {
@@ -44,18 +45,18 @@ func (cli *Client) ContainerCommit(ctx context.Context, containerID string, opti
 		}
 		ref = reference.TagNameOnly(ref)
 
+		query.Set("repo", ref.Name())
 		if tagged, ok := ref.(reference.Tagged); ok {
-			tag = tagged.Tag()
+			query.Set("tag", tagged.Tag())
 		}
-		repository = ref.Name()
 	}
 
-	query := url.Values{}
-	query.Set("container", containerID)
-	query.Set("repo", repository)
-	query.Set("tag", tag)
-	query.Set("comment", options.Comment)
-	query.Set("author", options.Author)
+	if options.Comment != "" {
+		query.Set("comment", options.Comment)
+	}
+	if options.Author != "" {
+		query.Set("author", options.Author)
+	}
 	for _, change := range options.Changes {
 		query.Add("changes", change)
 	}

--- a/vendor/github.com/moby/moby/client/service_inspect.go
+++ b/vendor/github.com/moby/moby/client/service_inspect.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/url"
 
 	"github.com/moby/moby/api/types/swarm"
@@ -28,7 +27,9 @@ func (cli *Client) ServiceInspect(ctx context.Context, serviceID string, options
 	}
 
 	query := url.Values{}
-	query.Set("insertDefaults", fmt.Sprintf("%v", options.InsertDefaults))
+	if options.InsertDefaults {
+		query.Set("insertDefaults", "1")
+	}
 	resp, err := cli.get(ctx, "/services/"+serviceID, query, nil)
 	if err != nil {
 		return ServiceInspectResult{}, err


### PR DESCRIPTION

### client: ServiceInspect: omit insertDefaults if not set

The default is to not insert defaults, so we can skip if it's not
set; this also removes a fmt.Sprintf that wasn't needed.


### client: ContainerCommit: omit optional query args if not set

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
