### PR TITLE
client: ServiceCreate, ServiceUpdate: fix duplicate and 'unkown' platforms

### DIFF
--- a/client/service_create.go
+++ b/client/service_create.go
@@ -137,21 +137,37 @@ func imageDigestAndPlatforms(ctx context.Context, cli DistributionAPIClient, ima
 
 	if len(distributionInspect.Platforms) > 0 {
 		platforms = make([]swarm.Platform, 0, len(distributionInspect.Platforms))
+		seen := make(map[swarm.Platform]struct{}, len(distributionInspect.Platforms))
 		for _, p := range distributionInspect.Platforms {
+			// skip attestations and other data included in the manifest index.
+			if p.OS == "unknown" || p.Architecture == "unknown" {
+				continue
+			}
 			// clear architecture field for arm. This is a temporary patch to address
-			// https://github.com/docker/swarmkit/issues/2294. The issue is that while
+			// https://github.com/moby/swarmkit/issues/2294. The issue is that while
 			// image manifests report "arm" as the architecture, the node reports
 			// something like "armv7l" (includes the variant), which causes arm images
 			// to stop working with swarm mode. This patch removes the architecture
 			// constraint for arm images to ensure tasks get scheduled.
 			arch := p.Architecture
-			if strings.ToLower(arch) == "arm" {
+			if strings.EqualFold(arch, "arm") {
 				arch = ""
 			}
-			platforms = append(platforms, swarm.Platform{
+			platform := swarm.Platform{
 				Architecture: arch,
 				OS:           p.OS,
-			})
+			}
+
+			// Skip duplicates. Swarm currently only uses os/arch, and doesn't
+			// support other fields (Variant, OSVersion, OSFeatures), which
+			// usually results in duplicate "os/arch" combinations coming from
+			// the image.
+			if _, ok := seen[platform]; ok {
+				continue
+			}
+			seen[platform] = struct{}{}
+
+			platforms = append(platforms, platform)
 		}
 	}
 	return imageWithDigest, platforms, err

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -65,7 +65,16 @@ func TestServiceCreateCompatiblePlatforms(t *testing.T) {
 			}
 
 			assert.Check(t, is.Equal("foobar:1.0@sha256:c0537ff6a5218ef531ece93d4984efc99bbf3f7497c0a7726c88e2bb7584dc96", serviceSpec.TaskTemplate.ContainerSpec.Image))
-			assert.Check(t, is.Len(serviceSpec.TaskTemplate.Placement.Platforms, 1))
+			assert.Check(t, is.Len(serviceSpec.TaskTemplate.Placement.Platforms, 7))
+			assert.Check(t, is.DeepEqual(serviceSpec.TaskTemplate.Placement.Platforms, []swarm.Platform{
+				{Architecture: "amd64", OS: "linux"},
+				{Architecture: "", OS: "linux"}, // arm (v6/v7 collapse to a single entry); https://github.com/moby/swarmkit/issues/2294
+				{Architecture: "arm64", OS: "linux"},
+				{Architecture: "386", OS: "linux"},
+				{Architecture: "ppc64le", OS: "linux"},
+				{Architecture: "riscv64", OS: "linux"},
+				{Architecture: "s390x", OS: "linux"},
+			}))
 
 			p := serviceSpec.TaskTemplate.Placement.Platforms[0]
 			return mockJSONResponse(http.StatusOK, nil, swarm.ServiceCreateResponse{
@@ -77,10 +86,22 @@ func TestServiceCreateCompatiblePlatforms(t *testing.T) {
 					Digest: "sha256:c0537ff6a5218ef531ece93d4984efc99bbf3f7497c0a7726c88e2bb7584dc96",
 				},
 				Platforms: []ocispec.Platform{
-					{
-						Architecture: "amd64",
-						OS:           "linux",
-					},
+					{Architecture: "amd64", OS: "linux"},
+					{Architecture: "unknown", OS: "unknown"},
+					{Architecture: "arm", OS: "linux", Variant: "v6"},
+					{Architecture: "unknown", OS: "unknown"},
+					{Architecture: "arm", OS: "linux", Variant: "v7"},
+					{Architecture: "unknown", OS: "unknown"},
+					{Architecture: "arm64", OS: "linux", Variant: "v8"},
+					{Architecture: "unknown", OS: "unknown"},
+					{Architecture: "386", OS: "linux"},
+					{Architecture: "unknown", OS: "unknown"},
+					{Architecture: "ppc64le", OS: "linux"},
+					{Architecture: "unknown", OS: "unknown"},
+					{Architecture: "riscv64", OS: "linux"},
+					{Architecture: "unknown", OS: "unknown"},
+					{Architecture: "s390x", OS: "linux"},
+					{Architecture: "unknown", OS: "unknown"},
 				},
 			})(req)
 		} else {

--- a/vendor/github.com/moby/moby/client/service_create.go
+++ b/vendor/github.com/moby/moby/client/service_create.go
@@ -137,21 +137,37 @@ func imageDigestAndPlatforms(ctx context.Context, cli DistributionAPIClient, ima
 
 	if len(distributionInspect.Platforms) > 0 {
 		platforms = make([]swarm.Platform, 0, len(distributionInspect.Platforms))
+		seen := make(map[swarm.Platform]struct{}, len(distributionInspect.Platforms))
 		for _, p := range distributionInspect.Platforms {
+			// skip attestations and other data included in the manifest index.
+			if p.OS == "unknown" || p.Architecture == "unknown" {
+				continue
+			}
 			// clear architecture field for arm. This is a temporary patch to address
-			// https://github.com/docker/swarmkit/issues/2294. The issue is that while
+			// https://github.com/moby/swarmkit/issues/2294. The issue is that while
 			// image manifests report "arm" as the architecture, the node reports
 			// something like "armv7l" (includes the variant), which causes arm images
 			// to stop working with swarm mode. This patch removes the architecture
 			// constraint for arm images to ensure tasks get scheduled.
 			arch := p.Architecture
-			if strings.ToLower(arch) == "arm" {
+			if strings.EqualFold(arch, "arm") {
 				arch = ""
 			}
-			platforms = append(platforms, swarm.Platform{
+			platform := swarm.Platform{
 				Architecture: arch,
 				OS:           p.OS,
-			})
+			}
+
+			// Skip duplicates. Swarm currently only uses os/arch, and doesn't
+			// support other fields (Variant, OSVersion, OSFeatures), which
+			// usually results in duplicate "os/arch" combinations coming from
+			// the image.
+			if _, ok := seen[platform]; ok {
+				continue
+			}
+			seen[platform] = struct{}{}
+
+			platforms = append(platforms, platform)
 		}
 	}
 	return imageWithDigest, platforms, err


### PR DESCRIPTION
Before this patch, the Task and Plugin placement would contain "unkown/unknown" platforms and duplicates. Swarm currently only supports os/arch for placement preferences, but images often provide variants that differ in Variant, OSVersion and OSFeatures. These duplicates unlikely caused issues in practice, but made the service spec more verbose;

    docker service inspect --format '{{json .Spec.TaskTemplate.Placement.Platforms}}' foo
    [
        {"Architecture":"amd64","OS":"linux"},
        {"Architecture":"unknown","OS":"unknown"},
        {"OS":"linux"},
        {"Architecture":"unknown","OS":"unknown"},
        {"OS":"linux"},
        {"Architecture":"unknown","OS":"unknown"},
        {"Architecture":"arm64","OS":"linux"},
        {"Architecture":"unknown","OS":"unknown"},
        {"Architecture":"386","OS":"linux"},
        {"Architecture":"unknown","OS":"unknown"},
        {"Architecture":"ppc64le","OS":"linux"},
        {"Architecture":"unknown","OS":"unknown"},
        {"Architecture":"riscv64","OS":"linux"},
        {"Architecture":"unknown","OS":"unknown"},
        {"Architecture":"s390x","OS":"linux"},
        {"Architecture":"unknown","OS":"unknown"}
    ]

Update the imageDigestAndPlatforms utility to filter out "unknown" platforms and to remove duplicates.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
