### PR TITLE
daemon: prepareMountPoints: use mount type to skip non-volume mounts

### DIFF
--- a/daemon/mounts.go
+++ b/daemon/mounts.go
@@ -31,8 +31,10 @@ func (daemon *Daemon) prepareMountPoints(ctr *container.Container) error {
 			config.Layer = layer
 		}
 
+		if config.Type != mounttypes.TypeVolume && config.Type != mounttypes.TypeCluster {
+			continue
+		}
 		if config.Volume == nil {
-			// FIXME(thaJeztah): should we check for config.Type here as well? (i.e., skip bind-mounts etc)
 			continue
 		}
 		if alive {

--- a/daemon/mounts.go
+++ b/daemon/mounts.go
@@ -28,8 +28,10 @@ func (daemon *Daemon) prepareMountPoints(container *container.Container) error {
 			config.Layer = layer
 		}
 
+		if config.Type != mounttypes.TypeVolume && config.Type != mounttypes.TypeCluster {
+			continue
+		}
 		if config.Volume == nil {
-			// FIXME(thaJeztah): should we check for config.Type here as well? (i.e., skip bind-mounts etc)
 			continue
 		}
 		if alive {


### PR DESCRIPTION
## Summary

`prepareMountPoints` was skipping LiveRestore by checking `config.Volume == nil`,
which implicitly filtered out bind-mounts, tmpfs, image, and named-pipe mounts
(none of which carry a Volume object). This worked correctly, but the intent
was not obvious from the code.

This change makes the skipping explicit by checking `config.Type` first,
consistent with the approach already used in `removeMountPoints` in the same file.
The `Volume == nil` guard is kept as a safety check for `TypeVolume` and
`TypeCluster` mounts where `lazyInitializeVolume` may not have populated the Volume field.

## Release notes (optional)

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)

🐹

---

Created with: Claude Sonnet 4.6