### PR TITLE
integration/networking: Restore netns on the locked thread

### DIFF
--- a/integration/internal/testutils/networking/l3_segment_linux.go
+++ b/integration/internal/testutils/networking/l3_segment_linux.go
@@ -149,11 +149,16 @@ func (h Host) Do(t *testing.T, fn func()) {
 	t.Helper()
 
 	if h.ns != CurrentNetns {
-		targetNs, err := netns.GetFromName(h.ns)
-		if err != nil {
-			t.Fatalf("failed to get netns handle: %v", err)
-		}
-		defer targetNs.Close()
+		runtime.LockOSThread()
+		// If restore fails, keep the goroutine locked to the thread so the
+		// runtime can retire the contaminated thread instead of returning it
+		// to the scheduler.
+		unlockThread := true
+		defer func() {
+			if unlockThread {
+				runtime.UnlockOSThread()
+			}
+		}()
 
 		origNs, err := netns.Get()
 		if err != nil {
@@ -161,13 +166,21 @@ func (h Host) Do(t *testing.T, fn func()) {
 		}
 		defer origNs.Close()
 
-		runtime.LockOSThread()
-		defer runtime.UnlockOSThread()
+		targetNs, err := netns.GetFromName(h.ns)
+		if err != nil {
+			t.Fatalf("failed to get netns handle: %v", err)
+		}
+		defer targetNs.Close()
 
 		if err := netns.Set(targetNs); err != nil {
 			t.Fatalf("failed to enter netns: %v", err)
 		}
-		defer netns.Set(origNs)
+		defer func() {
+			if err := netns.Set(origNs); err != nil {
+				unlockThread = false
+				t.Errorf("failed to restore netns: %v", err)
+			}
+		}()
 	}
 
 	fn()


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

- should help with flakiness from: https://github.com/moby/moby/actions/runs/28682554173/job/85069083182

Host.Do captured the original network namespace before locking its OS thread.
netns.Get is thread-local: it opens `/proc/<pid>/task/<tid>/ns/net`. If the goroutine moves to another thread before LockOSThread, Host.Do can save one thread's namespace and later restore that namespace onto a different locked thread.

Lock the OS thread before reading the original namespace so the saved handle matches the thread that enters the test namespace.

If restore fails, keep the goroutine locked to the thread so the runtime can retire the contaminated thread instead of returning it to the scheduler.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
