### PR TITLE
golangci-lint: enable perfsprint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,7 @@ linters:
     - nakedret                  # Detects uses of naked returns.
     - nilnesserr                # Detects returning nil errors. It combines the features of nilness and nilerr,
     - nosprintfhostport         # Detects misuse of Sprintf to construct a host with port in a URL.
+    - perfsprint                # Detects if fmt.Sprintf can be replaced with a faster alternative.
     - reassign                  # Detects reassigning a top-level variable in another package.
     - revive                    # Metalinter; drop-in replacement for golint.
     - spancheck                 # Detects mistakes with OpenTelemetry/Census spans.

--- a/client/internal/mod/mod.go
+++ b/client/internal/mod/mod.go
@@ -87,7 +87,7 @@ func getVersion(name string, dep *debug.Module) (string, bool) {
 func normalize(v string) string {
 	base, metas, dirty := splitMetadata(v)
 
-	out := base
+	var out strings.Builder
 	if base2, rev, undoPatch, ok := splitPseudo(base); ok {
 		if undoPatch {
 			// Downgrade the patch version that was raised by pseudo-versions:
@@ -102,18 +102,22 @@ func normalize(v string) string {
 		if len(rev) > 12 {
 			rev = rev[:12]
 		}
-		out = base2 + "+" + rev
+		out.WriteString(base2)
+		out.WriteByte('+')
+		out.WriteString(rev)
+	} else {
+		out.WriteString(base)
 	}
 
 	// Preserve other metadata (except for "+incompatible").
 	for _, m := range metas {
-		out += m
+		out.WriteString(m)
 	}
 	if dirty {
 		// +dirty goes last
-		out += "+dirty"
+		out.WriteString("+dirty")
 	}
-	return out
+	return out.String()
 }
 
 func splitMetadata(v string) (base string, metas []string, dirty bool) {

--- a/client/internal/timestamp/timestamp_test.go
+++ b/client/internal/timestamp/timestamp_test.go
@@ -1,7 +1,7 @@
 package timestamp
 
 import (
-	"fmt"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -45,9 +45,9 @@ func TestGetTimestamp(t *testing.T) {
 		{"1136073600", "1136073600", false},
 		{"1136073600.000000001", "1136073600.000000001", false},
 		// Durations
-		{"1m", fmt.Sprintf("%d", now.Add(-1*time.Minute).Unix()), false},
-		{"1.5h", fmt.Sprintf("%d", now.Add(-90*time.Minute).Unix()), false},
-		{"1h30m", fmt.Sprintf("%d", now.Add(-90*time.Minute).Unix()), false},
+		{"1m", strconv.FormatInt(now.Add(-1*time.Minute).Unix(), 10), false},
+		{"1.5h", strconv.FormatInt(now.Add(-90*time.Minute).Unix(), 10), false},
+		{"1h30m", strconv.FormatInt(now.Add(-90*time.Minute).Unix(), 10), false},
 
 		{"invalid", "", true},
 		{"", "", true},

--- a/daemon/builder/dockerfile/internals_test.go
+++ b/daemon/builder/dockerfile/internals_test.go
@@ -1,7 +1,6 @@
 package dockerfile
 
 import (
-	"fmt"
 	"os"
 	"runtime"
 	"testing"
@@ -36,7 +35,7 @@ func TestSymlinkDockerfile(t *testing.T) {
 	// in the builder, the symlink is resolved within the context, therefore
 	// Dockerfile -> /etc/passwd becomes etc/passwd from the context which is
 	// a nonexistent file.
-	expectedError := fmt.Sprintf("Cannot locate specified Dockerfile: %s", builder.DefaultDockerfileName)
+	expectedError := "Cannot locate specified Dockerfile: " + builder.DefaultDockerfileName
 
 	readAndCheckDockerfile(t, "symlinkDockerfile", contextDir, builder.DefaultDockerfileName, expectedError)
 }

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -531,7 +532,7 @@ func (c *containerAdapter) logs(ctx context.Context, options api.LogSubscription
 
 	if options.Tail < 0 {
 		// See protobuf documentation for details of how this works.
-		apiOptions.Tail = fmt.Sprint(-options.Tail - 1)
+		apiOptions.Tail = strconv.FormatInt(-options.Tail-1, 10)
 	} else if options.Tail > 0 {
 		return nil, errors.New("tail relative to start of logs not supported via docker API")
 	}

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -126,7 +126,7 @@ func (c *containerConfig) name() string {
 		return c.task.Annotations.Name
 	}
 
-	slot := fmt.Sprint(c.task.Slot)
+	slot := strconv.FormatUint(c.task.Slot, 10)
 	if slot == "" || c.task.Slot == 0 {
 		slot = c.task.NodeID
 	}

--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -294,7 +294,7 @@ func (c *Cluster) DetachNetwork(target string, containerID string) error {
 // CreateNetwork creates a new cluster managed network.
 func (c *Cluster) CreateNetwork(s network.CreateRequest) (string, error) {
 	if networkSettings.IsPredefined(s.Name) {
-		err := notAllowedError(fmt.Sprintf("%s is a pre-defined network and cannot be created", s.Name))
+		err := notAllowedError(s.Name + " is a pre-defined network and cannot be created")
 		return "", errors.WithStack(err)
 	}
 

--- a/daemon/container/container.go
+++ b/daemon/container/container.go
@@ -461,7 +461,7 @@ func (container *Container) StartLogger() (logger.Logger, error) {
 	// TODO(@cpuguy83): Setup here based on log driver is a little weird.
 	switch cfg.Type {
 	case jsonfilelog.Name:
-		info.LogPath, err = container.GetRootResourcePath(fmt.Sprintf("%s-json.log", container.ID))
+		info.LogPath, err = container.GetRootResourcePath(container.ID + "-json.log")
 		if err != nil {
 			return nil, err
 		}

--- a/daemon/container/container_test.go
+++ b/daemon/container/container_test.go
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"fmt"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -82,7 +81,7 @@ func TestContainerLogPathSetForJSONFileLogger(t *testing.T) {
 		assert.NilError(t, logger.Close())
 	}()
 
-	expectedLogPath, err := filepath.Abs(filepath.Join(containerRoot, fmt.Sprintf("%s-json.log", c.ID)))
+	expectedLogPath, err := filepath.Abs(filepath.Join(containerRoot, c.ID+"-json.log"))
 	assert.NilError(t, err)
 	assert.Equal(t, c.LogPath, expectedLogPath)
 }
@@ -110,7 +109,7 @@ func TestContainerLogPathSetForRingLogger(t *testing.T) {
 		assert.NilError(t, logger.Close())
 	}()
 
-	expectedLogPath, err := filepath.Abs(filepath.Join(containerRoot, fmt.Sprintf("%s-json.log", c.ID)))
+	expectedLogPath, err := filepath.Abs(filepath.Join(containerRoot, c.ID+"-json.log"))
 	assert.NilError(t, err)
 	assert.Equal(t, c.LogPath, expectedLogPath)
 }

--- a/daemon/container/state.go
+++ b/daemon/container/state.go
@@ -92,7 +92,7 @@ func (s *State) String() string {
 			return fmt.Sprintf("Up %s (%s)", units.HumanDuration(time.Now().UTC().Sub(s.StartedAt)), h.String())
 		}
 
-		return fmt.Sprintf("Up %s", units.HumanDuration(time.Now().UTC().Sub(s.StartedAt)))
+		return "Up " + units.HumanDuration(time.Now().UTC().Sub(s.StartedAt))
 	}
 
 	if s.RemovalInProgress {

--- a/daemon/containerd/identitycache/bbolt.go
+++ b/daemon/containerd/identitycache/bbolt.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 
@@ -184,7 +185,7 @@ func openDB(dbPath string, mode os.FileMode, opts *bolt.Options) (*bolt.DB, erro
 }
 
 func fallbackOpen(dbPath string, mode os.FileMode, opts *bolt.Options, openErr error) (*bolt.DB, error) {
-	backupPath := dbPath + "." + fmt.Sprintf("%d", time.Now().UnixNano()) + ".bak"
+	backupPath := dbPath + "." + strconv.FormatInt(time.Now().UnixNano(), 10) + ".bak"
 	log.L.Errorf("failed to open moby image identity cache database %s, resetting to empty. "+
 		"Old database is backed up to %s. This usually means dockerd crashed or was terminated abruptly, leaving the cache DB corrupted. "+
 		"If this keeps happening, please report at https://github.com/moby/moby/issues. original error: %v",

--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -599,8 +599,8 @@ func writeContentsForImage(ctx context.Context, snName string, cs content.Store,
 
 	// config should reference to snapshotter and container config
 	labelOpt := content.WithLabels(map[string]string{
-		fmt.Sprintf("containerd.io/gc.ref.snapshot.%s", snName): identity.ChainID(newConfig.RootFS.DiffIDs).String(),
-		contentLabelGcRefContainerConfig:                        ccDesc.Digest.String(),
+		"containerd.io/gc.ref.snapshot." + snName: identity.ChainID(newConfig.RootFS.DiffIDs).String(),
+		contentLabelGcRefContainerConfig:          ccDesc.Digest.String(),
 	})
 	err = content.WriteBlob(ctx, cs, configDesc.Digest.String(), bytes.NewReader(newConfigJSON), configDesc, labelOpt)
 	if err != nil {

--- a/daemon/containerd/image_delete.go
+++ b/daemon/containerd/image_delete.go
@@ -501,7 +501,7 @@ func (i *ImageService) checkImageDeleteConflict(ctx context.Context, imgID image
 				reference: stringid.TruncateID(imgID.String()),
 				hard:      true,
 				used:      true,
-				message:   fmt.Sprintf("image is being used by running container %s", stringid.TruncateID(ctr.ID)),
+				message:   "image is being used by running container " + stringid.TruncateID(ctr.ID),
 			}
 		}
 	}
@@ -514,7 +514,7 @@ func (i *ImageService) checkImageDeleteConflict(ctx context.Context, imgID image
 			return &imageDeleteConflict{
 				reference: stringid.TruncateID(imgID.String()),
 				used:      true,
-				message:   fmt.Sprintf("image is being used by stopped container %s", stringid.TruncateID(ctr.ID)),
+				message:   "image is being used by stopped container " + stringid.TruncateID(ctr.ID),
 			}
 		}
 	}

--- a/daemon/containerd/migration/migration.go
+++ b/daemon/containerd/migration/migration.go
@@ -221,7 +221,7 @@ func (lm *LayerMigrator) MigrateTocontainerd(ctx context.Context, snKey string, 
 		}
 
 		configLabels := map[string]string{
-			fmt.Sprintf("containerd.io/gc.ref.snapshot.%s", snKey): parent,
+			"containerd.io/gc.ref.snapshot." + snKey: parent,
 		}
 		if err = content.WriteBlob(ctx, lm.content, "config"+manifest.Config.Digest.String(), bytes.NewReader(configBytes), manifest.Config, content.WithLabels(configLabels)); err != nil && !cerrdefs.IsAlreadyExists(err) {
 			return err

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -502,7 +502,7 @@ func verifyPlatformContainerResources(resources *containertypes.Resources, sysIn
 		return warnings, errors.New("CPU cfs quota can not be less than 1ms (i.e. 1000)")
 	}
 	if resources.CPUPercent > 0 {
-		warnings = append(warnings, fmt.Sprintf("%s does not support CPU percent. Percent discarded.", runtime.GOOS))
+		warnings = append(warnings, runtime.GOOS+" does not support CPU percent. Percent discarded.")
 		resources.CPUPercent = 0
 	}
 

--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -129,7 +129,7 @@ func parseOptions(opt []string) (btrfsOptions, bool, error) {
 			userDiskQuota = true
 			options.minSpace = uint64(minSpace)
 		default:
-			return options, userDiskQuota, fmt.Errorf("Unknown option %s", key)
+			return options, userDiskQuota, errors.New("unknown option " + key)
 		}
 	}
 	return options, userDiskQuota, nil
@@ -498,7 +498,7 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 			return err
 		}
 		if !st.IsDir() {
-			return fmt.Errorf("%s: not a directory", parentDir)
+			return errors.New(parentDir + ": not a directory")
 		}
 		if err := subvolSnapshot(parentDir, subvolumes, id); err != nil {
 			return err
@@ -522,7 +522,7 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 		if err := user.MkdirAllAndChown(quotas, 0o700, os.Getuid(), os.Getegid()); err != nil {
 			return err
 		}
-		if err := os.WriteFile(path.Join(quotas, id), []byte(fmt.Sprint(driver.options.size)), 0o644); err != nil {
+		if err := os.WriteFile(path.Join(quotas, id), []byte(strconv.FormatUint(driver.options.size, 10)), 0o644); err != nil {
 			return err
 		}
 	}
@@ -556,7 +556,7 @@ func (d *Driver) parseStorageOpt(storageOpt map[string]string, driver *Driver) e
 			}
 			driver.options.size = uint64(size)
 		default:
-			return fmt.Errorf("Unknown option %s", key)
+			return errors.New("unknown option " + key)
 		}
 	}
 
@@ -624,7 +624,7 @@ func (d *Driver) Get(id, mountLabel string) (string, error) {
 	}
 
 	if !st.IsDir() {
-		return "", fmt.Errorf("%s: not a directory", dir)
+		return "", errors.New(dir + ": not a directory")
 	}
 
 	if quota, err := os.ReadFile(d.quotasDirID(id)); err == nil {

--- a/daemon/hosts.go
+++ b/daemon/hosts.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -90,7 +89,7 @@ func mirrorsToRegistryHosts(mirrors []string, dHost docker.RegistryHost) []docke
 
 		u, err := url.Parse(mirror)
 		if err != nil || u.Host == "" {
-			u, err = url.Parse(fmt.Sprintf("dummy://%s", mirror))
+			u, err = url.Parse("dummy://" + mirror)
 		}
 		if err == nil && u.Host != "" {
 			h.Host = u.Host

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -3,7 +3,6 @@ package images
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/containerd/containerd/v2/core/content"
@@ -31,7 +30,7 @@ func (e ErrImageDoesNotExist) Error() string {
 	if named, ok := ref.(reference.Named); ok {
 		ref = reference.TagNameOnly(named)
 	}
-	return fmt.Sprintf("No such image: %s", reference.FamiliarString(ref))
+	return "No such image: " + reference.FamiliarString(ref)
 }
 
 // NotFound implements the NotFound interface

--- a/daemon/images/image_delete.go
+++ b/daemon/images/image_delete.go
@@ -390,7 +390,7 @@ func (i *ImageService) checkImageDeleteConflict(imgID image.ID, mask conflictTyp
 				imgID:   imgID,
 				hard:    true,
 				used:    true,
-				message: fmt.Sprintf("image is being used by running container %s", stringid.TruncateID(ctr.ID)),
+				message: "image is being used by running container " + stringid.TruncateID(ctr.ID),
 			}
 		}
 	}
@@ -412,7 +412,7 @@ func (i *ImageService) checkImageDeleteConflict(imgID image.ID, mask conflictTyp
 			return &imageDeleteConflict{
 				imgID:   imgID,
 				used:    true,
-				message: fmt.Sprintf("image is being used by stopped container %s", stringid.TruncateID(ctr.ID)),
+				message: "image is being used by stopped container " + stringid.TruncateID(ctr.ID),
 			}
 		}
 	}

--- a/daemon/images/image_squash.go
+++ b/daemon/images/image_squash.go
@@ -72,7 +72,7 @@ func (i *ImageService) SquashImage(id, parent string) (string, error) {
 	if parent != "" {
 		historyComment = fmt.Sprintf("merge %s to %s", id, parent)
 	} else {
-		historyComment = fmt.Sprintf("create new from %s", id)
+		historyComment = "create new from " + id
 	}
 
 	newImage.History = append(newImage.History, image.History{

--- a/daemon/internal/builder-next/adapters/containerimage/pull.go
+++ b/daemon/internal/builder-next/adapters/containerimage/pull.go
@@ -480,7 +480,7 @@ func (p *puller) Snapshot(ctx context.Context, jobCtx solver.JobContext) (cache.
 			l, err := p.is.LayerStore.Get(img.RootFS.ChainID())
 			if err == nil {
 				layer.ReleaseAndLog(p.is.LayerStore, l)
-				ref, err := p.getRef(ctx, img.RootFS.DiffIDs, cache.WithDescription(fmt.Sprintf("from local %s", p.ref)))
+				ref, err := p.getRef(ctx, img.RootFS.DiffIDs, cache.WithDescription("from local "+p.ref))
 				if err != nil {
 					return nil, err
 				}
@@ -664,7 +664,7 @@ func (p *puller) Snapshot(ctx context.Context, jobCtx solver.JobContext) (cache.
 		return nil, err
 	}
 
-	ref, err := p.getRef(ctx, rootFS.DiffIDs, cache.WithDescription(fmt.Sprintf("pulled from %s", p.ref)))
+	ref, err := p.getRef(ctx, rootFS.DiffIDs, cache.WithDescription("pulled from "+p.ref))
 	release()
 	if err != nil {
 		return nil, err

--- a/daemon/internal/builder-next/controller.go
+++ b/daemon/internal/builder-next/controller.go
@@ -2,7 +2,6 @@ package buildkit
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -553,7 +552,7 @@ func parseGCPolicy(p config.BuilderGCRule, prefix string) (reservedSpace, maxUse
 		if prefix != "" {
 			key = prefix + strings.ToTitle(key)
 		}
-		return fmt.Sprintf("failed to parse %s", key)
+		return "failed to parse " + key
 	}
 
 	if p.ReservedSpace != "" {

--- a/daemon/internal/distribution/registry.go
+++ b/daemon/internal/distribution/registry.go
@@ -2,7 +2,6 @@ package distribution
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -155,6 +154,6 @@ func (th *passThruTokenHandler) Scheme() string {
 }
 
 func (th *passThruTokenHandler) AuthorizeRequest(req *http.Request, params map[string]string) error {
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", th.token))
+	req.Header.Set("Authorization", "Bearer "+th.token)
 	return nil
 }

--- a/daemon/internal/layer/layer_store.go
+++ b/daemon/internal/layer/layer_store.go
@@ -658,7 +658,7 @@ func (ls *layerStore) initMount(graphID, parent, mountLabel string, initFunc Mou
 	// which are expecting this layer with this special name. If all
 	// graph drivers can be updated to not rely on knowing about this layer
 	// then the initID should be randomly generated.
-	initID := fmt.Sprintf("%s-init", graphID)
+	initID := graphID + "-init"
 
 	createOpts := &graphdriver.CreateOpts{
 		MountLabel: mountLabel,

--- a/daemon/internal/mod/mod.go
+++ b/daemon/internal/mod/mod.go
@@ -88,7 +88,7 @@ func getVersion(name string, dep *debug.Module) (string, bool) {
 func normalize(v string) string {
 	base, metas, dirty := splitMetadata(v)
 
-	out := base
+	var out strings.Builder
 	if base2, rev, undoPatch, ok := splitPseudo(base); ok {
 		if undoPatch {
 			// Downgrade the patch version that was raised by pseudo-versions:
@@ -103,18 +103,22 @@ func normalize(v string) string {
 		if len(rev) > 12 {
 			rev = rev[:12]
 		}
-		out = base2 + "+" + rev
+		out.WriteString(base2)
+		out.WriteByte('+')
+		out.WriteString(rev)
+	} else {
+		out.WriteString(base)
 	}
 
 	// Preserve other metadata (except for "+incompatible").
 	for _, m := range metas {
-		out += m
+		out.WriteString(m)
 	}
 	if dirty {
 		// +dirty goes last
-		out += "+dirty"
+		out.WriteString("+dirty")
 	}
-	return out
+	return out.String()
 }
 
 func splitMetadata(v string) (base string, metas []string, dirty bool) {

--- a/daemon/internal/runconfig/hostconfig_unix.go
+++ b/daemon/internal/runconfig/hostconfig_unix.go
@@ -39,10 +39,10 @@ func validateIsolation(hc *container.HostConfig) error {
 // validateQoS performs platform specific validation of the QoS settings
 func validateQoS(hc *container.HostConfig) error {
 	if hc.IOMaximumBandwidth != 0 {
-		return validationError(fmt.Sprintf("invalid option: QoS maximum bandwidth configuration is not supported on %s", runtime.GOOS))
+		return validationError("invalid option: QoS maximum bandwidth configuration is not supported on " + runtime.GOOS)
 	}
 	if hc.IOMaximumIOps != 0 {
-		return validationError(fmt.Sprintf("invalid option: QoS maximum IOPs configuration is not supported on %s", runtime.GOOS))
+		return validationError("invalid option: QoS maximum IOPs configuration is not supported on " + runtime.GOOS)
 	}
 	return nil
 }

--- a/daemon/libnetwork/cmd/networkdb-test/dummyclient/dummyClient.go
+++ b/daemon/libnetwork/cmd/networkdb-test/dummyclient/dummyClient.go
@@ -36,7 +36,7 @@ func watchTable(nDB *networkdb.NetworkDB) func(w http.ResponseWriter, r *http.Re
 		r.ParseForm() //nolint:errcheck
 		diagnostic.DebugHTTPForm(r)
 		if len(r.Form["tname"]) < 1 {
-			rsp := diagnostic.WrongCommand(missingParameter, fmt.Sprintf("%s?tname=table_name", r.URL.Path))
+			rsp := diagnostic.WrongCommand(missingParameter, r.URL.Path+"?tname=table_name")
 			diagnostic.HTTPReply(w, rsp, &diagnostic.JSONOutput{}) //nolint:errcheck
 			return
 		}
@@ -59,7 +59,7 @@ func watchTableEntries(w http.ResponseWriter, r *http.Request) {
 	r.ParseForm() //nolint:errcheck
 	diagnostic.DebugHTTPForm(r)
 	if len(r.Form["tname"]) < 1 {
-		rsp := diagnostic.WrongCommand(missingParameter, fmt.Sprintf("%s?tname=table_name", r.URL.Path))
+		rsp := diagnostic.WrongCommand(missingParameter, r.URL.Path+"?tname=table_name")
 		diagnostic.HTTPReply(w, rsp, &diagnostic.JSONOutput{}) //nolint:errcheck
 		return
 	}

--- a/daemon/libnetwork/cnmallocator/networkallocator_test.go
+++ b/daemon/libnetwork/cnmallocator/networkallocator_test.go
@@ -1,7 +1,6 @@
 package cnmallocator
 
 import (
-	"fmt"
 	"net"
 	"net/netip"
 	"testing"
@@ -733,7 +732,7 @@ func (a *mockIpam) RequestPool(req ipamapi.PoolRequest) (ipamapi.AllocatedPool, 
 
 	poolCidr := netip.MustParsePrefix(req.Pool)
 	return ipamapi.AllocatedPool{
-		PoolID: fmt.Sprintf("defaultAS/%s", req.Pool),
+		PoolID: "defaultAS/" + req.Pool,
 		Pool:   poolCidr,
 	}, nil
 }

--- a/daemon/libnetwork/drivers/bridge/errors.go
+++ b/daemon/libnetwork/drivers/bridge/errors.go
@@ -4,7 +4,6 @@ package bridge
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/moby/moby/v2/errdefs"
 )
@@ -17,7 +16,7 @@ var errInvalidGateway = errdefs.InvalidParameter(errors.New("default gateway ip 
 type invalidNetworkIDError string
 
 func (e invalidNetworkIDError) Error() string {
-	return fmt.Sprintf("invalid network id %s", string(e))
+	return "invalid network id " + string(e)
 }
 
 // NotFound denotes the type of this error
@@ -28,7 +27,7 @@ func (e invalidNetworkIDError) NotFound() {}
 type invalidEndpointIDError string
 
 func (e invalidEndpointIDError) Error() string {
-	return fmt.Sprintf("invalid endpoint id: %s", string(e))
+	return "invalid endpoint id: " + string(e)
 }
 
 // InvalidParameter denotes the type of this error
@@ -39,7 +38,7 @@ func (e invalidEndpointIDError) InvalidParameter() {}
 type endpointNotFoundError string
 
 func (e endpointNotFoundError) Error() string {
-	return fmt.Sprintf("endpoint not found: %s", string(e))
+	return "endpoint not found: " + string(e)
 }
 
 // NotFound denotes the type of this error

--- a/daemon/libnetwork/ipams/remote/remote_test.go
+++ b/daemon/libnetwork/ipams/remote/remote_test.go
@@ -219,7 +219,7 @@ func TestRemoteDriver(t *testing.T) {
 		if ip == "" {
 			ip = "172.20.0.34"
 		}
-		ip = fmt.Sprintf("%s/16", ip)
+		ip = ip + "/16"
 		return map[string]any{
 			"Address": ip,
 		}

--- a/daemon/libnetwork/libnetwork_internal_test.go
+++ b/daemon/libnetwork/libnetwork_internal_test.go
@@ -171,7 +171,7 @@ func printIpamConf(list []*IpamConf) string {
 	for _, i := range list {
 		s = fmt.Sprintf("%s %v,", s, i)
 	}
-	s = fmt.Sprintf("%s}", s)
+	s = s + "}"
 	return s
 }
 
@@ -180,7 +180,7 @@ func printIpamInfo(list []*IpamInfo) string {
 	for _, i := range list {
 		s = fmt.Sprintf("%s\n{\n%s\n}", s, i)
 	}
-	s = fmt.Sprintf("%s\n}", s)
+	s = s + "\n}"
 	return s
 }
 

--- a/daemon/libnetwork/networkdb/networkdbdiagnostic.go
+++ b/daemon/libnetwork/networkdb/networkdbdiagnostic.go
@@ -50,7 +50,7 @@ func (nDB *NetworkDB) dbJoin(w http.ResponseWriter, r *http.Request) {
 	logger.Info("join cluster")
 
 	if len(r.Form["members"]) < 1 {
-		rsp := diagnostic.WrongCommand(missingParameter, fmt.Sprintf("%s?members=ip1,ip2,...", r.URL.Path))
+		rsp := diagnostic.WrongCommand(missingParameter, r.URL.Path+"?members=ip1,ip2,...")
 		logger.Error("join cluster failed, wrong input")
 		diagnostic.HTTPReply(w, rsp, json)
 		return
@@ -83,7 +83,7 @@ func (nDB *NetworkDB) dbPeers(w http.ResponseWriter, r *http.Request) {
 	logger.Info("network peers")
 
 	if len(r.Form["nid"]) < 1 {
-		rsp := diagnostic.WrongCommand(missingParameter, fmt.Sprintf("%s?nid=test", r.URL.Path))
+		rsp := diagnostic.WrongCommand(missingParameter, r.URL.Path+"?nid=test")
 		logger.Error("network peers failed, wrong input")
 		diagnostic.HTTPReply(w, rsp, json)
 		return
@@ -143,7 +143,7 @@ func (nDB *NetworkDB) dbCreateEntry(w http.ResponseWriter, r *http.Request) {
 		len(r.Form["nid"]) < 1 ||
 		len(r.Form["key"]) < 1 ||
 		len(r.Form["value"]) < 1 {
-		rsp := diagnostic.WrongCommand(missingParameter, fmt.Sprintf("%s?tname=table_name&nid=network_id&key=k&value=v", r.URL.Path))
+		rsp := diagnostic.WrongCommand(missingParameter, r.URL.Path+"?tname=table_name&nid=network_id&key=k&value=v")
 		logger.Error("create entry failed, wrong input")
 		diagnostic.HTTPReply(w, rsp, json)
 		return
@@ -192,7 +192,7 @@ func (nDB *NetworkDB) dbUpdateEntry(w http.ResponseWriter, r *http.Request) {
 		len(r.Form["nid"]) < 1 ||
 		len(r.Form["key"]) < 1 ||
 		len(r.Form["value"]) < 1 {
-		rsp := diagnostic.WrongCommand(missingParameter, fmt.Sprintf("%s?tname=table_name&nid=network_id&key=k&value=v", r.URL.Path))
+		rsp := diagnostic.WrongCommand(missingParameter, r.URL.Path+"?tname=table_name&nid=network_id&key=k&value=v")
 		logger.Error("update entry failed, wrong input")
 		diagnostic.HTTPReply(w, rsp, json)
 		return
@@ -239,7 +239,7 @@ func (nDB *NetworkDB) dbDeleteEntry(w http.ResponseWriter, r *http.Request) {
 	if len(r.Form["tname"]) < 1 ||
 		len(r.Form["nid"]) < 1 ||
 		len(r.Form["key"]) < 1 {
-		rsp := diagnostic.WrongCommand(missingParameter, fmt.Sprintf("%s?tname=table_name&nid=network_id&key=k", r.URL.Path))
+		rsp := diagnostic.WrongCommand(missingParameter, r.URL.Path+"?tname=table_name&nid=network_id&key=k")
 		logger.Error("delete entry failed, wrong input")
 		diagnostic.HTTPReply(w, rsp, json)
 		return
@@ -276,7 +276,7 @@ func (nDB *NetworkDB) dbGetEntry(w http.ResponseWriter, r *http.Request) {
 	if len(r.Form["tname"]) < 1 ||
 		len(r.Form["nid"]) < 1 ||
 		len(r.Form["key"]) < 1 {
-		rsp := diagnostic.WrongCommand(missingParameter, fmt.Sprintf("%s?tname=table_name&nid=network_id&key=k", r.URL.Path))
+		rsp := diagnostic.WrongCommand(missingParameter, r.URL.Path+"?tname=table_name&nid=network_id&key=k")
 		logger.Error("get entry failed, wrong input")
 		diagnostic.HTTPReply(w, rsp, json)
 		return
@@ -320,7 +320,7 @@ func (nDB *NetworkDB) dbJoinNetwork(w http.ResponseWriter, r *http.Request) {
 	logger.Info("join network")
 
 	if len(r.Form["nid"]) < 1 {
-		rsp := diagnostic.WrongCommand(missingParameter, fmt.Sprintf("%s?nid=network_id", r.URL.Path))
+		rsp := diagnostic.WrongCommand(missingParameter, r.URL.Path+"?nid=network_id")
 		logger.Error("join network failed, wrong input")
 		diagnostic.HTTPReply(w, rsp, json)
 		return
@@ -352,7 +352,7 @@ func (nDB *NetworkDB) dbLeaveNetwork(w http.ResponseWriter, r *http.Request) {
 	logger.Info("leave network")
 
 	if len(r.Form["nid"]) < 1 {
-		rsp := diagnostic.WrongCommand(missingParameter, fmt.Sprintf("%s?nid=network_id", r.URL.Path))
+		rsp := diagnostic.WrongCommand(missingParameter, r.URL.Path+"?nid=network_id")
 		logger.Error("leave network failed, wrong input")
 		diagnostic.HTTPReply(w, rsp, json)
 		return
@@ -385,7 +385,7 @@ func (nDB *NetworkDB) dbGetTable(w http.ResponseWriter, r *http.Request) {
 
 	if len(r.Form["tname"]) < 1 ||
 		len(r.Form["nid"]) < 1 {
-		rsp := diagnostic.WrongCommand(missingParameter, fmt.Sprintf("%s?tname=table_name&nid=network_id", r.URL.Path))
+		rsp := diagnostic.WrongCommand(missingParameter, r.URL.Path+"?tname=table_name&nid=network_id")
 		logger.Error("get table failed, wrong input")
 		diagnostic.HTTPReply(w, rsp, json)
 		return
@@ -432,7 +432,7 @@ func (nDB *NetworkDB) dbNetworkStats(w http.ResponseWriter, r *http.Request) {
 	logger.Info("network stats")
 
 	if len(r.Form["nid"]) < 1 {
-		rsp := diagnostic.WrongCommand(missingParameter, fmt.Sprintf("%s?nid=test", r.URL.Path))
+		rsp := diagnostic.WrongCommand(missingParameter, r.URL.Path+"?nid=test")
 		logger.Error("network stats failed, wrong input")
 		diagnostic.HTTPReply(w, rsp, json)
 		return

--- a/daemon/libnetwork/service.go
+++ b/daemon/libnetwork/service.go
@@ -3,6 +3,7 @@ package libnetwork
 import (
 	"fmt"
 	"net"
+	strings "strings"
 	"sync"
 
 	"github.com/moby/moby/v2/daemon/libnetwork/internal/setmatrix"
@@ -24,9 +25,11 @@ func (p portConfigs) String() string {
 
 	pc := p[0]
 	str := fmt.Sprintf("%d:%d/%s", pc.PublishedPort, pc.TargetPort, PortConfig_Protocol_name[int32(pc.Protocol)])
+	var strSb27 strings.Builder
 	for _, pc := range p[1:] {
-		str = str + fmt.Sprintf(",%d:%d/%s", pc.PublishedPort, pc.TargetPort, PortConfig_Protocol_name[int32(pc.Protocol)])
+		strSb27.WriteString(fmt.Sprintf(",%d:%d/%s", pc.PublishedPort, pc.TargetPort, PortConfig_Protocol_name[int32(pc.Protocol)]))
 	}
+	str += strSb27.String()
 
 	return str
 }

--- a/daemon/logger/splunk/splunk_test.go
+++ b/daemon/logger/splunk/splunk_test.go
@@ -1154,7 +1154,7 @@ func TestBufferMaximum(t *testing.T) {
 		if event, err := message.EventAsMap(); err != nil {
 			t.Fatal(err)
 		} else {
-			if event["line"] != fmt.Sprintf("%d", i+2) {
+			if event["line"] != strconv.Itoa(i+2) {
 				t.Fatalf("Unexpected event in message %v", event)
 			}
 		}

--- a/daemon/mounts.go
+++ b/daemon/mounts.go
@@ -89,7 +89,7 @@ func (daemon *Daemon) removeMountPoints(container *container.Container, rm bool)
 					continue
 				}
 			} else {
-				rmErrors = append(rmErrors, fmt.Sprintf("layer not found for image %s", m.Name))
+				rmErrors = append(rmErrors, "layer not found for image "+m.Name)
 			}
 		}
 	}

--- a/daemon/server/middleware/version_test.go
+++ b/daemon/server/middleware/version_test.go
@@ -101,7 +101,7 @@ func TestVersionMiddlewareVersion(t *testing.T) {
 		},
 		{
 			reqVersion: "9999.9999",
-			errString:  fmt.Sprintf("client version 9999.9999 is too new. Maximum supported API version is %s", config.MaxAPIVersion),
+			errString:  "client version 9999.9999 is too new. Maximum supported API version is " + config.MaxAPIVersion,
 		},
 	}
 

--- a/daemon/server/router/volume/volume_routes_test.go
+++ b/daemon/server/router/volume/volume_routes_test.go
@@ -24,7 +24,7 @@ import (
 func callGetVolume(v *volumeRouter, name string) (*httptest.ResponseRecorder, error) {
 	ctx := context.WithValue(context.Background(), httputils.APIVersionKey{}, clusterVolumesVersion)
 	vars := map[string]string{"name": name}
-	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/volumes/%s", name), http.NoBody)
+	req := httptest.NewRequest(http.MethodGet, "/volumes/"+name, http.NoBody)
 	resp := httptest.NewRecorder()
 
 	err := v.getVolumeByName(ctx, resp, req, vars)

--- a/integration-cli/docker_api_swarm_service_test.go
+++ b/integration-cli/docker_api_swarm_service_test.go
@@ -463,7 +463,7 @@ func (s *DockerSwarmSuite) TestAPISwarmServiceConstraintLabel(c *testing.T) {
 	// multiple constraints
 	constraints = []string{
 		"node.labels.security==high",
-		fmt.Sprintf("node.id==%s", nodes[1].ID),
+		"node.id==" + nodes[1].ID,
 	}
 	id = daemons[0].CreateService(ctx, c, simpleTestService, setConstraints(constraints), setInstances(instances))
 	// wait for tasks created

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -361,7 +361,7 @@ ONBUILD CMD ["hello world"]
 ONBUILD ENTRYPOINT ["echo"]
 ONBUILD RUN ["true"]`))
 
-	cli.BuildCmd(c, name2, build.WithDockerfile(fmt.Sprintf(`FROM %s`, name1)))
+	cli.BuildCmd(c, name2, build.WithDockerfile("FROM "+name1))
 
 	result := cli.DockerCmd(c, "run", name2)
 	result.Assert(c, icmd.Expected{Out: "hello world"})
@@ -966,7 +966,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddBadLinks(c *testing.T) {
 		tempDirWithoutDrive := tempDir[2:]
 		symlinkTarget = fmt.Sprintf(`%s:\..\..\..\..\..\..\..\..\..\..\..\..%s`, driveLetter, tempDirWithoutDrive)
 	} else {
-		symlinkTarget = fmt.Sprintf("/../../../../../../../../../../../..%s", tempDir)
+		symlinkTarget = "/../../../../../../../../../../../.." + tempDir
 	}
 
 	tarPath := filepath.Join(ctx.Dir, "links.tar")
@@ -1444,8 +1444,7 @@ func (s *DockerCLIBuildSuite) TestBuildBlankName(c *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		cli.Docker(cli.Args("build", "-t", name), build.WithDockerfile(fmt.Sprintf(`FROM busybox
-		%s`, tc.expression))).Assert(c, icmd.Expected{
+		cli.Docker(cli.Args("build", "-t", name), build.WithDockerfile("FROM busybox\n"+tc.expression)).Assert(c, icmd.Expected{
 			ExitCode: 1,
 			Err:      tc.expectedStderr,
 		})
@@ -1637,8 +1636,7 @@ func (s *DockerCLIBuildSuite) TestBuildExposeMorePorts(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildExposeOrder(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Expose not implemented on Windows
 	buildID := func(name, exposed string) string {
-		cli.BuildCmd(c, name, build.WithDockerfile(fmt.Sprintf(`FROM scratch
-		EXPOSE %s`, exposed)))
+		cli.BuildCmd(c, name, build.WithDockerfile("FROM scratch\nEXPOSE "+exposed))
 		id := inspectField(c, name, "Id")
 		return id
 	}
@@ -3052,7 +3050,7 @@ func (s *DockerCLIBuildSuite) TestBuildFromGitWithContext(c *testing.T) {
 	}, true)
 	defer git.Close()
 
-	cli.BuildCmd(c, name, build.WithContextPath(fmt.Sprintf("%s#master:docker", git.RepoURL)))
+	cli.BuildCmd(c, name, build.WithContextPath(git.RepoURL+"#master:docker"))
 
 	res := inspectField(c, name, "Author")
 	if res != "docker" {
@@ -4315,8 +4313,8 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgExpansion(c *testing.T) {
 	volVar := "VOL"
 	volVal := "/testVol/"
 	if DaemonIsWindows() {
-		volVal = "C:\\testVol"
-		wdVal = "C:\\tmp"
+		volVal = `C:\testVol`
+		wdVal = `C:\tmp`
 	}
 
 	cli.BuildCmd(c, imgName,
@@ -4366,7 +4364,7 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgExpansion(c *testing.T) {
 
 	var resMap map[string]any
 	inspectFieldAndUnmarshall(c, imgName, "Config.ExposedPorts", &resMap)
-	if _, ok := resMap[fmt.Sprintf("%s/tcp", exposeVal)]; !ok {
+	if _, ok := resMap[exposeVal+"/tcp"]; !ok {
 		c.Fatalf("Config.ExposedPorts value mismatch. Expected exposed port: %s/tcp, got: %v", exposeVal, resMap)
 	}
 
@@ -5013,7 +5011,7 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestBuildWithExternalAuth(c *testing.T
 
 	icmd.RunCmd(icmd.Cmd{
 		Command: []string{dockerBinary, "--config", tmp, "build", "-"},
-		Stdin:   strings.NewReader(fmt.Sprintf("FROM %s", imgName)),
+		Stdin:   strings.NewReader("FROM " + imgName),
 	}).Assert(c, icmd.Success)
 }
 

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -99,13 +99,13 @@ func (s *DockerRegistrySuite) TestPullByDigest(t *testing.T) {
 func (s *DockerRegistrySuite) TestPullByDigestNoFallback(t *testing.T) {
 	testRequires(t, DaemonIsLinux)
 	// pull from the registry using the <name>@<digest> reference
-	imageReference := fmt.Sprintf("%s@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", repoName)
+	imageReference := repoName + "@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 	out, _, err := dockerCmdWithError("pull", imageReference)
 	assert.Assert(t, err != nil, "expected non-zero exit status and correct error message when pulling non-existing image")
 
 	expectedMsg := fmt.Sprintf("manifest for %s not found", imageReference)
 	if testEnv.UsingSnapshotter() {
-		expectedMsg = fmt.Sprintf("%s: not found", imageReference)
+		expectedMsg = imageReference + ": not found"
 	}
 
 	assert.Check(t, is.Contains(out, expectedMsg), "expected non-zero exit status and correct error message when pulling non-existing image")
@@ -135,7 +135,7 @@ func (s *DockerRegistrySuite) TestRunByDigest(t *testing.T) {
 
 	foundRegex := regexp.MustCompile("found=([^\n]+)")
 	matches := foundRegex.FindStringSubmatch(out)
-	assert.Equal(t, len(matches), 2, fmt.Sprintf("unable to parse digest from pull output: %s", out))
+	assert.Equal(t, len(matches), 2, "unable to parse digest from pull output: "+out)
 	assert.Equal(t, matches[1], "1", fmt.Sprintf("Expected %q, got %q", "1", matches[1]))
 
 	res := inspectField(t, containerName, "Config.Image")

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -540,7 +540,7 @@ func (s *DockerCLICpSuite) TestCopyAndRestart(c *testing.T) {
 	assert.NilError(c, err)
 	defer os.RemoveAll(tmpDir)
 
-	cli.DockerCmd(c, "cp", fmt.Sprintf("%s:/etc/group", containerID), tmpDir)
+	cli.DockerCmd(c, "cp", containerID+":/etc/group", tmpDir)
 
 	out = cli.DockerCmd(c, "start", "-a", containerID).Combined()
 	assert.Equal(c, strings.TrimSpace(out), expectedMsg)

--- a/integration-cli/docker_cli_cp_to_container_unix_test.go
+++ b/integration-cli/docker_cli_cp_to_container_unix_test.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -48,7 +47,7 @@ func (s *DockerCLICpSuite) TestCpCheckDestOwnership(c *testing.T) {
 	testRequires(c, DaemonIsLinux, testEnv.IsLocalDaemon)
 	tmpVolDir := getTestDir(c, "test-cp-tmpvol")
 	containerID := makeTestContainer(c,
-		testContainerOptions{volumes: []string{fmt.Sprintf("%s:/tmpvol", tmpVolDir)}})
+		testContainerOptions{volumes: []string{tmpVolDir + ":/tmpvol"}})
 
 	tmpDir := getTestDir(c, "test-cp-to-check-ownership")
 	defer os.RemoveAll(tmpDir)

--- a/integration-cli/docker_cli_cp_utils_test.go
+++ b/integration-cli/docker_cli_cp_utils_test.go
@@ -42,7 +42,7 @@ func (fd fileData) creationCommand() string {
 		// Don't overwrite the file if it already exists!
 		command = fmt.Sprintf("if [ ! -f %s ]; then echo %q > %s; fi", fd.path, fd.contents, fd.path)
 	case ftDir:
-		command = fmt.Sprintf("mkdir -p %s", fd.path)
+		command = "mkdir -p " + fd.path
 	case ftSymlink:
 		command = fmt.Sprintf("ln -fs %s %s", fd.contents, fd.path)
 	}
@@ -187,7 +187,7 @@ func containerCpPath(containerID string, pathElements ...string) string {
 }
 
 func containerCpPathTrailingSep(containerID string, pathElements ...string) string {
-	return fmt.Sprintf("%s/", containerCpPath(containerID, pathElements...))
+	return containerCpPath(containerID, pathElements...) + "/"
 }
 
 func runDockerCp(t *testing.T, src, dst string) error {
@@ -274,9 +274,9 @@ func defaultVolumes(tmpDir string) []string {
 	if testEnv.IsLocalDaemon() {
 		return []string{
 			"/vol1",
-			fmt.Sprintf("%s:/vol2", tmpDir),
-			fmt.Sprintf("%s:/vol3", filepath.Join(tmpDir, "vol3")),
-			fmt.Sprintf("%s:/vol_ro:ro", filepath.Join(tmpDir, "vol_ro")),
+			tmpDir + ":/vol2",
+			filepath.Join(tmpDir, "vol3") + ":/vol3",
+			filepath.Join(tmpDir, "vol_ro") + ":/vol_ro:ro",
 		}
 	}
 

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -47,7 +48,7 @@ func (s *DockerCLICreateSuite) TestCreateArgs(c *testing.T) {
 	assert.Equal(c, len(containers), 1)
 
 	cont := containers[0]
-	assert.Equal(c, cont.Path, "command", fmt.Sprintf("Unexpected container path. Expected command, received: %s", cont.Path))
+	assert.Equal(c, cont.Path, "command", "Unexpected container path. Expected command, received: "+cont.Path)
 
 	b := false
 	expected := []string{"arg1", "arg2", "arg with space", "-c", "flags"}
@@ -106,7 +107,7 @@ func (s *DockerCLICreateSuite) TestCreateWithPortRange(c *testing.T) {
 
 	for k, v := range cont.HostConfig.PortBindings {
 		assert.Equal(c, len(v), 1, fmt.Sprintf("Expected 1 ports binding, for the port %s but found %s", k, v))
-		assert.Equal(c, fmt.Sprintf("%d", k.Num()), v[0].HostPort, fmt.Sprintf("Expected host port %d to match published port %s", k.Num(), v[0].HostPort))
+		assert.Equal(c, strconv.FormatUint(uint64(k.Num()), 10), v[0].HostPort, fmt.Sprintf("Expected host port %d to match published port %s", k.Num(), v[0].HostPort))
 	}
 }
 
@@ -132,7 +133,7 @@ func (s *DockerCLICreateSuite) TestCreateWithLargePortRange(c *testing.T) {
 
 	for k, v := range cont.HostConfig.PortBindings {
 		assert.Equal(c, len(v), 1)
-		assert.Equal(c, fmt.Sprintf("%d", k.Num()), v[0].HostPort, fmt.Sprintf("Expected host port %d to match published port %s", k.Num(), v[0].HostPort))
+		assert.Equal(c, strconv.FormatUint(uint64(k.Num()), 10), v[0].HostPort, fmt.Sprintf("Expected host port %d to match published port %s", k.Num(), v[0].HostPort))
 	}
 }
 
@@ -224,7 +225,7 @@ func (s *DockerCLICreateSuite) TestCreateModeIpcContainer(c *testing.T) {
 	id := cli.DockerCmd(c, "create", "busybox").Stdout()
 	id = strings.TrimSpace(id)
 
-	cli.DockerCmd(c, "create", fmt.Sprintf("--ipc=container:%s", id), "busybox")
+	cli.DockerCmd(c, "create", "--ipc=container:"+id, "busybox")
 }
 
 func (s *DockerCLICreateSuite) TestCreateStopSignal(c *testing.T) {

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1560,7 +1560,7 @@ func (s *DockerDaemonSuite) TestDaemonMaxConcurrencyWithConfigFile(c *testing.T)
 	err := os.WriteFile(configFilePath, []byte(`{ "max-concurrent-downloads" : 8 }`), 0o666)
 	assert.NilError(c, err)
 	defer os.Remove(configFilePath)
-	s.d.Start(c, fmt.Sprintf("--config-file=%s", configFilePath))
+	s.d.Start(c, "--config-file="+configFilePath)
 
 	expectedMaxConcurrentUploads := `level=debug msg="Max Concurrent Uploads: 5"`
 	expectedMaxConcurrentDownloads := `level=debug msg="Max Concurrent Downloads: 8"`
@@ -1595,7 +1595,7 @@ func (s *DockerDaemonSuite) TestDaemonMaxConcurrencyWithConfigFileReload(c *test
 	assert.NilError(c, err)
 	defer os.Remove(configFilePath)
 
-	s.d.Start(c, fmt.Sprintf("--config-file=%s", configFilePath))
+	s.d.Start(c, "--config-file="+configFilePath)
 
 	expectedMaxConcurrentUploads := `level=debug msg="Max Concurrent Uploads: 5"`
 	expectedMaxConcurrentDownloads := `level=debug msg="Max Concurrent Downloads: 3"`
@@ -1963,7 +1963,7 @@ func (s *DockerDaemonSuite) TestDaemonShutdownTimeoutWithConfigFile(c *testing.T
 	assert.NilError(c, err)
 	defer os.Remove(configFilePath)
 
-	s.d.Start(c, fmt.Sprintf("--config-file=%s", configFilePath))
+	s.d.Start(c, "--config-file="+configFilePath)
 
 	err = os.WriteFile(configFilePath, []byte(`{ "shutdown-timeout" : 5 }`), 0o666)
 	assert.NilError(c, err)
@@ -2106,7 +2106,7 @@ func (s *DockerDaemonSuite) TestShmSize(c *testing.T) {
 	size := 67108864 * 2
 	pattern := regexp.MustCompile(fmt.Sprintf("shm on /dev/shm type tmpfs(.*)size=%dk", size/1024))
 
-	s.d.StartWithBusybox(testutil.GetContext(c), c, "--default-shm-size", fmt.Sprintf("%v", size))
+	s.d.StartWithBusybox(testutil.GetContext(c), c, "--default-shm-size", strconv.Itoa(size))
 
 	name := "shm1"
 	out, err := s.d.Cmd("run", "--name", name, "busybox", "mount")
@@ -2114,7 +2114,7 @@ func (s *DockerDaemonSuite) TestShmSize(c *testing.T) {
 	assert.Assert(c, pattern.MatchString(out))
 	out, err = s.d.Cmd("inspect", "--format", "{{.HostConfig.ShmSize}}", name)
 	assert.NilError(c, err, "Output: %s", out)
-	assert.Equal(c, strings.TrimSpace(out), fmt.Sprintf("%v", size))
+	assert.Equal(c, strings.TrimSpace(out), strconv.Itoa(size))
 }
 
 func (s *DockerDaemonSuite) TestShmSizeReload(c *testing.T) {
@@ -2138,7 +2138,7 @@ func (s *DockerDaemonSuite) TestShmSizeReload(c *testing.T) {
 	assert.Assert(c, pattern.MatchString(out))
 	out, err = s.d.Cmd("inspect", "--format", "{{.HostConfig.ShmSize}}", name)
 	assert.NilError(c, err, "Output: %s", out)
-	assert.Equal(c, strings.TrimSpace(out), fmt.Sprintf("%v", size))
+	assert.Equal(c, strings.TrimSpace(out), strconv.Itoa(size))
 
 	size = 67108864 * 3
 	configData = fmt.Appendf(nil, `{"default-shm-size": "%dM"}`, size/1024/1024)
@@ -2154,7 +2154,7 @@ func (s *DockerDaemonSuite) TestShmSizeReload(c *testing.T) {
 	assert.Assert(c, pattern.MatchString(out))
 	out, err = s.d.Cmd("inspect", "--format", "{{.HostConfig.ShmSize}}", name)
 	assert.NilError(c, err, "Output: %s", out)
-	assert.Equal(c, strings.TrimSpace(out), fmt.Sprintf("%v", size))
+	assert.Equal(c, strings.TrimSpace(out), strconv.Itoa(size))
 }
 
 func testDaemonStartIpcMode(t *testing.T, from, mode string, valid bool) {

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -47,7 +47,7 @@ func (s *DockerCLIEventSuite) TestEventsTimestampFormats(c *testing.T) {
 	end := daemonTime(c)
 
 	// List of available time formats to --since
-	unixTs := func(t time.Time) string { return fmt.Sprint(t.Unix()) }
+	unixTs := func(t time.Time) string { return strconv.FormatInt(t.Unix(), 10) }
 	rfc3339 := func(t time.Time) string { return t.Format(time.RFC3339) }
 	duration := func(t time.Time) string { return time.Since(t).String() }
 
@@ -279,7 +279,7 @@ func (s *DockerCLIEventSuite) TestEventsFilterImageName(c *testing.T) {
 	container2 := strings.TrimSpace(out)
 
 	name := "busybox"
-	out = cli.DockerCmd(c, "events", "--since", since, "--until", daemonUnixTime(c), "--filter", fmt.Sprintf("image=%s", name)).Stdout()
+	out = cli.DockerCmd(c, "events", "--since", since, "--until", daemonUnixTime(c), "--filter", "image="+name).Stdout()
 	events := strings.Split(out, "\n")
 	events = events[:len(events)-1]
 	assert.Assert(c, len(events) != 0, "Expected events but found none for the image busybox:latest")
@@ -349,7 +349,7 @@ func (s *DockerCLIEventSuite) TestEventsFilterImageLabels(c *testing.T) {
 		"events",
 		"--since", since,
 		"--until", daemonUnixTime(c),
-		"--filter", fmt.Sprintf("label=%s", label),
+		"--filter", "label="+label,
 		"--filter", "type="+string(eventtypes.ImageEventType),
 
 		// Depending on the API version, 3 or 4 events are produced; 2 events from

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -449,23 +449,23 @@ func (s *DockerDaemonSuite) TestDaemonEventsWithFilters(c *testing.T) {
 	assert.NilError(c, s.d.Signal(unix.SIGHUP))
 	time.Sleep(3 * time.Second)
 
-	out, err := s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", fmt.Sprintf("daemon=%s", info.ID))
+	out, err := s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", "daemon="+info.ID)
 	assert.NilError(c, err)
-	assert.Assert(c, is.Contains(out, fmt.Sprintf("daemon reload %s", info.ID)))
+	assert.Assert(c, is.Contains(out, "daemon reload "+info.ID))
 
-	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", fmt.Sprintf("daemon=%s", info.ID))
+	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", "daemon="+info.ID)
 	assert.NilError(c, err)
-	assert.Assert(c, is.Contains(out, fmt.Sprintf("daemon reload %s", info.ID)))
+	assert.Assert(c, is.Contains(out, "daemon reload "+info.ID))
 
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", "daemon=foo")
 	assert.NilError(c, err)
-	assert.Assert(c, !strings.Contains(out, fmt.Sprintf("daemon reload %s", info.ID)))
+	assert.Assert(c, !strings.Contains(out, "daemon reload "+info.ID))
 
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", "type=daemon")
 	assert.NilError(c, err)
-	assert.Assert(c, is.Contains(out, fmt.Sprintf("daemon reload %s", info.ID)))
+	assert.Assert(c, is.Contains(out, "daemon reload "+info.ID))
 
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", "type=container")
 	assert.NilError(c, err)
-	assert.Assert(c, !strings.Contains(out, fmt.Sprintf("daemon reload %s", info.ID)))
+	assert.Assert(c, !strings.Contains(out, "daemon reload "+info.ID))
 }

--- a/integration-cli/docker_cli_external_volume_driver_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_test.go
@@ -366,7 +366,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverDeleteContainer(c *t
 }
 
 func hostVolumePath(name string) string {
-	return fmt.Sprintf("/var/lib/docker/volumes/%s", name)
+	return "/var/lib/docker/volumes/" + name
 }
 
 // Make sure a request to use a down driver doesn't block other requests
@@ -463,7 +463,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverList(c *testing.T) {
 	cli.DockerCmd(c, "volume", "create", "-d", volumePluginName, "abc3")
 	out := cli.DockerCmd(c, "volume", "ls").Stdout()
 	ls := strings.Split(strings.TrimSpace(out), "\n")
-	assert.Equal(c, len(ls), 2, fmt.Sprintf("\n%s", out))
+	assert.Equal(c, len(ls), 2, "\n"+out)
 
 	vol := strings.Fields(ls[len(ls)-1])
 	assert.Equal(c, len(vol), 2, fmt.Sprint(vol))

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -274,7 +274,7 @@ func (s *DockerCLIInspectSuite) TestInspectNoSizeFlagContainer(c *testing.T) {
 
 	formatStr := "--format={{.SizeRw}},{{.SizeRootFs}}"
 	out := cli.DockerCmd(c, "inspect", "--type=container", formatStr, "busybox").Stdout()
-	assert.Equal(c, strings.TrimSpace(out), "<nil>,<nil>", fmt.Sprintf("Expected not to display size info: %s", out))
+	assert.Equal(c, strings.TrimSpace(out), "<nil>,<nil>", "Expected not to display size info: "+out)
 }
 
 func (s *DockerCLIInspectSuite) TestInspectSizeFlagContainer(c *testing.T) {

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -173,7 +173,7 @@ func (s *DockerCLILinksSuite) TestLinksUpdateOnRestart(c *testing.T) {
 	content := readContainerFileWithExec(c, id, "/etc/hosts")
 
 	getIP := func(hosts []byte, hostname string) string {
-		re := regexp.MustCompile(fmt.Sprintf(`(\S*)\t%s`, regexp.QuoteMeta(hostname)))
+		re := regexp.MustCompile(`(\S*)\t` + regexp.QuoteMeta(hostname))
 		matches := re.FindSubmatch(hosts)
 		assert.Assert(c, matches != nil, "Hostname %s have no matches in hosts", hostname)
 		return string(matches[1])

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -351,7 +351,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkLsFilter(c *testing.T) {
 
 	out = cli.DockerCmd(c, "network", "ls", "-f", "label=nonexistent").Stdout()
 	outArr := strings.Split(strings.TrimSpace(out), "\n")
-	assert.Equal(c, len(outArr), 1, fmt.Sprintf("%s\n", out))
+	assert.Equal(c, len(outArr), 1, out+"\n")
 
 	out = cli.DockerCmd(c, "network", "ls", "-f", "driver=null").Stdout()
 	assertNwList(c, out, []string{"none"})
@@ -1232,7 +1232,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkConnectDisconnectToStoppedContaine
 	cli.WaitRun(c, "foo")
 	ip := inspectField(c, "foo", "NetworkSettings.Networks.test.IPAddress")
 	ip = strings.TrimSpace(ip)
-	cli.DockerCmd(c, "run", "--net=test", "busybox", "sh", "-c", fmt.Sprintf("ping -c 1 %s", ip))
+	cli.DockerCmd(c, "run", "--net=test", "busybox", "sh", "-c", "ping -c 1 "+ip)
 
 	cli.DockerCmd(c, "stop", "foo")
 

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -53,79 +53,79 @@ func (s *DockerCLIPsSuite) TestPsListContainersBase(c *testing.T) {
 
 	// all
 	out = cli.DockerCmd(c, "ps", "-a").Stdout()
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), []string{fourthID, thirdID, secondID, firstID}), true, fmt.Sprintf("ALL: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), []string{fourthID, thirdID, secondID, firstID}), true, "ALL: Container list is not in the correct order: \n"+out)
 
 	// running
 	out = cli.DockerCmd(c, "ps").Stdout()
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), []string{fourthID, secondID, firstID}), true, fmt.Sprintf("RUNNING: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), []string{fourthID, secondID, firstID}), true, "RUNNING: Container list is not in the correct order: \n"+out)
 
 	// limit
 	out = cli.DockerCmd(c, "ps", "-n=2", "-a").Stdout()
 	expected := []string{fourthID, thirdID}
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("LIMIT & ALL: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, "LIMIT & ALL: Container list is not in the correct order: \n"+out)
 
 	out = cli.DockerCmd(c, "ps", "-n=2").Stdout()
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("LIMIT: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, "LIMIT: Container list is not in the correct order: \n"+out)
 
 	// filter since
 	out = cli.DockerCmd(c, "ps", "-f", "since="+firstID, "-a").Stdout()
 	expected = []string{fourthID, thirdID, secondID}
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("SINCE filter & ALL: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, "SINCE filter & ALL: Container list is not in the correct order: \n"+out)
 
 	out = cli.DockerCmd(c, "ps", "-f", "since="+firstID).Stdout()
 	expected = []string{fourthID, secondID}
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("SINCE filter: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, "SINCE filter: Container list is not in the correct order: \n"+out)
 
 	out = cli.DockerCmd(c, "ps", "-f", "since="+thirdID).Stdout()
 	expected = []string{fourthID}
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("SINCE filter: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, "SINCE filter: Container list is not in the correct order: \n"+out)
 
 	// filter before
 	out = cli.DockerCmd(c, "ps", "-f", "before="+fourthID, "-a").Stdout()
 	expected = []string{thirdID, secondID, firstID}
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("BEFORE filter & ALL: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, "BEFORE filter & ALL: Container list is not in the correct order: \n"+out)
 
 	out = cli.DockerCmd(c, "ps", "-f", "before="+fourthID).Stdout()
 	expected = []string{secondID, firstID}
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("BEFORE filter: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, "BEFORE filter: Container list is not in the correct order: \n"+out)
 
 	out = cli.DockerCmd(c, "ps", "-f", "before="+thirdID).Stdout()
 	expected = []string{secondID, firstID}
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("SINCE filter: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, "SINCE filter: Container list is not in the correct order: \n"+out)
 
 	// filter since & before
 	out = cli.DockerCmd(c, "ps", "-f", "since="+firstID, "-f", "before="+fourthID, "-a").Stdout()
 	expected = []string{thirdID, secondID}
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("SINCE filter, BEFORE filter & ALL: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, "SINCE filter, BEFORE filter & ALL: Container list is not in the correct order: \n"+out)
 
 	out = cli.DockerCmd(c, "ps", "-f", "since="+firstID, "-f", "before="+fourthID).Stdout()
 	expected = []string{secondID}
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("SINCE filter, BEFORE filter: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, "SINCE filter, BEFORE filter: Container list is not in the correct order: \n"+out)
 
 	// filter since & limit
 	out = cli.DockerCmd(c, "ps", "-f", "since="+firstID, "-n=2", "-a").Stdout()
 	expected = []string{fourthID, thirdID}
 
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("SINCE filter, LIMIT & ALL: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, "SINCE filter, LIMIT & ALL: Container list is not in the correct order: \n"+out)
 
 	out = cli.DockerCmd(c, "ps", "-f", "since="+firstID, "-n=2").Stdout()
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("SINCE filter, LIMIT: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, "SINCE filter, LIMIT: Container list is not in the correct order: \n"+out)
 
 	// filter before & limit
 	out = cli.DockerCmd(c, "ps", "-f", "before="+fourthID, "-n=1", "-a").Stdout()
 	expected = []string{thirdID}
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("BEFORE filter, LIMIT & ALL: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, "BEFORE filter, LIMIT & ALL: Container list is not in the correct order: \n"+out)
 
 	out = cli.DockerCmd(c, "ps", "-f", "before="+fourthID, "-n=1").Stdout()
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("BEFORE filter, LIMIT: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, "BEFORE filter, LIMIT: Container list is not in the correct order: \n"+out)
 
 	// filter since & filter before & limit
 	out = cli.DockerCmd(c, "ps", "-f", "since="+firstID, "-f", "before="+fourthID, "-n=1", "-a").Stdout()
 	expected = []string{thirdID}
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("SINCE filter, BEFORE filter, LIMIT & ALL: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, "SINCE filter, BEFORE filter, LIMIT & ALL: Container list is not in the correct order: \n"+out)
 
 	out = cli.DockerCmd(c, "ps", "-f", "since="+firstID, "-f", "before="+fourthID, "-n=1").Stdout()
-	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, fmt.Sprintf("SINCE filter, BEFORE filter, LIMIT: Container list is not in the correct order: \n%s", out))
+	assert.Equal(c, assertContainerList(RemoveOutputForExistingElements(out, existingContainers), expected), true, "SINCE filter, BEFORE filter, LIMIT: Container list is not in the correct order: \n"+out)
 }
 
 func assertContainerList(out string, expected []string) bool {
@@ -370,7 +370,7 @@ func (s *DockerCLIPsSuite) TestPsListContainersFilterAncestorImage(c *testing.T)
 		{imageName1, []string{thirdID, fifthID}},
 		{imageName2, []string{fifthID}},
 		// image:tag
-		{fmt.Sprintf("%s:latest", imageName1), []string{thirdID, fifthID}},
+		{imageName1 + ":latest", []string{thirdID, fifthID}},
 		{imageName1Tagged, []string{fourthID}},
 		// short-id
 		{stringid.TruncateID(imageID1), []string{thirdID, fifthID}},

--- a/integration-cli/docker_cli_pull_local_test.go
+++ b/integration-cli/docker_cli_pull_local_test.go
@@ -301,7 +301,7 @@ func (s *DockerRegistrySuite) TestPullManifestList(c *testing.T) {
 
 	// The pull output includes "Digest: <digest>", so find that
 	matches := digestRegex.FindStringSubmatch(out)
-	assert.Equal(c, len(matches), 2, fmt.Sprintf("unable to parse digest from pull output: %s", out))
+	assert.Equal(c, len(matches), 2, "unable to parse digest from pull output: "+out)
 	pullDigest := matches[1]
 
 	// Make sure the pushed and pull digests match

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -288,7 +288,7 @@ RUN echo 2 #layer2
 	// See if the "tmp2" can be untagged.
 	out = cli.DockerCmd(c, "rmi", newTag).Combined()
 	// Expected 1 untagged entry
-	assert.Equal(c, strings.Count(out, "Untagged: "), 1, fmt.Sprintf("out: %s", out))
+	assert.Equal(c, strings.Count(out, "Untagged: "), 1, "out: "+out)
 
 	// Now let's add the tag again and create a container based on it.
 	cli.DockerCmd(c, "tag", idToTag, newTag)

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -77,7 +77,7 @@ func (s *DockerCLIRunSuite) TestRunWithVolumesIsRecursive(c *testing.T) {
 	assert.NilError(c, err)
 	defer f.Close()
 
-	out := cli.DockerCmd(c, "run", "--name", "test-data", "--volume", fmt.Sprintf("%s:/tmp:ro", tmpDir), "busybox:latest", "ls", "/tmp/tmpfs").Combined()
+	out := cli.DockerCmd(c, "run", "--name", "test-data", "--volume", tmpDir+":/tmp:ro", "busybox:latest", "ls", "/tmp/tmpfs").Combined()
 	assert.Assert(c, strings.Contains(out, filepath.Base(f.Name())), "Recursive bind mount test failed. Expected file not found")
 }
 

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -202,7 +202,7 @@ func (s *DockerCLISaveLoadSuite) TestSaveWithNoExistImage(c *testing.T) {
 
 	out, _, err := dockerCmdWithError("save", "-o", "test-img.tar", imgName)
 	assert.ErrorContains(c, err, "", "save image should fail for non-existing image")
-	assert.Assert(c, is.Contains(out, fmt.Sprintf("No such image: %s", imgName)))
+	assert.Assert(c, is.Contains(out, "No such image: "+imgName))
 }
 
 func (s *DockerCLISaveLoadSuite) TestSaveMultipleNames(c *testing.T) {

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -89,7 +89,7 @@ func (s *DockerSwarmSuite) TestSwarmUpdate(c *testing.T) {
 	tempFile := fs.NewFile(c, "testfile", fs.WithContent("fakecert"))
 
 	result := cli.Docker(cli.Args("swarm", "update",
-		"--external-ca", fmt.Sprintf("protocol=cfssl,url=https://something.org,cacert=%s", tempFile.Path())),
+		"--external-ca", "protocol=cfssl,url=https://something.org,cacert="+tempFile.Path()),
 		cli.Daemon(d))
 	result.Assert(c, icmd.Expected{
 		ExitCode: 125,
@@ -110,7 +110,7 @@ func (s *DockerSwarmSuite) TestSwarmInit(c *testing.T) {
 	tempFile := fs.NewFile(c, "testfile", fs.WithContent("fakecert"))
 
 	result := cli.Docker(cli.Args("swarm", "init", "--cert-expiry", "30h", "--dispatcher-heartbeat", "11s",
-		"--external-ca", fmt.Sprintf("protocol=cfssl,url=https://somethingelse.org,cacert=%s", tempFile.Path())),
+		"--external-ca", "protocol=cfssl,url=https://somethingelse.org,cacert="+tempFile.Path()),
 		cli.Daemon(d))
 	result.Assert(c, icmd.Expected{
 		ExitCode: 125,

--- a/integration-cli/docker_cli_userns_test.go
+++ b/integration-cli/docker_cli_userns_test.go
@@ -43,7 +43,7 @@ func (s *DockerDaemonSuite) TestDaemonUserNamespaceRootSetting(c *testing.T) {
 
 	// we need to find the uid and gid of the remapped root from the daemon's root dir info
 	uidgid := strings.Split(filepath.Base(s.d.Root), ".")
-	assert.Equal(c, len(uidgid), 2, fmt.Sprintf("Should have gotten uid/gid strings from root dirname: %s", filepath.Base(s.d.Root)))
+	assert.Equal(c, len(uidgid), 2, "Should have gotten uid/gid strings from root dirname: "+filepath.Base(s.d.Root))
 	uid, err := strconv.Atoi(uidgid[0])
 	assert.NilError(c, err, "Can't parse uid")
 	gid, err := strconv.Atoi(uidgid[1])

--- a/integration-cli/docker_cli_v2_only_test.go
+++ b/integration-cli/docker_cli_v2_only_test.go
@@ -37,7 +37,7 @@ func (s *DockerRegistrySuite) TestV2Only(c *testing.T) {
 		c.Fatal("V1 registry contacted")
 	})
 
-	repoName := fmt.Sprintf("%s/busybox", reg.URL())
+	repoName := reg.URL() + "/busybox"
 
 	s.d.Start(c, "--insecure-registry", reg.URL())
 

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -224,7 +224,7 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLIInspectTmplError(c *testing.T) {
 
 	out, exitCode, err := dockerCmdWithError("volume", "inspect", "--format='{{ .FooBar }}'", name)
 	assert.Assert(c, err != nil, "Output: %s", out)
-	assert.Equal(c, exitCode, 1, fmt.Sprintf("Output: %s", out))
+	assert.Equal(c, exitCode, 1, "Output: "+out)
 	assert.Assert(c, is.Contains(out, "parsing error"))
 }
 
@@ -312,11 +312,11 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLILsFilterLabels(c *testing.T) {
 
 	out = cli.DockerCmd(c, "volume", "ls", "--filter", "label=non-exist").Stdout()
 	outArr := strings.Split(strings.TrimSpace(out), "\n")
-	assert.Equal(c, len(outArr), 1, fmt.Sprintf("\n%s", out))
+	assert.Equal(c, len(outArr), 1, "\n"+out)
 
 	out = cli.DockerCmd(c, "volume", "ls", "--filter", "label=foo=non-exist").Stdout()
 	outArr = strings.Split(strings.TrimSpace(out), "\n")
-	assert.Equal(c, len(outArr), 1, fmt.Sprintf("\n%s", out))
+	assert.Equal(c, len(outArr), 1, "\n"+out)
 }
 
 func (s *DockerCLIVolumeSuite) TestVolumeCLILsFilterDrivers(c *testing.T) {
@@ -337,17 +337,17 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLILsFilterDrivers(c *testing.T) {
 	// filter with driver=invaliddriver
 	out = cli.DockerCmd(c, "volume", "ls", "--filter", "driver=invaliddriver").Stdout()
 	outArr := strings.Split(strings.TrimSpace(out), "\n")
-	assert.Equal(c, len(outArr), 1, fmt.Sprintf("\n%s", out))
+	assert.Equal(c, len(outArr), 1, "\n"+out)
 
 	// filter with driver=loca
 	out = cli.DockerCmd(c, "volume", "ls", "--filter", "driver=loca").Stdout()
 	outArr = strings.Split(strings.TrimSpace(out), "\n")
-	assert.Equal(c, len(outArr), 1, fmt.Sprintf("\n%s", out))
+	assert.Equal(c, len(outArr), 1, "\n"+out)
 
 	// filter with driver=
 	out = cli.DockerCmd(c, "volume", "ls", "--filter", "driver=").Stdout()
 	outArr = strings.Split(strings.TrimSpace(out), "\n")
-	assert.Equal(c, len(outArr), 1, fmt.Sprintf("\n%s", out))
+	assert.Equal(c, len(outArr), 1, "\n"+out)
 }
 
 func (s *DockerCLIVolumeSuite) TestVolumeCLIRmForceUsage(c *testing.T) {

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -68,7 +67,7 @@ func Network() bool {
 
 	resp, err := c.Get(url)
 	if err != nil && !errors.Is(err, net.ErrClosed) {
-		panic(fmt.Sprintf("Timeout for GET request on %s", url))
+		panic("Timeout for GET request on " + url)
 	}
 	if resp != nil {
 		resp.Body.Close()

--- a/integration/container/list_test.go
+++ b/integration/container/list_test.go
@@ -2,7 +2,6 @@ package container
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -65,7 +64,7 @@ func TestContainerList_Annotations(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		t.Run(fmt.Sprintf("run with version v%s", tc.apiVersion), func(t *testing.T) {
+		t.Run("run with version v"+tc.apiVersion, func(t *testing.T) {
 			apiClient := request.NewAPIClient(t, client.WithAPIVersion(tc.apiVersion))
 			id := container.Create(ctx, t, apiClient, container.WithAnnotations(tc.expectedAnnotations))
 			defer container.Remove(ctx, t, apiClient, id, client.ContainerRemoveOptions{Force: true})
@@ -190,7 +189,7 @@ func TestContainerList_HealthSummary(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		t.Run(fmt.Sprintf("run with version v%s", tc.apiVersion), func(t *testing.T) {
+		t.Run("run with version v"+tc.apiVersion, func(t *testing.T) {
 			apiClient := request.NewAPIClient(t, client.WithAPIVersion(tc.apiVersion))
 
 			cID := container.Run(ctx, t, apiClient, container.WithTty(true), container.WithWorkingDir("/foo"), func(c *container.TestContainerConfig) {

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -125,7 +125,7 @@ func startServerContainer(ctx context.Context, t *testing.T, msg string, port ui
 			c.HostConfig.PortBindings = network.PortMap{
 				network.MustParsePort(fmt.Sprintf("%d/tcp", port)): []network.PortBinding{
 					{
-						HostPort: fmt.Sprintf("%d", port),
+						HostPort: strconv.FormatUint(uint64(port), 10),
 					},
 				},
 			}

--- a/integration/image/tag_test.go
+++ b/integration/image/tag_test.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/moby/moby/client"
@@ -102,5 +101,5 @@ func TestTagMatchesDigest(t *testing.T) {
 
 	// check that no new image matches the digest
 	_, err = apiClient.ImageInspect(ctx, digest)
-	assert.Check(t, is.ErrorContains(err, fmt.Sprintf("No such image: %s", digest)))
+	assert.Check(t, is.ErrorContains(err, "No such image: "+digest))
 }

--- a/integration/network/helpers.go
+++ b/integration/network/helpers.go
@@ -62,7 +62,7 @@ func IsNetworkAvailable(ctx context.Context, c client.NetworkAPIClient, name str
 				return is.ResultSuccess
 			}
 		}
-		return is.ResultFailure(fmt.Sprintf("could not find network %s", name))
+		return is.ResultFailure("could not find network " + name)
 	}
 }
 

--- a/integration/network/network_linux_test.go
+++ b/integration/network/network_linux_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"slices"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -144,7 +145,7 @@ func TestDefaultNetworkOpts(t *testing.T) {
 				network.CreateNoError(ctx, t, c, "from-net", func(create *client.NetworkCreateOptions) {
 					create.ConfigOnly = true
 					create.Options = map[string]string{
-						"com.docker.network.driver.mtu": fmt.Sprint(tc.mtu),
+						"com.docker.network.driver.mtu": strconv.Itoa(tc.mtu),
 					}
 				})
 				defer c.NetworkRemove(ctx, "from-net", client.NetworkRemoveOptions{})

--- a/integration/network/network_test.go
+++ b/integration/network/network_test.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"slices"
 	"testing"
@@ -146,7 +145,7 @@ func TestAPINetworkFilter(t *testing.T) {
 			found = true
 		}
 	}
-	assert.Assert(t, found, fmt.Sprintf("%s is not found", networkName))
+	assert.Assert(t, found, networkName+" is not found")
 }
 
 func TestNetworkInspectWithScope(t *testing.T) {

--- a/internal/testutil/environment/environment.go
+++ b/internal/testutil/environment/environment.go
@@ -94,7 +94,7 @@ func getPlatformDefaults(info system.Info) PlatformDefaults {
 			ContainerStoragePath: filepath.FromSlash(containersPath),
 		}
 	default:
-		panic(fmt.Sprintf("unknown OSType for daemon: %s", info.OSType))
+		panic("unknown OSType for daemon: " + info.OSType)
 	}
 }
 

--- a/internal/testutil/fakestorage/storage.go
+++ b/internal/testutil/fakestorage/storage.go
@@ -133,8 +133,8 @@ func (f *remoteFileServer) Close() error {
 
 func newRemoteFileServer(t testing.TB, ctx *fakecontext.Fake, c client.APIClient) *remoteFileServer {
 	var (
-		imgName = fmt.Sprintf("fileserver-img-%s", testutil.RandomAlpha(10))
-		ctrName = fmt.Sprintf("fileserver-cnt-%s", testutil.RandomAlpha(10))
+		imgName = "fileserver-img-" + testutil.RandomAlpha(10)
+		ctrName = "fileserver-cnt-" + testutil.RandomAlpha(10)
 	)
 
 	ensureHTTPServerImage(t)

--- a/pkg/plugins/discovery_unix_test.go
+++ b/pkg/plugins/discovery_unix_test.go
@@ -3,7 +3,6 @@
 package plugins
 
 import (
-	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -53,7 +52,7 @@ func TestLocalSocket(t *testing.T) {
 			t.Fatalf("Expected plugin `echo`, got %s\n", p.name)
 		}
 
-		addr := fmt.Sprintf("unix://%s", c)
+		addr := "unix://" + c
 		if p.Addr != addr {
 			t.Fatalf("Expected plugin addr `%s`, got %s\n", addr, p.Addr)
 		}

--- a/pkg/plugins/pluginrpc-gen/main.go
+++ b/pkg/plugins/pluginrpc-gen/main.go
@@ -67,7 +67,7 @@ func main() {
 	errorOut("error", checkFlags())
 
 	pkg, err := Parse(*inputFile, *typeName)
-	errorOut(fmt.Sprintf("error parsing requested type %s", *typeName), err)
+	errorOut("error parsing requested type "+*typeName, err)
 
 	analysis := struct {
 		InterfaceType string

--- a/vendor/github.com/moby/moby/client/internal/mod/mod.go
+++ b/vendor/github.com/moby/moby/client/internal/mod/mod.go
@@ -87,7 +87,7 @@ func getVersion(name string, dep *debug.Module) (string, bool) {
 func normalize(v string) string {
 	base, metas, dirty := splitMetadata(v)
 
-	out := base
+	var out strings.Builder
 	if base2, rev, undoPatch, ok := splitPseudo(base); ok {
 		if undoPatch {
 			// Downgrade the patch version that was raised by pseudo-versions:
@@ -102,18 +102,22 @@ func normalize(v string) string {
 		if len(rev) > 12 {
 			rev = rev[:12]
 		}
-		out = base2 + "+" + rev
+		out.WriteString(base2)
+		out.WriteByte('+')
+		out.WriteString(rev)
+	} else {
+		out.WriteString(base)
 	}
 
 	// Preserve other metadata (except for "+incompatible").
 	for _, m := range metas {
-		out += m
+		out.WriteString(m)
 	}
 	if dirty {
 		// +dirty goes last
-		out += "+dirty"
+		out.WriteString("+dirty")
 	}
-	return out
+	return out.String()
 }
 
 func splitMetadata(v string) (base string, metas []string, dirty bool) {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/53007#issuecomment-4892082215

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
