### PR TITLE
internal/testutil/daemon: Auto-register Cleanup in daemon.New

### DIFF
--- a/internal/testutil/daemon/daemon.go
+++ b/internal/testutil/daemon/daemon.go
@@ -211,6 +211,11 @@ func NewDaemon(workingDir string, ops ...Option) (*Daemon, error) {
 // This will create a directory such as d123456789 in the folder specified by
 // $DOCKER_INTEGRATION_DAEMON_DEST or $DEST.
 // The daemon will not automatically start.
+// Cleanup of the daemon's storage is registered via [testing.TB.Cleanup]:
+// overlay mounts, Raft state and heavy storage subdirectories are removed when
+// the test ends, preserving logs for artifact collection.
+// The daemon must still be stopped explicitly (e.g. with [Daemon.Stop]) before
+// the test returns; the registered cleanup only handles directory removal.
 func New(t testing.TB, ops ...Option) *Daemon {
 	t.Helper()
 	dest := os.Getenv("DOCKER_INTEGRATION_DAEMON_DEST")
@@ -238,6 +243,15 @@ func New(t testing.TB, ops ...Option) *Daemon {
 	if d.rootlessUser != nil && d.dockerdBinary != defaultDockerdBinary {
 		t.Skipf("DOCKER_ROOTLESS doesn't support specifying non-default dockerd binary path %q", d.dockerdBinary)
 	}
+
+	// Cleanup runs after all defers in the test function, so an explicit
+	// defer d.Stop(t) in the test fires first and leaves Cleanup to handle
+	// only directory removal. For tests that forget to stop, Stop here is a
+	// no-op if already stopped, or a safety net if not.
+	t.Cleanup(func() {
+		d.Stop(t)
+		d.Cleanup(t)
+	})
 
 	return d
 }


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

daemon.New creates a directory under DEST for each daemon (overlay storage, Raft state, logs, network namespaces) but never registered cleanup. Any test that forgot to call Cleanup left those directories on disk for the remainder of the test run. With the stress runner executing a test 10 times in a row, 40+ daemon directories accumulated and filled the disk:

no space left on device: could not create daemon root ".../bundles/test-integration-flaky/TestInspectNetwork/d8488af0.../root"

Cleanup heavy storage subdirectories (overlay2, image, containers, buildkit, …) but deliberately preserve the daemon log file so it is still available for artifact collection when a test fails.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
