### PR TITLE
libnetwork: skip storing ingress proxy listener on bind failure

### DIFF
--- a/daemon/libnetwork/service_linux.go
+++ b/daemon/libnetwork/service_linux.go
@@ -552,6 +552,7 @@ func plumbIngressPortsProxy(ingressPorts []*PortConfig) {
 
 		if err != nil {
 			log.G(context.TODO()).Warnf("failed to create proxy for port %s: %v", iPort, err)
+			continue
 		}
 
 		ingressProxyTbl[portSpec] = l

--- a/daemon/libnetwork/service_linux_test.go
+++ b/daemon/libnetwork/service_linux_test.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+package libnetwork
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCloseIngressPortsProxyAfterBindFailure(t *testing.T) {
+	ingressMu.Lock()
+	defer ingressMu.Unlock()
+
+	origTbl := ingressProxyTbl
+	t.Cleanup(func() {
+		ingressProxyTbl = origTbl
+	})
+	ingressProxyTbl = make(map[string]io.Closer)
+
+	blocker, err := net.ListenUDP("udp", &net.UDPAddr{Port: 0})
+	assert.NilError(t, err)
+	defer blocker.Close()
+
+	port := uint32(blocker.LocalAddr().(*net.UDPAddr).Port)
+	ingressPort := &PortConfig{
+		Protocol:      ProtocolUDP,
+		PublishedPort: port,
+	}
+
+	plumbIngressPortsProxy([]*PortConfig{ingressPort})
+
+	portSpec := fmt.Sprintf("%d/%s", ingressPort.PublishedPort, strings.ToLower(ingressPort.Protocol.String()))
+	if _, ok := ingressProxyTbl[portSpec]; ok {
+		t.Fatal("bind failure must not store a listener in ingressProxyTbl")
+	}
+
+	closeIngressPortsProxy([]*PortConfig{ingressPort})
+}


### PR DESCRIPTION
- Related to: https://github.com/moby/moby/pull/50443

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary
When plumbIngressPortsProxy fails to bind a port, it stored a typed-nil listener in ingressProxyTbl. closeIngressPortsProxy then panicked on Close() during ingress port removal.

Add a regression test and continue on bind error instead of recording the failed listener.

## Info

Observed on Docker Engine 29.5.2 with an active Swarm cluster while removing a service binding. The daemon crashed with:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2c5f4e0]
goroutine 4292 [running]:
net.(*UDPConn).Close(0xb038ad?)
	<autogenerated>:1
github.com/moby/moby/v2/daemon/libnetwork.closeIngressPortsProxy({0x3fe1a7e5e420, 0x4, 0x8?})
	/go/src/github.com/docker/docker/daemon/libnetwork/service_linux.go:523 +0x11f
github.com/moby/moby/v2/daemon/libnetwork.removeIngressPorts({0x3fe1a43258d8, 0x4, 0x8}, {0x3fe1a9c929a0, 0x4, 0x4})
	/go/src/github.com/docker/docker/daemon/libnetwork/service_linux.go:377 +0x211
github.com/moby/moby/v2/daemon/libnetwork.(*Network).rmLBBackend(0x3fe1a5fc5520, {0x3fe1a43256d0, 0x4, 0x4}, 0x3fe1a8d27540, 0x1, 0x1)
	/go/src/github.com/docker/docker/daemon/libnetwork/service_linux.go:233 +0xc75
github.com/moby/moby/v2/daemon/libnetwork.(*Controller).rmServiceBinding(0x3fe1a4c89c20, ...)
	/go/src/github.com/docker/docker/daemon/libnetwork/service_common.go:439 +0xc6c
github.com/moby/moby/v2/daemon/libnetwork.handleEpTableEvent(...)
	/go/src/github.com/docker/docker/daemon/libnetwork/agent.go:967 +0x776
```

Regression introduced in 8b208f1b95 (PR #50443) when `plumbProxy` was inlined into `plumbIngressPortsProxy`. The old `return err` on bind failure prevented storing a typed-nil listener; the refactor logged the error but still assigned to `ingressProxyTbl`.

## Release notes (optional)


<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
- Fix a daemon panic when removing swarm ingress ports after failing to bind an ingress proxy listener.
```

