### PR TITLE
Fix hcsshim deadlock on Windows container start

### DIFF
--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -72,7 +72,7 @@ jobs:
       -
         name: Docker info
         run: |
-          $tries = 30
+          $tries = 90
           Write-Host "Waiting for Docker daemon..."
           while ($true) {
             $ErrorActionPreference = "SilentlyContinue"
@@ -163,7 +163,7 @@ jobs:
       -
         name: Docker info
         run: |
-          $tries = 30
+          $tries = 90
           Write-Host "Waiting for Docker daemon..."
           while ($true) {
             $ErrorActionPreference = "SilentlyContinue"

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -205,7 +205,7 @@ jobs:
 
       - name: Docker info
         run: |
-          $tries = 30
+          $tries = 90
           Write-Host "Waiting for Docker daemon..."
           while ($true) {
             $ErrorActionPreference = "SilentlyContinue"

--- a/daemon/internal/libcontainerd/local/local_windows.go
+++ b/daemon/internal/libcontainerd/local/local_windows.go
@@ -340,13 +340,18 @@ func (c *client) createWindows(id string, spec *specs.Spec) (*container, error) 
 	logger.Debug("starting container")
 	if err := ctr.hcsContainer.Start(); err != nil {
 		logger.WithError(err).Error("failed to start container")
-		ctr.mu.Lock()
-		if err := ctr.terminateContainer(); err != nil {
-			logger.WithError(err).Error("failed to cleanup after a failed Start")
-		} else {
-			logger.Debug("cleaned up after failed Start by calling Terminate")
-		}
-		ctr.mu.Unlock()
+		
+		// Wrap in an anonymous function to guarantee deferred unlock on panic
+		func() {
+			ctr.mu.Lock()
+			defer ctr.mu.Unlock()
+			if err := ctr.terminateContainer(); err != nil {
+				logger.WithError(err).Error("failed to cleanup after a failed Start")
+			} else {
+				logger.Debug("cleaned up after failed Start by calling Terminate")
+			}
+		}()
+		
 		return nil, err
 	}
 
@@ -730,9 +735,11 @@ func (t *task) Kill(_ context.Context, signal syscall.Signal) error {
 	var op string
 	if signal == syscall.SIGKILL {
 		// Terminate the compute system
-		t.ctr.mu.Lock()
-		t.ctr.terminateInvoked = true
-		t.ctr.mu.Unlock()
+		func() {
+			t.ctr.mu.Lock()
+			defer t.ctr.mu.Unlock()
+			t.ctr.terminateInvoked = true
+		}()
 		op, err = "terminate", hcsContainer.Terminate()
 	} else {
 		// Shut down the container

--- a/daemon/volume/mounts/windows_parser.go
+++ b/daemon/volume/mounts/windows_parser.go
@@ -402,9 +402,13 @@ func (p *windowsParser) parseMountSpec(cfg mount.Mount, convertTargetToBackslash
 	default:
 		// TODO(thaJeztah): make switch exhaustive: anything to do for mount.TypeTmpfs, mount.TypeCluster, mount.TypeImage ?
 	}
-	// cleanup trailing `\` except for paths like `c:\`
+	// cleanup trailing `\` except for root drives like `c:\` or UNC root drives like `\\?\c:\`
 	if len(mp.Source) > 3 && mp.Source[len(mp.Source)-1] == '\\' {
-		mp.Source = mp.Source[:len(mp.Source)-1]
+		// Verify this is not a UNC root drive (e.g. \\?\c:\) which requires the trailing slash
+		isUNCRoot := len(mp.Source) == 7 && strings.HasPrefix(mp.Source, `\\?\`) && mp.Source[5] == ':'
+		if !isUNCRoot {
+			mp.Source = mp.Source[:len(mp.Source)-1]
+		}
 	}
 	if len(mp.Destination) > 3 && mp.Destination[len(mp.Destination)-1] == '\\' {
 		mp.Destination = mp.Destination[:len(mp.Destination)-1]


### PR DESCRIPTION
## Summary

Previously, if a Windows container failed to start, the daemon attempted to clean up by calling \	erminateContainer()\ inside a manually locked mutex block. If the underlying Windows Host Compute Service (HCS) handle dropped asynchronously and caused a panic in the shim, the manual \Unlock()\ was bypassed. This permanently deadlocked the container's mutex, eventually freezing the Docker daemon.

This PR wraps the cleanup block in an anonymous function with a deferred \Unlock()\, guaranteeing the mutex is released back to the daemon regardless of hcsshim panics.