### PR TITLE
update to go1.26.5

### DIFF
--- a/.github/workflows/.test-unit.yml
+++ b/.github/workflows/.test-unit.yml
@@ -22,7 +22,7 @@ on:
         required: false
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   SETUP_BUILDX_VERSION: edge

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -30,7 +30,7 @@ on:
         required: false
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   ITG_CLI_MATRIX_SIZE: 6

--- a/.github/workflows/.vm.yml
+++ b/.github/workflows/.vm.yml
@@ -19,7 +19,7 @@ on:
         default: ""
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
   TESTSTAT_VERSION: v0.1.25
   TEMPLATE_NAME: ${{ inputs.template }}
 

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -25,7 +25,7 @@ on:
         required: false
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   WINDOWS_BASE_IMAGE: mcr.microsoft.com/windows/servercore

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -19,7 +19,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
   DESTDIR: ./build
   SETUP_BUILDX_VERSION: edge
   SETUP_BUILDKIT_IMAGE: moby/buildkit:latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ on:
     - cron: '0 9 * * 4'
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
 
 jobs:
   codeql:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
   GIT_PAGER: "cat"
   PAGER: "cat"
   SETUP_BUILDX_VERSION: edge

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ version: "2"
 
 run:
   # prevent golangci-lint from deducting the go version to lint for through go.mod,
-  go: "1.26.4"
+  go: "1.26.5"
   # Only supported with go modules enabled (build flag -mod=vendor only valid when using modules)
   # modules-download-mode: vendor
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"
 

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -161,7 +161,7 @@ FROM ${WINDOWS_BASE_IMAGE}:${WINDOWS_BASE_IMAGE_TAG}
 # Use PowerShell as the default shell
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 
 # GOTESTSUM_VERSION is the version of gotest.tools/gotestsum to install.
 ARG GOTESTSUM_VERSION=v1.13.0

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 
 FROM golang:${GO_VERSION}-alpine AS base
 RUN apk add --no-cache bash make yamllint

--- a/hack/dockerfiles/generate-files.Dockerfile
+++ b/hack/dockerfiles/generate-files.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG PROTOC_VERSION=3.11.4
 

--- a/hack/dockerfiles/govulncheck.Dockerfile
+++ b/hack/dockerfiles/govulncheck.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 ARG GOVULNCHECK_VERSION=v1.1.4
 ARG FORMAT=text
 


### PR DESCRIPTION
go1.26.5 (released 2026-07-07) includes security fixes to the crypto/tls and os packages, as well as bug fixes to the compiler, the runtime, the go command, and the net, os, and syscall packages. See the Go 1.26.5 milestone on our issue tracker for details;

- https://github.com/golang/go/issues?q=milestone%3AGo1.26.5+label%3ACherryPickApproved
- full diff: https://github.com/golang/go/compare/go1.26.4...go1.26.5

From the security announcement:

We have just released Go versions 1.26.5 and 1.25.12, minor point releases.

These releases include 2 security fixes following the security policy:

- os: Root escape via symlink plus trailing slash

  On Unix systems, opening a file in an os.Root improperly
  followed symlinks to locations outside of the Root when
  the final path component of the a path is a symbolic link
  and the path ends in /.

  For example, root.Open("symlink/") would open "symlink"
  even when "symlink" is a symbolic link pointing outside of the root.

  On Unix, openat(fd, path, O_NOFOLLOW) will follow symlinks
  in path when path ends in a /. Root failed to account for
  this behavior, permitting paths with a trailing / to escape.
  It now properly sanitizes the path parameter provided to openat.

  hanks to Mundur for reporting this issue.

  This is CVE-2026-39822 and Go issue https://go.dev/issue/79005.

- crypto/tls: Encrypted Client Hello privacy leak

  he Encrypted Client Hello implementation would leak the pre-shared key
  dentities during the handshake, allowing a passive network observer who can
  ollect handshakes to de-anonymize the hostname of the server, even when ECH was
  eing used.

  Thanks to Coia Prant (github.com/rbqvq) for reporting this issue.

  This is CVE-2026-42505 and Go issue https://go.dev/issue/79282.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Update Go runtime to [1.26.5](https://go.dev/doc/devel/release#go1.26.5)
```

## A picture of a cute animal (not mandatory but encouraged)
