### PR TITLE
gha/sync-release-branch: Fix a couple of issues

### DIFF
--- a/.github/workflows/sync-release-branch.yml
+++ b/.github/workflows/sync-release-branch.yml
@@ -15,7 +15,7 @@ on:
         required: true
         type: string
       dry_run:
-        description: Print the tag range without merging or pushing
+        description: Merge but don't push
         required: true
         default: false
         type: boolean

--- a/.github/workflows/sync-release-branch.yml
+++ b/.github/workflows/sync-release-branch.yml
@@ -77,7 +77,7 @@ jobs:
           echo >> "$GITHUB_STEP_SUMMARY"
           sed 's/^/- /' "$tags_file" >> "$GITHUB_STEP_SUMMARY"
 
-          xargs releases/scripts/sync-branch < "$tags_file" | tee -a "$GITHUB_STEP_SUMMARY"
+          xargs -r releases/scripts/sync-branch < "$tags_file" | tee -a "$GITHUB_STEP_SUMMARY"
 
           if [[ "$DRY_RUN" == "true" ]]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sync-release-branch.yml
+++ b/.github/workflows/sync-release-branch.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           BRANCH: ${{ github.ref_name }}
         run: |
-          if [ "$branch" = "master " ]; then
+          if [ "$BRANCH" = "master" ]; then
             echo "::error::This workflow is expected to be run on a release branch, not master"
             exit 1
           fi

--- a/.github/workflows/sync-release-branch.yml
+++ b/.github/workflows/sync-release-branch.yml
@@ -47,7 +47,6 @@ jobs:
           fi
 
       - name: Configure git author
-        if: ${{ !inputs.dry_run }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/releases/scripts/sync-branch
+++ b/releases/scripts/sync-branch
@@ -18,7 +18,7 @@ for tag_to_sync in "${tags_to_sync[@]}"; do
 		exit 1
 	fi
 
-	git checkout "$tag_to_sync" -- '*'
+	git checkout "$tag_to_sync" -- '.'
 	git add --all
 	git merge --continue
 done

--- a/releases/scripts/sync-branch
+++ b/releases/scripts/sync-branch
@@ -3,7 +3,7 @@
 set -Eeuo pipefail
 
 if [[ $# -lt 1 ]]; then
-	echo "usage: $0 [--dry-run] TAG..." >&2
+	echo "usage: $0 TAG..." >&2
 	exit 1
 fi
 

--- a/releases/scripts/unmerged-tags
+++ b/releases/scripts/unmerged-tags
@@ -14,8 +14,14 @@ if git merge-base --is-ancestor "$tag" "$release_branch"; then
 	exit 0
 fi
 
+if git rev-parse --verify --quiet upstream/master > /dev/null 2>&1; then
+	master="upstream/master"
+else
+	master="origin/master"
+fi
+
 # Get all docker release tags merged into master but not into release branch
-git tag --merged upstream/master --no-merged "$release_branch" \
+git tag --merged "$master" --no-merged "$release_branch" \
 	| grep '^docker-v' \
 	| grep -v -- "-rc." \
 	| sort \

--- a/releases/scripts/unmerged-tags
+++ b/releases/scripts/unmerged-tags
@@ -25,6 +25,11 @@ else
 	master="origin/master"
 fi
 
+if ! git merge-base --is-ancestor "$tag" "$master"; then
+	echo "error: Tag $tag is not in $master" >&2
+	exit 1
+fi
+
 # Get all docker release tags merged into master but not into release branch
 git tag --merged "$master" --no-merged "$release_branch" \
 	| grep '^docker-v' \

--- a/releases/scripts/unmerged-tags
+++ b/releases/scripts/unmerged-tags
@@ -25,4 +25,4 @@ git tag --merged "$master" --no-merged "$release_branch" \
 	| grep '^docker-v' \
 	| grep -v -- "-rc." \
 	| sort \
-	| sed "/$tag/q"
+	| awk -v tag="$tag" '{print} $0==tag{exit}'

--- a/releases/scripts/unmerged-tags
+++ b/releases/scripts/unmerged-tags
@@ -31,8 +31,11 @@ if ! git merge-base --is-ancestor "$tag" "$master"; then
 fi
 
 # Get all docker release tags merged into master but not into release branch
-git tag --merged "$master" --no-merged "$release_branch" \
-	| grep '^docker-v' \
-	| grep -v -- "-rc." \
-	| sort \
+git -c versionsort.suffix=-alpha. \
+	-c versionsort.suffix=-beta. \
+	-c versionsort.suffix=-rc. \
+	tag --merged "$master" --no-merged "$release_branch" \
+	--sort=v:refname \
+	--format='%(refname:short)' \
+	'docker-v*' \
 	| awk -v tag="$tag" '{print} $0==tag{exit}'

--- a/releases/scripts/unmerged-tags
+++ b/releases/scripts/unmerged-tags
@@ -9,6 +9,11 @@ fi
 release_branch="$1"
 tag="$2"
 
+if ! git rev-parse --verify --quiet "refs/tags/$tag" > /dev/null; then
+	echo "error: Tag $tag does not exist" >&2
+	exit 1
+fi
+
 # Return early the requested tag is already merged into release branch.
 if git merge-base --is-ancestor "$tag" "$release_branch"; then
 	exit 0


### PR DESCRIPTION
Prefer upstream/master when available (local development), but fall back to origin/master so the script works in CI where actions/checkout only sets up an origin remote.

Also, addressed some issues detected by reviewer in https://github.com/docker/cli/pull/7091