### PR TITLE
integration/container: Run logs test without networking

### DIFF
--- a/integration/container/logs_test.go
+++ b/integration/container/logs_test.go
@@ -132,6 +132,9 @@ func testLogs(t *testing.T, logDriver string) {
 				container.WithCmd("sh", "-c", "echo -n this is fine; echo -n accidents happen >&2"),
 				container.WithTty(tty),
 				container.WithLogDriver(logDriver),
+				// Logs do not need networking, and Windows HNS endpoint
+				// setup is sensitive to these parallel short-lived starts.
+				container.WithNetworkMode("none"),
 			)
 			defer apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

- tries to fix: https://github.com/moby/moby/issues/53031

TestLogs checks how ContainerLogs returns stdout and stderr for tty and non-tty containers. Network connectivity is not part of that contract, but every case currently starts on the default network.

In the Windows the test is sometimes flaky and the failing starts report:

```
hcs::CreateComputeSystem ... The parameter is incorrect.
```

That HCS error is not specific enough to prove the exact failing subsystem.
The surrounding daemon log, however, shows default NAT endpoint allocation, service-record updates, and endpoint teardown around those starts, all while several short-lived log-test containers run in parallel.

Use network mode none so this log-streaming test no longer depends on Windows default-network endpoint setup.

/flaky-check=TestLogs


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
