### PR TITLE
Fix flaky `Swarm is encrypted and needs to be unlocked` error (take 2)

### DIFF
--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -104,6 +104,19 @@ func (c *Cluster) Init(req types.InitRequest) (string, error) {
 		return "", err
 	}
 
+	if !req.ForceNewCluster {
+		// A normal init creates a brand-new cluster. If c.nr is nil, the
+		// daemon is not tracking a swarm, but late swarmkit writes from a
+		// previous autolocked manager can leave encrypted credentials under
+		// stateDir after Leave has cleared it. Discard orphaned state here so
+		// init cannot load a stale encrypted key and report the new swarm as
+		// locked. ForceNewCluster is excluded because it deliberately reuses
+		// on-disk state to recover a cluster that lost quorum.
+		if err := clearPersistentState(c.stateDir); err != nil {
+			return "", err
+		}
+	}
+
 	nr, err := c.newNodeRunner(nodeStartConfig{
 		forceNewCluster:    req.ForceNewCluster,
 		autolock:           req.AutoLockManagers,


### PR DESCRIPTION
## Summary

- follow up to: https://github.com/moby/moby/pull/52479

The docker-py SwarmTest.test_init_swarm_with_ca_config can fail after SwarmTest.test_init_swarm_with_autolock_managers with:

```
Swarm is encrypted and needs to be unlocked before it can be used.
```

The CA-config test does not request autolock itself. The locked state is left behind by the preceding autolock test: swarm init first creates the node, then applies the requested spec through UpdateCluster. Enabling autolock through that update causes swarmkit to encrypt the manager TLS key and renew credentials.

An earlier change (0acd23fce0a7) fixed one producer of this failure by making Stop() mark the node runner as stopped before the nil swarmNode check. That prevents the reconnect watcher from restarting an orphaned swarmkit node after Moby has already left the swarm.

This change handles the remaining init-side failure mode. If force-leave clears the daemon's node runner while late swarmkit disk writes leave encrypted credentials under the swarm state directory, the next normal init can load those stale credentials without an unlock key and fail as a locked swarm.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->



## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
```

## A picture of a cute animal (not mandatory but encouraged)
