### PR TITLE
daemon/container: State: fixes and cleanups (step 2)

### DIFF
--- a/daemon/container/state.go
+++ b/daemon/container/state.go
@@ -44,8 +44,8 @@ type State struct {
 	StartedAt         time.Time
 	FinishedAt        time.Time
 	Health            *Health
-	Removed           bool `json:"-"`
 
+	removed           bool // used internally for container.WaitConditionRemoved
 	stopWaiters       []chan<- StateStatus
 	removeOnlyWaiters []chan<- StateStatus
 
@@ -204,7 +204,7 @@ func (s *State) conditionAlreadyMet(condition container.WaitCondition) bool {
 	case container.WaitConditionNotRunning:
 		return !s.Running
 	case container.WaitConditionRemoved:
-		return s.Removed
+		return s.removed
 	default:
 		// TODO(thaJeztah): how do we want to handle "WaitConditionNextExit"?
 		return false
@@ -403,7 +403,7 @@ func (s *State) SetRemoved() {
 func (s *State) SetRemovalError(err error) {
 	s.SetError(err)
 	s.Lock()
-	s.Removed = true
+	s.removed = true
 	s.notifyAndClear(&s.removeOnlyWaiters)
 	s.notifyAndClear(&s.stopWaiters)
 	s.Unlock()

--- a/daemon/container/state.go
+++ b/daemon/container/state.go
@@ -80,6 +80,9 @@ func (s StateStatus) Err() error {
 
 // String returns a human-readable description of the state
 func (s *State) String() string {
+	if s.RemovalInProgress {
+		return "Removal In Progress"
+	}
 	if s.Running {
 		if s.Paused {
 			return fmt.Sprintf("Up %s (Paused)", units.HumanDuration(time.Now().UTC().Sub(s.StartedAt)))
@@ -93,10 +96,6 @@ func (s *State) String() string {
 		}
 
 		return "Up " + units.HumanDuration(time.Now().UTC().Sub(s.StartedAt))
-	}
-
-	if s.RemovalInProgress {
-		return "Removal In Progress"
 	}
 
 	if s.Dead {
@@ -118,6 +117,9 @@ func (s *State) String() string {
 // [State.Running], [State.Paused], [State.Restarting], [State.RemovalInProgress],
 // [State.StartedAt] and [State.Dead] fields.
 func (s *State) State() container.ContainerState {
+	if s.RemovalInProgress {
+		return container.StateRemoving
+	}
 	if s.Running {
 		if s.Paused {
 			return container.StatePaused
@@ -130,9 +132,6 @@ func (s *State) State() container.ContainerState {
 
 	// TODO(thaJeztah): should [State.Removed] also have an corresponding string?
 	// TODO(thaJeztah): should [State.OOMKilled] be taken into account anywhere?
-	if s.RemovalInProgress {
-		return container.StateRemoving
-	}
 
 	if s.Dead {
 		return container.StateDead

--- a/daemon/container/state.go
+++ b/daemon/container/state.go
@@ -83,6 +83,9 @@ func (s *State) String() string {
 	if s.RemovalInProgress {
 		return "Removal In Progress"
 	}
+	if s.Dead {
+		return "Dead"
+	}
 	if s.Running {
 		if s.Paused {
 			return fmt.Sprintf("Up %s (Paused)", units.HumanDuration(time.Now().UTC().Sub(s.StartedAt)))
@@ -96,10 +99,6 @@ func (s *State) String() string {
 		}
 
 		return "Up " + units.HumanDuration(time.Now().UTC().Sub(s.StartedAt))
-	}
-
-	if s.Dead {
-		return "Dead"
 	}
 
 	if s.StartedAt.IsZero() {
@@ -120,6 +119,9 @@ func (s *State) State() container.ContainerState {
 	if s.RemovalInProgress {
 		return container.StateRemoving
 	}
+	if s.Dead {
+		return container.StateDead
+	}
 	if s.Running {
 		if s.Paused {
 			return container.StatePaused
@@ -132,10 +134,6 @@ func (s *State) State() container.ContainerState {
 
 	// TODO(thaJeztah): should [State.Removed] also have an corresponding string?
 	// TODO(thaJeztah): should [State.OOMKilled] be taken into account anywhere?
-
-	if s.Dead {
-		return container.StateDead
-	}
 
 	if s.StartedAt.IsZero() {
 		return container.StateCreated

--- a/daemon/container/state.go
+++ b/daemon/container/state.go
@@ -87,11 +87,14 @@ func (s *State) String() string {
 		return "Dead"
 	}
 	if s.Running {
-		if s.Paused {
-			return fmt.Sprintf("Up %s (Paused)", units.HumanDuration(time.Now().UTC().Sub(s.StartedAt)))
-		}
+		// Restarting is expected to be set only while Running, so only
+		// report it for running containers.
 		if s.Restarting {
 			return fmt.Sprintf("Restarting (%d) %s ago", s.ExitCode, units.HumanDuration(time.Now().UTC().Sub(s.FinishedAt)))
+		}
+
+		if s.Paused {
+			return fmt.Sprintf("Up %s (Paused)", units.HumanDuration(time.Now().UTC().Sub(s.StartedAt)))
 		}
 
 		if h := s.Health; h != nil {
@@ -123,11 +126,13 @@ func (s *State) State() container.ContainerState {
 		return container.StateDead
 	}
 	if s.Running {
-		if s.Paused {
-			return container.StatePaused
-		}
+		// Restarting is expected to be set only while Running, so only
+		// report it for running containers.
 		if s.Restarting {
 			return container.StateRestarting
+		}
+		if s.Paused {
+			return container.StatePaused
 		}
 		return container.StateRunning
 	}

--- a/daemon/container/state.go
+++ b/daemon/container/state.go
@@ -92,16 +92,16 @@ func (s *State) String() string {
 		if s.Restarting {
 			return fmt.Sprintf("Restarting (%d) %s ago", s.ExitCode, units.HumanDuration(time.Now().UTC().Sub(s.FinishedAt)))
 		}
-
+		out := "Up " + units.HumanDuration(time.Now().UTC().Sub(s.StartedAt))
 		if s.Paused {
-			return fmt.Sprintf("Up %s (Paused)", units.HumanDuration(time.Now().UTC().Sub(s.StartedAt)))
+			return out + " (Paused)"
 		}
 
 		if h := s.Health; h != nil {
-			return fmt.Sprintf("Up %s (%s)", units.HumanDuration(time.Now().UTC().Sub(s.StartedAt)), h.String())
+			return out + " (" + h.String() + ")"
 		}
 
-		return "Up " + units.HumanDuration(time.Now().UTC().Sub(s.StartedAt))
+		return out
 	}
 
 	if s.StartedAt.IsZero() {

--- a/daemon/container/state_test.go
+++ b/daemon/container/state_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/moby/moby/api/types/container"
 	libcontainerdtypes "github.com/moby/moby/v2/daemon/internal/libcontainerd/types"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 type mockTask struct {
@@ -183,5 +185,84 @@ func TestStateWaitReturnsExitStatusAfterRestart(t *testing.T) {
 	got := <-waitC
 	if got.ExitCode() != want.ExitCode {
 		t.Fatalf("expected exit code %v, got %v", want.ExitCode, got.ExitCode())
+	}
+}
+
+func TestStateStateAndString(t *testing.T) {
+	now := time.Now().UTC()
+
+	tests := []struct {
+		doc        string
+		state      *State
+		wantState  container.ContainerState
+		wantString string
+	}{
+		{
+			doc:        "removal in progress",
+			state:      &State{RemovalInProgress: true},
+			wantState:  container.StateRemoving,
+			wantString: "Removal In Progress",
+		},
+		{
+			doc:        "dead",
+			state:      &State{Dead: true},
+			wantState:  container.StateDead,
+			wantString: "Dead",
+		},
+		{
+			doc:        "restarting",
+			state:      &State{Running: true, Restarting: true, ExitCode: 1, FinishedAt: now.Add(-72 * time.Hour)},
+			wantState:  container.StateRestarting,
+			wantString: "Restarting (1) 3 days ago",
+		},
+		{
+			doc:        "running",
+			state:      &State{Running: true, StartedAt: now.Add(-72 * time.Hour)},
+			wantState:  container.StateRunning,
+			wantString: "Up 3 days",
+		},
+		{
+			doc:        "paused",
+			state:      &State{Running: true, Paused: true, StartedAt: now.Add(-72 * time.Hour)},
+			wantState:  container.StatePaused,
+			wantString: "Up 3 days (Paused)",
+		},
+		{
+			doc:        "created",
+			state:      &State{},
+			wantState:  container.StateCreated,
+			wantString: "Created",
+		},
+		{
+			doc:        "exited",
+			state:      &State{StartedAt: now.Add(-96 * time.Hour), FinishedAt: now.Add(-72 * time.Hour), ExitCode: 137},
+			wantState:  container.StateExited,
+			wantString: "Exited (137) 3 days ago",
+		},
+		{
+			doc:        "started but not finished",
+			state:      &State{StartedAt: now.Add(-72 * time.Hour)},
+			wantState:  container.StateExited,
+			wantString: "",
+		},
+		{
+			doc:        "restarting while not running",
+			state:      &State{Restarting: true, StartedAt: now.Add(-96 * time.Hour), FinishedAt: now.Add(-72 * time.Hour), ExitCode: 1},
+			wantState:  container.StateExited,
+			wantString: "Exited (1) 3 days ago",
+		},
+		{
+			doc:        "paused while not running",
+			state:      &State{Paused: true},
+			wantState:  container.StateCreated,
+			wantString: "Created",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			assert.Check(t, is.Equal(tc.state.State(), tc.wantState))
+			assert.Check(t, is.Equal(tc.state.String(), tc.wantString))
+		})
 	}
 }

--- a/daemon/container/state_test.go
+++ b/daemon/container/state_test.go
@@ -157,8 +157,12 @@ func TestStateTimeoutWait(t *testing.T) {
 	}
 }
 
-// Related issue: #39352
-func TestCorrectStateWaitResultAfterRestart(t *testing.T) {
+// TestStateWaitReturnsExitStatusAfterRestart verifies that Wait returns the
+// correct exit status when a container is restarted immediately after exiting,
+// covering a race where Wait could observe the restarted state instead.
+//
+// Related issue: https://github.com/moby/moby/issues/39352
+func TestStateWaitReturnsExitStatusAfterRestart(t *testing.T) {
 	s := &State{}
 
 	s.Lock()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- [x] depends on https://github.com/moby/moby/pull/53039

### daemon/container: State: prioritize RemovalInProgress over other states

A container in process of being removed is a terminal state; it should
not report itself as any other state (and changing state should no longer
be possible, except from possibly marking it "dead").


### daemon/container: State: prioritize "Dead" over other states

A Dead container is defunct; any states it carries are "undefined",
so make Dead take priority over other states.

The only exception here is RemovalInProgress; a dead container may be
in process of being removed, in which case removing that state is more
informative and may prevent attempting to remove it again.

### daemon/container: State: prioritize Restarting over other states

[Daemon.containerPause] rejects pausing containers that are restarting
and [State.SetRestarting] resets the Paused state.

Consider Restarting to be a higher priority state than the other ones

[Daemon.containerPause]: https://github.com/moby/moby/blob/311560920ef5fc2676fbfe310a44ed6a5107f4e6/daemon/pause.go#L39-L42
[State.SetRestarting]: https://github.com/moby/moby/blob/311560920ef5fc2676fbfe310a44ed6a5107f4e6/daemon/container/state.go#L295-L300

### daemon/container: State: reduce some uses of fmt.Sprintf



## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
