### PR TITLE
daemon/containerd: rename desc utility to reduce shadowing

### DIFF
--- a/daemon/containerd/image_delete_test.go
+++ b/daemon/containerd/image_delete_test.go
@@ -36,7 +36,7 @@ func TestImageDelete(t *testing.T) {
 			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/justoneimage:latest",
-					Target: desc(10),
+					Target: newDescriptor(10),
 				},
 			},
 		},
@@ -45,17 +45,17 @@ func TestImageDelete(t *testing.T) {
 			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/justoneref:latest",
-					Target: desc(10),
+					Target: newDescriptor(10),
 				},
 				{
 					Name:   "docker.io/library/differentrepo:latest",
-					Target: desc(10),
+					Target: newDescriptor(10),
 				},
 			},
 			remaining: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/differentrepo:latest",
-					Target: desc(10),
+					Target: newDescriptor(10),
 				},
 			},
 		},
@@ -64,11 +64,11 @@ func TestImageDelete(t *testing.T) {
 			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/hasdigest:latest",
-					Target: desc(10),
+					Target: newDescriptor(10),
 				},
 				{
 					Name:   "docker.io/library/hasdigest@" + digestFor(10).String(),
-					Target: desc(10),
+					Target: newDescriptor(10),
 				},
 			},
 		},
@@ -77,11 +77,11 @@ func TestImageDelete(t *testing.T) {
 			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/byid:latest",
-					Target: desc(11),
+					Target: newDescriptor(11),
 				},
 				{
 					Name:   "docker.io/library/byid@" + digestFor(11).String(),
-					Target: desc(11),
+					Target: newDescriptor(11),
 				},
 			},
 		},
@@ -90,11 +90,11 @@ func TestImageDelete(t *testing.T) {
 			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/bydigest:latest",
-					Target: desc(12),
+					Target: newDescriptor(12),
 				},
 				{
 					Name:   "docker.io/library/bydigest@" + digestFor(12).String(),
-					Target: desc(12),
+					Target: newDescriptor(12),
 				},
 			},
 		},
@@ -103,25 +103,25 @@ func TestImageDelete(t *testing.T) {
 			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/onerefoftwo:latest",
-					Target: desc(12),
+					Target: newDescriptor(12),
 				},
 				{
 					Name:   "docker.io/library/onerefoftwo:other",
-					Target: desc(12),
+					Target: newDescriptor(12),
 				},
 				{
 					Name:   "docker.io/library/onerefoftwo@" + digestFor(12).String(),
-					Target: desc(12),
+					Target: newDescriptor(12),
 				},
 			},
 			remaining: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/onerefoftwo:other",
-					Target: desc(12),
+					Target: newDescriptor(12),
 				},
 				{
 					Name:   "docker.io/library/onerefoftwo@" + digestFor(12).String(),
-					Target: desc(12),
+					Target: newDescriptor(12),
 				},
 			},
 		},
@@ -130,21 +130,21 @@ func TestImageDelete(t *testing.T) {
 			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/otherreporemaining:latest",
-					Target: desc(12),
+					Target: newDescriptor(12),
 				},
 				{
 					Name:   "docker.io/library/otherreporemaining@" + digestFor(12).String(),
-					Target: desc(12),
+					Target: newDescriptor(12),
 				},
 				{
 					Name:   "docker.io/library/someotherrepo:latest",
-					Target: desc(12),
+					Target: newDescriptor(12),
 				},
 			},
 			remaining: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/someotherrepo:latest",
-					Target: desc(12),
+					Target: newDescriptor(12),
 				},
 			},
 		},
@@ -153,21 +153,21 @@ func TestImageDelete(t *testing.T) {
 			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/repoanddigest:latest",
-					Target: desc(15),
+					Target: newDescriptor(15),
 				},
 				{
 					Name:   "docker.io/library/repoanddigest:latest@" + digestFor(15).String(),
-					Target: desc(15),
+					Target: newDescriptor(15),
 				},
 				{
 					Name:   "docker.io/library/someotherrepo:latest",
-					Target: desc(15),
+					Target: newDescriptor(15),
 				},
 			},
 			remaining: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/someotherrepo:latest",
-					Target: desc(15),
+					Target: newDescriptor(15),
 				},
 			},
 		},
@@ -176,29 +176,29 @@ func TestImageDelete(t *testing.T) {
 			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/repoanddigestothertags:v1",
-					Target: desc(15),
+					Target: newDescriptor(15),
 				},
 				{
 					Name:   "docker.io/library/repoanddigestothertags:v1@" + digestFor(15).String(),
-					Target: desc(15),
+					Target: newDescriptor(15),
 				},
 				{
 					Name:   "docker.io/library/repoanddigestothertags:v2",
-					Target: desc(15),
+					Target: newDescriptor(15),
 				},
 				{
 					Name:   "docker.io/library/repoanddigestothertags:v2@" + digestFor(15).String(),
-					Target: desc(15),
+					Target: newDescriptor(15),
 				},
 				{
 					Name:   "docker.io/library/someotherrepo:latest",
-					Target: desc(15),
+					Target: newDescriptor(15),
 				},
 			},
 			remaining: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/someotherrepo:latest",
-					Target: desc(15),
+					Target: newDescriptor(15),
 				},
 			},
 		},
@@ -207,13 +207,13 @@ func TestImageDelete(t *testing.T) {
 			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/someotherrepo:latest",
-					Target: desc(16),
+					Target: newDescriptor(16),
 				},
 			},
 			remaining: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/someotherrepo:latest",
-					Target: desc(16),
+					Target: newDescriptor(16),
 				},
 			},
 			err: dimages.ErrImageDoesNotExist{Ref: nameDigest("repoanddigestzerocase", digestFor(16))},

--- a/daemon/containerd/image_test.go
+++ b/daemon/containerd/image_test.go
@@ -33,27 +33,27 @@ func TestLookup(t *testing.T) {
 
 	ubuntuLatest := c8dimages.Image{
 		Name:   "docker.io/library/ubuntu:latest",
-		Target: desc(10),
+		Target: newDescriptor(10),
 	}
 	ubuntuLatestWithDigest := c8dimages.Image{
 		Name:   "docker.io/library/ubuntu:latest@" + digestFor(10).String(),
-		Target: desc(10),
+		Target: newDescriptor(10),
 	}
 	ubuntuLatestWithOldDigest := c8dimages.Image{
 		Name:   "docker.io/library/ubuntu:latest@" + digestFor(11).String(),
-		Target: desc(11),
+		Target: newDescriptor(11),
 	}
 	ambiguousShortName := c8dimages.Image{
 		Name:   "docker.io/library/abcdef:latest",
-		Target: desc(12),
+		Target: newDescriptor(12),
 	}
 	ambiguousShortNameWithDigest := c8dimages.Image{
 		Name:   "docker.io/library/abcdef:latest@" + digestFor(12).String(),
-		Target: desc(12),
+		Target: newDescriptor(12),
 	}
 	shortNameIsHashAlgorithm := c8dimages.Image{
 		Name:   "docker.io/library/sha256:defcab",
-		Target: desc(13),
+		Target: newDescriptor(13),
 	}
 
 	testImages := []c8dimages.Image{
@@ -65,11 +65,11 @@ func TestLookup(t *testing.T) {
 		shortNameIsHashAlgorithm,
 		{
 			Name:   "docker.io/test/volatile:retried",
-			Target: desc(14),
+			Target: newDescriptor(14),
 		},
 		{
 			Name:   "docker.io/test/volatile:inconsistent",
-			Target: desc(15),
+			Target: newDescriptor(15),
 		},
 	}
 	for _, img := range testImages {
@@ -175,23 +175,23 @@ func TestLookup(t *testing.T) {
 				getMutations: []c8dimages.Image{
 					{
 						Name:   "docker.io/test/volatile:inconsistent",
-						Target: desc(18),
+						Target: newDescriptor(18),
 					},
 					{
 						Name:   "docker.io/test/volatile:inconsistent",
-						Target: desc(19),
+						Target: newDescriptor(19),
 					},
 					{
 						Name:   "docker.io/test/volatile:inconsistent",
-						Target: desc(20),
+						Target: newDescriptor(20),
 					},
 					{
 						Name:   "docker.io/test/volatile:inconsistent",
-						Target: desc(21),
+						Target: newDescriptor(21),
 					},
 					{
 						Name:   "docker.io/test/volatile:inconsistent",
-						Target: desc(22),
+						Target: newDescriptor(22),
 					},
 				},
 				t: t,
@@ -209,11 +209,11 @@ func TestLookup(t *testing.T) {
 				getMutations: []c8dimages.Image{
 					{
 						Name:   "docker.io/test/volatile:retried",
-						Target: desc(16),
+						Target: newDescriptor(16),
 					},
 					{
 						Name:   "docker.io/test/volatile:retried",
-						Target: desc(17),
+						Target: newDescriptor(17),
 					},
 				},
 				t: t,
@@ -260,7 +260,7 @@ func nameTag(name, tag string) reference.Reference {
 	return tagged
 }
 
-func desc(size int64) ocispec.Descriptor {
+func newDescriptor(size int64) ocispec.Descriptor {
 	return ocispec.Descriptor{
 		Digest:    digestFor(size),
 		Size:      size,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
