### PR TITLE
daemon/container: State: fixes and cleanups

### DIFF
--- a/daemon/container/state.go
+++ b/daemon/container/state.go
@@ -44,8 +44,8 @@ type State struct {
 	StartedAt         time.Time
 	FinishedAt        time.Time
 	Health            *Health
-	Removed           bool `json:"-"`
 
+	removed           bool // used internally for container.WaitConditionRemoved
 	stopWaiters       []chan<- StateStatus
 	removeOnlyWaiters []chan<- StateStatus
 
@@ -202,7 +202,7 @@ func (s *State) conditionAlreadyMet(condition container.WaitCondition) bool {
 	case container.WaitConditionNotRunning:
 		return !s.Running
 	case container.WaitConditionRemoved:
-		return s.Removed
+		return s.removed
 	default:
 		// TODO(thaJeztah): how do we want to handle "WaitConditionNextExit"?
 		return false
@@ -401,7 +401,7 @@ func (s *State) SetRemoved() {
 func (s *State) SetRemovalError(err error) {
 	s.SetError(err)
 	s.Lock()
-	s.Removed = true
+	s.removed = true
 	s.notifyAndClear(&s.removeOnlyWaiters)
 	s.notifyAndClear(&s.stopWaiters)
 	s.Unlock()

--- a/daemon/container/state.go
+++ b/daemon/container/state.go
@@ -81,18 +81,19 @@ func (s StateStatus) Err() error {
 // String returns a human-readable description of the state
 func (s *State) String() string {
 	if s.Running {
+		out := "Up " + units.HumanDuration(time.Now().UTC().Sub(s.StartedAt))
 		if s.Paused {
-			return fmt.Sprintf("Up %s (Paused)", units.HumanDuration(time.Now().UTC().Sub(s.StartedAt)))
+			return out + " (Paused)"
 		}
 		if s.Restarting {
 			return fmt.Sprintf("Restarting (%d) %s ago", s.ExitCode, units.HumanDuration(time.Now().UTC().Sub(s.FinishedAt)))
 		}
 
 		if h := s.Health; h != nil {
-			return fmt.Sprintf("Up %s (%s)", units.HumanDuration(time.Now().UTC().Sub(s.StartedAt)), h.String())
+			return out + " (" + h.String() + ")"
 		}
 
-		return "Up " + units.HumanDuration(time.Now().UTC().Sub(s.StartedAt))
+		return out
 	}
 
 	if s.RemovalInProgress {

--- a/daemon/container/state_test.go
+++ b/daemon/container/state_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/moby/moby/api/types/container"
 	libcontainerdtypes "github.com/moby/moby/v2/daemon/internal/libcontainerd/types"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 type mockTask struct {
@@ -183,5 +185,84 @@ func TestStateWaitReturnsExitStatusAfterRestart(t *testing.T) {
 	got := <-waitC
 	if got.ExitCode() != want.ExitCode {
 		t.Fatalf("expected exit code %v, got %v", want.ExitCode, got.ExitCode())
+	}
+}
+
+func TestStateStateAndString(t *testing.T) {
+	now := time.Now().UTC()
+
+	tests := []struct {
+		doc        string
+		state      *State
+		wantState  container.ContainerState
+		wantString string
+	}{
+		{
+			doc:        "removal in progress",
+			state:      &State{RemovalInProgress: true},
+			wantState:  container.StateRemoving,
+			wantString: "Removal In Progress",
+		},
+		{
+			doc:        "dead",
+			state:      &State{Dead: true},
+			wantState:  container.StateDead,
+			wantString: "Dead",
+		},
+		{
+			doc:        "restarting",
+			state:      &State{Running: true, Restarting: true, ExitCode: 1, FinishedAt: now.Add(-72 * time.Hour)},
+			wantState:  container.StateRestarting,
+			wantString: "Restarting (1) 3 days ago",
+		},
+		{
+			doc:        "running",
+			state:      &State{Running: true, StartedAt: now.Add(-72 * time.Hour)},
+			wantState:  container.StateRunning,
+			wantString: "Up 3 days",
+		},
+		{
+			doc:        "paused",
+			state:      &State{Running: true, Paused: true, StartedAt: now.Add(-72 * time.Hour)},
+			wantState:  container.StatePaused,
+			wantString: "Up 3 days (Paused)",
+		},
+		{
+			doc:        "created",
+			state:      &State{},
+			wantState:  container.StateCreated,
+			wantString: "Created",
+		},
+		{
+			doc:        "exited",
+			state:      &State{StartedAt: now.Add(-96 * time.Hour), FinishedAt: now.Add(-72 * time.Hour), ExitCode: 137},
+			wantState:  container.StateExited,
+			wantString: "Exited (137) 3 days ago",
+		},
+		{
+			doc:        "started but not finished",
+			state:      &State{StartedAt: now.Add(-72 * time.Hour)},
+			wantState:  container.StateExited,
+			wantString: "",
+		},
+		{
+			doc:        "restarting while not running",
+			state:      &State{Restarting: true, StartedAt: now.Add(-96 * time.Hour), FinishedAt: now.Add(-72 * time.Hour), ExitCode: 1},
+			wantState:  container.StateExited,
+			wantString: "Exited (1) 3 days ago",
+		},
+		{
+			doc:        "paused while not running",
+			state:      &State{Paused: true},
+			wantState:  container.StateCreated,
+			wantString: "Created",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			assert.Check(t, is.Equal(tc.state.State(), tc.wantState))
+			assert.Check(t, is.Equal(tc.state.String(), tc.wantString))
+		})
 	}
 }

--- a/daemon/container/state_test.go
+++ b/daemon/container/state_test.go
@@ -157,8 +157,12 @@ func TestStateTimeoutWait(t *testing.T) {
 	}
 }
 
-// Related issue: #39352
-func TestCorrectStateWaitResultAfterRestart(t *testing.T) {
+// TestStateWaitReturnsExitStatusAfterRestart verifies that Wait returns the
+// correct exit status when a container is restarted immediately after exiting,
+// covering a race where Wait could observe the restarted state instead.
+//
+// Related issue: https://github.com/moby/moby/issues/39352
+func TestStateWaitReturnsExitStatusAfterRestart(t *testing.T) {
 	s := &State{}
 
 	s.Lock()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

### daemon/container: rename State test to have common prefix

Rename TestCorrectStateWaitResultAfterRestart to
TestStateWaitReturnsExitStatusAfterRestart so that it has
a common prefix with other State-related tests; this allows
running all related tests with `-run TestState`.

### daemon/container: State: add unit-tests for .State and .String

### daemon/container: State: un-export "Removed" field

It's only used internally to notify removeOnlyWaiters that the
container is removed and is not persisted to disk.


### daemon/container: State: reduce some uses of fmt.Sprintf

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
