### PR TITLE
internal/testutil/daemon: Correctly check image load response

### DIFF
--- a/internal/testutil/daemon/daemon.go
+++ b/internal/testutil/daemon/daemon.go
@@ -24,6 +24,7 @@ import (
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/system"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/pkg/jsonmessage"
 	"github.com/moby/moby/client/pkg/stringid"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/internal/testutil/request"
@@ -933,8 +934,9 @@ func (d *Daemon) LoadImage(ctx context.Context, t testing.TB, img string) {
 
 	resp, err := c.ImageLoad(ctx, reader, client.ImageLoadWithQuiet(true))
 	assert.NilError(t, err, "[%s] failed to load %s", d.id, img)
-	_, _ = io.Copy(io.Discard, resp)
-	_ = resp.Close()
+	defer func() { _ = resp.Close() }()
+
+	assert.NilError(t, jsonmessage.DisplayStream(resp, io.Discard), "[%s] failed to read load response for %s", d.id, img)
 }
 
 func (d *Daemon) getClientConfig() (*clientConfig, error) {


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

LoadImage checked the immediate ImageLoad error, but then discarded the response body.
The daemon can report load failures in that JSON message stream, so tests could miss a structured load error and continue after a failed image load.

Parse the ImageLoad response with jsonmessage.DisplayStream and discard only the rendered output, so streamed errors fail the test.


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
