### PR TITLE
use FreelistMapType for boltdb

### DIFF
--- a/daemon/containerd/identitycache/bbolt.go
+++ b/daemon/containerd/identitycache/bbolt.go
@@ -31,7 +31,9 @@ func NewBoltDBBackend(root string) (Backend, error) {
 	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
 		return nil, err
 	}
-	db, err := safeOpen(filepath.Join(cacheDir, "identity-cache.db"), 0o600, nil)
+	db, err := safeOpen(filepath.Join(cacheDir, "identity-cache.db"), 0o600, &bolt.Options{
+		FreelistType: bolt.FreelistMapType,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/content.go
+++ b/daemon/content.go
@@ -20,7 +20,9 @@ func (daemon *Daemon) configureLocalContentStore(ns string) (*namespacedContent,
 	if err := os.MkdirAll(filepath.Join(daemon.root, "content"), 0o700); err != nil {
 		return nil, nil, errors.Wrap(err, "error creating dir for content store")
 	}
-	db, err := bolt.Open(filepath.Join(daemon.root, "content", "metadata.db"), 0o600, nil)
+	db, err := bolt.Open(filepath.Join(daemon.root, "content", "metadata.db"), 0o600, &bolt.Options{
+		FreelistType: bolt.FreelistMapType,
+	})
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error opening bolt db for content metadata store")
 	}

--- a/daemon/internal/builder-next/adapters/snapshot/snapshot.go
+++ b/daemon/internal/builder-next/adapters/snapshot/snapshot.go
@@ -62,7 +62,9 @@ type snapshotter struct {
 // NewSnapshotter creates a new snapshotter
 func NewSnapshotter(opt Opt, prevLM leases.Manager, ns string) (_ snapshot.Snapshotter, _ *leaseutil.Manager, retErr error) {
 	dbPath := filepath.Join(opt.Root, "snapshots.db")
-	db, err := bolt.Open(dbPath, 0o600, nil)
+	db, err := bolt.Open(dbPath, 0o600, &bolt.Options{
+		FreelistType: bolt.FreelistMapType,
+	})
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to open database file %s", dbPath)
 	}

--- a/daemon/internal/builder-next/controller.go
+++ b/daemon/internal/builder-next/controller.go
@@ -235,7 +235,9 @@ func newSnapshotterController(ctx context.Context, rt http.RoundTripper, opt Opt
 }
 
 func openHistoryDB(root string, fn string, cfg *config.BuilderHistoryConfig) (*bolt.DB, *bkconfig.HistoryConfig, error) {
-	db, err := bolt.Open(filepath.Join(root, fn), 0o600, nil)
+	db, err := bolt.Open(filepath.Join(root, fn), 0o600, &bolt.Options{
+		FreelistType: bolt.FreelistMapType,
+	})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -285,7 +287,9 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 		return nil, err
 	}
 
-	db, err := bolt.Open(filepath.Join(root, "containerdmeta.db"), 0o644, nil)
+	db, err := bolt.Open(filepath.Join(root, "containerdmeta.db"), 0o644, &bolt.Options{
+		FreelistType: bolt.FreelistMapType,
+	})
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/daemon/libnetwork/internal/kvstore/boltdb/boltdb.go
+++ b/daemon/libnetwork/internal/kvstore/boltdb/boltdb.go
@@ -45,7 +45,8 @@ func New(path, bucket string) (store.Store, error) {
 		// bbolt package returns an ErrTimeout straight away. That way, the
 		// daemon, and unit tests, will fail fast and loudly instead of
 		// silently introducing delays.
-		Timeout: time.Nanosecond,
+		Timeout:      time.Nanosecond,
+		FreelistType: bolt.FreelistMapType,
 	})
 	if err != nil {
 		if errors.Is(err, berrors.ErrTimeout) {

--- a/daemon/volume/service/store.go
+++ b/daemon/volume/service/store.go
@@ -104,7 +104,10 @@ func NewStore(rootPath string, drivers *drivers.Store, opts ...StoreOpt) (*Volum
 
 		var err error
 		dbPath := filepath.Join(volPath, "metadata.db")
-		vs.db, err = bolt.Open(dbPath, 0o600, &bolt.Options{Timeout: 1 * time.Second})
+		vs.db, err = bolt.Open(dbPath, 0o600, &bolt.Options{
+			Timeout:      1 * time.Second,
+			FreelistType: bolt.FreelistMapType,
+		})
 		if err != nil {
 			return nil, errors.Wrapf(err, "error while opening volume store metadata database (%s)", dbPath)
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

From the [DB.FreelistType] GoDoc:

    // FreelistType sets the backend freelist type. There are two options. Array which is simple but endures
    // dramatic performance degradation if database is large and fragmentation in freelist is common.
    // The alternative one is using hashmap, it is faster in almost all circumstances
    // but it doesn't guarantee that it offers the smallest page id available. In normal case it is safe.
    // The default type is array
    FreelistType FreelistType

While the default is still `FreelistArrayType`, the package shows that
the intent is to make `FreelistMapType` the default in future;
https://pkg.go.dev/go.etcd.io/bbolt@v1.5.0#pkg-constants

    // TODO(ahrtr): eventually we should (step by step)
    //  1. default to `FreelistMapType`;
    //  2. remove the `FreelistArrayType`, do not export `FreelistMapType`
    //     and remove field `FreelistType' from both `DB` and `Options`;

[DB.FreelistType]: https://pkg.go.dev/go.etcd.io/bbolt@v1.5.0#DB.FreelistType


## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
