### PR TITLE
ScopedPath: reject traversal outside PropagatedMount root

### DIFF
--- a/daemon/pkg/plugin/v2/plugin.go
+++ b/daemon/pkg/plugin/v2/plugin.go
@@ -49,8 +49,14 @@ func (e ErrInadequateCapability) Error() string {
 // ScopedPath returns the path scoped to the plugin rootfs
 func (p *Plugin) ScopedPath(s string) string {
 	if p.PluginObj.Config.PropagatedMount != "" && strings.HasPrefix(s, p.PluginObj.Config.PropagatedMount) {
+		pRoot := filepath.Join(filepath.Dir(p.Rootfs), "propagated-mount")
 		// re-scope to the propagated mount path on the host
-		return filepath.Join(filepath.Dir(p.Rootfs), "propagated-mount", strings.TrimPrefix(s, p.PluginObj.Config.PropagatedMount))
+		hostPath := filepath.Join(pRoot, strings.TrimPrefix(s, p.PluginObj.Config.PropagatedMount))
+		// Ensure the resolved path doesn't escape the propagated mount root
+		if !strings.HasPrefix(filepath.Clean(hostPath), pRoot) {
+			return pRoot
+		}
+		return hostPath
 	}
 	return filepath.Join(p.Rootfs, s)
 }

--- a/daemon/pkg/plugin/v2/plugin_test.go
+++ b/daemon/pkg/plugin/v2/plugin_test.go
@@ -1,0 +1,108 @@
+package v2
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	plugintypes "github.com/moby/moby/api/types/plugin"
+)
+
+func TestScopedPath(t *testing.T) {
+	const (
+		pluginID = "abc123"
+		rootfs   = "/var/lib/docker/plugins/" + pluginID + "/rootfs"
+		propRoot = "/var/lib/docker/plugins/" + pluginID + "/propagated-mount"
+	)
+
+	newPlugin := func(propagatedMount, rootfs string) *Plugin {
+		return &Plugin{
+			Rootfs: rootfs,
+			PluginObj: plugintypes.Plugin{
+				Config: plugintypes.Config{
+					PropagatedMount: propagatedMount,
+				},
+			},
+		}
+	}
+
+	t.Run("normal path within propagated mount", func(t *testing.T) {
+		p := newPlugin("/propagated", rootfs)
+		got := p.ScopedPath("/propagated/vol/_data")
+		want := propRoot + "/vol/_data"
+		if got != want {
+			t.Errorf("ScopedPath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("path traversal escape via ../", func(t *testing.T) {
+		p := newPlugin("/propagated", rootfs)
+		got := p.ScopedPath("/propagated/../../../etc/passwd")
+		// After cleaning, the escaped path should fall back to propRoot
+		if !strings.HasPrefix(filepath.Clean(got), propRoot) {
+			t.Errorf("ScopedPath() = %q, cleaned=%q, should start with %q", got, filepath.Clean(got), propRoot)
+		}
+		if got != propRoot {
+			t.Errorf("ScopedPath() = %q, want fallback %q", got, propRoot)
+		}
+	})
+
+	t.Run("path traversal with exact prefix then ../", func(t *testing.T) {
+		p := newPlugin("/propagated", rootfs)
+		got := p.ScopedPath("/propagated/../rootfs/etc")
+		if !strings.HasPrefix(filepath.Clean(got), propRoot) {
+			t.Errorf("ScopedPath() = %q, cleaned=%q, should start with %q", got, filepath.Clean(got), propRoot)
+		}
+		if got != propRoot {
+			t.Errorf("ScopedPath() = %q, want fallback %q", got, propRoot)
+		}
+	})
+
+	t.Run("traversal with many ../", func(t *testing.T) {
+		p := newPlugin("/propagated", rootfs)
+		got := p.ScopedPath("/propagated/../../../../../../../../../tmp/evil")
+		if !strings.HasPrefix(filepath.Clean(got), propRoot) {
+			t.Errorf("ScopedPath() = %q, cleaned=%q, should start with %q", got, filepath.Clean(got), propRoot)
+		}
+		if got != propRoot {
+			t.Errorf("ScopedPath() = %q, want fallback %q", got, propRoot)
+		}
+	})
+
+	t.Run("empty propagated mount falls through to rootfs", func(t *testing.T) {
+		p := newPlugin("", rootfs)
+		got := p.ScopedPath("/some/path")
+		want := filepath.Join(rootfs, "/some/path")
+		if got != want {
+			t.Errorf("ScopedPath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("non-prefix path ignores propagated mount", func(t *testing.T) {
+		p := newPlugin("/propagated", rootfs)
+		// Path doesn't start with PropagatedMount, so should go to rootfs
+		got := p.ScopedPath("/other/path")
+		want := filepath.Join(rootfs, "/other/path")
+		if got != want {
+			t.Errorf("ScopedPath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("exact propagated mount prefix match returns propRoot", func(t *testing.T) {
+		p := newPlugin("/propagated", rootfs)
+		got := p.ScopedPath("/propagated")
+		want := propRoot
+		if got != want {
+			t.Errorf("ScopedPath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("deeply nested normal path unaffected", func(t *testing.T) {
+		p := newPlugin("/propagated", rootfs)
+		got := p.ScopedPath("/propagated/a/b/c/d/e/f/_data")
+		want := propRoot + "/a/b/c/d/e/f/_data"
+		if got != want {
+			t.Errorf("ScopedPath() = %q, want %q", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## Description

```markdown
- Fixes: https://github.com/moby/moby/issues/53023

### What was the issue

A v2 volume plugin with `PropagatedMount` configured could escape its
sandbox via path traversal. `ScopedPath` validated plugin-returned
mountpoints with `strings.HasPrefix`, then composed the host-side path
with `filepath.Join`. A malicious plugin could return a mountpoint like
`/propagated/../../../volumes/victimvol/_data` which would pass the
prefix check, but `filepath.Join` would normalize the `..` components,
producing a host path outside the intended `propagated-mount` root.
This allowed a container to access arbitrary host paths.

### Where was the issue

`daemon/pkg/plugin/v2/plugin.go:50-56` — the `ScopedPath` method
on v2 managed plugins.

### How it was fixed

After composing the host-side path, `filepath.Clean` is applied and the
result is verified to still have the `propRoot` directory as its prefix.
If the path escaped (e.g. via `../` traversal), `propRoot` is returned
as a safe fallback.

### Why this approach

- Keeps the `ScopedPath(string) string` signature unchanged — no
  breaking interface changes across the codebase
- Uses only the standard library (`filepath.Clean` + `strings.HasPrefix`)
- Matches existing code patterns in the project
- Minimal diff: 7 lines added, 1 removed

### How to test

```bash
go test ./daemon/pkg/plugin/v2/... -v -run TestScopedPath
go vet ./daemon/pkg/plugin/v2/...
```

Unit tests cover: normal paths within propagated mount, traversal via
`../`, traversal with exact prefix then `../`, deep traversal with many
`../`, empty PropagatedMount fallthrough, non-prefix paths, exact prefix
match, and deeply nested normal paths.

## Release notes

```markdown changelog
Fix an issue where a malicious v2 volume plugin could use path traversal
to escape its PropagatedMount root and expose arbitrary host paths to
containers.