### PR TITLE
Dockerfile: update to containerd v2.3.3, runhcs v0.15.0-rc.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,7 @@ WORKDIR /usr/src/containerd
 # It is used to build containerd binaries, and used for the integration tests.
 # The distributed docker .deb and .rpm packages depend on a separate (containerd.io)
 # package, which may be a different version than specified here.
-ARG CONTAINERD_VERSION=v2.3.2
+ARG CONTAINERD_VERSION=v2.3.3
 ADD https://github.com/containerd/containerd.git?ref=${CONTAINERD_VERSION}&keep-git-dir=1 .
 
 FROM base AS containerd-build

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -170,7 +170,7 @@ ARG GOTESTSUM_VERSION=v1.13.0
 ARG GOWINRES_VERSION=v0.3.3
 
 # CONTAINERD_VERSION is the version of containerd to use for CI.
-ARG CONTAINERD_VERSION=v2.3.2
+ARG CONTAINERD_VERSION=v2.3.3
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.


### PR DESCRIPTION
This also updates the runhcs binary to v0.15.0-rc.3

Highlights

- Set SystemTemp environment variable on Windows so temp directory overrides work for SYSTEM services

Container Runtime Interface (CRI)

- Fix nil pointer dereference in NRI GetIPs during pod sandbox teardown or container exit
- Reject CreateContainer calls when the target sandbox is not running
- Ensure sandbox shutdown on RunPodSandbox hook failures to avoid mount leaks

Image Distribution

- Surface OCI error bodies in registry 403 responses by falling back to GET requests

Snapshotters

- Align default 4K mkfs block size for EROFS across all platforms

release notes: https://github.com/containerd/containerd/releases/tag/v2.3.3
full diff: https://github.com/containerd/containerd/compare/v2.3.2...v2.3.3

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Update containerd (static binaries) to [v2.3.3](https://github.com/containerd/containerd/releases/tag/v2.3.3)
```

## A picture of a cute animal (not mandatory but encouraged)
