### PR TITLE
Dockerfile: update RootlessKit to v3.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -322,7 +322,7 @@ FROM tini-${TARGETOS} AS tini
 # rootlesskit
 FROM base AS rootlesskit-src
 WORKDIR /usr/src/rootlesskit
-ARG ROOTLESSKIT_VERSION=v3.0.1
+ARG ROOTLESSKIT_VERSION=v3.0.2
 ADD https://github.com/rootless-containers/rootlesskit.git?ref=${ROOTLESSKIT_VERSION}&keep-git-dir=1 .
 
 FROM base AS rootlesskit-build

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # When updating, also update go.mod and Dockerfile accordingly.
-: "${ROOTLESSKIT_VERSION:=v3.0.1}"
+: "$ROOTLESSKIT_VERSION:=v3.0.2}"
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION
- brings in https://github.com/rootless-containers/rootlesskit/pull/603

release notes: https://github.com/rootless-containers/rootlesskit/releases/tag/v3.0.2
full diff: https://github.com/rootless-containers/rootlesskit/compare/v3.0.1...v3.0.2

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Update RootlessKit to [v3.0.2](https://github.com/rootless-containers/rootlesskit/releases/tag/v3.0.2)
```

## A picture of a cute animal (not mandatory but encouraged)
