### PR TITLE
libnet: add DNS upgrade regression test

### DIFF
--- a/daemon/libnetwork/sandbox_dns_unix_test.go
+++ b/daemon/libnetwork/sandbox_dns_unix_test.go
@@ -6,8 +6,10 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/moby/v2/daemon/libnetwork/config"
 	"github.com/moby/moby/v2/daemon/libnetwork/internal/resolvconf"
 	"gotest.tools/v3/assert"
@@ -89,4 +91,50 @@ func TestDNSOptions(t *testing.T) {
 	assert.NilError(t, err)
 	dnsOptionsList = getResolvConfOptions(t, sb2.config.resolvConfPath)
 	assert.Check(t, is.DeepEqual([]string{"ndots:0"}, dnsOptionsList))
+}
+
+// TestDNSRebuildAfterUpgradeWithStaleHash is a regression test for
+// https://github.com/moby/moby/issues/51619.
+func TestDNSRebuildAfterUpgradeWithStaleHash(t *testing.T) {
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	c, err := New(ctx, config.OptionDataDir(tmpDir))
+	assert.NilError(t, err)
+
+	hostResolvConfPath := filepath.Join(tmpDir, "host-resolv.conf")
+	err = os.WriteFile(hostResolvConfPath, []byte("nameserver 192.0.2.53\n"), filePerm)
+	assert.NilError(t, err)
+
+	sb, err := c.NewSandbox(ctx, "cnt-upgrade", OptionOriginResolvConfPath(hostResolvConfPath))
+	assert.NilError(t, err)
+	sb.startResolver(false)
+
+	err = sb.setupDNS()
+	assert.NilError(t, err)
+	err = sb.rebuildDNS()
+	assert.NilError(t, err)
+
+	resolvConfPath := sb.config.resolvConfPath
+	err = sb.Delete(ctx)
+	assert.NilError(t, err)
+
+	sbRestart, err := c.NewSandbox(ctx, "cnt-upgrade",
+		OptionResolvConfPath(resolvConfPath),
+		OptionOriginResolvConfPath(hostResolvConfPath),
+	)
+	assert.NilError(t, err)
+	defer func() {
+		if err := sbRestart.Delete(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	err = sbRestart.setupDNS()
+	assert.NilError(t, err)
+	sbRestart.startResolver(false)
+
+	assert.Check(t, is.DeepEqual(sbRestart.extDNS, []extDNSEntry{{
+		IPStr:        "192.0.2.53",
+		HostLoopback: true,
+	}}, cmpopts.EquateComparable(extDNSEntry{})))
 }

--- a/daemon/libnetwork/sandbox_dns_unix_test.go
+++ b/daemon/libnetwork/sandbox_dns_unix_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/moby/v2/daemon/libnetwork/config"
 	"github.com/moby/moby/v2/daemon/libnetwork/internal/resolvconf"
+	"github.com/opencontainers/go-digest"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -115,6 +116,18 @@ func TestDNSRebuildAfterUpgradeWithStaleHash(t *testing.T) {
 	assert.NilError(t, err)
 
 	resolvConfPath := sb.config.resolvConfPath
+
+	// Simulate an upgrade from an Engine version whose rebuildDNS() wrote the
+	// container's resolv.conf without updating its hash file: the on-disk file no
+	// longer matches the recorded hash. This out-of-sync ("stale") hash is the
+	// exact state that regressed external DNS resolution on restart (#51619),
+	// where setupDNS/rebuildDNS were skipped and upstream nameservers never got
+	// extracted. Without this, both the fixed and regressed code keep the hash in
+	// sync within a single run, so the test would pass either way.
+	staleHash := digest.FromBytes([]byte("resolv.conf written by a previous Engine version"))
+	err = os.WriteFile(sb.config.resolvConfHashFile, []byte(staleHash), filePerm)
+	assert.NilError(t, err)
+
 	err = sb.Delete(ctx)
 	assert.NilError(t, err)
 

--- a/daemon/libnetwork/sandbox_dns_unix_test.go
+++ b/daemon/libnetwork/sandbox_dns_unix_test.go
@@ -6,10 +6,13 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/moby/v2/daemon/libnetwork/config"
 	"github.com/moby/moby/v2/daemon/libnetwork/internal/resolvconf"
+	"github.com/opencontainers/go-digest"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -89,4 +92,62 @@ func TestDNSOptions(t *testing.T) {
 	assert.NilError(t, err)
 	dnsOptionsList = getResolvConfOptions(t, sb2.config.resolvConfPath)
 	assert.Check(t, is.DeepEqual([]string{"ndots:0"}, dnsOptionsList))
+}
+
+// TestDNSRebuildAfterUpgradeWithStaleHash is a regression test for
+// https://github.com/moby/moby/issues/51619.
+func TestDNSRebuildAfterUpgradeWithStaleHash(t *testing.T) {
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	c, err := New(ctx, config.OptionDataDir(tmpDir))
+	assert.NilError(t, err)
+
+	hostResolvConfPath := filepath.Join(tmpDir, "host-resolv.conf")
+	err = os.WriteFile(hostResolvConfPath, []byte("nameserver 192.0.2.53\n"), filePerm)
+	assert.NilError(t, err)
+
+	sb, err := c.NewSandbox(ctx, "cnt-upgrade", OptionOriginResolvConfPath(hostResolvConfPath))
+	assert.NilError(t, err)
+	sb.startResolver(false)
+
+	err = sb.setupDNS()
+	assert.NilError(t, err)
+	err = sb.rebuildDNS()
+	assert.NilError(t, err)
+
+	resolvConfPath := sb.config.resolvConfPath
+
+	// Simulate an upgrade from an Engine version whose rebuildDNS() wrote the
+	// container's resolv.conf without updating its hash file: the on-disk file no
+	// longer matches the recorded hash. This out-of-sync ("stale") hash is the
+	// exact state that regressed external DNS resolution on restart (#51619),
+	// where setupDNS/rebuildDNS were skipped and upstream nameservers never got
+	// extracted. Without this, both the fixed and regressed code keep the hash in
+	// sync within a single run, so the test would pass either way.
+	staleHash := digest.FromBytes([]byte("resolv.conf written by a previous Engine version"))
+	err = os.WriteFile(sb.config.resolvConfHashFile, []byte(staleHash), filePerm)
+	assert.NilError(t, err)
+
+	err = sb.Delete(ctx)
+	assert.NilError(t, err)
+
+	sbRestart, err := c.NewSandbox(ctx, "cnt-upgrade",
+		OptionResolvConfPath(resolvConfPath),
+		OptionOriginResolvConfPath(hostResolvConfPath),
+	)
+	assert.NilError(t, err)
+	defer func() {
+		if err := sbRestart.Delete(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	err = sbRestart.setupDNS()
+	assert.NilError(t, err)
+	sbRestart.startResolver(false)
+
+	assert.Check(t, is.DeepEqual(sbRestart.extDNS, []extDNSEntry{{
+		IPStr:        "192.0.2.53",
+		HostLoopback: true,
+	}}, cmpopts.EquateComparable(extDNSEntry{})))
 }


### PR DESCRIPTION
- Fixes: #51619
- relates to https://github.com/moby/moby/pull/51615

**- What I did**

Added a regression test for the DNS upgrade/restart path restored by #51615. The test covers a stale `resolv.conf.hash` scenario and verifies that rebuilding DNS still extracts the upstream resolver from the host `resolv.conf`.

**- How I did it**

The test creates a sandbox with a host resolver, rebuilds DNS, deletes the sandbox while preserving the sandbox `resolv.conf`, then recreates the sandbox with that existing file to exercise the restart/upgrade path.

**- How to verify it**

```bash
TESTDIRS=./daemon/libnetwork TESTFLAGS="-run ^(TestDNSOptions|TestRebuildDNSAfterUpgradeWithStaleHash)$ -count=1 -v" hack/test/unit
```

**- Human readable description for the release notes**

No release note; test-only change.

```markdown changelog

```

## Test verification (RED -> GREEN)

RED, reviewer suggestion applied without the required comparable option:

```text
=== RUN   TestDNSRebuildAfterUpgradeWithStaleHash
sandbox_dns_unix_test.go:135: assertion failed: cannot handle unexported field at {[]libnetwork.extDNSEntry}[0].port
--- FAIL: TestDNSRebuildAfterUpgradeWithStaleHash (0.06s)
FAIL
```

GREEN, final patch:

```text
=== RUN   TestDNSRebuildAfterUpgradeWithStaleHash
--- PASS: TestDNSRebuildAfterUpgradeWithStaleHash (0.07s)
PASS
ok   github.com/moby/moby/v2/daemon/libnetwork  0.082s
```

Package suite:

```text
ok   github.com/moby/moby/v2/daemon/libnetwork  40.105s
```

