### PR TITLE
daemon: move machineMemory initialization out of newStatsCollector

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -85,6 +85,7 @@ import (
 	volumesservice "github.com/moby/moby/v2/daemon/volume/service"
 	"github.com/moby/moby/v2/dockerversion"
 	"github.com/moby/moby/v2/pkg/authorization"
+	"github.com/moby/moby/v2/pkg/meminfo"
 	"github.com/moby/moby/v2/pkg/plugingetter"
 	"github.com/moby/moby/v2/pkg/sysinfo"
 	policyverifier "github.com/moby/policy-helpers"
@@ -1103,6 +1104,11 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		return nil, err
 	}
 	d.execCommands = container.NewExecStore()
+	if runtime.GOOS == "linux" {
+		if mi, err := meminfo.Read(); err == nil && mi.MemTotal > 0 {
+			d.machineMemory = uint64(mi.MemTotal)
+		}
+	}
 	d.statsCollector = d.newStatsCollector(1 * time.Second)
 
 	d.EventsService = events.New()

--- a/daemon/stats_collector.go
+++ b/daemon/stats_collector.go
@@ -1,11 +1,9 @@
 package daemon
 
 import (
-	"runtime"
 	"time"
 
 	"github.com/moby/moby/v2/daemon/stats"
-	"github.com/moby/moby/v2/pkg/meminfo"
 )
 
 // newStatsCollector returns a new statsCollector that collections
@@ -13,13 +11,6 @@ import (
 // The collector allows non-running containers to be added
 // and will start processing stats when they are started.
 func (daemon *Daemon) newStatsCollector(interval time.Duration) *stats.Collector {
-	// FIXME(vdemeester) move this elsewhere
-	if runtime.GOOS == "linux" {
-		meminfo, err := meminfo.Read()
-		if err == nil && meminfo.MemTotal > 0 {
-			daemon.machineMemory = uint64(meminfo.MemTotal)
-		}
-	}
 	s := stats.NewCollector(daemon, interval)
 	go s.Run()
 	return s


### PR DESCRIPTION
## Summary

`newStatsCollector` had an unrelated side effect of reading the host's total
memory and storing it on the `Daemon` (`daemon.machineMemory`), despite having
nothing to do with constructing the `stats.Collector`. This addressed a
long-standing `FIXME(vdemeester)` asking for this initialization to be moved
elsewhere.

This moves the `machineMemory` initialization to `NewDaemon`, next to the
other one-time startup steps, and removes the now-unrelated `runtime`/`meminfo`
imports from `stats_collector.go`.

No behavior change: `machineMemory` is still only populated on Linux.

## Release notes (optional)

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)

<img width="769" height="475" alt="image" src="https://github.com/user-attachments/assets/11383a2a-3755-4ea6-8f33-f8501bfc457a" />

---

Created with: Claude Sonnet 4.6