### PR TITLE
vendor: github.com/rootless-containers/rootlesskit/v3 v3.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.3.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
-	github.com/rootless-containers/rootlesskit/v3 v3.0.1
+	github.com/rootless-containers/rootlesskit/v3 v3.0.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -681,8 +681,8 @@ github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEy
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rootless-containers/rootlesskit/v3 v3.0.1 h1:AbYUo1O3b8YFL9X8YuEaaWkVFTwdU551CKyuOt0nJok=
-github.com/rootless-containers/rootlesskit/v3 v3.0.1/go.mod h1:7HrjR+SnuEMVvGexEinuuTmhvVW+kxj+6+pkQ/O4ja4=
+github.com/rootless-containers/rootlesskit/v3 v3.0.2 h1:8hRSEUdzKxmMdy+PHD/rJ3E0+nWEkh9woMDbXjSnMKQ=
+github.com/rootless-containers/rootlesskit/v3 v3.0.2/go.mod h1:oFY5X3mj9mOpi/F+oBaD5ojo6QZhr9JdcpsQ6qepz6Q=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=

--- a/vendor/github.com/rootless-containers/rootlesskit/v3/pkg/api/api.go
+++ b/vendor/github.com/rootless-containers/rootlesskit/v3/pkg/api/api.go
@@ -5,7 +5,7 @@ import "net"
 const (
 	// Version of the REST API, not implementation version.
 	// See openapi.yaml for the definition.
-	Version = "1.1.1"
+	Version = "1.1.2"
 )
 
 // Info is the structure returned by `GET /info`
@@ -24,6 +24,7 @@ type NetworkDriverInfo struct {
 	DNS            []net.IP `json:"dns,omitempty"`
 	ChildIP        net.IP   `json:"childIP,omitempty"`        // since API v1.1.1 (RootlessKit v0.14.1)
 	DynamicChildIP bool     `json:"dynamicChildIP,omitempty"` // since API v1.1.1
+	IPv6           bool     `json:"ipv6,omitempty"`           // since API v1.1.2
 }
 
 // PortDriverInfo in Info

--- a/vendor/github.com/rootless-containers/rootlesskit/v3/pkg/api/openapi.yaml
+++ b/vendor/github.com/rootless-containers/rootlesskit/v3/pkg/api/openapi.yaml
@@ -1,7 +1,7 @@
 # When you made a change to this YAML, please validate with https://editor.swagger.io
 openapi: 3.0.3
 info:
-  version: 1.1.1
+  version: 1.1.2
   title: RootlessKit API
 servers:
   - url: 'http://rootlesskit/v1'
@@ -151,6 +151,9 @@ components:
         dynamicChildIP:
           type: boolean
           description: "Child IP may change"
+        ipv6:
+          type: boolean
+          description: "Whether the network driver has IPv6 enabled"
     PortDriverInfo:
       required:
         - driver

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1432,7 +1432,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/rootless-containers/rootlesskit/v3 v3.0.1
+# github.com/rootless-containers/rootlesskit/v3 v3.0.2
 ## explicit; go 1.25.0
 github.com/rootless-containers/rootlesskit/v3/pkg/api
 github.com/rootless-containers/rootlesskit/v3/pkg/api/client


### PR DESCRIPTION
- [x] depends on https://github.com/moby/moby/pull/53055 (https://github.com/moby/moby/commit/6dbd34245cbf83f9c7fa284a656cd6af8458a783)


full diff: https://github.com/rootless-containers/rootlesskit/compare/v3.0.1...v3.0.2

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
