### PR TITLE
test/docker-py: Bump to 7.2.0

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -4,7 +4,7 @@ set -e
 source hack/make/.integration-test-helpers
 
 # The commit or tag to use for testing
-: "${DOCKER_PY_COMMIT:=ae5dfe9111b1f4e9fafd4107a8ac4a3fa52644dc}" # master (v7.2.0-dev)
+: "${DOCKER_PY_COMMIT:=7.2.0}"
 
 # custom options to pass py.test
 #


### PR DESCRIPTION
release notes: https://github.com/docker/docker-py/releases/tag/7.2.0
full diff: https://github.com/docker/docker-py/compare/ae5dfe9111b1f4e9fafd4107a8ac4a3fa52644dc...7.2.0

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
