### PR TITLE
d/libn/i/nftables: fix setting multiple flags

### DIFF
--- a/daemon/libnetwork/internal/nftables/incremental_update.nft.gotmpl
+++ b/daemon/libnetwork/internal/nftables/incremental_update.nft.gotmpl
@@ -21,14 +21,14 @@ Steps are:
 table {{$family}} {{$tableName}} {
 	{{range .Maps}}map {{.Name}} {
 		{{.ElementTypeExpr}}
-		{{if len .Flags}}flags{{range .Flags}} {{.}}{{end}}{{end}}
+		{{if len .Flags}}flags {{join .Flags ", "}}{{end}}
 		{{if .Size}}size {{.Size}}{{end}}
 		{{if .Timeout}}timeout {{.Timeout.Milliseconds}}ms{{end}}
 	}
 	{{end}}
 	{{range .Sets}}set {{.Name}} {
 		{{.ElementTypeExpr}}
-		{{if len .Flags}}flags{{range .Flags}} {{.}}{{end}}{{end}}
+		{{if len .Flags}}flags {{join .Flags ", "}}{{end}}
 		{{if .Size}}size {{.Size}}{{end}}
 		{{if .Timeout}}timeout {{.Timeout.Milliseconds}}ms{{end}}
 	}

--- a/daemon/libnetwork/internal/nftables/nftables_linux.go
+++ b/daemon/libnetwork/internal/nftables/nftables_linux.go
@@ -1196,7 +1196,11 @@ var reloadTemplText string
 
 func parseTemplate() error {
 	var errs [2]error
-	incrementalUpdateTempl, errs[0] = template.New("incremental_update.nft.gotmpl").Parse(incrementalUpdateTemplText)
-	reloadTempl, errs[1] = template.New("reload.nft.gotmpl").Parse(reloadTemplText)
+	incrementalUpdateTempl, errs[0] = template.New("incremental_update.nft.gotmpl").Funcs(templateFuncs).Parse(incrementalUpdateTemplText)
+	reloadTempl, errs[1] = template.New("reload.nft.gotmpl").Funcs(templateFuncs).Parse(reloadTemplText)
 	return errors.Join(errs[:]...)
+}
+
+var templateFuncs = template.FuncMap{
+	"join": strings.Join,
 }

--- a/daemon/libnetwork/internal/nftables/nftables_linux_test.go
+++ b/daemon/libnetwork/internal/nftables/nftables_linux_test.go
@@ -190,7 +190,11 @@ func TestVMap(t *testing.T) {
 
 	// Create a verdict map.
 	const mapName = "this_is_a_vmap"
-	tm.Create(Map{Name: mapName, ElementType: Ifname.VMap()})
+	tm.Create(Map{
+		Name:        mapName,
+		ElementType: Ifname.VMap(),
+		Flags:       []string{"dynamic", "timeout"},
+	})
 	tm.Create(MapElement{MapName: mapName, Key: "eth0", Value: "return"})
 	tm.Create(MapElement{MapName: mapName, Key: "eth1", Value: "drop", Comment: `/// this is a comment on a map element \\\`})
 
@@ -221,7 +225,7 @@ func TestSet(t *testing.T) {
 	tm4.Create(Set{Name: set4Name, ElementType: IPv4Addr, Flags: []string{"interval"}})
 	const set6Name = "set6"
 	tm6 := Modifier{}
-	tm6.Create(Set{Name: set6Name, ElementType: IPv6Addr, Flags: []string{"interval"}})
+	tm6.Create(Set{Name: set6Name, ElementType: IPv6Addr, Flags: []string{"interval", "timeout"}})
 
 	// Add elements to each set.
 	tm4.Create(SetElement{SetName: set4Name, Element: "192.0.2.0/24"})
@@ -265,8 +269,8 @@ func TestReload(t *testing.T) {
 	tm.Create(Set{Name: setName, ElementType: IPv4Addr, Flags: []string{"interval"}})
 	tm.Create(SetElement{SetName: setName, Element: "192.0.2.0/24", Comment: "}bar{"})
 
-	tm.Create(Map{Name: "dynamic_map", ElementType: IPv4Addr.MapTo(EtherAddr), Flags: []string{"dynamic"}, Size: 1024, Timeout: 2*time.Minute + 30*time.Second + 500*time.Millisecond + 654*time.Microsecond})
-	tm.Create(Set{Name: "dynamic_set", ElementType: IPv4Addr, Flags: []string{"dynamic"}, Size: 4096, Timeout: 5*time.Minute + 10*time.Second + 250*time.Millisecond + 123*time.Microsecond})
+	tm.Create(Map{Name: "dynamic_map", ElementType: IPv4Addr.MapTo(EtherAddr), Flags: []string{"dynamic", "timeout"}, Size: 1024, Timeout: 2*time.Minute + 30*time.Second + 500*time.Millisecond + 654*time.Microsecond})
+	tm.Create(Set{Name: "dynamic_set", ElementType: IPv4Addr, Flags: []string{"dynamic", "timeout"}, Size: 4096, Timeout: 5*time.Minute + 10*time.Second + 250*time.Millisecond + 123*time.Microsecond})
 
 	applyAndCheck(t, t.Name()+"/created.golden", tbl, tm)
 

--- a/daemon/libnetwork/internal/nftables/reload.nft.gotmpl
+++ b/daemon/libnetwork/internal/nftables/reload.nft.gotmpl
@@ -12,7 +12,7 @@ delete table {{$family}} {{$tableName}}
 table {{$family}} {{$tableName}} {
 	{{range .Maps}}map {{.Name}} {
 		{{.ElementTypeExpr}}
-		{{if len .Flags}}flags{{range .Flags}} {{.}}{{end}}{{end}}
+		{{if len .Flags}}flags {{join .Flags ", "}}{{end}}
 		{{if .Size}}size {{.Size}}{{end}}
 		{{if .Timeout}}timeout {{.Timeout.Milliseconds}}ms{{end}}
         {{if .Elements}}elements = {
@@ -23,7 +23,7 @@ table {{$family}} {{$tableName}} {
 	{{end}}
 	{{range .Sets}}set {{.Name}} {
 		{{.ElementTypeExpr}}
-		{{if len .Flags}}flags{{range .Flags}} {{.}}{{end}}{{end}}
+		{{if len .Flags}}flags {{join .Flags ", "}}{{end}}
 		{{if .Size}}size {{.Size}}{{end}}
 		{{if .Timeout}}timeout {{.Timeout.Milliseconds}}ms{{end}}
         {{if .Elements}}elements = {

--- a/daemon/libnetwork/internal/nftables/testdata/TestSet/created6.golden
+++ b/daemon/libnetwork/internal/nftables/testdata/TestSet/created6.golden
@@ -1,7 +1,7 @@
 table ip6 table6 {
 	set set6 {
 		type ipv6_addr
-		flags interval
+		flags interval,timeout
 		elements = { 2001:db8::/64 comment "/// this is a comment on a set element \\\" }
 	}
 }

--- a/daemon/libnetwork/internal/nftables/testdata/TestVMap/created.golden
+++ b/daemon/libnetwork/internal/nftables/testdata/TestVMap/created.golden
@@ -1,6 +1,7 @@
 table ip6 this_is_a_table {
 	map this_is_a_vmap {
 		type ifname : verdict
+		flags dynamic,timeout
 		elements = { "eth0" : return,
 			     "eth1" comment "/// this is a comment on a map element \\\" : drop }
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary
Map and set flags are a comma-separated list.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
