### PR TITLE
Add experimental nftables implementation of Swarm load balancing

### DIFF
--- a/daemon/libnetwork/controller_linux.go
+++ b/daemon/libnetwork/controller_linux.go
@@ -97,8 +97,10 @@ func (c *Controller) setupOSLSandbox(sb *Sandbox) error {
 		if err != nil {
 			log.G(context.TODO()).Errorf("Failed to apply performance tuning sysctls to the sandbox: %v", err)
 		}
-		// Keep this just so performance is not changed
-		sb.osSbox.ApplyOSTweaks(sb.oslTypes)
+		if !nftables.Enabled() {
+			// Keep this just so performance is not changed
+			sb.osSbox.ApplyOSTweaks(sb.oslTypes)
+		}
 	}
 	return nil
 }

--- a/daemon/libnetwork/internal/nftables/incremental_update.nft.gotmpl
+++ b/daemon/libnetwork/internal/nftables/incremental_update.nft.gotmpl
@@ -36,7 +36,7 @@ table {{$family}} {{$tableName}} {
 	}
 	{{end}}
 	{{range .Chains}}{{if .MustFlush}}chain {{.Name}} {
-		{{if .ChainType}}type {{.ChainType}} hook {{.Hook}}{{if .Device}} device "{{.Device}}"{{end}} priority {{.Priority}}; policy {{.Policy}}{{end}}
+		{{if .ChainType}}type {{.ChainType}} hook {{.Hook}}{{if .Device}} device "{{.Device}}"{{end}} priority {{.Priority}}; policy {{.Policy}};{{end}}
 	} ; {{end}}{{end}}
 }
 {{if .MustFlush}}flush table {{$family}} {{$tableName}}{{end}}
@@ -54,7 +54,7 @@ table {{$family}} {{$tableName}} {
 {{end}}
 table {{$family}} {{$tableName}} {
 	{{range .Chains}}{{if .MustFlush}}chain {{.Name}} {
-		{{if .ChainType}}type {{.ChainType}} hook {{.Hook}}{{if .Device}} device "{{.Device}}"{{end}} priority {{.Priority}}; policy {{.Policy}}{{end}}
+		{{if .ChainType}}type {{.ChainType}} hook {{.Hook}}{{if .Device}} device "{{.Device}}"{{end}} priority {{.Priority}}; policy {{.Policy}};{{end}}
 		{{range .Rules}}{{.}}
 		{{end}}
 	}

--- a/daemon/libnetwork/internal/nftables/incremental_update.nft.gotmpl
+++ b/daemon/libnetwork/internal/nftables/incremental_update.nft.gotmpl
@@ -23,6 +23,7 @@ table {{$family}} {{$tableName}} {
 		{{.ElementTypeExpr}}
 		{{if len .Flags}}flags {{join .Flags ", "}}{{end}}
 		{{if .Size}}size {{.Size}}{{end}}
+		{{if .Counter}}counter{{end}}
 		{{if .Timeout}}timeout {{.Timeout.Milliseconds}}ms{{end}}
 	}
 	{{end}}
@@ -30,6 +31,7 @@ table {{$family}} {{$tableName}} {
 		{{.ElementTypeExpr}}
 		{{if len .Flags}}flags {{join .Flags ", "}}{{end}}
 		{{if .Size}}size {{.Size}}{{end}}
+		{{if .Counter}}counter{{end}}
 		{{if .Timeout}}timeout {{.Timeout.Milliseconds}}ms{{end}}
 	}
 	{{end}}

--- a/daemon/libnetwork/internal/nftables/interval_helper.go
+++ b/daemon/libnetwork/internal/nftables/interval_helper.go
@@ -1,0 +1,39 @@
+package nftables
+
+import (
+	"fmt"
+	"iter"
+)
+
+type Interval struct {
+	Start int
+	End   int
+}
+
+func (i Interval) String() string {
+	return fmt.Sprintf("%d-%d", i.Start, i.End)
+}
+
+// EqualWeightIntervals partitions the range [0, length) into len(values) equal intervals,
+// assigning successive intervals to each of the values.
+func EqualWeightIntervals[Slice ~[]E, E any](values Slice, length int) iter.Seq2[Interval, E] {
+	return func(yield func(Interval, E) bool) {
+		n := len(values)
+		if length == 0 || n == 0 {
+			return
+		}
+		per, rem := length/n, length%n
+		start := 0
+		for i, value := range values {
+			size := per
+			if i < rem {
+				size++
+			}
+			end := start + size - 1
+			if !yield(Interval{start, end}, value) {
+				return
+			}
+			start = end + 1
+		}
+	}
+}

--- a/daemon/libnetwork/internal/nftables/interval_helper_test.go
+++ b/daemon/libnetwork/internal/nftables/interval_helper_test.go
@@ -1,0 +1,45 @@
+package nftables
+
+import (
+	"maps"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"pgregory.net/rapid"
+)
+
+func TestEqualWeightIntervals(t *testing.T) {
+	// Zero values do something defensible
+	m := maps.Collect(EqualWeightIntervals([]int(nil), 10))
+	assert.Check(t, is.Len(m, 0))
+	m = maps.Collect(EqualWeightIntervals([]int{1, 2, 3}, 0))
+	assert.Check(t, is.Len(m, 0))
+
+	// Iterator is reusable
+	it := EqualWeightIntervals([]int{1, 2, 3}, 10)
+	m, m2 := maps.Collect(it), maps.Collect(it)
+	assert.Check(t, is.DeepEqual(m, m2))
+
+	rapid.Check(t, testEqualWeightIntervals)
+}
+
+func testEqualWeightIntervals(t *rapid.T) {
+	length := rapid.IntRange(1, 65536).Draw(t, "length")
+	nvalues := rapid.IntRange(1, length).Draw(t, "nvalues")
+	values := make([]int, nvalues)
+	for i := range values {
+		values[i] = i
+	}
+
+	var prev Interval
+	for i, v := range EqualWeightIntervals(values, length) {
+		if v == 0 {
+			assert.Check(t, i.Start == 0)
+		} else {
+			assert.Check(t, i.Start == prev.End+1)
+		}
+		prev = i
+	}
+	assert.Check(t, prev.End == length-1)
+}

--- a/daemon/libnetwork/internal/nftables/nftables_linux.go
+++ b/daemon/libnetwork/internal/nftables/nftables_linux.go
@@ -769,6 +769,7 @@ type nftMap struct {
 	ElementTypeExpr string
 	Flags           []string
 	Size            int
+	Counter         bool
 	Timeout         time.Duration
 	Elements        map[string]mapValue
 	AddedElements   map[string]mapValue
@@ -783,6 +784,7 @@ type Map struct {
 	ElementType MapTyper
 	Flags       []string
 	Size        int
+	Counter     bool
 	Timeout     time.Duration
 }
 
@@ -802,6 +804,7 @@ func (m Map) create(ctx context.Context, t *table) (bool, error) {
 		ElementTypeExpr: m.ElementType.mapType(),
 		Flags:           slices.Clone(m.Flags),
 		Size:            m.Size,
+		Counter:         m.Counter,
 		Timeout:         m.Timeout,
 		Elements:        map[string]mapValue{},
 		AddedElements:   map[string]mapValue{},
@@ -924,6 +927,7 @@ type set struct {
 	ElementTypeExpr string
 	Flags           []string
 	Size            int
+	Counter         bool
 	Timeout         time.Duration
 	Elements        map[string]setElementOptions
 	AddedElements   map[string]setElementOptions
@@ -938,6 +942,7 @@ type Set struct {
 	ElementType SetTyper
 	Flags       []string
 	Size        int
+	Counter     bool
 	Timeout     time.Duration
 }
 
@@ -959,6 +964,7 @@ func (sd Set) create(ctx context.Context, t *table) (bool, error) {
 		ElementTypeExpr: sd.ElementType.setType(),
 		Flags:           slices.Clone(sd.Flags),
 		Size:            sd.Size,
+		Counter:         sd.Counter,
 		Timeout:         sd.Timeout,
 		AddedElements:   map[string]setElementOptions{},
 		DeletedElements: map[string]struct{}{},

--- a/daemon/libnetwork/internal/nftables/nftables_linux.go
+++ b/daemon/libnetwork/internal/nftables/nftables_linux.go
@@ -447,6 +447,8 @@ func (tm *Modifier) Reverse() Modifier {
 	return rtm
 }
 
+var incrementalUpdateFailedHook func(applied string, err error)
+
 // Apply makes incremental updates to nftables. If there's a validation
 // error in any of the enqueued objects, or an error applying the updates
 // to the underlying nftables, the [Table] will be unmodified.
@@ -499,6 +501,9 @@ func (t *Table) Apply(ctx context.Context, tm ...Modifier) (retErr error) {
 			sb.Write(line)
 		}
 		log.G(ctx).Error("nftables: failed to update nftables:\n", sb.String(), "\n", err)
+		if incrementalUpdateFailedHook != nil {
+			incrementalUpdateFailedHook(sb.String(), err)
+		}
 
 		// It's possible something destructive has happened to nftables. For example, in
 		// integration-cli tests, tests start daemons in the same netns as the integration
@@ -872,7 +877,6 @@ func (me MapElement) create(ctx context.Context, t *table) (bool, error) {
 		Comment: me.Comment,
 	}
 	nm.AddedElements[me.Key] = nm.Elements[me.Key]
-	delete(nm.DeletedElements, me.Key)
 	log.G(ctx).WithFields(log.Fields{
 		"family":  t.Family,
 		"table":   t.Name,
@@ -898,7 +902,6 @@ func (me MapElement) delete(ctx context.Context, t *table) (bool, error) {
 			me.MapName, me.Key, oldValue.Value, me.Value)
 	}
 	delete(nm.Elements, me.Key)
-	delete(nm.AddedElements, me.Key)
 	nm.DeletedElements[me.Key] = me.Value
 	log.G(ctx).WithFields(log.Fields{
 		"family":  t.Family,

--- a/daemon/libnetwork/internal/nftables/nftables_linux_test.go
+++ b/daemon/libnetwork/internal/nftables/nftables_linux_test.go
@@ -26,7 +26,12 @@ func testSetup(t *testing.T) func() {
 		t.Fatalf("Failed to enable nftables: %s", err)
 	}
 	cleanupContext := netnsutils.SetupTestOSContext(t)
+
+	incrementalUpdateFailedHook = func(applied string, err error) {
+		t.Errorf("Incremental update failed\n%s\n---\n%s", applied, err)
+	}
 	return func() {
+		incrementalUpdateFailedHook = nil
 		cleanupContext()
 		Disable()
 	}
@@ -241,6 +246,32 @@ func TestSet(t *testing.T) {
 	applyAndCheck(t, t.Name()+"/deleted6.golden", tbl6, tm6.Reverse())
 }
 
+func TestMapElementAtomicReplace(t *testing.T) {
+	defer testSetup(t)()
+
+	tbl, err := NewTable(IPv4, "x")
+	assert.NilError(t, err)
+	defer tbl.Close()
+
+	const mapName = "a_map"
+	init := Modifier{}
+	init.Create(Map{
+		Name:        mapName,
+		ElementType: Typeof("numgen random mod 1024").MapTo("ip daddr"),
+		Flags:       []string{"interval"},
+	})
+
+	gen1 := Modifier{}
+	gen1.Create(MapElement{MapName: mapName, Key: "0-511", Value: "127.0.0.1"})
+	gen1.Create(MapElement{MapName: mapName, Key: "512-1023", Value: "192.168.0.1"})
+	applyAndCheck(t, t.Name()+"/init.golden", tbl, init, gen1)
+
+	gen2 := Modifier{}
+	gen2.Create(MapElement{MapName: mapName, Key: "0-511", Value: "169.254.169.254"})
+	gen2.Create(MapElement{MapName: mapName, Key: "512-1023", Value: "1.1.1.1"})
+	applyAndCheck(t, t.Name()+"/updated.golden", tbl, gen1.Reverse(), gen2)
+}
+
 func TestReload(t *testing.T) {
 	defer testSetup(t)()
 
@@ -298,6 +329,7 @@ func TestReload(t *testing.T) {
 
 	// Check implicit/recovery reload - only deleting something that's gone missing
 	// from a vmap/set will trigger this.
+	incrementalUpdateFailedHook = nil
 	tm = Modifier{}
 	tm.Delete(SetElement{SetName: setName, Element: "192.0.2.0/24"})
 	applyAndCheck(t, t.Name()+"/recovered.golden", tbl, tm)
@@ -736,6 +768,9 @@ func TestValidation(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			defer testSetup(t)()
+			if tc.expErr != "" {
+				incrementalUpdateFailedHook = nil
+			}
 			tbl, err := NewTable(IPv4, "tablename")
 			assert.NilError(t, err)
 			defer tbl.Close()

--- a/daemon/libnetwork/internal/nftables/nftables_linux_test.go
+++ b/daemon/libnetwork/internal/nftables/nftables_linux_test.go
@@ -194,6 +194,7 @@ func TestVMap(t *testing.T) {
 		Name:        mapName,
 		ElementType: Ifname.VMap(),
 		Flags:       []string{"dynamic", "timeout"},
+		Counter:     true,
 	})
 	tm.Create(MapElement{MapName: mapName, Key: "eth0", Value: "return"})
 	tm.Create(MapElement{MapName: mapName, Key: "eth1", Value: "drop", Comment: `/// this is a comment on a map element \\\`})
@@ -222,7 +223,7 @@ func TestSet(t *testing.T) {
 	// Create a set in each table.
 	const set4Name = "set4"
 	tm4 := Modifier{}
-	tm4.Create(Set{Name: set4Name, ElementType: IPv4Addr, Flags: []string{"interval"}})
+	tm4.Create(Set{Name: set4Name, ElementType: IPv4Addr, Flags: []string{"interval"}, Counter: true})
 	const set6Name = "set6"
 	tm6 := Modifier{}
 	tm6.Create(Set{Name: set6Name, ElementType: IPv6Addr, Flags: []string{"interval", "timeout"}})

--- a/daemon/libnetwork/internal/nftables/reload.nft.gotmpl
+++ b/daemon/libnetwork/internal/nftables/reload.nft.gotmpl
@@ -14,6 +14,7 @@ table {{$family}} {{$tableName}} {
 		{{.ElementTypeExpr}}
 		{{if len .Flags}}flags {{join .Flags ", "}}{{end}}
 		{{if .Size}}size {{.Size}}{{end}}
+		{{if .Counter}}counter{{end}}
 		{{if .Timeout}}timeout {{.Timeout.Milliseconds}}ms{{end}}
         {{if .Elements}}elements = {
 			{{range $k,$v := .Elements}}{{$k}}{{if $v.Comment}} comment "{{$v.Comment}}"{{end}} : {{$v.Value}},
@@ -25,6 +26,7 @@ table {{$family}} {{$tableName}} {
 		{{.ElementTypeExpr}}
 		{{if len .Flags}}flags {{join .Flags ", "}}{{end}}
 		{{if .Size}}size {{.Size}}{{end}}
+		{{if .Counter}}counter{{end}}
 		{{if .Timeout}}timeout {{.Timeout.Milliseconds}}ms{{end}}
         {{if .Elements}}elements = {
 			{{range $k,$v := .Elements}}{{$k}}{{if $v.Comment}} comment "{{$v.Comment}}"{{end}},

--- a/daemon/libnetwork/internal/nftables/reload.nft.gotmpl
+++ b/daemon/libnetwork/internal/nftables/reload.nft.gotmpl
@@ -35,7 +35,7 @@ table {{$family}} {{$tableName}} {
 	}
 	{{end}}
 	{{range .Chains}}chain {{.Name}} {
-		{{if .ChainType}}type {{.ChainType}} hook {{.Hook}}{{if .Device}} device "{{.Device}}"{{end}} priority {{.Priority}}; policy {{.Policy}}{{end}}
+		{{if .ChainType}}type {{.ChainType}} hook {{.Hook}}{{if .Device}} device "{{.Device}}"{{end}} priority {{.Priority}}; policy {{.Policy}};{{end}}
 		{{range .Rules}}{{.}}
 		{{end}}
 	}

--- a/daemon/libnetwork/internal/nftables/testdata/TestMapElementAtomicReplace/init.golden
+++ b/daemon/libnetwork/internal/nftables/testdata/TestMapElementAtomicReplace/init.golden
@@ -1,0 +1,7 @@
+table ip x {
+	map a_map {
+		typeof numgen random mod 1024 : ip daddr
+		flags interval
+		elements = { 0-511 : 127.0.0.1, 512-1023 : 192.168.0.1 }
+	}
+}

--- a/daemon/libnetwork/internal/nftables/testdata/TestMapElementAtomicReplace/updated.golden
+++ b/daemon/libnetwork/internal/nftables/testdata/TestMapElementAtomicReplace/updated.golden
@@ -1,0 +1,7 @@
+table ip x {
+	map a_map {
+		typeof numgen random mod 1024 : ip daddr
+		flags interval
+		elements = { 0-511 : 169.254.169.254, 512-1023 : 1.1.1.1 }
+	}
+}

--- a/daemon/libnetwork/internal/nftables/testdata/TestSet/created4.golden
+++ b/daemon/libnetwork/internal/nftables/testdata/TestSet/created4.golden
@@ -2,6 +2,7 @@ table ip table4 {
 	set set4 {
 		type ipv4_addr
 		flags interval
-		elements = { 192.0.2.0/24 }
+		counter
+		elements = { 192.0.2.0/24 counter packets 0 bytes 0 }
 	}
 }

--- a/daemon/libnetwork/internal/nftables/testdata/TestVMap/created.golden
+++ b/daemon/libnetwork/internal/nftables/testdata/TestVMap/created.golden
@@ -2,7 +2,8 @@ table ip6 this_is_a_table {
 	map this_is_a_vmap {
 		type ifname : verdict
 		flags dynamic,timeout
-		elements = { "eth0" : return,
-			     "eth1" comment "/// this is a comment on a map element \\\" : drop }
+		counter
+		elements = { "eth0" counter packets 0 bytes 0 : return,
+			     "eth1" counter packets 0 bytes 0 comment "/// this is a comment on a map element \\\" : drop }
 	}
 }

--- a/daemon/libnetwork/osl/namespace_linux.go
+++ b/daemon/libnetwork/osl/namespace_linux.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/internal/rootless"
 	"github.com/moby/moby/v2/daemon/internal/unshare"
+	"github.com/moby/moby/v2/daemon/libnetwork/internal/nftables"
 	"github.com/moby/moby/v2/daemon/libnetwork/nlwrap"
 	"github.com/moby/moby/v2/daemon/libnetwork/ns"
 	"github.com/moby/moby/v2/daemon/libnetwork/osl/kernel"
@@ -249,6 +250,14 @@ type Namespace struct {
 	ipv6LoEnabledCached bool
 	nlHandle            nlwrap.Handle // nlHandle is the netlink handle for the network namespace. It is safe to access it concurrently.
 	mu                  sync.Mutex
+
+	nftMu    sync.Mutex
+	nftables map[nftables.Family]map[string]*nftable
+}
+
+type nftable struct {
+	InitMu sync.Mutex
+	Table  nftables.Table
 }
 
 // Interfaces returns the collection of Interface previously added with the AddInterface
@@ -398,6 +407,17 @@ func (n *Namespace) Key() string {
 // Destroy destroys the sandbox.
 func (n *Namespace) Destroy() error {
 	n.nlHandle.Handle.Close()
+
+	n.nftMu.Lock()
+	nftables := n.nftables
+	n.nftables = nil
+	n.nftMu.Unlock()
+	for _, family := range nftables {
+		for _, table := range family {
+			_ = table.Table.Close()
+		}
+	}
+
 	// Assuming no running process is executing in this network namespace,
 	// unmounting is sufficient to destroy it.
 	if err := syscall.Unmount(n.path, syscall.MNT_DETACH); err != nil {
@@ -567,6 +587,9 @@ func (n *Namespace) RefreshIPv6LoEnabled() {
 
 // ApplyOSTweaks applies operating system specific knobs on the sandbox.
 func (n *Namespace) ApplyOSTweaks(types []SandboxType) {
+	if nftables.Enabled() {
+		return
+	}
 	for _, t := range types {
 		switch t {
 		case SandboxTypeLoadBalancer, SandboxTypeIngress:
@@ -662,4 +685,56 @@ func setIPv6(nspath, iface string, enable bool) error {
 		}
 	}()
 	return <-errCh
+}
+
+// ApplyNFTable applies tm to the specified nftables table in the namespace,
+// creating and initializing the table if it does not already exist.
+// The table is initialized by calling the initialize function and applying the
+// resulting modifier to the table before tm.
+//
+// This function is safe for concurrent use.
+func (n *Namespace) ApplyNFTable(ctx context.Context, family nftables.Family, name string, initialize func(*nftables.Modifier) error, tm ...nftables.Modifier) (retErr error) {
+	n.nftMu.Lock()
+	if n.nftables == nil {
+		n.nftables = make(map[nftables.Family]map[string]*nftable)
+	}
+	if _, ok := n.nftables[family]; !ok {
+		n.nftables[family] = make(map[string]*nftable)
+	}
+	table, ok := n.nftables[family][name]
+	if !ok {
+		table = &nftable{}
+		n.nftables[family][name] = table
+	}
+	n.nftMu.Unlock()
+
+	var tbl nftables.Table
+	table.InitMu.Lock()
+	if table.Table.IsValid() {
+		tbl = table.Table
+		table.InitMu.Unlock()
+	} else {
+		defer func() {
+			if retErr == nil {
+				table.Table = tbl
+			}
+			table.InitMu.Unlock()
+		}()
+		var initTM = nftables.Modifier{}
+		if err := initialize(&initTM); err != nil {
+			return err
+		}
+		var err error
+		tbl, err = nftables.NewTable(family, name)
+		if err != nil {
+			return err
+		}
+		tm = append([]nftables.Modifier{initTM}, tm...)
+	}
+
+	var err error
+	invokeErr := n.InvokeFunc(func() {
+		err = tbl.Apply(ctx, tm...)
+	})
+	return errors.Join(invokeErr, err)
 }

--- a/daemon/libnetwork/service.go
+++ b/daemon/libnetwork/service.go
@@ -110,4 +110,6 @@ type loadBalancer struct {
 	// Back pointer to service to which the loadbalancer belongs.
 	service *service
 	sync.Mutex
+
+	osLoadBalancer
 }

--- a/daemon/libnetwork/service_iptables_linux.go
+++ b/daemon/libnetwork/service_iptables_linux.go
@@ -1,0 +1,446 @@
+package libnetwork
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/containerd/log"
+	"github.com/moby/ipvs"
+	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge"
+	"github.com/moby/moby/v2/daemon/libnetwork/iptables"
+	"github.com/vishvananda/netlink/nl"
+)
+
+// addLBBackendIPTables adds a loadbalancer backend to the loadbalancer sandbox for the network.
+// If needed add the service as well.
+func (n *Network) addLBBackendIPTables(ip net.IP, lb *loadBalancer) {
+	ep, sb, err := n.findLBEndpointSandbox()
+	if err != nil {
+		log.G(context.TODO()).Errorf("addLBBackendIPTables %s/%s: %v", n.ID(), n.Name(), err)
+		return
+	}
+	if sb.osSbox == nil {
+		return
+	}
+
+	eIP := ep.Iface().Address()
+
+	i, err := ipvs.New(sb.Key())
+	if err != nil {
+		log.G(context.TODO()).Errorf("Failed to create an ipvs handle for sbox %.7s (%.7s,%s) for lb addition: %v", sb.ID(), sb.ContainerID(), sb.Key(), err)
+		return
+	}
+	defer i.Close()
+
+	s := &ipvs.Service{
+		AddressFamily: nl.FAMILY_V4,
+		FWMark:        lb.fwMark,
+		SchedName:     ipvs.RoundRobin,
+	}
+
+	if !i.IsServicePresent(s) {
+		// Add IP alias for the VIP to the endpoint
+		ifName := findIfaceDstName(sb, ep)
+		if ifName == "" {
+			log.G(context.TODO()).Errorf("Failed find interface name for endpoint %s(%s) to create LB alias", ep.ID(), ep.Name())
+			return
+		}
+		err := sb.osSbox.AddAliasIP(ifName, &net.IPNet{IP: lb.vip, Mask: net.CIDRMask(32, 32)})
+		if err != nil {
+			log.G(context.TODO()).Errorf("Failed add IP alias %s to network %s LB endpoint interface %s: %v", lb.vip, n.ID(), ifName, err)
+			return
+		}
+
+		if sb.ingress {
+			var gwIP net.IP
+			if gwEP, _ := sb.getGatewayEndpoint(); gwEP != nil {
+				gwIP = gwEP.Iface().Address().IP
+			}
+			if err := addIngressPorts(gwIP, lb.service.ingressPorts); err != nil {
+				log.G(context.TODO()).Errorf("Failed to add ingress: %v", err)
+				return
+			}
+		}
+
+		log.G(context.TODO()).Debugf("Creating service for vip %s fwMark %d ingressPorts %#v in sbox %.7s (%.7s)", lb.vip, lb.fwMark, lb.service.ingressPorts, sb.ID(), sb.ContainerID())
+		if err := sb.configureFWMarkIPTables(lb.vip, lb.fwMark, lb.service.ingressPorts, eIP, false, n.loadBalancerMode); err != nil {
+			log.G(context.TODO()).Errorf("Failed to add firewall mark rule in sbox %.7s (%.7s): %v", sb.ID(), sb.ContainerID(), err)
+			return
+		}
+
+		if err := i.NewService(s); err != nil && !errors.Is(err, syscall.EEXIST) {
+			log.G(context.TODO()).Errorf("Failed to create a new service for vip %s fwmark %d in sbox %.7s (%.7s): %v", lb.vip, lb.fwMark, sb.ID(), sb.ContainerID(), err)
+			return
+		}
+	}
+
+	// Remove the sched name before using the service to add
+	// destination.
+	s.SchedName = ""
+
+	var flags uint32
+	if n.loadBalancerMode == loadBalancerModeDSR {
+		flags = ipvs.ConnFwdDirectRoute
+	}
+	err = i.NewDestination(s, &ipvs.Destination{
+		AddressFamily:   nl.FAMILY_V4,
+		Address:         ip,
+		Weight:          1,
+		ConnectionFlags: flags,
+	})
+	if err != nil && !errors.Is(err, syscall.EEXIST) {
+		log.G(context.TODO()).Errorf("Failed to create real server %s for vip %s fwmark %d in sbox %.7s (%.7s): %v", ip, lb.vip, lb.fwMark, sb.ID(), sb.ContainerID(), err)
+	}
+
+	// Ensure that kernel tweaks are applied in case this is the first time
+	// we've initialized ip_vs
+	sb.osSbox.ApplyOSTweaks(sb.oslTypes)
+}
+
+// rmLBBackendIPTables removes loadbalancer backend the load balancing endpoint for this
+// network. If 'rmService' is true, then remove the service entry as well.
+// If 'fullRemove' is true then completely remove the entry, otherwise
+// just deweight it for now.
+func (n *Network) rmLBBackendIPTables(ip net.IP, lb *loadBalancer, rmService bool, fullRemove bool) {
+	ep, sb, err := n.findLBEndpointSandbox()
+	if err != nil {
+		log.G(context.TODO()).Debugf("rmLBBackend for %s/%s: %v -- probably transient state", n.ID(), n.Name(), err)
+		return
+	}
+	if sb.osSbox == nil {
+		return
+	}
+
+	eIP := ep.Iface().Address()
+
+	i, err := ipvs.New(sb.Key())
+	if err != nil {
+		log.G(context.TODO()).Errorf("Failed to create an ipvs handle for sbox %.7s (%.7s,%s) for lb removal: %v", sb.ID(), sb.ContainerID(), sb.Key(), err)
+		return
+	}
+	defer i.Close()
+
+	s := &ipvs.Service{
+		AddressFamily: nl.FAMILY_V4,
+		FWMark:        lb.fwMark,
+	}
+
+	d := &ipvs.Destination{
+		AddressFamily: nl.FAMILY_V4,
+		Address:       ip,
+		Weight:        1,
+	}
+	if n.loadBalancerMode == loadBalancerModeDSR {
+		d.ConnectionFlags = ipvs.ConnFwdDirectRoute
+	}
+
+	if fullRemove {
+		if err := i.DelDestination(s, d); err != nil && !errors.Is(err, syscall.ENOENT) {
+			log.G(context.TODO()).Errorf("Failed to delete real server %s for vip %s fwmark %d in sbox %.7s (%.7s): %v", ip, lb.vip, lb.fwMark, sb.ID(), sb.ContainerID(), err)
+		}
+	} else {
+		d.Weight = 0
+		if err := i.UpdateDestination(s, d); err != nil && !errors.Is(err, syscall.ENOENT) {
+			log.G(context.TODO()).Errorf("Failed to set LB weight of real server %s to 0 for vip %s fwmark %d in sbox %.7s (%.7s): %v", ip, lb.vip, lb.fwMark, sb.ID(), sb.ContainerID(), err)
+		}
+	}
+
+	if rmService {
+		s.SchedName = ipvs.RoundRobin
+		if err := i.DelService(s); err != nil && !errors.Is(err, syscall.ENOENT) {
+			log.G(context.TODO()).Errorf("Failed to delete service for vip %s fwmark %d in sbox %.7s (%.7s): %v", lb.vip, lb.fwMark, sb.ID(), sb.ContainerID(), err)
+		}
+
+		if sb.ingress {
+			var gwIP net.IP
+			if gwEP, _ := sb.getGatewayEndpoint(); gwEP != nil {
+				gwIP = gwEP.Iface().Address().IP
+			}
+			if err := removeIngressPorts(gwIP, lb.service.ingressPorts); err != nil {
+				log.G(context.TODO()).Errorf("Failed to delete ingress: %v", err)
+			}
+		}
+
+		if err := sb.configureFWMarkIPTables(lb.vip, lb.fwMark, lb.service.ingressPorts, eIP, true, n.loadBalancerMode); err != nil {
+			log.G(context.TODO()).Errorf("Failed to delete firewall mark rule in sbox %.7s (%.7s): %v", sb.ID(), sb.ContainerID(), err)
+		}
+
+		// Remove IP alias from the VIP to the endpoint
+		ifName := findIfaceDstName(sb, ep)
+		if ifName == "" {
+			log.G(context.TODO()).Errorf("Failed find interface name for endpoint %s(%s) to create LB alias", ep.ID(), ep.Name())
+			return
+		}
+		err := sb.osSbox.RemoveAliasIP(ifName, &net.IPNet{IP: lb.vip, Mask: net.CIDRMask(32, 32)})
+		if err != nil {
+			log.G(context.TODO()).Errorf("Failed to remove IP alias %s from network %s LB endpoint interface %s: %v", lb.vip, n.ID(), ifName, err)
+		}
+	}
+}
+
+const ingressChain = "DOCKER-INGRESS"
+
+var iptablesIngressOnce sync.Once
+
+func initIngressConfigurationIPTables(gwIP net.IP, iptable *iptables.IPTable) error {
+	iptablesIngressOnce.Do(func() {
+		// Flush nat table and filter table ingress chain rules during init if it
+		// exists. It might contain stale rules from previous life.
+		if err := iptable.FlushChain(iptables.Nat, ingressChain); err != nil {
+			log.G(context.TODO()).Errorf("Could not flush nat table ingress chain rules during init: %v", err)
+		}
+		if err := iptable.FlushChain(iptables.Filter, ingressChain); err != nil {
+			log.G(context.TODO()).Errorf("Could not flush filter table ingress chain rules during init: %v", err)
+		}
+		// Remove the jump from FORWARD to DOCKER-INGRESS, if it was created there by a version of
+		// the daemon older than 28.0.1.
+		if err := iptable.DeleteJumpRule(iptables.Filter, "FORWARD", ingressChain); err != nil {
+			log.G(context.TODO()).WithError(err).Debug("Failed to delete jump from FORWARD to " + ingressChain)
+		}
+	})
+
+	for _, table := range []iptables.Table{iptables.Nat, iptables.Filter} {
+		// Create the DOCKER-INGRESS chain in the NAT and FILTER tables if it does not exist.
+		if _, err := iptable.NewChain(ingressChain, table); err != nil {
+			return fmt.Errorf("failed to create ingress chain: %v in table %s: %v", ingressChain, table, err)
+		}
+		// Add a RETURN rule to the end of the DOCKER-INGRESS chain in the NAT and FILTER tables.
+		if err := iptable.AddReturnRule(table, ingressChain); err != nil {
+			return fmt.Errorf("failed to add return rule in %s table %s chain: %v", table, ingressChain, err)
+		}
+	}
+
+	// Add a jump rule in the OUTPUT and PREROUTING chains of the NAT table to the DOCKER-INGRESS chain.
+	for _, chain := range []string{"OUTPUT", "PREROUTING"} {
+		if err := iptable.EnsureJumpRule(iptables.Nat, chain, ingressChain, "-m", "addrtype", "--dst-type", "LOCAL"); err != nil {
+			return fmt.Errorf("failed to add jump rule in %s to %s chain: %v", chain, ingressChain, err)
+		}
+	}
+
+	// The DOCKER-FORWARD chain is created by the bridge driver on startup. It's a stable place to
+	// put the jump to DOCKER-INGRESS (nothing else will ever be inserted before it, and the jump
+	// will precede the bridge driver's other rules).
+	// Add a jump rule in the DOCKER-FORWARD chain of the FILTER table to the DOCKER-INGRESS chain.
+	if err := iptable.EnsureJumpRule(iptables.Filter, bridge.DockerForwardChain, ingressChain); err != nil {
+		return fmt.Errorf("failed to add jump rule in %s to %s chain: %v", bridge.DockerForwardChain, ingressChain, err)
+	}
+
+	// Find the bridge interface name for the gateway IP.
+	oifName, err := findOIFName(gwIP)
+	if err != nil {
+		return fmt.Errorf("failed to find gateway bridge interface name for %s: %v", gwIP, err)
+	}
+	// Enable local routing for the gateway bridge interface by writing to /proc/sys/net/ipv4/conf/<oifName>/route_localnet.
+	path := filepath.Join("/proc/sys/net/ipv4/conf", oifName, "route_localnet")
+	if err := os.WriteFile(path, []byte{'1', '\n'}, 0o644); err != nil {
+		return fmt.Errorf("could not write to %s: %v", path, err)
+	}
+	// Add a POSTROUTING rule to the NAT table to masquerade traffic
+	rule := iptables.Rule{IPVer: iptables.IPv4, Table: iptables.Nat, Chain: "POSTROUTING", Args: []string{"-m", "addrtype", "--src-type", "LOCAL", "-o", oifName, "-j", "MASQUERADE"}}
+	if err := rule.Insert(); err != nil {
+		return fmt.Errorf("failed to insert ingress localhost POSTROUTING rule for %s: %v", oifName, err)
+	}
+	return nil
+}
+
+func generateIngressRulesIPTables(port *PortConfig, destIP net.IP) []iptables.Rule {
+	var (
+		protocol      = strings.ToLower(port.Protocol.String())
+		publishedPort = strconv.FormatUint(uint64(port.PublishedPort), 10)
+		destination   = net.JoinHostPort(destIP.String(), publishedPort)
+	)
+	return []iptables.Rule{
+		{
+			IPVer: iptables.IPv4,
+			Table: iptables.Nat,
+			Chain: ingressChain,
+			Args:  []string{"-p", protocol, "--dport", publishedPort, "-j", "DNAT", "--to-destination", destination},
+		},
+		{
+			IPVer: iptables.IPv4,
+			Table: iptables.Filter,
+			Chain: ingressChain,
+			Args:  []string{"-p", protocol, "--sport", publishedPort, "-m", "conntrack", "--ctstate", "ESTABLISHED,RELATED", "-j", "ACCEPT"},
+		},
+		{
+			IPVer: iptables.IPv4,
+			Table: iptables.Filter,
+			Chain: ingressChain,
+			Args:  []string{"-p", protocol, "--dport", publishedPort, "-j", "ACCEPT"},
+		},
+	}
+}
+
+func programIngressPortsRulesIPTables(gwIP net.IP, filteredPorts []*PortConfig) (portErr error) {
+	// TODO IPv6 support
+	iptable := iptables.GetIptable(iptables.IPv4)
+
+	if err := initIngressConfigurationIPTables(gwIP, iptable); err != nil {
+		return err
+	}
+
+	rollbackRules := make([]iptables.Rule, 0, len(filteredPorts)*3)
+	defer func() {
+		if portErr != nil {
+			for _, rule := range rollbackRules {
+				if err := rule.Delete(); err != nil {
+					log.G(context.TODO()).Warnf("roll back rule failed, %v: %v", rule, err)
+				}
+			}
+		}
+	}()
+
+	for _, iPort := range filteredPorts {
+		for _, rule := range generateIngressRulesIPTables(iPort, gwIP) {
+			if portErr = rule.Insert(); portErr != nil {
+				err := fmt.Errorf("set up rule failed, %v: %v", rule, portErr)
+				return err
+			}
+			rollbackRules = append(rollbackRules, rule)
+		}
+	}
+
+	return nil
+}
+
+func deleteIngressPortsRulesIPTables(gwIP net.IP, filteredPorts []*PortConfig) error {
+	var portErr error
+
+	for _, iPort := range filteredPorts {
+		for _, rule := range generateIngressRulesIPTables(iPort, gwIP) {
+			if portErr = rule.Delete(); portErr != nil {
+				err := fmt.Errorf("delete rule failed, %v: %v", rule, portErr)
+				log.G(context.TODO()).Warn(err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// configureFWMarkIPTables configures the sandbox firewall to mark vip destined packets
+// with the firewall mark fwMark.
+func (sb *Sandbox) configureFWMarkIPTables(vip net.IP, fwMark uint32, ingressPorts []*PortConfig, eIP *net.IPNet, isDelete bool, lbMode string) error {
+	// TODO IPv6 support
+	iptable := iptables.GetIptable(iptables.IPv4)
+
+	fwMarkStr := strconv.FormatUint(uint64(fwMark), 10)
+	addDelOpt := "-A"
+	if isDelete {
+		addDelOpt = "-D"
+	}
+
+	rules := make([][]string, 0, len(ingressPorts))
+	for _, iPort := range ingressPorts {
+		var (
+			protocol      = strings.ToLower(PortConfig_Protocol_name[int32(iPort.Protocol)])
+			publishedPort = strconv.FormatUint(uint64(iPort.PublishedPort), 10)
+		)
+		rule := []string{"-t", "mangle", addDelOpt, "PREROUTING", "-p", protocol, "--dport", publishedPort, "-j", "MARK", "--set-mark", fwMarkStr}
+		rules = append(rules, rule)
+	}
+
+	var innerErr error
+	err := sb.ExecFunc(func() {
+		if !isDelete && lbMode == loadBalancerModeNAT {
+			subnet := net.IPNet{IP: eIP.IP.Mask(eIP.Mask), Mask: eIP.Mask}
+			ruleParams := []string{"-m", "ipvs", "--ipvs", "-d", subnet.String(), "-j", "SNAT", "--to-source", eIP.IP.String()}
+			if !iptable.Exists("nat", "POSTROUTING", ruleParams...) {
+				rule := append([]string{"-t", "nat", "-A", "POSTROUTING"}, ruleParams...)
+				rules = append(rules, rule)
+
+				err := os.WriteFile("/proc/sys/net/ipv4/vs/conntrack", []byte{'1', '\n'}, 0o644)
+				if err != nil {
+					innerErr = err
+					return
+				}
+			}
+		}
+
+		rule := []string{"-t", "mangle", addDelOpt, "INPUT", "-d", vip.String() + "/32", "-j", "MARK", "--set-mark", fwMarkStr}
+		rules = append(rules, rule)
+
+		for _, rule := range rules {
+			if err := iptable.RawCombinedOutputNative(rule...); err != nil {
+				innerErr = fmt.Errorf("set up rule failed, %v: %w", rule, err)
+				return
+			}
+		}
+	})
+	if err != nil {
+		return err
+	}
+	return innerErr
+}
+
+func (sb *Sandbox) addRedirectRulesIPTables(eIP *net.IPNet, ingressPorts []*PortConfig) error {
+	// TODO IPv6 support
+	iptable := iptables.GetIptable(iptables.IPv4)
+	ipAddr := eIP.IP.String()
+
+	rules := make([][]string, 0, len(ingressPorts)*3) // 3 rules per port
+	for _, iPort := range ingressPorts {
+		var (
+			protocol      = strings.ToLower(PortConfig_Protocol_name[int32(iPort.Protocol)])
+			publishedPort = strconv.FormatUint(uint64(iPort.PublishedPort), 10)
+			targetPort    = strconv.FormatUint(uint64(iPort.TargetPort), 10)
+		)
+
+		rules = append(rules,
+			[]string{"-t", "nat", "-A", "PREROUTING", "-d", ipAddr, "-p", protocol, "--dport", publishedPort, "-j", "REDIRECT", "--to-port", targetPort},
+
+			// Allow only incoming connections to exposed ports
+			[]string{"-I", "INPUT", "-d", ipAddr, "-p", protocol, "--dport", targetPort, "-m", "conntrack", "--ctstate", "NEW,ESTABLISHED", "-j", "ACCEPT"},
+
+			// Allow only outgoing connections from exposed ports
+			[]string{"-I", "OUTPUT", "-s", ipAddr, "-p", protocol, "--sport", targetPort, "-m", "conntrack", "--ctstate", "ESTABLISHED", "-j", "ACCEPT"},
+		)
+	}
+
+	var innerErr error
+	err := sb.ExecFunc(func() {
+		for _, rule := range rules {
+			if err := iptable.RawCombinedOutputNative(rule...); err != nil {
+				innerErr = fmt.Errorf("set up rule failed, %v: %w", rule, err)
+				return
+			}
+		}
+
+		if len(ingressPorts) == 0 {
+			return
+		}
+
+		// Ensure blocking rules for anything else in/to ingress network
+		for _, rule := range [][]string{
+			{"-d", ipAddr, "-p", "sctp", "-j", "DROP"},
+			{"-d", ipAddr, "-p", "udp", "-j", "DROP"},
+			{"-d", ipAddr, "-p", "tcp", "-j", "DROP"},
+		} {
+			if !iptable.ExistsNative(iptables.Filter, "INPUT", rule...) {
+				if err := iptable.RawCombinedOutputNative(append([]string{"-A", "INPUT"}, rule...)...); err != nil {
+					innerErr = fmt.Errorf("set up rule failed, %v: %w", rule, err)
+					return
+				}
+			}
+			rule[0] = "-s"
+			if !iptable.ExistsNative(iptables.Filter, "OUTPUT", rule...) {
+				if err := iptable.RawCombinedOutputNative(append([]string{"-A", "OUTPUT"}, rule...)...); err != nil {
+					innerErr = fmt.Errorf("set up rule failed, %v: %w", rule, err)
+					return
+				}
+			}
+		}
+	})
+	if err != nil {
+		return err
+	}
+	return innerErr
+}

--- a/daemon/libnetwork/service_iptables_linux.go
+++ b/daemon/libnetwork/service_iptables_linux.go
@@ -21,14 +21,14 @@ import (
 
 // addLBBackendIPTables adds a loadbalancer backend to the loadbalancer sandbox for the network.
 // If needed add the service as well.
-func (n *Network) addLBBackendIPTables(ip net.IP, lb *loadBalancer) {
+func (n *Network) addLBBackendIPTables(ip net.IP, lb *loadBalancer) bool {
 	ep, sb, err := n.findLBEndpointSandbox()
 	if err != nil {
 		log.G(context.TODO()).Errorf("addLBBackendIPTables %s/%s: %v", n.ID(), n.Name(), err)
-		return
+		return false
 	}
 	if sb.osSbox == nil {
-		return
+		return false
 	}
 
 	eIP := ep.Iface().Address()
@@ -36,7 +36,7 @@ func (n *Network) addLBBackendIPTables(ip net.IP, lb *loadBalancer) {
 	i, err := ipvs.New(sb.Key())
 	if err != nil {
 		log.G(context.TODO()).Errorf("Failed to create an ipvs handle for sbox %.7s (%.7s,%s) for lb addition: %v", sb.ID(), sb.ContainerID(), sb.Key(), err)
-		return
+		return false
 	}
 	defer i.Close()
 
@@ -46,39 +46,30 @@ func (n *Network) addLBBackendIPTables(ip net.IP, lb *loadBalancer) {
 		SchedName:     ipvs.RoundRobin,
 	}
 
+	var newService bool
 	if !i.IsServicePresent(s) {
+		newService = true
 		// Add IP alias for the VIP to the endpoint
 		ifName := findIfaceDstName(sb, ep)
 		if ifName == "" {
 			log.G(context.TODO()).Errorf("Failed find interface name for endpoint %s(%s) to create LB alias", ep.ID(), ep.Name())
-			return
+			return false
 		}
 		err := sb.osSbox.AddAliasIP(ifName, &net.IPNet{IP: lb.vip, Mask: net.CIDRMask(32, 32)})
 		if err != nil {
 			log.G(context.TODO()).Errorf("Failed add IP alias %s to network %s LB endpoint interface %s: %v", lb.vip, n.ID(), ifName, err)
-			return
-		}
-
-		if sb.ingress {
-			var gwIP net.IP
-			if gwEP, _ := sb.getGatewayEndpoint(); gwEP != nil {
-				gwIP = gwEP.Iface().Address().IP
-			}
-			if err := addIngressPorts(gwIP, lb.service.ingressPorts); err != nil {
-				log.G(context.TODO()).Errorf("Failed to add ingress: %v", err)
-				return
-			}
+			return false
 		}
 
 		log.G(context.TODO()).Debugf("Creating service for vip %s fwMark %d ingressPorts %#v in sbox %.7s (%.7s)", lb.vip, lb.fwMark, lb.service.ingressPorts, sb.ID(), sb.ContainerID())
 		if err := sb.configureFWMarkIPTables(lb.vip, lb.fwMark, lb.service.ingressPorts, eIP, false, n.loadBalancerMode); err != nil {
 			log.G(context.TODO()).Errorf("Failed to add firewall mark rule in sbox %.7s (%.7s): %v", sb.ID(), sb.ContainerID(), err)
-			return
+			return false
 		}
 
 		if err := i.NewService(s); err != nil && !errors.Is(err, syscall.EEXIST) {
 			log.G(context.TODO()).Errorf("Failed to create a new service for vip %s fwmark %d in sbox %.7s (%.7s): %v", lb.vip, lb.fwMark, sb.ID(), sb.ContainerID(), err)
-			return
+			return false
 		}
 	}
 
@@ -103,6 +94,8 @@ func (n *Network) addLBBackendIPTables(ip net.IP, lb *loadBalancer) {
 	// Ensure that kernel tweaks are applied in case this is the first time
 	// we've initialized ip_vs
 	sb.osSbox.ApplyOSTweaks(sb.oslTypes)
+
+	return newService
 }
 
 // rmLBBackendIPTables removes loadbalancer backend the load balancing endpoint for this
@@ -157,16 +150,6 @@ func (n *Network) rmLBBackendIPTables(ip net.IP, lb *loadBalancer, rmService boo
 		s.SchedName = ipvs.RoundRobin
 		if err := i.DelService(s); err != nil && !errors.Is(err, syscall.ENOENT) {
 			log.G(context.TODO()).Errorf("Failed to delete service for vip %s fwmark %d in sbox %.7s (%.7s): %v", lb.vip, lb.fwMark, sb.ID(), sb.ContainerID(), err)
-		}
-
-		if sb.ingress {
-			var gwIP net.IP
-			if gwEP, _ := sb.getGatewayEndpoint(); gwEP != nil {
-				gwIP = gwEP.Iface().Address().IP
-			}
-			if err := removeIngressPorts(gwIP, lb.service.ingressPorts); err != nil {
-				log.G(context.TODO()).Errorf("Failed to delete ingress: %v", err)
-			}
 		}
 
 		if err := sb.configureFWMarkIPTables(lb.vip, lb.fwMark, lb.service.ingressPorts, eIP, true, n.loadBalancerMode); err != nil {

--- a/daemon/libnetwork/service_linux.go
+++ b/daemon/libnetwork/service_linux.go
@@ -380,15 +380,8 @@ func removeIngressPorts(gwIP net.IP, ingressPorts []*PortConfig) error {
 }
 
 func addIngressPorts(gwIP net.IP, ingressPorts []*PortConfig) error {
-	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
-
 	ingressMu.Lock()
 	defer ingressMu.Unlock()
-
-	if err := initIngressConfiguration(gwIP, iptable); err != nil {
-		return err
-	}
 
 	// Filter the ingress ports until port rules start to be added/deleted
 	filteredPorts := filterPortConfigs(ingressPorts, false)
@@ -404,15 +397,8 @@ func addIngressPorts(gwIP net.IP, ingressPorts []*PortConfig) error {
 }
 
 func restoreIngressPorts(gwIP net.IP, ingressPorts []*PortConfig) error {
-	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
-
 	ingressMu.Lock()
 	defer ingressMu.Unlock()
-
-	if err := initIngressConfiguration(gwIP, iptable); err != nil {
-		return err
-	}
 
 	if err := programIngressPortsRules(gwIP, ingressPorts); err != nil {
 		return fmt.Errorf("failed to program ingress ports: %v", err)
@@ -450,6 +436,13 @@ func generateIngressRules(port *PortConfig, destIP net.IP) []iptables.Rule {
 }
 
 func programIngressPortsRules(gwIP net.IP, filteredPorts []*PortConfig) (portErr error) {
+	// TODO IPv6 support
+	iptable := iptables.GetIptable(iptables.IPv4)
+
+	if err := initIngressConfiguration(gwIP, iptable); err != nil {
+		return err
+	}
+
 	rollbackRules := make([]iptables.Rule, 0, len(filteredPorts)*3)
 	defer func() {
 		if portErr != nil {

--- a/daemon/libnetwork/service_linux.go
+++ b/daemon/libnetwork/service_linux.go
@@ -76,7 +76,23 @@ func (n *Network) addLBBackend(ip net.IP, lb *loadBalancer) {
 	if len(lb.vip) == 0 {
 		return
 	}
-	n.addLBBackendIPTables(ip, lb)
+	newService := n.addLBBackendIPTables(ip, lb)
+
+	if newService && n.ingress {
+		_, sb, err := n.findLBEndpointSandbox()
+		if err != nil {
+			log.G(context.TODO()).Errorf("Failed to find load balancer endpoint sandbox: %v", err)
+			return
+		}
+		var gwIP net.IP
+		if gwEP, _ := sb.getGatewayEndpoint(); gwEP != nil {
+			gwIP = gwEP.Iface().Address().IP
+		}
+		if err := addIngressPorts(gwIP, lb.service.ingressPorts); err != nil {
+			log.G(context.TODO()).Errorf("Failed to add ingress: %v", err)
+			return
+		}
+	}
 }
 
 // Remove loadbalancer backend the load balancing endpoint for this
@@ -88,6 +104,22 @@ func (n *Network) rmLBBackend(ip net.IP, lb *loadBalancer, rmService bool, fullR
 		return
 	}
 	n.rmLBBackendIPTables(ip, lb, rmService, fullRemove)
+
+	if rmService && n.ingress {
+		_, sb, err := n.findLBEndpointSandbox()
+		if err != nil {
+			log.G(context.TODO()).Errorf("Failed to find load balancer endpoint sandbox: %v", err)
+			return
+		}
+		var gwIP net.IP
+		if gwEP, _ := sb.getGatewayEndpoint(); gwEP != nil {
+			gwIP = gwEP.Iface().Address().IP
+		}
+		if err := removeIngressPorts(gwIP, lb.service.ingressPorts); err != nil {
+			log.G(context.TODO()).Errorf("Failed to remove ingress: %v", err)
+			return
+		}
+	}
 }
 
 var (

--- a/daemon/libnetwork/service_linux.go
+++ b/daemon/libnetwork/service_linux.go
@@ -10,8 +10,14 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/ishidawataru/sctp"
+	"github.com/moby/moby/v2/daemon/libnetwork/internal/nftables"
 	"github.com/moby/moby/v2/daemon/libnetwork/ns"
 )
+
+type osLoadBalancer struct {
+	nftClearNAT, nftClearDSR nftables.Modifier
+	nftBackendsProgrammed    int
+}
 
 // Populate all loadbalancers on the network that the passed endpoint
 // belongs to, into this sandbox.
@@ -76,7 +82,12 @@ func (n *Network) addLBBackend(ip net.IP, lb *loadBalancer) {
 	if len(lb.vip) == 0 {
 		return
 	}
-	newService := n.addLBBackendIPTables(ip, lb)
+	var newService bool
+	if nftables.Enabled() {
+		newService = n.syncLBBackendsNftables(context.TODO(), lb, false)
+	} else {
+		newService = n.addLBBackendIPTables(ip, lb)
+	}
 
 	if newService && n.ingress {
 		_, sb, err := n.findLBEndpointSandbox()
@@ -103,7 +114,11 @@ func (n *Network) rmLBBackend(ip net.IP, lb *loadBalancer, rmService bool, fullR
 	if len(lb.vip) == 0 {
 		return
 	}
-	n.rmLBBackendIPTables(ip, lb, rmService, fullRemove)
+	if nftables.Enabled() {
+		n.syncLBBackendsNftables(context.TODO(), lb, rmService)
+	} else {
+		n.rmLBBackendIPTables(ip, lb, rmService, fullRemove)
+	}
 
 	if rmService && n.ingress {
 		_, sb, err := n.findLBEndpointSandbox()
@@ -175,7 +190,13 @@ func removeIngressPorts(gwIP net.IP, ingressPorts []*PortConfig) error {
 	// Filter the ingress ports until port rules start to be added/deleted
 	filteredPorts := filterPortConfigs(ingressPorts, true)
 
-	if err := deleteIngressPortsRulesIPTables(gwIP, filteredPorts); err != nil {
+	var err error
+	if nftables.Enabled() {
+		err = deleteIngressPortsNftables(context.TODO(), filteredPorts)
+	} else {
+		err = deleteIngressPortsRulesIPTables(gwIP, filteredPorts)
+	}
+	if err != nil {
 		filterPortConfigs(ingressPorts, false)
 		return fmt.Errorf("failed to program ingress ports: %v", err)
 	}
@@ -192,7 +213,13 @@ func addIngressPorts(gwIP net.IP, ingressPorts []*PortConfig) error {
 	// Filter the ingress ports until port rules start to be added/deleted
 	filteredPorts := filterPortConfigs(ingressPorts, false)
 
-	if err := programIngressPortsRulesIPTables(gwIP, filteredPorts); err != nil {
+	var err error
+	if nftables.Enabled() {
+		err = addIngressPortsNftables(context.TODO(), gwIP, filteredPorts)
+	} else {
+		err = programIngressPortsRulesIPTables(gwIP, filteredPorts)
+	}
+	if err != nil {
 		filterPortConfigs(filteredPorts, true)
 		return fmt.Errorf("failed to program ingress ports: %v", err)
 	}
@@ -203,6 +230,12 @@ func addIngressPorts(gwIP net.IP, ingressPorts []*PortConfig) error {
 }
 
 func restoreIngressPorts(gwIP net.IP, ingressPorts []*PortConfig) error {
+	if nftables.Enabled() {
+		// No-op in nftables world as firewalld doesn't touch our tables
+		// and we don't touch theirs.
+		return nil
+	}
+
 	ingressMu.Lock()
 	defer ingressMu.Unlock()
 
@@ -283,5 +316,9 @@ func plumbIngressPortsProxy(ingressPorts []*PortConfig) {
 }
 
 func (sb *Sandbox) addRedirectRules(eIP *net.IPNet, ingressPorts []*PortConfig) error {
-	return sb.addRedirectRulesIPTables(eIP, ingressPorts)
+	if nftables.Enabled() {
+		return sb.addRedirectRulesNftables(context.TODO(), eIP, ingressPorts)
+	} else {
+		return sb.addRedirectRulesIPTables(eIP, ingressPorts)
+	}
 }

--- a/daemon/libnetwork/service_linux.go
+++ b/daemon/libnetwork/service_linux.go
@@ -2,24 +2,15 @@ package libnetwork
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net"
-	"os"
-	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 
 	"github.com/containerd/log"
 	"github.com/ishidawataru/sctp"
-	"github.com/moby/ipvs"
-	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge"
-	"github.com/moby/moby/v2/daemon/libnetwork/iptables"
 	"github.com/moby/moby/v2/daemon/libnetwork/ns"
-	"github.com/vishvananda/netlink/nl"
 )
 
 // Populate all loadbalancers on the network that the passed endpoint
@@ -85,87 +76,7 @@ func (n *Network) addLBBackend(ip net.IP, lb *loadBalancer) {
 	if len(lb.vip) == 0 {
 		return
 	}
-	ep, sb, err := n.findLBEndpointSandbox()
-	if err != nil {
-		log.G(context.TODO()).Errorf("addLBBackend %s/%s: %v", n.ID(), n.Name(), err)
-		return
-	}
-	if sb.osSbox == nil {
-		return
-	}
-
-	eIP := ep.Iface().Address()
-
-	i, err := ipvs.New(sb.Key())
-	if err != nil {
-		log.G(context.TODO()).Errorf("Failed to create an ipvs handle for sbox %.7s (%.7s,%s) for lb addition: %v", sb.ID(), sb.ContainerID(), sb.Key(), err)
-		return
-	}
-	defer i.Close()
-
-	s := &ipvs.Service{
-		AddressFamily: nl.FAMILY_V4,
-		FWMark:        lb.fwMark,
-		SchedName:     ipvs.RoundRobin,
-	}
-
-	if !i.IsServicePresent(s) {
-		// Add IP alias for the VIP to the endpoint
-		ifName := findIfaceDstName(sb, ep)
-		if ifName == "" {
-			log.G(context.TODO()).Errorf("Failed find interface name for endpoint %s(%s) to create LB alias", ep.ID(), ep.Name())
-			return
-		}
-		err := sb.osSbox.AddAliasIP(ifName, &net.IPNet{IP: lb.vip, Mask: net.CIDRMask(32, 32)})
-		if err != nil {
-			log.G(context.TODO()).Errorf("Failed add IP alias %s to network %s LB endpoint interface %s: %v", lb.vip, n.ID(), ifName, err)
-			return
-		}
-
-		if sb.ingress {
-			var gwIP net.IP
-			if gwEP, _ := sb.getGatewayEndpoint(); gwEP != nil {
-				gwIP = gwEP.Iface().Address().IP
-			}
-			if err := addIngressPorts(gwIP, lb.service.ingressPorts); err != nil {
-				log.G(context.TODO()).Errorf("Failed to add ingress: %v", err)
-				return
-			}
-		}
-
-		log.G(context.TODO()).Debugf("Creating service for vip %s fwMark %d ingressPorts %#v in sbox %.7s (%.7s)", lb.vip, lb.fwMark, lb.service.ingressPorts, sb.ID(), sb.ContainerID())
-		if err := sb.configureFWMark(lb.vip, lb.fwMark, lb.service.ingressPorts, eIP, false, n.loadBalancerMode); err != nil {
-			log.G(context.TODO()).Errorf("Failed to add firewall mark rule in sbox %.7s (%.7s): %v", sb.ID(), sb.ContainerID(), err)
-			return
-		}
-
-		if err := i.NewService(s); err != nil && !errors.Is(err, syscall.EEXIST) {
-			log.G(context.TODO()).Errorf("Failed to create a new service for vip %s fwmark %d in sbox %.7s (%.7s): %v", lb.vip, lb.fwMark, sb.ID(), sb.ContainerID(), err)
-			return
-		}
-	}
-
-	// Remove the sched name before using the service to add
-	// destination.
-	s.SchedName = ""
-
-	var flags uint32
-	if n.loadBalancerMode == loadBalancerModeDSR {
-		flags = ipvs.ConnFwdDirectRoute
-	}
-	err = i.NewDestination(s, &ipvs.Destination{
-		AddressFamily:   nl.FAMILY_V4,
-		Address:         ip,
-		Weight:          1,
-		ConnectionFlags: flags,
-	})
-	if err != nil && !errors.Is(err, syscall.EEXIST) {
-		log.G(context.TODO()).Errorf("Failed to create real server %s for vip %s fwmark %d in sbox %.7s (%.7s): %v", ip, lb.vip, lb.fwMark, sb.ID(), sb.ContainerID(), err)
-	}
-
-	// Ensure that kernel tweaks are applied in case this is the first time
-	// we've initialized ip_vs
-	sb.osSbox.ApplyOSTweaks(sb.oslTypes)
+	n.addLBBackendIPTables(ip, lb)
 }
 
 // Remove loadbalancer backend the load balancing endpoint for this
@@ -176,86 +87,10 @@ func (n *Network) rmLBBackend(ip net.IP, lb *loadBalancer, rmService bool, fullR
 	if len(lb.vip) == 0 {
 		return
 	}
-	ep, sb, err := n.findLBEndpointSandbox()
-	if err != nil {
-		log.G(context.TODO()).Debugf("rmLBBackend for %s/%s: %v -- probably transient state", n.ID(), n.Name(), err)
-		return
-	}
-	if sb.osSbox == nil {
-		return
-	}
-
-	eIP := ep.Iface().Address()
-
-	i, err := ipvs.New(sb.Key())
-	if err != nil {
-		log.G(context.TODO()).Errorf("Failed to create an ipvs handle for sbox %.7s (%.7s,%s) for lb removal: %v", sb.ID(), sb.ContainerID(), sb.Key(), err)
-		return
-	}
-	defer i.Close()
-
-	s := &ipvs.Service{
-		AddressFamily: nl.FAMILY_V4,
-		FWMark:        lb.fwMark,
-	}
-
-	d := &ipvs.Destination{
-		AddressFamily: nl.FAMILY_V4,
-		Address:       ip,
-		Weight:        1,
-	}
-	if n.loadBalancerMode == loadBalancerModeDSR {
-		d.ConnectionFlags = ipvs.ConnFwdDirectRoute
-	}
-
-	if fullRemove {
-		if err := i.DelDestination(s, d); err != nil && !errors.Is(err, syscall.ENOENT) {
-			log.G(context.TODO()).Errorf("Failed to delete real server %s for vip %s fwmark %d in sbox %.7s (%.7s): %v", ip, lb.vip, lb.fwMark, sb.ID(), sb.ContainerID(), err)
-		}
-	} else {
-		d.Weight = 0
-		if err := i.UpdateDestination(s, d); err != nil && !errors.Is(err, syscall.ENOENT) {
-			log.G(context.TODO()).Errorf("Failed to set LB weight of real server %s to 0 for vip %s fwmark %d in sbox %.7s (%.7s): %v", ip, lb.vip, lb.fwMark, sb.ID(), sb.ContainerID(), err)
-		}
-	}
-
-	if rmService {
-		s.SchedName = ipvs.RoundRobin
-		if err := i.DelService(s); err != nil && !errors.Is(err, syscall.ENOENT) {
-			log.G(context.TODO()).Errorf("Failed to delete service for vip %s fwmark %d in sbox %.7s (%.7s): %v", lb.vip, lb.fwMark, sb.ID(), sb.ContainerID(), err)
-		}
-
-		if sb.ingress {
-			var gwIP net.IP
-			if gwEP, _ := sb.getGatewayEndpoint(); gwEP != nil {
-				gwIP = gwEP.Iface().Address().IP
-			}
-			if err := removeIngressPorts(gwIP, lb.service.ingressPorts); err != nil {
-				log.G(context.TODO()).Errorf("Failed to delete ingress: %v", err)
-			}
-		}
-
-		if err := sb.configureFWMark(lb.vip, lb.fwMark, lb.service.ingressPorts, eIP, true, n.loadBalancerMode); err != nil {
-			log.G(context.TODO()).Errorf("Failed to delete firewall mark rule in sbox %.7s (%.7s): %v", sb.ID(), sb.ContainerID(), err)
-		}
-
-		// Remove IP alias from the VIP to the endpoint
-		ifName := findIfaceDstName(sb, ep)
-		if ifName == "" {
-			log.G(context.TODO()).Errorf("Failed find interface name for endpoint %s(%s) to create LB alias", ep.ID(), ep.Name())
-			return
-		}
-		err := sb.osSbox.RemoveAliasIP(ifName, &net.IPNet{IP: lb.vip, Mask: net.CIDRMask(32, 32)})
-		if err != nil {
-			log.G(context.TODO()).Errorf("Failed to remove IP alias %s from network %s LB endpoint interface %s: %v", lb.vip, n.ID(), ifName, err)
-		}
-	}
+	n.rmLBBackendIPTables(ip, lb, rmService, fullRemove)
 }
 
-const ingressChain = "DOCKER-INGRESS"
-
 var (
-	ingressOnce     sync.Once
 	ingressMu       sync.Mutex // lock for operations on ingress
 	ingressProxyTbl = make(map[string]io.Closer)
 	portConfigMu    sync.Mutex
@@ -299,67 +134,6 @@ func filterPortConfigs(ingressPorts []*PortConfig, isDelete bool) []*PortConfig 
 	return iPorts
 }
 
-func initIngressConfiguration(gwIP net.IP, iptable *iptables.IPTable) error {
-	ingressOnce.Do(func() {
-		// Flush nat table and filter table ingress chain rules during init if it
-		// exists. It might contain stale rules from previous life.
-		if err := iptable.FlushChain(iptables.Nat, ingressChain); err != nil {
-			log.G(context.TODO()).Errorf("Could not flush nat table ingress chain rules during init: %v", err)
-		}
-		if err := iptable.FlushChain(iptables.Filter, ingressChain); err != nil {
-			log.G(context.TODO()).Errorf("Could not flush filter table ingress chain rules during init: %v", err)
-		}
-		// Remove the jump from FORWARD to DOCKER-INGRESS, if it was created there by a version of
-		// the daemon older than 28.0.1.
-		if err := iptable.DeleteJumpRule(iptables.Filter, "FORWARD", ingressChain); err != nil {
-			log.G(context.TODO()).WithError(err).Debug("Failed to delete jump from FORWARD to " + ingressChain)
-		}
-	})
-
-	for _, table := range []iptables.Table{iptables.Nat, iptables.Filter} {
-		// Create the DOCKER-INGRESS chain in the NAT and FILTER tables if it does not exist.
-		if _, err := iptable.NewChain(ingressChain, table); err != nil {
-			return fmt.Errorf("failed to create ingress chain: %v in table %s: %v", ingressChain, table, err)
-		}
-		// Add a RETURN rule to the end of the DOCKER-INGRESS chain in the NAT and FILTER tables.
-		if err := iptable.AddReturnRule(table, ingressChain); err != nil {
-			return fmt.Errorf("failed to add return rule in %s table %s chain: %v", table, ingressChain, err)
-		}
-	}
-
-	// Add a jump rule in the OUTPUT and PREROUTING chains of the NAT table to the DOCKER-INGRESS chain.
-	for _, chain := range []string{"OUTPUT", "PREROUTING"} {
-		if err := iptable.EnsureJumpRule(iptables.Nat, chain, ingressChain, "-m", "addrtype", "--dst-type", "LOCAL"); err != nil {
-			return fmt.Errorf("failed to add jump rule in %s to %s chain: %v", chain, ingressChain, err)
-		}
-	}
-
-	// The DOCKER-FORWARD chain is created by the bridge driver on startup. It's a stable place to
-	// put the jump to DOCKER-INGRESS (nothing else will ever be inserted before it, and the jump
-	// will precede the bridge driver's other rules).
-	// Add a jump rule in the DOCKER-FORWARD chain of the FILTER table to the DOCKER-INGRESS chain.
-	if err := iptable.EnsureJumpRule(iptables.Filter, bridge.DockerForwardChain, ingressChain); err != nil {
-		return fmt.Errorf("failed to add jump rule in %s to %s chain: %v", bridge.DockerForwardChain, ingressChain, err)
-	}
-
-	// Find the bridge interface name for the gateway IP.
-	oifName, err := findOIFName(gwIP)
-	if err != nil {
-		return fmt.Errorf("failed to find gateway bridge interface name for %s: %v", gwIP, err)
-	}
-	// Enable local routing for the gateway bridge interface by writing to /proc/sys/net/ipv4/conf/<oifName>/route_localnet.
-	path := filepath.Join("/proc/sys/net/ipv4/conf", oifName, "route_localnet")
-	if err := os.WriteFile(path, []byte{'1', '\n'}, 0o644); err != nil {
-		return fmt.Errorf("could not write to %s: %v", path, err)
-	}
-	// Add a POSTROUTING rule to the NAT table to masquerade traffic
-	rule := iptables.Rule{IPVer: iptables.IPv4, Table: iptables.Nat, Chain: "POSTROUTING", Args: []string{"-m", "addrtype", "--src-type", "LOCAL", "-o", oifName, "-j", "MASQUERADE"}}
-	if err := rule.Insert(); err != nil {
-		return fmt.Errorf("failed to insert ingress localhost POSTROUTING rule for %s: %v", oifName, err)
-	}
-	return nil
-}
-
 func removeIngressPorts(gwIP net.IP, ingressPorts []*PortConfig) error {
 	// TODO IPv6 support
 
@@ -369,7 +143,7 @@ func removeIngressPorts(gwIP net.IP, ingressPorts []*PortConfig) error {
 	// Filter the ingress ports until port rules start to be added/deleted
 	filteredPorts := filterPortConfigs(ingressPorts, true)
 
-	if err := deleteIngressPortsRules(gwIP, filteredPorts); err != nil {
+	if err := deleteIngressPortsRulesIPTables(gwIP, filteredPorts); err != nil {
 		filterPortConfigs(ingressPorts, false)
 		return fmt.Errorf("failed to program ingress ports: %v", err)
 	}
@@ -386,7 +160,7 @@ func addIngressPorts(gwIP net.IP, ingressPorts []*PortConfig) error {
 	// Filter the ingress ports until port rules start to be added/deleted
 	filteredPorts := filterPortConfigs(ingressPorts, false)
 
-	if err := programIngressPortsRules(gwIP, filteredPorts); err != nil {
+	if err := programIngressPortsRulesIPTables(gwIP, filteredPorts); err != nil {
 		filterPortConfigs(filteredPorts, true)
 		return fmt.Errorf("failed to program ingress ports: %v", err)
 	}
@@ -400,83 +174,8 @@ func restoreIngressPorts(gwIP net.IP, ingressPorts []*PortConfig) error {
 	ingressMu.Lock()
 	defer ingressMu.Unlock()
 
-	if err := programIngressPortsRules(gwIP, ingressPorts); err != nil {
+	if err := programIngressPortsRulesIPTables(gwIP, ingressPorts); err != nil {
 		return fmt.Errorf("failed to program ingress ports: %v", err)
-	}
-
-	return nil
-}
-
-func generateIngressRules(port *PortConfig, destIP net.IP) []iptables.Rule {
-	var (
-		protocol      = strings.ToLower(port.Protocol.String())
-		publishedPort = strconv.FormatUint(uint64(port.PublishedPort), 10)
-		destination   = net.JoinHostPort(destIP.String(), publishedPort)
-	)
-	return []iptables.Rule{
-		{
-			IPVer: iptables.IPv4,
-			Table: iptables.Nat,
-			Chain: ingressChain,
-			Args:  []string{"-p", protocol, "--dport", publishedPort, "-j", "DNAT", "--to-destination", destination},
-		},
-		{
-			IPVer: iptables.IPv4,
-			Table: iptables.Filter,
-			Chain: ingressChain,
-			Args:  []string{"-p", protocol, "--sport", publishedPort, "-m", "conntrack", "--ctstate", "ESTABLISHED,RELATED", "-j", "ACCEPT"},
-		},
-		{
-			IPVer: iptables.IPv4,
-			Table: iptables.Filter,
-			Chain: ingressChain,
-			Args:  []string{"-p", protocol, "--dport", publishedPort, "-j", "ACCEPT"},
-		},
-	}
-}
-
-func programIngressPortsRules(gwIP net.IP, filteredPorts []*PortConfig) (portErr error) {
-	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
-
-	if err := initIngressConfiguration(gwIP, iptable); err != nil {
-		return err
-	}
-
-	rollbackRules := make([]iptables.Rule, 0, len(filteredPorts)*3)
-	defer func() {
-		if portErr != nil {
-			for _, rule := range rollbackRules {
-				if err := rule.Delete(); err != nil {
-					log.G(context.TODO()).Warnf("roll back rule failed, %v: %v", rule, err)
-				}
-			}
-		}
-	}()
-
-	for _, iPort := range filteredPorts {
-		for _, rule := range generateIngressRules(iPort, gwIP) {
-			if portErr = rule.Insert(); portErr != nil {
-				err := fmt.Errorf("set up rule failed, %v: %v", rule, portErr)
-				return err
-			}
-			rollbackRules = append(rollbackRules, rule)
-		}
-	}
-
-	return nil
-}
-
-func deleteIngressPortsRules(gwIP net.IP, filteredPorts []*PortConfig) error {
-	var portErr error
-
-	for _, iPort := range filteredPorts {
-		for _, rule := range generateIngressRules(iPort, gwIP) {
-			if portErr = rule.Delete(); portErr != nil {
-				err := fmt.Errorf("delete rule failed, %v: %v", rule, portErr)
-				log.G(context.TODO()).Warn(err)
-			}
-		}
 	}
 
 	return nil
@@ -551,121 +250,6 @@ func plumbIngressPortsProxy(ingressPorts []*PortConfig) {
 	}
 }
 
-// configureFWMark configures the sandbox firewall to mark vip destined packets
-// with the firewall mark fwMark.
-func (sb *Sandbox) configureFWMark(vip net.IP, fwMark uint32, ingressPorts []*PortConfig, eIP *net.IPNet, isDelete bool, lbMode string) error {
-	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
-
-	fwMarkStr := strconv.FormatUint(uint64(fwMark), 10)
-	addDelOpt := "-A"
-	if isDelete {
-		addDelOpt = "-D"
-	}
-
-	rules := make([][]string, 0, len(ingressPorts))
-	for _, iPort := range ingressPorts {
-		var (
-			protocol      = strings.ToLower(PortConfig_Protocol_name[int32(iPort.Protocol)])
-			publishedPort = strconv.FormatUint(uint64(iPort.PublishedPort), 10)
-		)
-		rule := []string{"-t", "mangle", addDelOpt, "PREROUTING", "-p", protocol, "--dport", publishedPort, "-j", "MARK", "--set-mark", fwMarkStr}
-		rules = append(rules, rule)
-	}
-
-	var innerErr error
-	err := sb.ExecFunc(func() {
-		if !isDelete && lbMode == loadBalancerModeNAT {
-			subnet := net.IPNet{IP: eIP.IP.Mask(eIP.Mask), Mask: eIP.Mask}
-			ruleParams := []string{"-m", "ipvs", "--ipvs", "-d", subnet.String(), "-j", "SNAT", "--to-source", eIP.IP.String()}
-			if !iptable.Exists("nat", "POSTROUTING", ruleParams...) {
-				rule := append([]string{"-t", "nat", "-A", "POSTROUTING"}, ruleParams...)
-				rules = append(rules, rule)
-
-				err := os.WriteFile("/proc/sys/net/ipv4/vs/conntrack", []byte{'1', '\n'}, 0o644)
-				if err != nil {
-					innerErr = err
-					return
-				}
-			}
-		}
-
-		rule := []string{"-t", "mangle", addDelOpt, "INPUT", "-d", vip.String() + "/32", "-j", "MARK", "--set-mark", fwMarkStr}
-		rules = append(rules, rule)
-
-		for _, rule := range rules {
-			if err := iptable.RawCombinedOutputNative(rule...); err != nil {
-				innerErr = fmt.Errorf("set up rule failed, %v: %w", rule, err)
-				return
-			}
-		}
-	})
-	if err != nil {
-		return err
-	}
-	return innerErr
-}
-
 func (sb *Sandbox) addRedirectRules(eIP *net.IPNet, ingressPorts []*PortConfig) error {
-	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
-	ipAddr := eIP.IP.String()
-
-	rules := make([][]string, 0, len(ingressPorts)*3) // 3 rules per port
-	for _, iPort := range ingressPorts {
-		var (
-			protocol      = strings.ToLower(PortConfig_Protocol_name[int32(iPort.Protocol)])
-			publishedPort = strconv.FormatUint(uint64(iPort.PublishedPort), 10)
-			targetPort    = strconv.FormatUint(uint64(iPort.TargetPort), 10)
-		)
-
-		rules = append(rules,
-			[]string{"-t", "nat", "-A", "PREROUTING", "-d", ipAddr, "-p", protocol, "--dport", publishedPort, "-j", "REDIRECT", "--to-port", targetPort},
-
-			// Allow only incoming connections to exposed ports
-			[]string{"-I", "INPUT", "-d", ipAddr, "-p", protocol, "--dport", targetPort, "-m", "conntrack", "--ctstate", "NEW,ESTABLISHED", "-j", "ACCEPT"},
-
-			// Allow only outgoing connections from exposed ports
-			[]string{"-I", "OUTPUT", "-s", ipAddr, "-p", protocol, "--sport", targetPort, "-m", "conntrack", "--ctstate", "ESTABLISHED", "-j", "ACCEPT"},
-		)
-	}
-
-	var innerErr error
-	err := sb.ExecFunc(func() {
-		for _, rule := range rules {
-			if err := iptable.RawCombinedOutputNative(rule...); err != nil {
-				innerErr = fmt.Errorf("set up rule failed, %v: %w", rule, err)
-				return
-			}
-		}
-
-		if len(ingressPorts) == 0 {
-			return
-		}
-
-		// Ensure blocking rules for anything else in/to ingress network
-		for _, rule := range [][]string{
-			{"-d", ipAddr, "-p", "sctp", "-j", "DROP"},
-			{"-d", ipAddr, "-p", "udp", "-j", "DROP"},
-			{"-d", ipAddr, "-p", "tcp", "-j", "DROP"},
-		} {
-			if !iptable.ExistsNative(iptables.Filter, "INPUT", rule...) {
-				if err := iptable.RawCombinedOutputNative(append([]string{"-A", "INPUT"}, rule...)...); err != nil {
-					innerErr = fmt.Errorf("set up rule failed, %v: %w", rule, err)
-					return
-				}
-			}
-			rule[0] = "-s"
-			if !iptable.ExistsNative(iptables.Filter, "OUTPUT", rule...) {
-				if err := iptable.RawCombinedOutputNative(append([]string{"-A", "OUTPUT"}, rule...)...); err != nil {
-					innerErr = fmt.Errorf("set up rule failed, %v: %w", rule, err)
-					return
-				}
-			}
-		}
-	})
-	if err != nil {
-		return err
-	}
-	return innerErr
+	return sb.addRedirectRulesIPTables(eIP, ingressPorts)
 }

--- a/daemon/libnetwork/service_nftables_linux.go
+++ b/daemon/libnetwork/service_nftables_linux.go
@@ -1,0 +1,450 @@
+package libnetwork
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/containerd/log"
+	"github.com/moby/moby/v2/daemon/libnetwork/internal/maputil"
+	"github.com/moby/moby/v2/daemon/libnetwork/internal/nftables"
+)
+
+var (
+	nftablesIngressInit  sync.Mutex
+	nftablesIngressTable nftables.Table
+)
+
+const (
+	ingressPublishedPortsSet = "published-ports"
+)
+
+// initIngressConfigurationNftables programs the kernel for ingress using
+// nftables. Unlike [initIngressConfigurationIPTables], the caller is
+// responsible for ensuring that this function is only called once.
+func initIngressConfigurationNftables(ctx context.Context, gwIP net.IP) error {
+	// Find the bridge interface name for the gateway IP.
+	oifName, err := findOIFName(gwIP)
+	if err != nil {
+		return fmt.Errorf("failed to find gateway bridge interface name for %s: %v", gwIP, err)
+	}
+	// Enable local routing for the gateway bridge interface by writing to /proc/sys/net/ipv4/conf/<oifName>/route_localnet.
+	path := filepath.Join("/proc/sys/net/ipv4/conf", oifName, "route_localnet")
+	if err := os.WriteFile(path, []byte{'1', '\n'}, 0o644); err != nil { //nolint:gosec // gosec complains about perms here, which must be 0644 in this case
+		return fmt.Errorf("could not write to %s: %v", path, err)
+	}
+
+	nftablesIngressTable, err = nftables.NewTable(nftables.IPv4, "docker-ingress")
+	if err != nil {
+		return err
+	}
+	var tm nftables.Modifier
+
+	tm.Create(nftables.Set{
+		Name:        ingressPublishedPortsSet,
+		ElementType: nftables.InetProto.Concat(nftables.InetService),
+		Counter:     true,
+	})
+
+	dnatRule := []string{"fib daddr type local meta l4proto { tcp, udp, sctp }",
+		"meta l4proto . th dport @" + ingressPublishedPortsSet, "dnat to", gwIP.String()}
+	nftables.BaseChain{
+		Name:      "prerouting",
+		ChainType: nftables.BaseChainTypeNAT,
+		Hook:      nftables.BaseChainHookPrerouting,
+		Priority:  nftables.BaseChainPriorityDstNAT,
+		Policy:    nftables.BaseChainPolicyAccept,
+	}.Builder().
+		Rule(dnatRule...).
+		Create(&tm)
+
+	nftables.BaseChain{
+		Name:      "output",
+		ChainType: nftables.BaseChainTypeNAT,
+		Hook:      nftables.BaseChainHookOutput,
+		Priority:  nftables.BaseChainPriorityDstNAT,
+		Policy:    nftables.BaseChainPolicyAccept,
+	}.Builder().
+		Rule(dnatRule...).
+		Create(&tm)
+
+	nftables.BaseChain{
+		Name:      "postrouting",
+		ChainType: nftables.BaseChainTypeNAT,
+		Hook:      nftables.BaseChainHookPostrouting,
+		Priority:  nftables.BaseChainPrioritySrcNAT,
+		Policy:    nftables.BaseChainPolicyAccept,
+	}.Builder().
+		Rule("meta l4proto . th dport @"+ingressPublishedPortsSet, "oifname", oifName,
+			"fib saddr type local counter masquerade").
+		Rule("meta l4proto . th dport @"+ingressPublishedPortsSet, "iifname !=", oifName,
+			"oifname", oifName, "ip daddr", gwIP.String(), "counter masquerade").
+		Create(&tm)
+
+	return nftablesIngressTable.Apply(ctx, tm)
+}
+
+func (n *Network) syncLBBackendsNftables(ctx context.Context, lb *loadBalancer, rmService bool) bool {
+	ep, sb, err := n.findLBEndpointSandbox()
+	if err != nil {
+		log.G(ctx).Errorf("syncLBBackendsNftables %s/%s: %v", n.ID(), n.Name(), err)
+		return false
+	}
+	if sb.osSbox == nil {
+		return false
+	}
+
+	// Add IP alias for the VIP to the endpoint
+	ifName := findIfaceDstName(sb, ep)
+	if ifName == "" {
+		log.G(ctx).Errorf("Failed find interface name for endpoint %s(%s) to create LB alias", ep.ID(), ep.Name())
+		return false
+	}
+
+	backends := maputil.FilterValues(lb.backEnds, func(backend *lbBackend) bool { return !backend.disabled })
+	newService := lb.nftBackendsProgrammed == 0 && len(backends) > 0
+	delService := rmService && lb.nftBackendsProgrammed > 0 && len(backends) == 0
+
+	vip := lb.vip.String()
+	if newService {
+		log.G(ctx).Debugf("Creating service for vip %s ingressPorts %#v in sbox %.7s (%.7s)", vip, lb.service.ingressPorts, sb.ID(), sb.ContainerID())
+
+		err := sb.osSbox.AddAliasIP(ifName, &net.IPNet{IP: lb.vip, Mask: net.CIDRMask(32, 32)})
+		if err != nil {
+			log.G(ctx).Errorf("Failed add IP alias %s to network %s LB endpoint interface %s: %v", vip, n.ID(), ifName, err)
+			return false
+		}
+	} else if delService {
+		err := sb.osSbox.RemoveAliasIP(ifName, &net.IPNet{IP: lb.vip, Mask: net.CIDRMask(32, 32)})
+		if err != nil {
+			log.G(ctx).Errorf("Failed remove IP alias %s from network %s LB endpoint interface %s: %v", vip, n.ID(), ifName, err)
+			return false
+		}
+	}
+
+	const (
+		natServiceVipMap  = "nat-service-vip"
+		natPublishPortMap = "nat-publish-port"
+		modulus           = 65536
+		numgenExpr        = "numgen random mod 65536"
+	)
+	backendIntervals := nftables.EqualWeightIntervals(backends, modulus)
+	var natAdd nftables.Modifier
+	for i, b := range backendIntervals {
+		bip := b.ip.String()
+		natAdd.Create(nftables.MapElement{
+			MapName: natServiceVipMap,
+			Key:     fmt.Sprintf("%s . %s", vip, i),
+			Value:   bip,
+		})
+		for _, p := range lb.service.ingressPorts {
+			natAdd.Create(nftables.MapElement{
+				MapName: natPublishPortMap,
+				Key:     fmt.Sprintf("%s . %v . %s", strings.ToLower(p.Protocol.String()), p.PublishedPort, i),
+				Value:   bip,
+			})
+		}
+	}
+
+	err = sb.osSbox.ApplyNFTable(ctx, nftables.IPv4, "docker-lb-nat", func(natInit *nftables.Modifier) error {
+		natInit.Create(nftables.Map{
+			Name:        natServiceVipMap,
+			ElementType: nftables.Typeof("ip daddr").Concat(numgenExpr).MapTo("ip daddr"),
+			Flags:       []string{"interval"},
+			Counter:     true,
+		})
+
+		natInit.Create(nftables.Map{
+			Name:        natPublishPortMap,
+			ElementType: nftables.Typeof("meta l4proto . th dport").Concat(numgenExpr).MapTo("ip daddr"),
+			Flags:       []string{"interval"},
+			Counter:     true,
+		})
+
+		nftables.BaseChain{
+			Name:      "prerouting",
+			ChainType: nftables.BaseChainTypeNAT,
+			Hook:      nftables.BaseChainHookPrerouting,
+			Priority:  nftables.BaseChainPriorityDstNAT,
+			Policy:    nftables.BaseChainPolicyAccept,
+		}.Builder().
+			Rule("dnat to ip daddr .", numgenExpr, "map @"+natServiceVipMap).
+			Rule("dnat to meta l4proto . th dport .", numgenExpr, "map @"+natPublishPortMap).
+			Create(natInit)
+
+		nftables.BaseChain{
+			Name:      "postrouting",
+			ChainType: nftables.BaseChainTypeNAT,
+			Hook:      nftables.BaseChainHookPostrouting,
+			Priority:  nftables.BaseChainPrioritySrcNAT,
+			Policy:    nftables.BaseChainPolicyAccept,
+		}.Builder().
+			Rule("ct status dnat counter masquerade").
+			Create(natInit)
+		return nil
+	}, lb.nftClearNAT, natAdd)
+	if err != nil {
+		log.G(ctx).WithError(err).Error("Failed to apply changes to nftables nat table")
+	} else {
+		lb.nftClearNAT = natAdd.Reverse()
+		lb.nftBackendsProgrammed = len(backends)
+	}
+
+	if n.loadBalancerMode == loadBalancerModeDSR {
+		const (
+			dsrVipSet        = "vip"
+			dsrRealServerMap = "real-server"
+		)
+		var dsrAdd nftables.Modifier
+		dsrAdd.Create(nftables.SetElement{
+			SetName: dsrVipSet,
+			Element: vip,
+			Comment: fmt.Sprintf("%s (%s)", lb.service.name, lb.service.id),
+		})
+
+		for i, b := range backendIntervals {
+			bip := b.ip.String()
+			dsrAdd.Create(nftables.MapElement{
+				MapName: dsrRealServerMap,
+				Key:     fmt.Sprintf("%s . %s", vip, i),
+				Value:   bip,
+			})
+		}
+
+		err := sb.osSbox.ApplyNFTable(ctx, nftables.Netdev, "docker-lb-dsr", func(dsrInit *nftables.Modifier) error {
+			l4protos := []string{"tcp", "udp", "sctp"}
+
+			dsrInit.Create(nftables.Set{
+				Name:        dsrVipSet,
+				ElementType: nftables.IPv4Addr,
+				Counter:     true,
+			})
+			dsrInit.Create(nftables.Map{
+				Name:        dsrRealServerMap,
+				ElementType: nftables.Typeof("ip daddr").Concat(numgenExpr).MapTo("ip daddr"),
+				Flags:       []string{"interval"},
+				Counter:     true,
+			})
+
+			// Sticky overlay DSR sessions.
+			// Split by L4 protocol as nftables 1.0.6 crashes when attempting to
+			// compile a ruleset that contains a map update on a 5-tuple key.
+			for _, l4proto := range l4protos {
+				dsrInit.Create(nftables.Map{
+					Name:        "dsr-conntrack-" + l4proto,
+					ElementType: nftables.Typeof("ip saddr . th sport . ip daddr . th dport").MapTo("ether daddr"),
+					Flags:       []string{"dynamic"},
+					Size:        65536,
+					Timeout:     60 * time.Second,
+				})
+			}
+
+			b := nftables.BaseChain{
+				Name:      "ingress",
+				ChainType: nftables.BaseChainTypeFilter,
+				Hook:      nftables.BaseChainHookIngress,
+				Device:    ifName,
+				Priority:  nftables.BaseChainPriorityFilter,
+				Policy:    nftables.BaseChainPolicyAccept,
+			}.Builder().
+				Rule("meta protocol arp counter accept").
+				Rule("ip daddr != @"+dsrVipSet, "counter accept").
+				Rule("notrack ether saddr set ether daddr counter")
+
+			for _, l4proto := range l4protos {
+				// Established session: reuse MAC from conntrack map.
+				b.Rule("ip protocol", l4proto,
+					"ether daddr set ip saddr . th sport . ip daddr . th dport",
+					"map @dsr-conntrack-"+l4proto, "counter fwd to", ifName)
+			}
+			b.
+				// New session: random bucket lookup. The session is
+				// persisted to the conntrack map in the egress chain.
+				Rule("ip protocol {", strings.Join(l4protos, ", "), "}",
+					"fwd ip to ip daddr .", numgenExpr, "map @"+dsrRealServerMap, "device", ifName).
+				// The service is defined but the packet does not correspond to
+				// an established session and no backends are available for a new
+				// session.
+				Rule("counter drop").
+				Create(dsrInit)
+
+			b = nftables.BaseChain{
+				Name:      "egress",
+				ChainType: nftables.BaseChainTypeFilter,
+				Hook:      nftables.BaseChainHookEgress,
+				Device:    ifName,
+				Priority:  nftables.BaseChainPriorityFilter,
+				Policy:    nftables.BaseChainPolicyAccept,
+			}.Builder().
+				Rule("meta protocol arp counter accept").
+				Rule("ip daddr != @"+dsrVipSet, "counter accept").
+				// We can confidently stop tracking a TCP session that has been reset.
+				Rule("tcp flags rst update @dsr-conntrack-tcp",
+					"{ ip saddr . th sport . ip daddr . th dport : ether daddr timeout 0s }",
+					"counter accept")
+			for _, l4proto := range l4protos {
+				b.Rule("ip protocol", l4proto, "update @dsr-conntrack-"+l4proto,
+					"{ ip saddr . th sport . ip daddr . th dport : ether daddr }",
+					"counter accept")
+			}
+			b.Create(dsrInit)
+			return nil
+		}, lb.nftClearDSR, dsrAdd)
+
+		if err != nil {
+			log.G(ctx).WithError(err).Error("Failed to apply changes to nftables dsr table")
+		} else {
+			lb.nftClearDSR = dsrAdd.Reverse()
+		}
+	}
+
+	return newService
+}
+
+func deleteIngressPortsNftables(ctx context.Context, filteredPorts []*PortConfig) error {
+	nftablesIngressInit.Lock()
+	valid := nftablesIngressTable.IsValid()
+	nftablesIngressInit.Unlock()
+	if !valid {
+		// There are no ports to delete if the table hasn't been initialized yet.
+		return nil
+	}
+
+	var tm nftables.Modifier
+	for _, p := range filteredPorts {
+		tm.Delete(nftables.SetElement{
+			SetName: ingressPublishedPortsSet,
+			Element: fmt.Sprintf("%s . %d", strings.ToLower(p.Protocol.String()), p.PublishedPort),
+			Comment: p.Name,
+		})
+	}
+
+	return nftablesIngressTable.Apply(ctx, tm)
+}
+
+func addIngressPortsNftables(ctx context.Context, gwIP net.IP, filteredPorts []*PortConfig) error {
+	err := func() error {
+		nftablesIngressInit.Lock()
+		defer nftablesIngressInit.Unlock()
+		if !nftablesIngressTable.IsValid() {
+			return initIngressConfigurationNftables(context.WithoutCancel(ctx), gwIP)
+		}
+		return nil
+	}()
+	if err != nil {
+		return err
+	}
+
+	var tm nftables.Modifier
+	for _, p := range filteredPorts {
+		tm.Create(nftables.SetElement{
+			SetName: ingressPublishedPortsSet,
+			Element: fmt.Sprintf("%s . %d", strings.ToLower(p.Protocol.String()), p.PublishedPort),
+			Comment: p.Name,
+		})
+	}
+
+	return nftablesIngressTable.Apply(ctx, tm)
+}
+
+func (sb *Sandbox) addRedirectRulesNftables(ctx context.Context, eIP *net.IPNet, ingressPorts []*PortConfig) error {
+	if sb.osSbox == nil {
+		return nil
+	}
+
+	// The iptables implementation skips programming the rules to drop
+	// packets addressed to eIP on unpublished ports when the list of
+	// ingress ports is empty. It's a very strange behavior, but it's been
+	// like that for a decade, so we are replicating it here for
+	// consistency.
+	if len(ingressPorts) == 0 {
+		return nil
+	}
+
+	const (
+		publishedPortsMap = "published-ports"
+		ingressIPsSet     = "ingress-ips"
+	)
+	var tm nftables.Modifier
+	ingressIP := eIP.IP.String()
+	tm.Create(nftables.SetElement{
+		SetName: ingressIPsSet,
+		Element: ingressIP,
+	})
+	for _, p := range ingressPorts {
+		tm.Create(nftables.MapElement{
+			MapName: publishedPortsMap,
+			Key:     fmt.Sprintf("%s . %s . %d", ingressIP, strings.ToLower(p.Protocol.String()), p.PublishedPort),
+			Value:   strconv.FormatUint(uint64(p.TargetPort), 10),
+			Comment: p.Name,
+		})
+	}
+
+	err := sb.osSbox.ApplyNFTable(ctx, nftables.IPv4, "docker-container-ingress", func(initIngress *nftables.Modifier) error {
+		// Map of ingress-IP . publishPort -> targetPort.
+		// Packets with a destination address of ingress-IP and a
+		// destination port in this map are redirected to the target
+		// port.
+		initIngress.Create(nftables.Map{
+			Name:        publishedPortsMap,
+			ElementType: nftables.IPv4Addr.Concat(nftables.InetProto).Concat(nftables.InetService).MapTo(nftables.InetService),
+		})
+		initIngress.Create(nftables.Set{
+			Name:        ingressIPsSet,
+			ElementType: nftables.IPv4Addr,
+		})
+
+		nftables.BaseChain{
+			Name:      "prerouting",
+			ChainType: nftables.BaseChainTypeNAT,
+			Hook:      nftables.BaseChainHookPrerouting,
+			Priority:  nftables.BaseChainPriorityDstNAT,
+			Policy:    nftables.BaseChainPolicyAccept,
+		}.Builder().
+			Rule("meta l4proto { tcp, udp, sctp } redirect to ip daddr . meta l4proto . th dport map @" + publishedPortsMap).
+			Create(initIngress)
+
+		nftables.BaseChain{
+			Name:      "input",
+			ChainType: nftables.BaseChainTypeFilter,
+			Hook:      nftables.BaseChainHookInput,
+			Priority:  nftables.BaseChainPriorityFilter,
+			Policy:    nftables.BaseChainPolicyAccept,
+		}.Builder().
+			Rule("ip daddr != @"+ingressIPsSet, "counter accept").
+			Rule("icmp type { destination-unreachable, time-exceeded } counter accept").
+			// Only allow incoming connections to exposed ports
+			// from the ingress network.
+			Rule("ct state { established, related } counter accept").
+			Rule("ct status dnat counter accept").
+			Rule("counter reject").
+			Create(initIngress)
+
+		nftables.BaseChain{
+			Name:      "output",
+			ChainType: nftables.BaseChainTypeFilter,
+			Hook:      nftables.BaseChainHookOutput,
+			Priority:  nftables.BaseChainPriorityFilter,
+			Policy:    nftables.BaseChainPolicyAccept,
+		}.Builder().
+			Rule("ip saddr != @"+ingressIPsSet, "counter accept").
+			Rule("icmp type { destination-unreachable, time-exceeded } counter accept").
+			// Only allow outgoing replies for incoming connections
+			// to be transmitted over the ingress network.
+			Rule("ct status dnat ct state { established, related } counter accept").
+			Rule("counter reject").
+			Create(initIngress)
+
+		return nil
+	}, tm)
+	if err != nil {
+		return fmt.Errorf("failed to add redirect rules to nftables ingress table: %v", err)
+	}
+	return nil
+}

--- a/daemon/libnetwork/service_unsupported.go
+++ b/daemon/libnetwork/service_unsupported.go
@@ -7,6 +7,8 @@ import (
 	"net"
 )
 
+type osLoadBalancer struct{}
+
 func (c *Controller) cleanupServiceDiscovery(cleanupNID string) {}
 
 func (c *Controller) cleanupServiceBindings(nid string) {}

--- a/daemon/libnetwork/service_windows.go
+++ b/daemon/libnetwork/service_windows.go
@@ -8,6 +8,8 @@ import (
 	"github.com/containerd/log"
 )
 
+type osLoadBalancer struct{}
+
 type policyLists struct {
 	ilb *hcsshim.PolicyList
 	elb *hcsshim.PolicyList


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- For #49638 

## Summary
Add a native nftables implementation of service load balancing which approaches feature parity with the iptables firewall mode. This is achieved using a static nftables ruleset with dynamic data. NAT and DSR modes are both supported. The backend server for each flow is chosen randomly rather than round-robin like the iptables+IPVS implementation.

As the load balancer endpoint only sees one side of DSR flows we cannot use netfilter's conntrack subsystem. And IPVS does not play well with nftables -- nftables is missing an analogue for the `ipvs` xtables matcher. DSR flows are made sticky by implementing one-sided connection tracking directly in the nftables ruleset using maps that are updated in the packet path.

**The implementation is not yet complete.** Load balancing of requests from containers connected to the overlay network is fully functional out of the box. However, services are not accessible from published ports unless the docker_gwbridge network is configured with the option

    com.docker.network.bridge.gateway_mode_ipv4=nat-unprotected

as the bridge driver's nftables ruleset drops packets addressed to the host from hairpinned local containers or remote peers with the default gateway mode.

The implementation has been verified using an E2E test suite that is not public and which I am not at liberty to publish at this time.

## Release notes (optional)

This change is deliberately being omitted from the changelog as it is not feature-complete enough for end-users to try out.

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
