### PR TITLE
Remove dead CODEOWNERS rules for non-existent builder/, contrib/mkimage/, plugin/ paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,11 +3,8 @@
 #
 # KEEP THIS FILE SORTED. Order is important. Last match takes precedence.
 
-builder/**                              @tonistiigi
-contrib/mkimage/**                      @tianon
 daemon/graphdriver/overlay2/**          @dmcgowan
 daemon/graphdriver/windows/**           @johnstep
 daemon/logger/awslogs/**                @samuelkarp  
 hack/**                                 @tianon
-plugin/**                               @cpuguy83
 project/**                              @thaJeztah


### PR DESCRIPTION
Hi, and thank you for Moby.

`.github/CODEOWNERS` has three path rules whose directories no longer exist at those paths:
- `builder/**` (line 6) → 404
- `contrib/mkimage/**` (line 7) → 404
- `plugin/**` (line 12) → 404

Since the paths don't exist, these rules match nothing. This removes the three dead lines and leaves the live rules untouched.

For transparency: I used AI assistance to spot and draft this; I verified the 404s myself.