### PR TITLE
api: document Task.NetworksAttachments in the swagger definition

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4969,6 +4969,28 @@ definitions:
       PortStatus:
         $ref: "#/definitions/PortStatus"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -5013,6 +5035,13 @@ definitions:
           the JobIteration of the Service this Task was created for. Absent if
           the Task was created for a Replicated or Global Service.
         $ref: "#/definitions/ObjectVersion"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:


### PR DESCRIPTION
**- What I did**

The `GET /tasks` and `GET /tasks/{id}` endpoints return a `NetworksAttachments`
field on each task — it already appears in the response examples in
`api/swagger.yaml`, and in the Go type `api/types/swarm.Task`
(`NetworksAttachments []NetworkAttachment`). However the `Task` definition in
the swagger spec never declares it as a property, and there is no
`NetworkAttachment` definition.

As a result, clients generated from the swagger spec (for example
[bollard](https://github.com/fussybeaver/bollard) for Rust) silently drop the
per-task network attachment / address information, so swarm task IP addresses
are not exposed to them.

**- How I did it**

Added a `NetworkAttachment` definition (`Network` + `Addresses`) and a
`NetworksAttachments` array property on `Task`, matching the existing
`api/types/swarm.NetworkAttachment` Go type and the response examples already
present in the spec. Documentation only — no behaviour change.

**- How to verify it**

`GET /tasks` on a swarm with running services already returns
`NetworksAttachments`; the schema now documents it. The spec still parses as
valid YAML.
