### PR TITLE
Add umask support

### DIFF
--- a/api/types/container/hostconfig.go
+++ b/api/types/container/hostconfig.go
@@ -454,6 +454,7 @@ type HostConfig struct {
 	ShmSize         int64             // Total shm memory usage
 	Sysctls         map[string]string `json:",omitempty"` // List of Namespaced sysctls used for the container
 	Runtime         string            `json:",omitempty"` // Runtime to use with this container
+	Umask           *uint32           `json:",omitempty"` // Umask to use for the container
 
 	// Applicable to Windows
 	Isolation Isolation // Isolation technology of the container (e.g. default, hyperv)

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -1003,6 +1003,16 @@ func WithUser(c *container.Container) coci.SpecOpts {
 	}
 }
 
+// WithUmask sets the container's umask.
+func WithUmask(c *container.Container) coci.SpecOpts {
+	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
+		if c.HostConfig.Umask == nil {
+			return nil
+		}
+		return coci.WithUmask(*c.HostConfig.Umask)(ctx, nil, nil, s)
+	}
+}
+
 func (daemon *Daemon) createSpec(ctx context.Context, daemonCfg *configStore, c *container.Container, mounts []container.Mount) (retSpec *specs.Spec, _ error) {
 	var (
 		opts []coci.SpecOpts
@@ -1015,6 +1025,7 @@ func (daemon *Daemon) createSpec(ctx context.Context, daemonCfg *configStore, c 
 		WithSysctls(c),
 		// Set the user before CDI device injection, which may append supplementary groups.
 		WithUser(c),
+		WithUmask(c),
 		WithDevices(daemon, c),
 		withRlimits(daemon, &daemonCfg.Config, c),
 		WithNamespaces(daemon, c),

--- a/vendor/github.com/moby/moby/api/types/container/hostconfig.go
+++ b/vendor/github.com/moby/moby/api/types/container/hostconfig.go
@@ -454,6 +454,7 @@ type HostConfig struct {
 	ShmSize         int64             // Total shm memory usage
 	Sysctls         map[string]string `json:",omitempty"` // List of Namespaced sysctls used for the container
 	Runtime         string            `json:",omitempty"` // Runtime to use with this container
+	Umask           *uint32           `json:",omitempty"` // Umask to use for the container
 
 	// Applicable to Windows
 	Isolation Isolation // Isolation technology of the container (e.g. default, hyperv)


### PR DESCRIPTION
- Related to: https://github.com/moby/moby/issues/19189

## Summary

opencontainers/runtime-spec#941 added `Spec.Process.User.Umask` in 2019.
containers/crun#217 added umask support in 2019.
opencontainers/runc#2527 added umask support in 2020.
opencontainers/runc#3661 added umask support for exec in 2023.

This PR added HostConfig.Umask field, which allows set initial umask value for a Unix container.
The umask value applies to container's entrypoint, exec and healthcheck command.

See also docker/cli#7108

## Release notes (optional)

```markdown changelog
- Add HostConfig.Umask field to set initial umask value for a Unix container. Applies to entrypoint/exec/healthcheck.
```

## A picture of a cute animal (not mandatory but encouraged)
