### PR TITLE
daemon/cp: Remap copied ownership under user namespaces

### DIFF
--- a/daemon/archive_tarcopyoptions_unix.go
+++ b/daemon/archive_tarcopyoptions_unix.go
@@ -23,6 +23,10 @@ func (daemon *Daemon) tarCopyOptions(ctr *container.Container, allowOverwriteDir
 	if err != nil {
 		return nil, errdefs.InvalidParameter(err)
 	}
+	uid, gid, err = daemon.idMapping.ToHost(uid, gid)
+	if err != nil {
+		return nil, errdefs.InvalidParameter(err)
+	}
 
 	return &archive.TarOptions{
 		NoOverwriteDirNonDir: !allowOverwriteDirWithFile,


### PR DESCRIPTION

## Summary

When `copyUIDGID=true` is used to copy files into a container, `tarCopyOptions` resolves the configured container user and group in the container ID namespace.

The resolved IDs were passed directly to the host `lchown` operation. On daemons using user-namespace remapping, those IDs are not mapped into the daemon's subordinate UID/GID range, so files appear inside the container as the overflow owner `65534:65534`.

Translate the resolved UID and GID through `daemon.idMapping.ToHost` before constructing `archive.ChownOpts`. Non-remapped daemons retain the existing identity mapping behavior.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Fix `docker cp -a` using the wrong file owner when copying files into containers with user namespace remapping enabled.
```

## A picture of a cute animal (not mandatory but encouraged)
