### PR TITLE
[docker-29.x backport] hack: fix malformed ROOTLESSKIT_VERSION

### DIFF
--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # When updating, also update go.mod and Dockerfile accordingly.
-: "$ROOTLESSKIT_VERSION:=v3.0.2}"
+: "${ROOTLESSKIT_VERSION:=v3.0.2}"
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/53078

relates to https://github.com/docker/packaging/actions/runs/29403797638/job/87314400234?pr=479#step:7:1966

```
#34 2.460 + . /root/rpmbuild/BUILD/src/engine/hack/dockerfile/install/rootlesskit.installer
#34 2.461 ++ : ':=v3.0.2}'
#34 2.461 + install_rootlesskit dynamic
```

regression introduced in https://github.com/moby/moby/pull/53053