### PR TITLE
[docker-29.x backport] vendor: update buildkit to v0.31.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/mistifyio/go-zfs/v4 v4.0.0
 	github.com/mitchellh/copystructure v1.2.0
-	github.com/moby/buildkit v0.31.1
+	github.com/moby/buildkit v0.31.2
 	github.com/moby/docker-image-spec v1.3.1
 	github.com/moby/go-archive v0.2.0
 	github.com/moby/ipvs v1.1.0
@@ -96,7 +96,7 @@ require (
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
-	github.com/tonistiigi/fsutil v0.0.0-20260609174605-b61e79c0c046
+	github.com/tonistiigi/fsutil v0.0.0-20260716115106-30cd4fc5d911
 	github.com/tonistiigi/go-archvariant v1.0.0
 	github.com/vbatts/tar-split v0.12.3
 	github.com/vishvananda/netlink v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -542,8 +542,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/moby/buildkit v0.31.1 h1:j3p55abBl4kiXXPZgYX+6zWgB2aefqHXoPown12fIzU=
-github.com/moby/buildkit v0.31.1/go.mod h1:YM5iNEbNCc6L1Zt3YWFB/aXNLufvf4Rcu0DPlc9HwQg=
+github.com/moby/buildkit v0.31.2 h1:UsaoSa0z45ycj+8DqWwmiXKnszDSNvv3wYPGLVtcEKE=
+github.com/moby/buildkit v0.31.2/go.mod h1:q1QO35x5YryiXLONScL2IybwMIziz6Rq3FBznz8fmGc=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/go-archive v0.2.0 h1:zg5QDUM2mi0JIM9fdQZWC7U8+2ZfixfTYoHL7rWUcP8=
@@ -781,8 +781,8 @@ github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 h1:e/5i7d4oYZ+C
 github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399/go.mod h1:LdwHTNJT99C5fTAzDz0ud328OgXz+gierycbcIx2fRs=
 github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323 h1:r0p7fK56l8WPequOaR3i9LBqfPtEdXIQbUTzT55iqT4=
 github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323/go.mod h1:3Iuxbr0P7D3zUzBMAZB+ois3h/et0shEz0qApgHYGpY=
-github.com/tonistiigi/fsutil v0.0.0-20260609174605-b61e79c0c046 h1:j29MScUISj0S98EHdM6/pzKgqppfswl9OZ7OVpnQdzE=
-github.com/tonistiigi/fsutil v0.0.0-20260609174605-b61e79c0c046/go.mod h1:K5zrLch9UaSGNiek5XHZeqZUf1zPWJHqDfLIcnpquQ4=
+github.com/tonistiigi/fsutil v0.0.0-20260716115106-30cd4fc5d911 h1:xJZz1fhsRSrGTzQ6wvh1gX6d5jQaYjbIuGXT2s0AWuM=
+github.com/tonistiigi/fsutil v0.0.0-20260716115106-30cd4fc5d911/go.mod h1:K5zrLch9UaSGNiek5XHZeqZUf1zPWJHqDfLIcnpquQ4=
 github.com/tonistiigi/go-actions-cache v0.0.0-20260120203934-54bc28c26fd2 h1:5p6hffZeB25G4rhBc3HU6x1aIlyDELfib+/Omq+ZfQA=
 github.com/tonistiigi/go-actions-cache v0.0.0-20260120203934-54bc28c26fd2/go.mod h1:cD0SB2270BYw6HYKriFn4H6NRLhGj6ytf48YTpsm8LY=
 github.com/tonistiigi/go-archvariant v1.0.0 h1:5LC1eDWiBNflnTF1prCiX09yfNHIxDC/aukdhCdTyb0=

--- a/vendor/github.com/moby/buildkit/executor/oci/spec_windows.go
+++ b/vendor/github.com/moby/buildkit/executor/oci/spec_windows.go
@@ -18,6 +18,7 @@ import (
 	"github.com/moby/sys/user"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -111,8 +112,129 @@ func sub(m mount.Mount, subPath string) (mount.Mount, func() error, error) {
 	if err != nil {
 		return mount.Mount{}, nil, err
 	}
-	m.Source = src
-	return m, func() error { return nil }, nil
+
+	realSrc, release, err := resolveAndPinPath(src)
+	if err != nil {
+		return mount.Mount{}, nil, errors.Wrapf(err, "resolving and pinning mount source subpath %q", subPath)
+	}
+	if err := verifySubpathWithinRoot(m.Source, realSrc, subPath); err != nil {
+		_ = release()
+		return mount.Mount{}, nil, err
+	}
+
+	// Use the path of the object represented by the pinned handle. HCS can then
+	// realize the mount without traversing attacker-controlled reparse points in
+	// the original source path again.
+	m.Source = mountSourcePath(realSrc)
+	return m, release, nil
+}
+
+// resolveAndPinPath opens src while following reparse points and returns the
+// normalized path of the object represented by that handle. GENERIC_READ makes
+// the handle participate in share-access checks without requiring delete access
+// to the source. Omitting delete sharing prevents the resolved directory from
+// being renamed or deleted before HCS realizes the mount. Write sharing is still
+// allowed so a writable cache mount can modify contents while the handle is alive.
+func resolveAndPinPath(src string) (string, func() error, error) {
+	pathPtr, err := windows.UTF16PtrFromString(src)
+	if err != nil {
+		return "", nil, err
+	}
+	h, err := windows.CreateFile(
+		pathPtr,
+		windows.GENERIC_READ,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	if err != nil {
+		return "", nil, err
+	}
+
+	realSrc, err := finalPathNameByHandle(h)
+	if err != nil {
+		_ = windows.CloseHandle(h)
+		return "", nil, err
+	}
+	return realSrc, func() error { return windows.CloseHandle(h) }, nil
+}
+
+func verifySubpathWithinRoot(root, realSrc, subPath string) error {
+	realRoot, err := resolveFinalPath(root)
+	if err != nil {
+		return errors.Wrapf(err, "resolving mount root %q", root)
+	}
+	if !pathWithinRoot(realRoot, realSrc) {
+		return errors.Errorf("mount source subpath %q resolves to %q which escapes the mount root %q", subPath, realSrc, realRoot)
+	}
+	return nil
+}
+
+// resolveFinalPath returns the real path of p with all reparse points followed.
+func resolveFinalPath(p string) (string, error) {
+	pathPtr, err := windows.UTF16PtrFromString(p)
+	if err != nil {
+		return "", err
+	}
+	// FILE_FLAG_BACKUP_SEMANTICS allows opening a directory; omitting
+	// FILE_FLAG_OPEN_REPARSE_POINT makes GetFinalPathNameByHandle follow links.
+	h, err := windows.CreateFile(
+		pathPtr,
+		0,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer windows.CloseHandle(h)
+	return finalPathNameByHandle(h)
+}
+
+func finalPathNameByHandle(h windows.Handle) (string, error) {
+	// flags 0 == FILE_NAME_NORMALIZED | VOLUME_NAME_DOS.
+	n := uint32(windows.MAX_PATH)
+	for {
+		buf := make([]uint16, n)
+		got, err := windows.GetFinalPathNameByHandle(h, &buf[0], n, 0)
+		if err != nil {
+			return "", err
+		}
+		if got <= n {
+			return windows.UTF16ToString(buf[:got]), nil
+		}
+		n = got
+	}
+}
+
+func mountSourcePath(p string) string {
+	if strings.HasPrefix(p, `\\?\UNC\`) {
+		return `\\` + p[len(`\\?\UNC\`):]
+	}
+	if len(p) >= len(`\\?\C:\`) && p[:4] == `\\?\` && isDriveLetter(p[4]) && p[5:7] == `:\` {
+		return p[4:]
+	}
+	return p
+}
+
+func isDriveLetter(c byte) bool {
+	return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
+}
+
+// pathWithinRoot reports whether p is root or a descendant of root. Inputs are
+// already-resolved real paths; filepath.Rel handles case-insensitivity and
+// cross-volume paths on Windows.
+func pathWithinRoot(root, p string) bool {
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 func generateLinuxResourceOpts(res *pb.LinuxResources) ([]oci.SpecOpts, error) {

--- a/vendor/github.com/moby/buildkit/solver/jobs.go
+++ b/vendor/github.com/moby/buildkit/solver/jobs.go
@@ -354,9 +354,14 @@ func (sb *subBuilder) InContext(ctx context.Context, f func(context.Context, Job
 }
 
 func (sb *subBuilder) EachValue(ctx context.Context, key string, fn func(any) error) error {
-	sb.mu.Lock()
-	defer sb.mu.Unlock()
+	sb.state.mu.Lock()
+	jobs := make([]*Job, 0, len(sb.jobs))
 	for j := range sb.jobs {
+		jobs = append(jobs, j)
+	}
+	sb.state.mu.Unlock()
+
+	for _, j := range jobs {
 		if err := j.EachValue(ctx, key, fn); err != nil {
 			return err
 		}

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/file/backend.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/file/backend.go
@@ -162,12 +162,12 @@ func rm(d string, action *pb.FileActionRm) (err error) {
 }
 
 func rmPath(root, src string, allowNotFound bool) error {
-	src = filepath.Clean(src)
+	src = filepath.Join("/", src)
 	dir, base := filepath.Split(src)
 	if base == "" {
 		return errors.New("rmPath: invalid empty path")
 	}
-	dir, err := fs.RootPath(root, filepath.Join("/", dir))
+	dir, err := fs.RootPath(root, dir)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/ops/build.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/ops/build.go
@@ -77,7 +77,7 @@ func (b *BuildOp) Exec(ctx context.Context, job solver.JobContext, inputs []solv
 	}
 
 	i := int(llbDef.Input)
-	if i >= len(inputs) {
+	if i < 0 || i >= len(inputs) {
 		return nil, errors.Errorf("invalid index %v", i) // TODO: this should be validated before
 	}
 	inp := inputs[i]

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/ops/diff.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/ops/diff.go
@@ -70,6 +70,9 @@ func (d *diffOp) Exec(ctx context.Context, jobCtx solver.JobContext, inputs []so
 
 	var lowerRef cache.ImmutableRef
 	if d.op.Lower.Input != int64(pb.Empty) {
+		if curInput >= len(inputs) {
+			return nil, errors.Errorf("invalid lower input index %d for diff op with %d inputs", curInput, len(inputs))
+		}
 		if lowerInp := inputs[curInput]; lowerInp != nil {
 			wref, ok := lowerInp.Sys().(*worker.WorkerRef)
 			if !ok {
@@ -84,6 +87,9 @@ func (d *diffOp) Exec(ctx context.Context, jobCtx solver.JobContext, inputs []so
 
 	var upperRef cache.ImmutableRef
 	if d.op.Upper.Input != int64(pb.Empty) {
+		if curInput >= len(inputs) {
+			return nil, errors.Errorf("invalid upper input index %d for diff op with %d inputs", curInput, len(inputs))
+		}
 		if upperInp := inputs[curInput]; upperInp != nil {
 			wref, ok := upperInp.Sys().(*worker.WorkerRef)
 			if !ok {

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec.go
@@ -302,7 +302,7 @@ func (e *ExecOp) getMountDeps() ([]dep, error) {
 		if m.Input == int64(pb.Empty) {
 			continue
 		}
-		if int(m.Input) >= len(deps) {
+		if m.Input < 0 || int(m.Input) >= len(deps) {
 			return nil, errors.Errorf("invalid mountinput %v", m)
 		}
 
@@ -394,7 +394,7 @@ func (e *ExecOp) Exec(ctx context.Context, jobCtx solver.JobContext, inputs []so
 		if err != nil {
 			execInputs := make([]solver.Result, len(e.op.Mounts))
 			for i, m := range e.op.Mounts {
-				if m.Input == -1 {
+				if m.Input < 0 || int(m.Input) >= len(inputs) {
 					continue
 				}
 				execInputs[i] = inputs[m.Input].Clone()

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/ops/file.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/ops/file.go
@@ -149,6 +149,9 @@ func (f *fileOp) CacheMap(ctx context.Context, jobCtx solver.JobContext, index i
 	}
 
 	for idx, m := range selectors {
+		if idx < 0 || idx >= len(cm.Deps) {
+			return nil, false, errors.Errorf("invalid input index %d in file op with %d inputs", idx, len(cm.Deps))
+		}
 		if _, ok := invalidSelectors[idx]; ok {
 			continue
 		}

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/ops/opsutils/validate.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/ops/opsutils/validate.go
@@ -59,6 +59,9 @@ func Validate(op *pb.Op) error {
 		if op.Diff == nil {
 			return errors.Errorf("invalid nil diff op")
 		}
+		if op.Diff.Lower == nil || op.Diff.Upper == nil {
+			return errors.Errorf("invalid diff op with nil lower or upper input")
+		}
 	case *pb.Op_Passthrough:
 		if op.Passthrough == nil {
 			return errors.Errorf("invalid nil passthrough op")

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/vertex.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/vertex.go
@@ -367,6 +367,11 @@ func loadLLB(ctx context.Context, def *pb.Definition, polEngine SourcePolicyEval
 		if err := pbop.Unmarshal(dt); err != nil {
 			return solver.Edge{}, errors.Wrap(err, "failed to parse llb proto op")
 		}
+		for i, input := range pbop.Inputs {
+			if input.Index < 0 {
+				return solver.Edge{}, errors.Errorf("invalid input %d output index %d", i, input.Index)
+			}
+		}
 		dgst := digest.FromBytes(dt)
 		if pbop.GetSource() != nil {
 			sources[dgst] = struct{}{}
@@ -482,25 +487,16 @@ func llbOpName(pbOp *pb.Op, load func(string) (solver.Vertex, error)) (string, e
 		}
 		return "merge " + fmt.Sprintf("(%s)", strings.Join(subnames, ", ")), nil
 	case *pb.Op_Diff:
-		var lowerName string
-		if op.Diff.Lower.Input == -1 {
-			lowerName = "scratch"
-		} else {
-			lowerVtx, err := load(pbOp.Inputs[op.Diff.Lower.Input].Digest)
-			if err != nil {
-				return "", err
-			}
-			lowerName = fmt.Sprintf("(%s)", lowerVtx.Name())
+		if op.Diff.Lower == nil || op.Diff.Upper == nil {
+			return "", errors.Errorf("invalid diff op with nil lower or upper input")
 		}
-		var upperName string
-		if op.Diff.Upper.Input == -1 {
-			upperName = "scratch"
-		} else {
-			upperVtx, err := load(pbOp.Inputs[op.Diff.Upper.Input].Digest)
-			if err != nil {
-				return "", err
-			}
-			upperName = fmt.Sprintf("(%s)", upperVtx.Name())
+		lowerName, err := diffSideName(pbOp, op.Diff.Lower.Input, load)
+		if err != nil {
+			return "", err
+		}
+		upperName, err := diffSideName(pbOp, op.Diff.Upper.Input, load)
+		if err != nil {
+			return "", err
 		}
 		return "diff " + lowerName + " -> " + upperName, nil
 	case *pb.Op_Passthrough:
@@ -508,6 +504,20 @@ func llbOpName(pbOp *pb.Op, load func(string) (solver.Vertex, error)) (string, e
 	default:
 		return "unknown", nil
 	}
+}
+
+func diffSideName(pbOp *pb.Op, input int64, load func(string) (solver.Vertex, error)) (string, error) {
+	if input == int64(pb.Empty) {
+		return "scratch", nil
+	}
+	if input < 0 || int(input) >= len(pbOp.Inputs) {
+		return "", errors.Errorf("invalid diff input index %d", input)
+	}
+	vtx, err := load(pbOp.Inputs[input].Digest)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("(%s)", vtx.Name()), nil
 }
 
 func fileOpName(actions []*pb.FileAction) string {

--- a/vendor/github.com/moby/buildkit/source/git/bundle.go
+++ b/vendor/github.com/moby/buildkit/source/git/bundle.go
@@ -398,8 +398,8 @@ func (gs *gitSourceHandler) checkoutAsBundle(ctx context.Context, repo *gitRepo,
 	// natural-name ref to pull; update-ref alone places the tip against
 	// the pinned commit under the target name.
 	sharedURL := "file://" + repo.dir
-	if _, err := tmpGit.Run(ctx, "fetch", sharedURL, commit); err != nil {
-		return nil, errors.Wrapf(err, "failed to fetch commit %s from shared repo for bundle creation", commit)
+	if err := fetchCommitForBundle(ctx, tmpGit, sharedURL, commit); err != nil {
+		return nil, err
 	}
 
 	if _, err := tmpGit.Run(ctx, "update-ref", targetRef, commit); err != nil {
@@ -439,6 +439,13 @@ func (gs *gitSourceHandler) checkoutAsBundle(ctx context.Context, repo *gitRepo,
 	}
 	checkoutRef = nil
 	return snap, nil
+}
+
+func fetchCommitForBundle(ctx context.Context, git *gitutil.GitCLI, sharedURL, commit string) error {
+	if _, err := git.Run(ctx, "fetch", sharedURL, "--", commit); err != nil {
+		return errors.Wrapf(err, "failed to fetch commit %s from shared repo for bundle creation", commit)
+	}
+	return nil
 }
 
 // writeBundleToMount copies the bytes at stagePath into

--- a/vendor/github.com/moby/buildkit/source/git/source.go
+++ b/vendor/github.com/moby/buildkit/source/git/source.go
@@ -1557,7 +1557,11 @@ func getDefaultBranch(ctx context.Context, git *gitutil.GitCLI, remoteURL string
 	if len(ss) == 0 || len(ss[0]) != 2 {
 		return "", errors.Errorf("could not find default branch for repository: %s", urlutil.RedactCredentials(remoteURL))
 	}
-	return ss[0][1], nil
+	ref := ss[0][1]
+	if err := validateGitRef(ref); err != nil {
+		return "", err
+	}
+	return ref, nil
 }
 
 const (

--- a/vendor/github.com/tonistiigi/fsutil/validator.go
+++ b/vendor/github.com/tonistiigi/fsutil/validator.go
@@ -38,7 +38,7 @@ func (v *Validator) HandleChange(kind ChangeKind, p string, fi os.FileInfo, err 
 	if dir == "." {
 		dir = ""
 	}
-	if dir == ".." || strings.HasPrefix(p, filepath.FromSlash("../")) {
+	if p == ".." || dir == ".." || strings.HasPrefix(p, filepath.FromSlash("../")) {
 		return errors.WithStack(&os.PathError{Path: p, Err: syscall.EINVAL, Op: "escape check"})
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -983,7 +983,7 @@ github.com/mitchellh/hashstructure/v2
 # github.com/mitchellh/reflectwalk v1.0.2
 ## explicit
 github.com/mitchellh/reflectwalk
-# github.com/moby/buildkit v0.31.1
+# github.com/moby/buildkit v0.31.2
 ## explicit; go 1.25.9
 github.com/moby/buildkit/api/services/control
 github.com/moby/buildkit/api/types
@@ -1590,7 +1590,7 @@ github.com/tinylib/msgp/msgp
 # github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323
 ## explicit; go 1.21
 github.com/tonistiigi/dchapes-mode
-# github.com/tonistiigi/fsutil v0.0.0-20260609174605-b61e79c0c046
+# github.com/tonistiigi/fsutil v0.0.0-20260716115106-30cd4fc5d911
 ## explicit; go 1.25.0
 github.com/tonistiigi/fsutil
 github.com/tonistiigi/fsutil/copy


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/53087

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Update BuildKit to [v0.31.2](https://github.com/moby/buildkit/releases/tag/v0.31.2)
```

## A picture of a cute animal (not mandatory but encouraged)
