### PR TITLE
daemon: Restore host-gateway options after networks load

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -529,12 +529,15 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 
 				c.ResetRestartManager(false)
 				if !c.HostConfig.NetworkMode.IsContainer() && c.State.IsRunning() {
-					options, err := buildSandboxOptions(&cfg.Config, c)
-					if err != nil {
-						logger(c).WithError(err).Warn("failed to build sandbox option to restore container")
-					}
 					mapLock.Lock()
-					activeSandboxes[c.NetworkSettings.SandboxID] = options
+					activeSandboxes[c.NetworkSettings.SandboxID] = libnetwork.ActiveSandboxOptionBuilder(func(controller *libnetwork.Controller) []libnetwork.SandboxOption {
+						setHostGatewayIP(controller, &cfg.Config)
+						options, err := buildSandboxOptions(&cfg.Config, c)
+						if err != nil {
+							logger(c).WithError(err).Warn("failed to build sandbox option to restore container")
+						}
+						return options
+					})
 					mapLock.Unlock()
 				}
 			}

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -46,6 +46,9 @@ func adjustParallelLimit(n int, limit int) int {
 	return int(math.Max(1, math.Floor(float64(runtime.NumCPU())*.8)))
 }
 
+func setHostGatewayIP(*libnetwork.Controller, *config.Config) {
+}
+
 // Windows has no concept of an execution state directory. So use config.Root here.
 func getPluginExecRoot(cfg *config.Config) string {
 	return filepath.Join(cfg.Root, "plugins")

--- a/daemon/libnetwork/sandbox_store.go
+++ b/daemon/libnetwork/sandbox_store.go
@@ -165,6 +165,10 @@ func (sb *Sandbox) storeDelete() error {
 	})
 }
 
+// ActiveSandboxOptionBuilder builds options for restoring an active sandbox.
+// Persisted networks are available through controller when the builder is called.
+type ActiveSandboxOptionBuilder func(controller *Controller) []SandboxOption
+
 // sandboxRestore restores Sandbox objects from the store, deleting them if they're not active.
 func (c *Controller) sandboxRestore(activeSandboxes map[string]any) error {
 	sandboxStates, err := c.store.List(&sbState{c: c})
@@ -196,7 +200,7 @@ func (c *Controller) sandboxRestore(activeSandboxes map[string]any) error {
 		if val, ok := activeSandboxes[sb.ID()]; ok {
 			sb.isStub = false
 			isRestore = true
-			opts := val.([]SandboxOption)
+			opts := val.(ActiveSandboxOptionBuilder)(c)
 			sb.processOptions(opts...)
 			sb.restoreHostsPath()
 			sb.restoreResolvConfPath()

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -61,6 +61,42 @@ func TestDaemonRestartWithLiveRestore(t *testing.T) {
 	assert.Equal(t, res1.Network.IPAM.Config[0].Subnet, subnet)
 }
 
+func TestLiveRestoreWithHostGateway(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support live-restore")
+	ctx := setupTest(t)
+
+	t.Parallel()
+	d := daemon.New(t)
+	defer d.Stop(t)
+	d.StartWithBusybox(ctx, t, "--live-restore=true")
+
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
+
+	ctrID := container.Run(ctx, t, apiClient,
+		container.WithCmd("top"),
+		container.WithExtraHost("host.docker.internal:host-gateway"),
+	)
+
+	d.Restart(t, "--live-restore=true")
+
+	const networkName = "test-live-restore-host-gateway"
+	network.CreateNoError(ctx, t, apiClient, networkName, network.WithDriver("bridge"))
+	defer func() {
+		container.Remove(ctx, t, apiClient, ctrID, client.ContainerRemoveOptions{Force: true})
+		network.RemoveNoError(ctx, t, apiClient, networkName)
+	}()
+
+	_, err := apiClient.NetworkConnect(ctx, networkName, client.NetworkConnectOptions{Container: ctrID})
+	assert.NilError(t, err)
+
+	res, err := container.Exec(ctx, apiClient, ctrID, []string{"grep", "host.docker.internal", "/etc/hosts"})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(res.ExitCode, 0), res.Stderr())
+}
+
 func TestDaemonDefaultNetworkPools(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	// Remove docker0 bridge and the start daemon defining the predefined address pools


### PR DESCRIPTION
- fix: https://github.com/moby/moby/issues/53089

Live restore builds sandbox options before libnetwork derives the implicit default-bridge address for `host-gateway`. When a running container uses a `host-gateway` extra-host mapping, option construction fails and the restored sandbox loses its container-specific hosts and resolv.conf paths.

Subsequent network operations, such as connecting the container to another network, then fail.

Build active-sandbox options lazily during libnetwork restoration, after persisted networks are available - this allows the daemon to derive the default bridge gateway before constructing and applying the complete sandbox configuration.

 /flaky-check=TestLiveRestoreWithHostGateway
  
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Fix connecting live-restored containers with an implicit `host-gateway` mapping to additional networks.
```

## A picture of a cute animal (not mandatory but encouraged)
