### PR TITLE
plugin: clean path before prefix check in ScopedPath to prevent traversal

### DIFF
--- a/daemon/pkg/plugin/v2/plugin.go
+++ b/daemon/pkg/plugin/v2/plugin.go
@@ -48,11 +48,16 @@ func (e ErrInadequateCapability) Error() string {
 
 // ScopedPath returns the path scoped to the plugin rootfs
 func (p *Plugin) ScopedPath(s string) string {
-	if p.PluginObj.Config.PropagatedMount != "" && strings.HasPrefix(s, p.PluginObj.Config.PropagatedMount) {
+	// Clean the path first to resolve any ".." components before the prefix
+	// check. Without this, a plugin can craft a path such as
+	// "/propagated/../../../escape" that passes the HasPrefix check but,
+	// after filepath.Join normalises it, escapes the PropagatedMount root.
+	cleaned := filepath.Clean(s)
+	if p.PluginObj.Config.PropagatedMount != "" && strings.HasPrefix(cleaned, p.PluginObj.Config.PropagatedMount) {
 		// re-scope to the propagated mount path on the host
-		return filepath.Join(filepath.Dir(p.Rootfs), "propagated-mount", strings.TrimPrefix(s, p.PluginObj.Config.PropagatedMount))
+		return filepath.Join(filepath.Dir(p.Rootfs), "propagated-mount", strings.TrimPrefix(cleaned, p.PluginObj.Config.PropagatedMount))
 	}
-	return filepath.Join(p.Rootfs, s)
+	return filepath.Join(p.Rootfs, cleaned)
 }
 
 // Client returns the plugin client.

--- a/daemon/pkg/plugin/v2/plugin_test.go
+++ b/daemon/pkg/plugin/v2/plugin_test.go
@@ -1,0 +1,67 @@
+package v2
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/moby/moby/api/types/plugin"
+)
+
+func TestScopedPath(t *testing.T) {
+	rootfs := "/var/lib/docker/plugins/abc123/rootfs"
+	propagatedMount := "/propagated"
+
+	tests := []struct {
+		name            string
+		propagatedMount string
+		input           string
+		want            string
+	}{
+		{
+			name:  "no propagated mount, plain path",
+			input: "/some/path",
+			want:  filepath.Join(rootfs, "/some/path"),
+		},
+		{
+			name:            "path within propagated mount",
+			propagatedMount: propagatedMount,
+			input:           "/propagated/data",
+			want:            filepath.Join(filepath.Dir(rootfs), "propagated-mount", "/data"),
+		},
+		{
+			name:            "path outside propagated mount",
+			propagatedMount: propagatedMount,
+			input:           "/other/path",
+			want:            filepath.Join(rootfs, "/other/path"),
+		},
+		{
+			name:            "traversal attempt via propagated mount prefix",
+			propagatedMount: propagatedMount,
+			input:           "/propagated/../../../volumes/victimvol/_data",
+			want:            filepath.Join(rootfs, "/volumes/victimvol/_data"),
+		},
+		{
+			name:            "traversal with double-dot stays within propagated mount",
+			propagatedMount: propagatedMount,
+			input:           "/propagated/sub/../data",
+			want:            filepath.Join(filepath.Dir(rootfs), "propagated-mount", "/data"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &Plugin{
+				PluginObj: plugin.Plugin{
+					Config: plugin.Config{
+						PropagatedMount: tc.propagatedMount,
+					},
+				},
+				Rootfs: rootfs,
+			}
+			got := p.ScopedPath(tc.input)
+			if got != tc.want {
+				t.Errorf("ScopedPath(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/53023

## Summary

`Plugin.ScopedPath` used `strings.HasPrefix` to decide whether a plugin-returned path falls under the declared `PropagatedMount` root, but the check ran on the raw (uncleaned) input. A plugin could return a path like:

```
/propagated/../../../volumes/victimvol/_data
```

This passes `strings.HasPrefix(s, "/propagated")` but `filepath.Join` then normalises the `..` components, so the final host-side path escapes the intended `PropagatedMount` root entirely.

**Fix:** call `filepath.Clean` on the input before the prefix check, so the check and the subsequent path join both operate on the same normalised form.

```go
// before
if p.PluginObj.Config.PropagatedMount != "" && strings.HasPrefix(s, p.PluginObj.Config.PropagatedMount) {
    return filepath.Join(filepath.Dir(p.Rootfs), "propagated-mount", strings.TrimPrefix(s, p.PluginObj.Config.PropagatedMount))
}
return filepath.Join(p.Rootfs, s)

// after
cleaned := filepath.Clean(s)
if p.PluginObj.Config.PropagatedMount != "" && strings.HasPrefix(cleaned, p.PluginObj.Config.PropagatedMount) {
    return filepath.Join(filepath.Dir(p.Rootfs), "propagated-mount", strings.TrimPrefix(cleaned, p.PluginObj.Config.PropagatedMount))
}
return filepath.Join(p.Rootfs, cleaned)
```

A unit test covering the traversal case is added in `daemon/pkg/plugin/v2/plugin_test.go`.

## Release notes (optional)

```markdown changelog
Fix path traversal in `Plugin.ScopedPath` where a plugin-returned mountpoint containing `..` components could escape the declared `PropagatedMount` root.
```

Created with: Claude Code