### PR TITLE
daemon/containerd: Ignore malformed progress digests

### DIFF
--- a/daemon/containerd/progress.go
+++ b/daemon/containerd/progress.go
@@ -77,12 +77,15 @@ func (j *jobs) showProgress(ctx context.Context, out progress.Output, updater pr
 	}
 }
 
-// Add adds a descriptor to be tracked
+// Add adds descriptors with valid digests to be tracked.
 func (j *jobs) Add(desc ...ocispec.Descriptor) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
 	for _, d := range desc {
+		if d.Digest.Validate() != nil {
+			continue
+		}
 		if _, ok := j.descs[d.Digest]; ok {
 			continue
 		}


### PR DESCRIPTION
Pull progress assumes tracked descriptor digests are valid before calling Digest.Encoded. A malformed layer digest from a registry can therefore panic the progress goroutine and terminate the daemon.

Silently skip descriptors with invalid digests when adding progress jobs so the progress goroutine never observes them.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
