### PR TITLE
daemon: restore missing content after platform pull

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -265,6 +265,10 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 		return translateRegistryError(ctx, err)
 	}
 
+	if err := i.ensurePulledContentAvailable(ctx, ref.String(), resolver, img.Metadata(), p); err != nil {
+		return err
+	}
+
 	logger := log.G(ctx).WithFields(log.Fields{
 		"digest": img.Target().Digest,
 		"remote": ref.String(),
@@ -284,6 +288,39 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 	outNewImg = img
 
 	return nil
+}
+
+func (i *ImageService) ensurePulledContentAvailable(ctx context.Context, ref string, resolver remotes.Resolver, img c8dimages.Image, platform platforms.MatchComparer) error {
+	var fetcher remotes.Fetcher
+	var lastMissing []ocispec.Descriptor
+	// A successful pull normally leaves the manifest in the content store, so
+	// Check returns all missing config and layer descriptors in one pass. Retry
+	// once in case a resolver returned only the selected manifest initially.
+	for range 2 {
+		available, _, _, missing, err := c8dimages.Check(ctx, i.content, img.Target, platform)
+		if err != nil {
+			return err
+		}
+		if available && len(missing) == 0 {
+			return nil
+		}
+
+		lastMissing = missing
+		if fetcher == nil {
+			fetcher, err = resolver.Fetcher(ctx, ref)
+			if err != nil {
+				return translateRegistryError(ctx, err)
+			}
+		}
+
+		for _, desc := range missing {
+			if err := remotes.Fetch(ctx, i.content, fetcher, desc); err != nil && !cerrdefs.IsAlreadyExists(err) {
+				return translateRegistryError(ctx, err)
+			}
+		}
+	}
+
+	return errdefs.NotFound(fmt.Errorf("failed to fetch all content for %s: %d descriptors still missing", ref, len(lastMissing)))
 }
 
 func joinHandlerWrappers(funcs ...func(c8dimages.Handler) c8dimages.Handler) func(c8dimages.Handler) c8dimages.Handler {

--- a/daemon/containerd/image_pull_test.go
+++ b/daemon/containerd/image_pull_test.go
@@ -1,0 +1,95 @@
+package containerd
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/content"
+	c8dimages "github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/platforms"
+	"github.com/moby/moby/v2/internal/testutil/specialimage"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"gotest.tools/v3/assert"
+)
+
+func TestEnsurePulledContentAvailableFetchesMissingPlatformLayer(t *testing.T) {
+	ctx := namespaces.WithNamespace(t.Context(), "testing-"+t.Name())
+	cs := newWritableContentStore(ctx, t)
+	imgSvc := fakeImageService(t, ctx, cs)
+
+	srcDir := t.TempDir()
+	linuxAmd64 := platforms.MustParse("linux/amd64")
+	idx, manifests, err := specialimage.MultiPlatform(srcDir, "multiplatform:latest", []ocispec.Platform{linuxAmd64})
+	assert.NilError(t, err)
+	assert.Assert(t, len(manifests) == 1)
+
+	img := imagesFromIndex(idx)[0]
+
+	manifest := readManifestBlob(t, srcDir, manifests[0])
+	writeBlobFromSpecialImage(ctx, t, cs, srcDir, img.Target)
+	writeBlobFromSpecialImage(ctx, t, cs, srcDir, manifests[0])
+	writeBlobFromSpecialImage(ctx, t, cs, srcDir, manifest.Config)
+
+	available, _, _, missing, err := c8dimages.Check(ctx, cs, manifests[0], platforms.All)
+	assert.NilError(t, err)
+	assert.Check(t, available)
+	assert.Check(t, len(missing) == 1)
+
+	resolver := staticResolver{
+		fetcher: remotes.FetcherFunc(func(ctx context.Context, desc ocispec.Descriptor) (io.ReadCloser, error) {
+			return os.Open(blobPathForDescriptor(srcDir, desc))
+		}),
+	}
+
+	err = imgSvc.ensurePulledContentAvailable(ctx, "multiplatform:latest", resolver, img, platforms.Only(linuxAmd64))
+	assert.NilError(t, err)
+
+	available, _, _, missing, err = c8dimages.Check(ctx, cs, manifests[0], platforms.All)
+	assert.NilError(t, err)
+	assert.Check(t, available)
+	assert.Check(t, len(missing) == 0)
+}
+
+type staticResolver struct {
+	fetcher remotes.Fetcher
+}
+
+func (r staticResolver) Resolve(ctx context.Context, ref string) (string, ocispec.Descriptor, error) {
+	return ref, ocispec.Descriptor{}, nil
+}
+
+func (r staticResolver) Fetcher(ctx context.Context, ref string) (remotes.Fetcher, error) {
+	return r.fetcher, nil
+}
+
+func (r staticResolver) Pusher(ctx context.Context, ref string) (remotes.Pusher, error) {
+	return nil, nil
+}
+
+func readManifestBlob(t *testing.T, dir string, desc ocispec.Descriptor) ocispec.Manifest {
+	t.Helper()
+
+	mfst, err := readManifest(context.Background(), &blobsDirContentStore{blobs: filepath.Join(dir, "blobs/sha256")}, desc)
+	assert.NilError(t, err)
+	return mfst
+}
+
+func writeBlobFromSpecialImage(ctx context.Context, t *testing.T, cs content.Store, dir string, desc ocispec.Descriptor) {
+	t.Helper()
+
+	f, err := os.Open(blobPathForDescriptor(dir, desc))
+	assert.NilError(t, err)
+	defer f.Close()
+
+	err = content.WriteBlob(ctx, cs, desc.Digest.String(), f, desc)
+	assert.NilError(t, err)
+}
+
+func blobPathForDescriptor(dir string, desc ocispec.Descriptor) string {
+	return filepath.Join(dir, "blobs/sha256", desc.Digest.Encoded())
+}


### PR DESCRIPTION
## Summary

When the containerd image store reuses an unpacked snapshot, `WithPullUnpack` can leave packed config or layer blobs absent. The image can run, but pushing fails because push requires those content-store blobs.

After a successful pull, verify the selected platform content using containerd's existing platform matcher and fetch only missing config or layer descriptors. This adds regression coverage for the missing-layer state.

## Testing

- `go test ./daemon/containerd` in `golang:1.26.3-bookworm`