### PR TITLE
libnetwork: change ndotsSet to ndotsSetAndNotZero to ensure ndots > 0 before returning failure. 

### DIFF
--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -2056,7 +2056,7 @@ func (n *Network) ResolveService(ctx context.Context, name string) ([]*net.SRV, 
 	return srv, ip
 }
 
-func (n *Network) NdotsSet() bool {
+func (n *Network) NdotsSetAndNotZero() bool {
 	return false
 }
 

--- a/daemon/libnetwork/resolver.go
+++ b/daemon/libnetwork/resolver.go
@@ -43,8 +43,8 @@ type DNSBackend interface {
 	// ExecFunc allows a function to be executed in the context of the backend
 	// on behalf of the resolver.
 	ExecFunc(f func()) error
-	// NdotsSet queries the backends ndots dns option settings
-	NdotsSet() bool
+	// NdotsSetAndNotZero queries the backends ndots dns option settings
+	NdotsSetAndNotZero() bool
 	// HandleQueryResp passes the name & IP from a response to the backend. backend
 	// can use it to maintain any required state about the resolution
 	HandleQueryResp(name string, ip net.IP)
@@ -463,7 +463,7 @@ func (r *Resolver) serveDNS(w dns.ResponseWriter, query *dns.Msg) {
 	// in the root domain don't forward it out. We will return
 	// failure and let the client retry with the search domain
 	// attached.
-	if (queryType == dns.TypeA || queryType == dns.TypeAAAA) && r.backend.NdotsSet() &&
+	if (queryType == dns.TypeA || queryType == dns.TypeAAAA) && r.backend.NdotsSetAndNotZero() &&
 		!strings.Contains(strings.TrimSuffix(queryName, "."), ".") {
 		resp = createRespMsg(query)
 	} else {

--- a/daemon/libnetwork/resolver_test.go
+++ b/daemon/libnetwork/resolver_test.go
@@ -250,7 +250,7 @@ func (noopDNSBackend) ResolveName(_ context.Context, name string, ipType types.I
 
 func (noopDNSBackend) ExecFunc(f func()) error { f(); return nil }
 
-func (noopDNSBackend) NdotsSet() bool { return false }
+func (noopDNSBackend) NdotsSetAndNotZero() bool { return false }
 
 func (noopDNSBackend) HandleQueryResp(name string, ip net.IP) {}
 

--- a/daemon/libnetwork/sandbox.go
+++ b/daemon/libnetwork/sandbox.go
@@ -38,23 +38,23 @@ func (sb *Sandbox) processOptions(options ...SandboxOption) {
 // Sandbox provides the control over the network container entity.
 // It is a one to one mapping with the container.
 type Sandbox struct {
-	id              string
-	containerID     string
-	config          containerConfig
-	extDNS          []extDNSEntry
-	osSbox          *osl.Namespace
-	controller      *Controller
-	resolver        *Resolver
-	resolverOnce    sync.Once
-	dbIndex         uint64
-	dbExists        bool
-	isStub          bool
-	inDelete        bool
-	ingress         bool
-	ndotsSet        bool
-	oslTypes        []osl.SandboxType // slice of properties of this sandbox
-	loadBalancerNID string            // NID that this SB is a load balancer for
-	mu              sync.Mutex
+	id                 string
+	containerID        string
+	config             containerConfig
+	extDNS             []extDNSEntry
+	osSbox             *osl.Namespace
+	controller         *Controller
+	resolver           *Resolver
+	resolverOnce       sync.Once
+	dbIndex            uint64
+	dbExists           bool
+	isStub             bool
+	inDelete           bool
+	ingress            bool
+	ndotsSetAndNotZero bool
+	oslTypes           []osl.SandboxType // slice of properties of this sandbox
+	loadBalancerNID    string            // NID that this SB is a load balancer for
+	mu                 sync.Mutex
 
 	// joinLeaveMu is required as well as mu to modify the following fields,
 	// acquire joinLeaveMu first, and keep it at-least until gateway changes
@@ -671,6 +671,6 @@ func (ep *Endpoint) Less(epj *Endpoint) bool {
 	return ep.network.Name() < epj.network.Name()
 }
 
-func (sb *Sandbox) NdotsSet() bool {
-	return sb.ndotsSet
+func (sb *Sandbox) NdotsSetAndNotZero() bool {
+	return sb.ndotsSetAndNotZero
 }

--- a/daemon/libnetwork/sandbox_dns_unix.go
+++ b/daemon/libnetwork/sandbox_dns_unix.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/containerd/log"
@@ -317,8 +318,14 @@ func (sb *Sandbox) rebuildDNS() error {
 		return errors.New("no listen-address for internal resolver")
 	}
 
-	// Work out whether ndots has been set from host config or overrides.
-	_, sb.ndotsSet = rc.Option("ndots")
+	// Work out whether ndots has been set and is greater than 0 from host config or overrides.
+	if ndotsStr, isSet := rc.Option("ndots"); isSet {
+		ndots, err := strconv.Atoi(ndotsStr)
+		sb.ndotsSetAndNotZero = err == nil && ndots > 0
+	} else {
+		sb.ndotsSetAndNotZero = false
+	}
+
 	// Swap nameservers for the internal one, and make sure the required options are set.
 	var extNameServers []resolvconf.ExtDNSEntry
 	extNameServers, err = rc.TransformForIntNS(intNS, sb.resolver.ResolverOptions())


### PR DESCRIPTION
This PR Fixes: #53104 

## Summary
Resolver drops queries which contain no dots when it is not the authoritative server and`ndots` is set > 0. `NDotsSet()` was being used, but the issue is that it only checks if `ndots` is **set** not if it is > 0. 

Fix is to change `NDotsSet` -> `NDotsSetAndNotZero` to ensure that we still forward queries when `ndots` is set & equal to 0. 

For now, tested manually, by recreating https://github.com/moby/moby/issues/53104 and confirming issue no longer occurs. 
Ran unit & integration test suit locally to ensure it was passing. 


