### PR TITLE
daemon/containerd: expand exposed port ranges

### DIFF
--- a/daemon/containerd/image_import_test.go
+++ b/daemon/containerd/image_import_test.go
@@ -3,10 +3,19 @@ package containerd
 import (
 	"testing"
 
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+)
+
+const (
+	testExposedPortRange      = "33060-33061/tcp"
+	testExposedPortRangeStart = "33060/tcp"
+	testExposedPortRangeEnd   = "33061/tcp"
+	testInvalidExposedPort    = "invalid/tcp"
 )
 
 // regression test for https://github.com/moby/moby/issues/45904
@@ -19,4 +28,32 @@ func TestContainerConfigToDockerImageConfig(t *testing.T) {
 
 	expected := map[string]struct{}{"80/tcp": {}}
 	assert.Check(t, is.DeepEqual(ociCFG.ExposedPorts, expected))
+}
+
+func TestDockerImageConfigToContainerConfigWithExposedPortRange(t *testing.T) {
+	cfg := dockerOCIImageConfigToContainerConfig(dockerspec.DockerOCIImageConfig{
+		ImageConfig: ocispec.ImageConfig{
+			ExposedPorts: map[string]struct{}{
+				testExposedPortRange: {},
+			},
+		},
+	})
+
+	assert.Check(t, is.Contains(cfg.ExposedPorts, network.MustParsePort(testExposedPortRangeStart)))
+	assert.Check(t, is.Contains(cfg.ExposedPorts, network.MustParsePort(testExposedPortRangeEnd)))
+}
+
+func TestDockerImageConfigToContainerConfigSkipsInvalidExposedPorts(t *testing.T) {
+	cfg := dockerOCIImageConfigToContainerConfig(dockerspec.DockerOCIImageConfig{
+		ImageConfig: ocispec.ImageConfig{
+			ExposedPorts: map[string]struct{}{
+				testInvalidExposedPort: {},
+				testExposedPortRange:   {},
+			},
+		},
+	})
+
+	assert.Check(t, is.Len(cfg.ExposedPorts, 2))
+	assert.Check(t, is.Contains(cfg.ExposedPorts, network.MustParsePort(testExposedPortRangeStart)))
+	assert.Check(t, is.Contains(cfg.ExposedPorts, network.MustParsePort(testExposedPortRangeEnd)))
 }

--- a/daemon/containerd/imagespec.go
+++ b/daemon/containerd/imagespec.go
@@ -96,7 +96,11 @@ func containerConfigToDockerOCIImageConfig(cfg *container.Config) dockerspec.Doc
 func dockerOCIImageConfigToContainerConfig(cfg dockerspec.DockerOCIImageConfig) *container.Config {
 	exposedPorts := make(network.PortSet, len(cfg.ExposedPorts))
 	for k := range cfg.ExposedPorts {
-		if p, err := network.ParsePort(k); err == nil {
+		portRange, err := network.ParsePortRange(k)
+		if err != nil {
+			continue
+		}
+		for p := range portRange.All() {
 			exposedPorts[p] = struct{}{}
 		}
 	}

--- a/daemon/internal/image/image.go
+++ b/daemon/internal/image/image.go
@@ -10,9 +10,17 @@ import (
 	"time"
 
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/v2/daemon/internal/layer"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const (
+	imageConfigJSONKey          = "config"
+	imageContainerConfigJSONKey = "container_config"
+	exposedPortsJSONKey         = "ExposedPorts"
+	jsonNullValue               = "null"
 )
 
 // ID is the content-addressable ID of an image.
@@ -287,7 +295,12 @@ type Exporter interface {
 func NewFromJSON(src []byte) (*Image, error) {
 	img := &Image{}
 
-	if err := json.Unmarshal(src, img); err != nil {
+	normalized, err := normalizeConfigExposedPortRanges(src)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(normalized, img); err != nil {
 		return nil, err
 	}
 	if img.RootFS == nil {
@@ -297,4 +310,87 @@ func NewFromJSON(src []byte) (*Image, error) {
 	img.rawJSON = src
 
 	return img, nil
+}
+
+func normalizeConfigExposedPortRanges(src []byte) ([]byte, error) {
+	var config map[string]json.RawMessage
+	if err := json.Unmarshal(src, &config); err != nil {
+		return nil, err
+	}
+
+	changed := false
+	for _, key := range []string{imageConfigJSONKey, imageContainerConfigJSONKey} {
+		normalized, ok, err := normalizeExposedPortRanges(config[key])
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			config[key] = normalized
+			changed = true
+		}
+	}
+
+	if !changed {
+		return src, nil
+	}
+	return json.Marshal(config)
+}
+
+func normalizeExposedPortRanges(src json.RawMessage) (json.RawMessage, bool, error) {
+	if len(src) == 0 || string(src) == jsonNullValue {
+		return nil, false, nil
+	}
+
+	var config map[string]json.RawMessage
+	if err := json.Unmarshal(src, &config); err != nil {
+		return nil, false, err
+	}
+
+	exposedPortsJSON, ok := config[exposedPortsJSONKey]
+	if !ok || string(exposedPortsJSON) == jsonNullValue {
+		return nil, false, nil
+	}
+
+	var exposedPorts map[string]json.RawMessage
+	if err := json.Unmarshal(exposedPortsJSON, &exposedPorts); err != nil {
+		return nil, false, err
+	}
+
+	normalizedPorts := make(map[string]json.RawMessage, len(exposedPorts))
+	changed := false
+	for port, value := range exposedPorts {
+		if parsedPort, err := network.ParsePort(port); err == nil {
+			normalizedPorts[parsedPort.String()] = value
+			if parsedPort.String() != port {
+				changed = true
+			}
+			continue
+		}
+
+		portRange, err := network.ParsePortRange(port)
+		if err != nil {
+			normalizedPorts[port] = value
+			continue
+		}
+		changed = true
+		for p := range portRange.All() {
+			normalizedPorts[p.String()] = value
+		}
+	}
+
+	if !changed {
+		return nil, false, nil
+	}
+
+	normalizedExposedPorts, err := json.Marshal(normalizedPorts)
+	if err != nil {
+		return nil, false, err
+	}
+	config[exposedPortsJSONKey] = normalizedExposedPorts
+
+	normalizedConfig, err := json.Marshal(config)
+	if err != nil {
+		return nil, false, err
+	}
+	return normalizedConfig, true, nil
 }

--- a/daemon/internal/image/image_test.go
+++ b/daemon/internal/image/image_test.go
@@ -9,9 +9,16 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/v2/daemon/internal/layer"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+)
+
+const (
+	testExposedPortRange      = "33060-33061/tcp"
+	testExposedPortRangeStart = "33060/tcp"
+	testExposedPortRangeEnd   = "33061/tcp"
 )
 
 const sampleImageJSON = `{
@@ -28,6 +35,28 @@ func TestNewFromJSON(t *testing.T) {
 	img, err := NewFromJSON([]byte(sampleImageJSON))
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(sampleImageJSON, string(img.RawJSON())))
+}
+
+func TestNewFromJSONWithExposedPortRange(t *testing.T) {
+	imageJSON := `{
+		"architecture": "amd64",
+		"os": "linux",
+		"config": {
+			"ExposedPorts": {
+				"` + testExposedPortRange + `": {}
+			}
+		},
+		"rootfs": {
+			"type": "layers",
+			"diff_ids": []
+		}
+	}`
+
+	img, err := NewFromJSON([]byte(imageJSON))
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(imageJSON, string(img.RawJSON())))
+	assert.Check(t, is.Contains(img.Config.ExposedPorts, network.MustParsePort(testExposedPortRangeStart)))
+	assert.Check(t, is.Contains(img.Config.ExposedPorts, network.MustParsePort(testExposedPortRangeEnd)))
 }
 
 func TestNewFromJSONWithInvalidJSON(t *testing.T) {

--- a/integration/image/load_test.go
+++ b/integration/image/load_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
+	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	iimage "github.com/moby/moby/v2/integration/internal/image"
 	"github.com/moby/moby/v2/internal/testutil/specialimage"
@@ -13,6 +15,11 @@ import (
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
+)
+
+const (
+	exposedPortRangeStart = "33060/tcp"
+	exposedPortRangeEnd   = "33061/tcp"
 )
 
 func TestLoadDanglingImages(t *testing.T) {
@@ -75,4 +82,29 @@ func TestLoadDanglingImages(t *testing.T) {
 	danglingImage, err := findImageById(imageList.Items, oldImage.ID)
 	assert.NilError(t, err)
 	assert.Check(t, is.Len(danglingImage.RepoTags, 0))
+}
+
+func TestLoadImageWithExposedPortRange(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	imageRef := iimage.Load(ctx, t, apiClient, specialimage.ExposedPortRange)
+
+	createResp, err := apiClient.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Config:           &containertypes.Config{Image: imageRef},
+		HostConfig:       &containertypes.HostConfig{},
+		NetworkingConfig: &network.NetworkingConfig{},
+	})
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		_, err := apiClient.ContainerRemove(ctx, createResp.ID, client.ContainerRemoveOptions{Force: true})
+		assert.Check(t, err)
+	})
+
+	inspect, err := apiClient.ContainerInspect(ctx, createResp.ID, client.ContainerInspectOptions{})
+	assert.NilError(t, err)
+	assert.Check(t, is.Contains(inspect.Container.Config.ExposedPorts, network.MustParsePort(exposedPortRangeStart)))
+	assert.Check(t, is.Contains(inspect.Container.Config.ExposedPorts, network.MustParsePort(exposedPortRangeEnd)))
 }

--- a/internal/testutil/specialimage/exposedports.go
+++ b/internal/testutil/specialimage/exposedports.go
@@ -1,0 +1,54 @@
+package specialimage
+
+import (
+	"github.com/containerd/platforms"
+	"github.com/distribution/reference"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const (
+	exposedPortRangeImageRef = "exposedportrange:latest"
+	exposedPortRangeCmd      = "true"
+	exposedPortRange         = "33060-33061/tcp"
+	exposedPortRangeRootFS   = "layers"
+)
+
+// ExposedPortRange creates a minimal image whose config contains a Docker
+// EXPOSE port range entry, matching images produced by some non-Docker builders.
+func ExposedPortRange(dir string) (*ocispec.Index, error) {
+	ref, err := reference.ParseNormalizedNamed(exposedPortRangeImageRef)
+	if err != nil {
+		return nil, err
+	}
+
+	configDesc, err := writeJsonBlob(dir, ocispec.MediaTypeImageConfig, ocispec.Image{
+		Platform: platforms.DefaultSpec(),
+		Config: ocispec.ImageConfig{
+			Cmd: []string{exposedPortRangeCmd},
+			ExposedPorts: map[string]struct{}{
+				exposedPortRange: {},
+			},
+		},
+		RootFS: ocispec.RootFS{
+			Type: exposedPortRangeRootFS,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	manifest := ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    []ocispec.Descriptor{},
+	}
+
+	legacyManifests := []manifestItem{
+		{
+			Config:   blobPath(configDesc),
+			RepoTags: []string{exposedPortRangeImageRef},
+		},
+	}
+
+	return singlePlatformImage(dir, ref, manifest, legacyManifests)
+}


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/52553

## Summary

Expand Docker image config `ExposedPorts` ranges when converting image metadata to the container config used for container creation.

Some images produced by non-Docker builders contain entries such as `33060-33061/tcp`. Keep loading those images non-fatal while preserving the exposed ports as individual `33060/tcp` and `33061/tcp` entries.

## Test verification (RED → GREEN)

RED with the new legacy image JSON unit test when the implementation is reverted:

```text
FAIL daemon/internal/image.TestNewFromJSONWithExposedPortRange
image_test.go:56: assertion failed: error is not nil: invalid port '33060-33061': invalid syntax
```

GREEN after the fix:

```text
PASS daemon/internal/image.TestNewFromJSONWithExposedPortRange
PASS daemon/internal/image
```

Additional local validation:

```text
make -o build test-unit TESTDIRS=./daemon/internal/image
PASS daemon/internal/image ... DONE 26 tests

TEST_SKIP_INTEGRATION_CLI=1 TEST_INTEGRATION_DIR=/usr/src/moby/integration/image TESTFLAGS='-test.run TestLoadImageWithExposedPortRange -test.count=1' make -o build test-integration
PASS amd64.usr.src.moby.integration.image.TestLoadImageWithExposedPortRange
DONE 1 tests
```

## Release notes (optional)

Requires a maintainer to add an `impact/*` label before adding the changelog block.

Created with: Codex