### PR TITLE
libnetwork: fix DNS ndots check — compare value > 0, not just presence

### DIFF
--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -2056,8 +2056,8 @@ func (n *Network) ResolveService(ctx context.Context, name string) ([]*net.SRV, 
 	return srv, ip
 }
 
-func (n *Network) NdotsSet() bool {
-	return false
+func (n *Network) Ndots() int {
+	return 0
 }
 
 // config-only network is looked up by name

--- a/daemon/libnetwork/resolver.go
+++ b/daemon/libnetwork/resolver.go
@@ -43,8 +43,9 @@ type DNSBackend interface {
 	// ExecFunc allows a function to be executed in the context of the backend
 	// on behalf of the resolver.
 	ExecFunc(f func()) error
-	// NdotsSet queries the backends ndots dns option settings
-	NdotsSet() bool
+	// Ndots returns the ndots value from the backend's DNS options, or 0 if
+	// the option is not set.
+	Ndots() int
 	// HandleQueryResp passes the name & IP from a response to the backend. backend
 	// can use it to maintain any required state about the resolution
 	HandleQueryResp(name string, ip net.IP)
@@ -463,7 +464,7 @@ func (r *Resolver) serveDNS(w dns.ResponseWriter, query *dns.Msg) {
 	// in the root domain don't forward it out. We will return
 	// failure and let the client retry with the search domain
 	// attached.
-	if (queryType == dns.TypeA || queryType == dns.TypeAAAA) && r.backend.NdotsSet() &&
+	if (queryType == dns.TypeA || queryType == dns.TypeAAAA) && r.backend.Ndots() > 0 &&
 		!strings.Contains(strings.TrimSuffix(queryName, "."), ".") {
 		resp = createRespMsg(query)
 	} else {

--- a/daemon/libnetwork/resolver_test.go
+++ b/daemon/libnetwork/resolver_test.go
@@ -250,7 +250,7 @@ func (noopDNSBackend) ResolveName(_ context.Context, name string, ipType types.I
 
 func (noopDNSBackend) ExecFunc(f func()) error { f(); return nil }
 
-func (noopDNSBackend) NdotsSet() bool { return false }
+func (noopDNSBackend) Ndots() int { return 0 }
 
 func (noopDNSBackend) HandleQueryResp(name string, ip net.IP) {}
 

--- a/daemon/libnetwork/sandbox.go
+++ b/daemon/libnetwork/sandbox.go
@@ -51,7 +51,7 @@ type Sandbox struct {
 	isStub          bool
 	inDelete        bool
 	ingress         bool
-	ndotsSet        bool
+	ndots           int
 	oslTypes        []osl.SandboxType // slice of properties of this sandbox
 	loadBalancerNID string            // NID that this SB is a load balancer for
 	mu              sync.Mutex
@@ -671,6 +671,6 @@ func (ep *Endpoint) Less(epj *Endpoint) bool {
 	return ep.network.Name() < epj.network.Name()
 }
 
-func (sb *Sandbox) NdotsSet() bool {
-	return sb.ndotsSet
+func (sb *Sandbox) Ndots() int {
+	return sb.ndots
 }

--- a/daemon/libnetwork/sandbox_dns_unix.go
+++ b/daemon/libnetwork/sandbox_dns_unix.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/containerd/log"
@@ -317,8 +318,12 @@ func (sb *Sandbox) rebuildDNS() error {
 		return errors.New("no listen-address for internal resolver")
 	}
 
-	// Work out whether ndots has been set from host config or overrides.
-	_, sb.ndotsSet = rc.Option("ndots")
+	// Work out the ndots value from host config or overrides.
+	if v, ok := rc.Option("ndots"); ok {
+		if n, err := strconv.Atoi(v); err == nil {
+			sb.ndots = n
+		}
+	}
 	// Swap nameservers for the internal one, and make sure the required options are set.
 	var extNameServers []resolvconf.ExtDNSEntry
 	extNameServers, err = rc.TransformForIntNS(intNS, sb.resolver.ResolverOptions())


### PR DESCRIPTION
## What

Fixes #53104.

The `DNSBackend` interface had `NdotsSet() bool`, which returned `true`
whenever `ndots` appeared in `resolv.conf` — **including `ndots:0`**.
In `serveDNS`, this caused single-label A/AAAA queries to be short-
circuited (returning empty NXDOMAIN) even when `ndots:0` explicitly
means "always forward immediately without search-domain retry."

The comment in the code already said *"If the user sets ndots > 0
explicitly"*, but the implementation didn't enforce the `> 0` part.

The bug reproduces most visibly in Docker-in-Docker: the inner Docker
daemon writes `options ndots:0` into its containers' `resolv.conf`, so
any container inside DinD that tries to resolve an outer container by
single-label name (`outer-2` instead of `outer-2.outer-test-net`) gets
an empty NXDOMAIN instead of being forwarded to the outer resolver.

## How

Replace `NdotsSet() bool` with `Ndots() int` throughout:

| File | Change |
|---|---|
| `resolver.go` | Interface method `NdotsSet() bool` → `Ndots() int`; condition `NdotsSet()` → `Ndots() > 0` |
| `sandbox.go` | Field `ndotsSet bool` → `ndots int`; method updated accordingly |
| `sandbox_dns_unix.go` | Parse the string value from `rc.Option("ndots")` with `strconv.Atoi` instead of discarding it |
| `network.go` | Stub updated to `Ndots() int { return 0 }` |
| `resolver_test.go` | Noop stub updated to `Ndots() int { return 0 }` |

## Testing

`GOOS=linux go build ./daemon/libnetwork/...` — clean build.

Manual reproduction via the DinD steps in issue #53104 confirms the fix.

## Release note

Fix DNS container name resolution failing inside Docker-in-Docker when the inner daemon sets `ndots:0`.

Created with: Claude Code