### PR TITLE
[docker-29.x backport] Dockerfile: Handle armel linux-libc-dev version skew

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -259,6 +259,7 @@ RUN --mount=type=cache,sharing=locked,id=moby-runc-aptlib,target=/var/lib/apt \
         apt-get update && xx-apt-get install -y --no-install-recommends \
             gcc \
             libc6-dev \
+            linux-libc-dev \
             libseccomp-dev \
             pkg-config
 ARG DOCKER_STATIC
@@ -304,6 +305,7 @@ RUN --mount=type=cache,sharing=locked,id=moby-tini-aptlib,target=/var/lib/apt \
         xx-apt-get install -y --no-install-recommends \
             gcc \
             libc6-dev \
+            linux-libc-dev \
             pkg-config
 RUN --mount=from=tini-src,src=/usr/src/tini,rw \
     --mount=type=cache,target=/root/.cache/go-build,id=tini-build-$TARGETPLATFORM <<EOT
@@ -333,6 +335,7 @@ RUN --mount=type=cache,sharing=locked,id=moby-rootlesskit-aptlib,target=/var/lib
         apt-get update && xx-apt-get install -y --no-install-recommends \
             gcc \
             libc6-dev \
+            linux-libc-dev \
             pkg-config
 ARG DOCKER_STATIC
 RUN --mount=from=rootlesskit-src,src=/usr/src/rootlesskit,rw \
@@ -541,6 +544,7 @@ RUN --mount=type=cache,sharing=locked,id=moby-build-aptlib,target=/var/lib/apt \
         xx-apt-get install --no-install-recommends -y \
             gcc \
             libc6-dev \
+            linux-libc-dev \
             libnftables-dev \
             libseccomp-dev \
             libsystemd-dev \


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/53100

## Summary

Debian's Bookworm LTS transition dropped armel from the architectures receiving security updates: https://www.debian.org/News/2026/20260712

The regular archive still provides linux-libc-dev 6.1.176-1 for armel, while supported native architectures receive 6.1.177-1 from bookworm-security.
Because linux-libc-dev is `Multi-Arch: same`, APT does not choose the armel package transitively for libc6-dev when the native package has a newer candidate.

Request linux-libc-dev explicitly in each Linux cross-build stage to keep the target headers aligned with the installed native version.

Fixes CI build failure:

```

#22 [build 4/6] RUN --mount=type=cache,sharing=locked,id=moby-build-aptlib,target=/var/lib/apt     --mount=type=cache,sharing=locked,id=moby-build-aptcache,target=/var/cache/apt         xx-apt-get install --no-install-recommends -y             gcc             libc6-dev             libnftables-dev             libseccomp-dev             libsystemd-dev             pkg-config
#22 0.175 Hit:1 http://deb.debian.org/debian bookworm InRelease
#22 0.180 Hit:2 http://deb.debian.org/debian bookworm-updates InRelease
#22 0.192 Hit:3 http://deb.debian.org/debian-security bookworm-security InRelease
#22 0.254 Get:4 http://deb.debian.org/debian bookworm/main armel Packages [8450 kB]
#22 0.431 Get:5 http://deb.debian.org/debian bookworm-updates/main armel Packages [6928 B]
#22 1.205 Fetched 8457 kB in 1s (7935 kB/s)
#22 1.205 Reading package lists...
#22 8.679 + apt-get  install --no-install-recommends -y gcc-arm-linux-gnueabi libc6-dev:armel libnftables-dev:armel libseccomp-dev:armel libsystemd-dev:armel pkg-config:armel
#22 8.686 Reading package lists...
#22 9.553 Building dependency tree...
#22 9.821 Reading state information...
#22 9.959 Some packages could not be installed. This may mean that you have
#22 9.959 requested an impossible situation or if you are using the unstable
#22 9.959 distribution that some required packages have not yet been created
#22 9.959 or been moved out of Incoming.
#22 9.959 The following information may help to resolve the situation:
#22 9.959 
#22 9.959 The following packages have unmet dependencies:
#22 10.02  libc6-dev:armel : Depends: linux-libc-dev:armel but it is not going to be installed
#22 10.03 E: Unable to correct problems, you have held broken packages.
#22 ERROR: process "/bin/sh -c xx-apt-get install --no-install-recommends -y             gcc             libc6-dev             libnftables-dev             libseccomp-dev             libsystemd-dev             pkg-config" did not complete successfully: exit code: 100
------
 > [build 4/6] RUN --mount=type=cache,sharing=locked,id=moby-build-aptlib,target=/var/lib/apt     --mount=type=cache,sharing=locked,id=moby-build-aptcache,target=/var/cache/apt         xx-apt-get install --no-install-recommends -y             gcc             libc6-dev             libnftables-dev             libseccomp-dev             libsystemd-dev             pkg-config:
9.821 Reading state information...
9.959 Some packages could not be installed. This may mean that you have
9.959 requested an impossible situation or if you are using the unstable
9.959 distribution that some required packages have not yet been created
9.959 or been moved out of Incoming.
9.959 The following information may help to resolve the situation:
9.959 
9.959 The following packages have unmet dependencies:
10.02  libc6-dev:armel : Depends: linux-libc-dev:armel but it is not going to be installed
10.03 E: Unable to correct problems, you have held broken packages.
------
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
