### PR TITLE
integration/build: TestBuildUncleanTarFilenames use path within root

### DIFF
--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -375,7 +375,12 @@ RUN cat somefile`
 	assert.Check(t, is.Contains(img.Config.Env, "bar=baz"))
 }
 
-// #35403 #36122
+// TestBuildUncleanTarFilenames is a regression test for cache invalidation
+// with non-canonical, in-context archive paths.
+//
+// See:
+// - https://github.com/moby/moby/issues/35403
+// - https://github.com/moby/moby/issues/36122
 func TestBuildUncleanTarFilenames(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 
@@ -391,7 +396,7 @@ COPY bar /
 	buf := bytes.NewBuffer(nil)
 	w := tar.NewWriter(buf)
 	writeTarRecord(t, w, "Dockerfile", dockerfile)
-	writeTarRecord(t, w, "../foo", "foocontents0")
+	writeTarRecord(t, w, "dir/../foo", "foocontents0")
 	writeTarRecord(t, w, "/bar", "barcontents0")
 	err := w.Close()
 	assert.NilError(t, err)
@@ -413,7 +418,7 @@ COPY bar /
 	buf = bytes.NewBuffer(nil)
 	w = tar.NewWriter(buf)
 	writeTarRecord(t, w, "Dockerfile", dockerfile)
-	writeTarRecord(t, w, "../foo", "foocontents1")
+	writeTarRecord(t, w, "dir/../foo", "foocontents1")
 	writeTarRecord(t, w, "/bar", "barcontents1")
 	err = w.Close()
 	assert.NilError(t, err)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/53098#issuecomment-5022288948
- originally added in https://github.com/moby/moby/pull/36329
- relates to https://github.com/moby/moby/issues/35403
- relates to https://github.com/moby/moby/issues/36122

This test was added in f6c8266afddcf24a2eb629af3b8e924e9c78ce73 ("Fix cache invalidation for tar with "unclean" paths") and used "../foo" as an unclean archive path.

Replace it with "dir/../foo", which exercises the same normalization logic while remaining within the archive root.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
