### PR TITLE
daemon: Prevent race between volume live-restore and cleanup

### DIFF
--- a/daemon/mounts.go
+++ b/daemon/mounts.go
@@ -12,7 +12,10 @@ import (
 )
 
 func (daemon *Daemon) prepareMountPoints(container *container.Container) error {
-	alive := container.State.IsRunning()
+	container.Lock()
+	defer container.Unlock()
+
+	alive := container.State.Running
 	for _, config := range container.MountPoints {
 		if err := daemon.lazyInitializeVolume(container.ID, config); err != nil {
 			return err

--- a/daemon/mounts_test.go
+++ b/daemon/mounts_test.go
@@ -1,0 +1,96 @@
+package daemon
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/moby/moby/v2/daemon/container"
+	"github.com/moby/moby/v2/daemon/volume/mounts"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestPrepareMountPointsSerializesLiveRestoreWithCleanup(t *testing.T) {
+	volume := &blockingLiveRestoreVolume{
+		restoreStarted:  make(chan struct{}),
+		continueRestore: make(chan struct{}),
+	}
+	mountPoint := &mounts.MountPoint{
+		Volume: volume,
+		ID:     "mount-id",
+	}
+	ctr := container.NewBaseContainer("container-id", t.TempDir())
+	ctr.State.Running = true
+	ctr.MountPoints["/volume"] = mountPoint
+
+	restoreErr := make(chan error, 1)
+	go func() {
+		restoreErr <- (&Daemon{}).prepareMountPoints(ctr)
+	}()
+	<-volume.restoreStarted
+
+	cleanupBeforeRestore := ctr.TryLock()
+	var cleanupErr error
+	if cleanupBeforeRestore {
+		cleanupErr = mountPoint.Cleanup(context.Background())
+		ctr.Unlock()
+	}
+
+	close(volume.continueRestore)
+	assert.NilError(t, <-restoreErr)
+
+	if !cleanupBeforeRestore {
+		ctr.Lock()
+		cleanupErr = mountPoint.Cleanup(context.Background())
+		ctr.Unlock()
+	}
+	assert.NilError(t, cleanupErr)
+	assert.Check(t, is.Equal(volume.active.Load(), int64(0)))
+	assert.Check(t, is.Equal(volume.unmounts.Load(), int64(1)))
+}
+
+type blockingLiveRestoreVolume struct {
+	active          atomic.Int64
+	unmounts        atomic.Int64
+	restoreStarted  chan struct{}
+	continueRestore chan struct{}
+}
+
+func (v *blockingLiveRestoreVolume) Name() string {
+	return "test-volume"
+}
+
+func (v *blockingLiveRestoreVolume) DriverName() string {
+	return "test"
+}
+
+func (v *blockingLiveRestoreVolume) Path() string {
+	return ""
+}
+
+func (v *blockingLiveRestoreVolume) Mount(string) (string, error) {
+	return "", nil
+}
+
+func (v *blockingLiveRestoreVolume) Unmount(string) error {
+	v.active.Add(-1)
+	v.unmounts.Add(1)
+	return nil
+}
+
+func (v *blockingLiveRestoreVolume) CreatedAt() (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (v *blockingLiveRestoreVolume) Status() map[string]any {
+	return nil
+}
+
+func (v *blockingLiveRestoreVolume) LiveRestoreVolume(context.Context, string) error {
+	close(v.restoreStarted)
+	<-v.continueRestore
+	v.active.Add(1)
+	return nil
+}

--- a/daemon/volume/local/local.go
+++ b/daemon/volume/local/local.go
@@ -366,7 +366,7 @@ func (v *localVolume) Unmount(id string) error {
 	// ultimately there's nothing that can be done. If we don't decrement the count
 	// this volume can never be removed until a daemon restart occurs.
 	if v.needsMount() {
-		// TODO: Remove once the real bug is fixed: https://github.com/moby/moby/issues/46508
+		// TODO: Remove once the fix is confirmed: https://github.com/moby/moby/issues/46508
 		if v.active.count > 0 {
 			v.active.count--
 			logger.WithField("active mounts", v.active).Debug("Decremented active mount count")

--- a/daemon/volume/mounts/mounts.go
+++ b/daemon/volume/mounts/mounts.go
@@ -107,7 +107,7 @@ func (m *MountPoint) Cleanup(ctx context.Context) error {
 
 	logger := log.G(ctx).WithFields(log.Fields{"active": m.active, "id": m.ID})
 
-	// TODO: Remove once the real bug is fixed: https://github.com/moby/moby/issues/46508
+	// TODO: Remove once the fix is confirmed: https://github.com/moby/moby/issues/46508
 	if m.active == 0 {
 		logger.Error("An attempt to decrement a zero mount count")
 		logger.Error(string(debug.Stack()))


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/46508

## Summary

Container exit events can run after prepareMountPoints observes a running container but before it restores the volume references.
Cleanup then sees zero active mounts, and restore leaves a reference that is never released.

Hold the container lock across the running-state check and mount-point preparation so exit cleanup runs wholly before or after reference restore.

/flaky-check=TestLiveRestore

## Release notes (optional)

```markdown changelog
Prevent live-restored volumes from retaining active mount references when containers exit during daemon startup.
```
 