### PR TITLE
vendor: swarmkit: fix TestAllocator deadlock by calling watchCancel before wg.Done

### DIFF
--- a/vendor/github.com/docker/swarmkit/manager/allocator/allocator.go
+++ b/vendor/github.com/docker/swarmkit/manager/allocator/allocator.go
@@ -122,8 +122,8 @@ func (a *Allocator) Run(ctx context.Context) error {
 			wg.Add(1)
 			go func(watch <-chan events.Event, watchCancel func()) {
 				defer func() {
-					wg.Done()
 					watchCancel()
+					wg.Done()
 				}()
 				a.run(ctx, *aaPtr, watch)
 			}(watch, watchCancel)


### PR DESCRIPTION
## What

Fix intermittent failure of `TestAllocator/TestAllocatorRestoreForUnallocatedNetwork` caused by a circular deadlock that produces a 5-minute test timeout panic.

## Why

In the allocator goroutine's deferred closure, `wg.Done()` was called **before** `watchCancel()`. This created a race where `a.Stop()` → `s.Close()` could run while `watchCancel()` (which calls `Broadcaster.Remove()`) was still in-flight, producing a 3-goroutine circular deadlock:

1. `LimitQueue.Close()` blocks in `cond.Wait()` waiting for `LimitQueue.run()` to drain
2. `LimitQueue.run()` blocks in `Channel.Write()` because `ch.closed` hasn't been closed yet
3. `Broadcaster.Remove()` (inside `watchCancel()`) blocks waiting for `broadcaster.run()` to respond, but `broadcaster.run()` is stuck in `LimitQueue.Close()`

This results in `panic: test timed out after 5m0s`.

## How

Swap the order of `watchCancel()` and `wg.Done()` in the goroutine's deferred closure:

```go
// Before (buggy)
defer func() {
    wg.Done()
    watchCancel()
}()

// After (fixed)
defer func() {
    watchCancel()
    wg.Done()
}()
```

By calling `watchCancel()` first, `Broadcaster.Remove()` completes and removes the allocator's sink from `b.sinks` before `wg.Done()` unblocks the `wg.Wait()` in `a.Run()`'s deferred function. When `s.Close()` → `Broadcaster.Close()` then runs, `b.sinks` is already empty so the broadcaster shuts down cleanly.

## Verification

This change addresses the flakiness identified in #50872. The fix was proposed by automated analysis of CI logs and source code.

Closes #50872