### PR TITLE
daemon: reject container hostnames longer than HOST_NAME_MAX

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -222,7 +222,7 @@ func (daemon *Daemon) verifyContainerSettings(daemonCfg *configStore, hostConfig
 	}
 
 	// Now do platform-specific verification
-	warns, err = verifyPlatformContainerSettings(daemon, daemonCfg, hostConfig, update)
+	warns, err = verifyPlatformContainerSettings(daemon, daemonCfg, hostConfig, config, update)
 	warnings = append(warnings, warns...)
 
 	return warnings, err

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -625,9 +625,17 @@ func isRunningSystemd() bool {
 	return runningSystemd
 }
 
+// maxHostnameLen is the maximum length (in bytes) of a container hostname on
+// Linux, as defined by HOST_NAME_MAX (include/uapi/linux/limits.h).
+const maxHostnameLen = 64
+
 // verifyPlatformContainerSettings performs platform-specific validation of the
 // hostconfig and config structures.
-func verifyPlatformContainerSettings(daemon *Daemon, daemonCfg *configStore, hostConfig *containertypes.HostConfig, update bool) (warnings []string, _ error) {
+func verifyPlatformContainerSettings(daemon *Daemon, daemonCfg *configStore, hostConfig *containertypes.HostConfig, config *containertypes.Config, update bool) (warnings []string, _ error) {
+	if runtime.GOOS == "linux" && config != nil && len(config.Hostname) > maxHostnameLen {
+		return warnings, errors.Errorf("hostname %q is too long (maximum %d bytes)", config.Hostname, maxHostnameLen)
+	}
+
 	if hostConfig == nil {
 		return nil, nil
 	}

--- a/daemon/daemon_unix_test.go
+++ b/daemon/daemon_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/moby/moby/api/types/blkiodev"
@@ -363,4 +364,20 @@ func TestGetBlkioThrottleDevices(t *testing.T) {
 		assert.Check(t, retDevs[0].Minor == MINOR, "get minor device type")
 		assert.Check(t, retDevs[0].Rate == WEIGHT, "get device rate")
 	})
+}
+
+func TestVerifyPlatformContainerSettingsHostnameLength(t *testing.T) {
+	d := &Daemon{}
+
+	// A 64-byte hostname is the longest one Linux allows (HOST_NAME_MAX);
+	// it must still be accepted.
+	okHostname := strings.Repeat("a", maxHostnameLen)
+	_, err := verifyPlatformContainerSettings(d, nil, nil, &containertypes.Config{Hostname: okHostname}, false)
+	assert.NilError(t, err)
+
+	// One byte over the limit must be rejected with a clear error, instead
+	// of being passed through to fail later with an opaque OCI runtime error.
+	tooLong := strings.Repeat("a", maxHostnameLen+1)
+	_, err = verifyPlatformContainerSettings(d, nil, nil, &containertypes.Config{Hostname: tooLong}, false)
+	assert.ErrorContains(t, err, "too long")
 }

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -167,7 +167,7 @@ func verifyPlatformContainerResources(resources *containertypes.Resources, isHyp
 
 // verifyPlatformContainerSettings performs platform-specific validation of the
 // hostconfig and config structures.
-func verifyPlatformContainerSettings(daemon *Daemon, daemonCfg *configStore, hostConfig *containertypes.HostConfig, update bool) (warnings []string, _ error) {
+func verifyPlatformContainerSettings(daemon *Daemon, daemonCfg *configStore, hostConfig *containertypes.HostConfig, config *containertypes.Config, update bool) (warnings []string, _ error) {
 	if hostConfig == nil {
 		return nil, nil
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md
-->

- Fixes: https://github.com/moby/moby/issues/36402

## Summary

Linux limits hostnames to 64 bytes (`HOST_NAME_MAX`). Previously, a container created with a longer hostname (for example, one expanded from a Swarm hostname template) passed daemon-side validation and only failed later with an opaque error from the OCI runtime:

```
OCI runtime create failed: ... sethostname: invalid argument
```

This validates the hostname length up front, in `verifyPlatformContainerSettings`, and returns a clear, actionable error instead:

```
hostname "..." is too long (maximum 64 bytes)
```

The check only applies on Linux, matches the existing 64-byte limit exactly (a 64-byte hostname is still valid), and does not affect Windows, which has no such limit.

This picks up the design agreed on in the (stalled/abandoned) #51793, which a maintainer confirmed should live in `verifyPlatformContainerSettings` rather than a separate platform-specific file, and keep the boundary at 64 (not 63) bytes.

## Release notes (optional)

```markdown changelog
Improve the error returned when a container hostname exceeds Linux's 64-byte limit.
```

## A picture of a cute animal (not mandatory but encouraged)

🐹

---
Created with: Claude Code