### PR TITLE
daemon: Add container shutdown timeout cap

### DIFF
--- a/daemon/command/config.go
+++ b/daemon/command/config.go
@@ -63,6 +63,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.IntVar(&conf.MaxConcurrentUploads, "max-concurrent-uploads", conf.MaxConcurrentUploads, "Set the max concurrent uploads")
 	flags.IntVar(&conf.MaxDownloadAttempts, "max-download-attempts", conf.MaxDownloadAttempts, "Set the max download attempts for each pull")
 	flags.IntVar(&conf.ShutdownTimeout, "shutdown-timeout", conf.ShutdownTimeout, "Set the default shutdown timeout")
+	flags.IntVar(&conf.MaxShutdownTimeout, "max-shutdown-timeout", conf.MaxShutdownTimeout, "Set the maximum container stop timeout during daemon shutdown")
 
 	flags.StringVar(&conf.SwarmDefaultAdvertiseAddr, "swarm-default-advertise-addr", "", "Set default address or interface for swarm advertised address")
 	flags.BoolVar(&conf.Experimental, "experimental", false, "Enable experimental features")

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -226,6 +226,11 @@ type CommonConfig struct {
 	// to stop when daemon is being shutdown
 	ShutdownTimeout int `json:"shutdown-timeout,omitempty"`
 
+	// MaxShutdownTimeout is the maximum stop timeout (in seconds) that the
+	// daemon applies to each container during daemon shutdown.
+	// A value of zero disables the limit.
+	MaxShutdownTimeout int `json:"max-shutdown-timeout,omitempty"`
+
 	Debug     bool     `json:"debug,omitempty"`
 	Hosts     []string `json:"hosts,omitempty"`
 	TLS       *bool    `json:"tls,omitempty"`
@@ -741,6 +746,9 @@ func Validate(config *Config) error {
 	}
 	if config.MaxDownloadAttempts < 0 {
 		return errors.Errorf("invalid max download attempts: %d", config.MaxDownloadAttempts)
+	}
+	if config.MaxShutdownTimeout < 0 {
+		return errors.Errorf("invalid max-shutdown-timeout (%d): value must be greater than or equal to 0", config.MaxShutdownTimeout)
 	}
 	if config.NetworkDiagnosticPort < 0 || config.NetworkDiagnosticPort > 65535 {
 		return errors.Errorf("invalid network-diagnostic-port (%d): value must be between 0 and 65535", config.NetworkDiagnosticPort)

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -337,6 +337,15 @@ func TestValidateConfigurationErrors(t *testing.T) {
 			expectedErr: "invalid network-diagnostic-port (65536): value must be between 0 and 65535",
 		},
 		{
+			name: "negative max shutdown timeout",
+			config: &Config{
+				CommonConfig: CommonConfig{
+					MaxShutdownTimeout: -1,
+				},
+			},
+			expectedErr: "invalid max-shutdown-timeout (-1): value must be greater than or equal to 0",
+		},
+		{
 			name: "generic resource without =",
 			config: &Config{
 				CommonConfig: CommonConfig{

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -449,7 +449,7 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 						}
 					} else if !cfg.LiveRestoreEnabled {
 						logger(c).Debug("shutting down container considered alive by containerd")
-						if err := daemon.shutdownContainer(c); err != nil && !cerrdefs.IsNotFound(err) {
+						if err := daemon.shutdownContainer(c, nil); err != nil && !cerrdefs.IsNotFound(err) {
 							baseLogger.WithError(err).Error("error shutting down container")
 							return
 						}
@@ -1445,11 +1445,11 @@ func (daemon *Daemon) waitForStartupDone() {
 	<-daemon.startupDone
 }
 
-func (daemon *Daemon) shutdownContainer(c *container.Container) error {
+func (daemon *Daemon) shutdownContainer(c *container.Container, timeout *int) error {
 	ctx := context.WithoutCancel(context.TODO())
 
-	// If container failed to exit in stopTimeout seconds of SIGTERM, then using the force
-	if err := daemon.containerStop(ctx, c, backend.ContainerStopOptions{}); err != nil {
+	// Force the container to exit if it does not handle its stop signal in time.
+	if err := daemon.containerStop(ctx, c, backend.ContainerStopOptions{Timeout: timeout}); err != nil {
 		return fmt.Errorf("Failed to stop container %s with error: %v", c.ID, err)
 	}
 
@@ -1459,13 +1459,14 @@ func (daemon *Daemon) shutdownContainer(c *container.Container) error {
 	return nil
 }
 
-// ShutdownTimeout returns the timeout (in seconds) before containers are forcibly
-// killed during shutdown. The default timeout can be configured both on the daemon
-// and per container, and the longest timeout will be used. A grace-period of
-// 5 seconds is added to the configured timeout.
+// ShutdownTimeout returns the timeout in seconds for daemon shutdown.
+// The configured daemon timeout is used as a minimum.
+// Otherwise, the longest effective container stop timeout plus five seconds is
+// used.
+// If MaxShutdownTimeout is positive, it caps each container stop timeout.
 //
-// A negative (-1) timeout means "indefinitely", which means that containers
-// are not forcibly killed, and the daemon shuts down after all containers exit.
+// A negative (-1) daemon timeout disables the outer shutdown deadline.
+// Container stop timeouts still determine when containers are forcibly killed.
 func (daemon *Daemon) ShutdownTimeout() int {
 	return daemon.shutdownTimeout(&daemon.config().Config)
 }
@@ -1481,7 +1482,7 @@ func (daemon *Daemon) shutdownTimeout(cfg *config.Config) int {
 
 	graceTimeout := 5
 	for _, c := range daemon.containers.List() {
-		stopTimeout := c.StopTimeout()
+		stopTimeout := containerShutdownTimeout(cfg, c)
 		if stopTimeout < 0 {
 			return -1
 		}
@@ -1490,6 +1491,14 @@ func (daemon *Daemon) shutdownTimeout(cfg *config.Config) int {
 		}
 	}
 	return shutdownTimeout
+}
+
+func containerShutdownTimeout(cfg *config.Config, c *container.Container) int {
+	stopTimeout := c.StopTimeout()
+	if cfg.MaxShutdownTimeout > 0 && (stopTimeout < 0 || stopTimeout > cfg.MaxShutdownTimeout) {
+		return cfg.MaxShutdownTimeout
+	}
+	return stopTimeout
 }
 
 // Shutdown stops the daemon.
@@ -1517,7 +1526,8 @@ func (daemon *Daemon) Shutdown(ctx context.Context) error {
 			}
 			logger := log.G(ctx).WithField("container", c.ID)
 			logger.Debug("shutting down container")
-			if err := daemon.shutdownContainer(c); err != nil {
+			stopTimeout := containerShutdownTimeout(cfg, c)
+			if err := daemon.shutdownContainer(c, &stopTimeout); err != nil {
 				logger.WithError(err).Error("failed to shut down container")
 				return
 			}

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -118,6 +118,7 @@ func (daemon *Daemon) Reload(conf *config.Config) error {
 		daemon.reloadMaxConcurrentDownloadsAndUploads,
 		daemon.reloadMaxDownloadAttempts,
 		daemon.reloadShutdownTimeout,
+		daemon.reloadMaxShutdownTimeout,
 		daemon.reloadFeatures,
 		daemon.reloadLabels,
 		daemon.reloadRegistryConfig,
@@ -216,6 +217,18 @@ func (daemon *Daemon) reloadShutdownTimeout(_ *reloadTxn, newCfg *configStore, c
 
 	// prepare reload event attributes with updatable configurations
 	attributes["shutdown-timeout"] = strconv.Itoa(newCfg.ShutdownTimeout)
+	return nil
+}
+
+// reloadMaxShutdownTimeout updates the maximum container shutdown timeout
+// and updates the passed attributes.
+func (daemon *Daemon) reloadMaxShutdownTimeout(_ *reloadTxn, newCfg *configStore, conf *config.Config, attributes map[string]string) error {
+	if conf.IsValueSet("max-shutdown-timeout") {
+		newCfg.MaxShutdownTimeout = conf.MaxShutdownTimeout
+		log.G(context.TODO()).Debugf("Reset maximum shutdown timeout: %d", newCfg.MaxShutdownTimeout)
+	}
+
+	attributes["max-shutdown-timeout"] = strconv.Itoa(newCfg.MaxShutdownTimeout)
 	return nil
 }
 

--- a/daemon/reload_test.go
+++ b/daemon/reload_test.go
@@ -74,6 +74,32 @@ func TestDaemonReloadLabels(t *testing.T) {
 	}
 }
 
+func TestDaemonReloadMaxShutdownTimeout(t *testing.T) {
+	daemon := newDaemonForReloadT(t, &config.Config{
+		CommonConfig: config.CommonConfig{
+			MaxShutdownTimeout: 10,
+		},
+	})
+	muteLogs(t)
+
+	newConfig := &config.Config{
+		CommonConfig: config.CommonConfig{
+			MaxShutdownTimeout: 5,
+			ValuesSet: map[string]any{
+				"max-shutdown-timeout": 5,
+			},
+		},
+	}
+
+	assert.NilError(t, daemon.Reload(newConfig))
+	assert.Equal(t, daemon.config().MaxShutdownTimeout, 5)
+
+	newConfig.MaxShutdownTimeout = 0
+	newConfig.ValuesSet["max-shutdown-timeout"] = 0
+	assert.NilError(t, daemon.Reload(newConfig))
+	assert.Equal(t, daemon.config().MaxShutdownTimeout, 0)
+}
+
 func TestDaemonReloadMirrors(t *testing.T) {
 	daemon := &Daemon{
 		imageService: images.NewImageService(t.Context(), images.ImageServiceConfig{}),

--- a/daemon/shutdown_test.go
+++ b/daemon/shutdown_test.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"testing"
+
+	containertypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/v2/daemon/config"
+	"github.com/moby/moby/v2/daemon/container"
+	"gotest.tools/v3/assert"
+)
+
+func TestShutdownTimeoutUsesContainerTimeoutCap(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name               string
+		daemonTimeout      int
+		containerTimeout   int
+		maxShutdownTimeout int
+		expected           int
+	}{
+		{
+			name:             "container timeout without cap",
+			containerTimeout: 10,
+			expected:         15,
+		},
+		{
+			name:               "container timeout capped",
+			containerTimeout:   10,
+			maxShutdownTimeout: 5,
+			expected:           10,
+		},
+		{
+			name:               "shorter container timeout preserved",
+			containerTimeout:   2,
+			maxShutdownTimeout: 5,
+			expected:           7,
+		},
+		{
+			name:               "indefinite container timeout capped",
+			containerTimeout:   -1,
+			maxShutdownTimeout: 5,
+			expected:           10,
+		},
+		{
+			name:             "indefinite container timeout without cap",
+			containerTimeout: -1,
+			expected:         -1,
+		},
+		{
+			name:               "cap prevents extending daemon timeout",
+			daemonTimeout:      15,
+			containerTimeout:   20,
+			maxShutdownTimeout: 5,
+			expected:           15,
+		},
+		{
+			name:               "negative daemon timeout disables outer deadline",
+			daemonTimeout:      -1,
+			containerTimeout:   10,
+			maxShutdownTimeout: 5,
+			expected:           -1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stopTimeout := tc.containerTimeout
+			ctr := &container.Container{
+				ID: "test",
+				Config: &containertypes.Config{
+					StopTimeout: &stopTimeout,
+				},
+			}
+			store := container.NewMemoryStore()
+			store.Add(ctr.ID, ctr)
+
+			cfg := config.Config{
+				CommonConfig: config.CommonConfig{
+					ShutdownTimeout:    tc.daemonTimeout,
+					MaxShutdownTimeout: tc.maxShutdownTimeout,
+				},
+			}
+			daemon := &Daemon{containers: store}
+			daemon.configStore.Store(&configStore{Config: cfg})
+
+			assert.Equal(t, daemon.ShutdownTimeout(), tc.expected)
+		})
+	}
+}

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -70,6 +70,7 @@ dockerd - Enable daemon mode
 [**-s**|**--storage-driver**[=*STORAGE-DRIVER*]]
 [**--seccomp-profile**[=*SECCOMP-PROFILE-PATH*]]
 [**--selinux-enabled**]
+[**--max-shutdown-timeout**[=*0*]]
 [**--shutdown-timeout**[=*15*]]
 [**--storage-opt**[=*[]*]]
 [**--swarm-default-advertise-addr**[=*IP|INTERFACE*]]
@@ -394,6 +395,12 @@ unix://[/path/to/socket] to use.
 
 **--selinux-enabled**=**true**|**false**
   Enable selinux support. Default is **false**.
+
+**--max-shutdown-timeout**=*seconds*
+  Set the maximum stop timeout in seconds that the daemon applies to each
+  container during daemon shutdown before forcing termination. If a container
+  has a shorter stop timeout, its configured timeout is used. The default is
+  **0**, which disables the limit.
 
 **--shutdown-timeout**=*seconds*
   Set the shutdown timeout value in seconds. Default is **15**.


### PR DESCRIPTION
Container stop timeouts can extend daemon shutdown indefinitely or
beyond an operator's shutdown budget.

Add shutdown-container-timeout as an optional per-container ceiling during daemon shutdown while preserving shorter container timeouts and the existing daemon-wide shutdown timeout.
    
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Add `--max-shutdown-timeout` to limit how long dockerd waits for each container to stop during daemon shutdown.
```

## A picture of a cute animal (not mandatory but encouraged)
