### PR TITLE
daemon/containerd: reject plugin configs during pull

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
+	"github.com/docker/distribution/manifest/schema2"
 	slsa02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	slsa1 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
 	"github.com/moby/buildkit/util/attestation"
@@ -36,6 +37,12 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+)
+
+const (
+	pluginConfigMediaTypePrefix = "application/vnd.docker.plugin."
+	pluginConfigMediaTypeClass  = "plugin"
+	unknownMediaTypeClass       = "unknown"
 )
 
 // PullImage initiates a pull operation. baseRef is the image to pull.
@@ -178,6 +185,9 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 
 	var sentPullingFrom, sentModelNotSupported atomic.Bool
 	ah := c8dimages.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		if err := checkPullDescriptorMediaType(desc); err != nil {
+			return nil, err
+		}
 		if desc.MediaType == c8dimages.MediaTypeDockerSchema1Manifest {
 			return nil, distribution.DeprecatedSchema1ImageError(ref)
 		}
@@ -284,6 +294,20 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 	outNewImg = img
 
 	return nil
+}
+
+func checkPullDescriptorMediaType(desc ocispec.Descriptor) error {
+	lowerMediaType := strings.ToLower(desc.MediaType)
+	if !strings.HasPrefix(lowerMediaType, pluginConfigMediaTypePrefix) {
+		return nil
+	}
+
+	configClass := unknownMediaTypeClass
+	if lowerMediaType == schema2.MediaTypePluginConfig {
+		configClass = pluginConfigMediaTypeClass
+	}
+
+	return errdefs.InvalidParameter(fmt.Errorf("Encountered remote %q(%s) when fetching", desc.MediaType, configClass))
 }
 
 func joinHandlerWrappers(funcs ...func(c8dimages.Handler) c8dimages.Handler) func(c8dimages.Handler) c8dimages.Handler {

--- a/daemon/containerd/image_pull_test.go
+++ b/daemon/containerd/image_pull_test.go
@@ -1,0 +1,55 @@
+package containerd
+
+import (
+	"testing"
+
+	cerrdefs "github.com/containerd/errdefs"
+	"github.com/docker/distribution/manifest/schema2"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+const testPluginConfigError = `Encountered remote "application/vnd.docker.plugin.v1+json"(plugin) when fetching`
+
+const (
+	testLegacyPluginConfigMediaType = "application/vnd.docker.plugin.v0+json"
+	testLegacyPluginConfigError     = `Encountered remote "application/vnd.docker.plugin.v0+json"(unknown) when fetching`
+)
+
+func TestCheckPullDescriptorMediaType(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		mediaType   string
+		expectError string
+	}{
+		{
+			name:        "plugin config",
+			mediaType:   schema2.MediaTypePluginConfig,
+			expectError: testPluginConfigError,
+		},
+		{
+			name:        "legacy plugin config",
+			mediaType:   testLegacyPluginConfigMediaType,
+			expectError: testLegacyPluginConfigError,
+		},
+		{
+			name:      "image config",
+			mediaType: schema2.MediaTypeImageConfig,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkPullDescriptorMediaType(ocispec.Descriptor{
+				MediaType: tc.mediaType,
+			})
+
+			if tc.expectError == "" {
+				assert.NilError(t, err)
+				return
+			}
+
+			assert.Check(t, is.Error(err, tc.expectError))
+			assert.Check(t, cerrdefs.IsInvalidArgument(err))
+		})
+	}
+}

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containerd/containerd/v2/plugins/content/local"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
+	"github.com/docker/distribution/manifest/schema2"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/internal/testutil/daemon"
 	"github.com/moby/moby/v2/internal/testutil/registry"
@@ -27,6 +28,8 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
 )
+
+const pluginConfigPullError = `Encountered remote "application/vnd.docker.plugin.v1+json"(plugin) when fetching`
 
 func TestImagePullPlatformInvalid(t *testing.T) {
 	ctx := setupTest(t)
@@ -116,6 +119,74 @@ func createTestImage(ctx context.Context, t testing.TB, store content.Store) oci
 	}
 }
 
+func createTestPlugin(ctx context.Context, t testing.TB, store content.Store) ocispec.Descriptor {
+	w, err := store.Writer(ctx, content.WithRef("plugin-layer"))
+	assert.NilError(t, err)
+	defer w.Close()
+
+	const layer = `./0000775000000000000000000000000014201045023007702 5ustar  rootroot`
+
+	_, err = w.Write([]byte(layer))
+	assert.NilError(t, err)
+
+	err = w.Commit(ctx, int64(len(layer)), digest.FromBytes([]byte(layer)))
+	assert.NilError(t, err)
+
+	layerDigest := w.Digest()
+	assert.Check(t, w.Close())
+
+	const pluginConfig = `{"description":"test plugin"}`
+
+	w, err = store.Writer(ctx, content.WithRef("plugin-config"))
+	assert.NilError(t, err)
+	defer w.Close()
+	_, err = w.Write([]byte(pluginConfig))
+	assert.NilError(t, err)
+	assert.NilError(t, w.Commit(ctx, int64(len(pluginConfig)), digest.FromBytes([]byte(pluginConfig))))
+
+	configDigest := w.Digest()
+	assert.Check(t, w.Close())
+
+	info, err := store.Info(ctx, layerDigest)
+	assert.NilError(t, err)
+
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		MediaType: c8dimages.MediaTypeDockerSchema2Manifest,
+		Config: ocispec.Descriptor{
+			MediaType: schema2.MediaTypePluginConfig,
+			Digest:    configDigest,
+			Size:      int64(len(pluginConfig)),
+		},
+		Layers: []ocispec.Descriptor{{
+			MediaType: c8dimages.MediaTypeDockerSchema2Layer,
+			Digest:    layerDigest,
+			Size:      info.Size,
+		}},
+	}
+
+	manifestJSON, err := json.Marshal(manifest)
+	assert.NilError(t, err)
+
+	w, err = store.Writer(ctx, content.WithRef("plugin-manifest"))
+	assert.NilError(t, err)
+	defer w.Close()
+	_, err = w.Write(manifestJSON)
+	assert.NilError(t, err)
+	assert.NilError(t, w.Commit(ctx, int64(len(manifestJSON)), digest.FromBytes(manifestJSON)))
+
+	manifestDigest := w.Digest()
+	assert.Check(t, w.Close())
+
+	return ocispec.Descriptor{
+		MediaType: c8dimages.MediaTypeDockerSchema2Manifest,
+		Digest:    manifestDigest,
+		Size:      int64(len(manifestJSON)),
+	}
+}
+
 // Make sure that pulling by an already cached digest but for a different ref (that should not have that digest)
 // verifies with the remote that the digest exists in that repo.
 func TestImagePullStoredDigestForOtherRepo(t *testing.T) {
@@ -160,6 +231,45 @@ func TestImagePullStoredDigestForOtherRepo(t *testing.T) {
 	assert.Assert(t, err != nil, "Expected error, got none: %v", err)
 	assert.Assert(t, cerrdefs.IsNotFound(err), err)
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
+}
+
+func TestImagePullPluginConfigReturnsUnsupportedRemoteError(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, !testEnv.UsingSnapshotter(), "only relevant to containerd image store")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "We don't run a test registry on Windows")
+	ctx := setupTest(t)
+
+	reg := registry.NewV2(t, registry.WithStdout(os.Stdout), registry.WithStderr(os.Stderr))
+	defer reg.Close()
+	reg.WaitReady(t)
+
+	dir := t.TempDir()
+	store, err := local.NewStore(dir)
+	assert.NilError(t, err)
+
+	desc := createTestPlugin(ctx, t, store)
+	remote := path.Join(registry.DefaultURL, "test-plugin:latest")
+
+	c8dClient, err := containerd.New("", containerd.WithServices(containerd.WithContentStore(store)))
+	assert.NilError(t, err)
+
+	err = c8dClient.Push(ctx, remote, desc)
+	assert.NilError(t, err)
+
+	apiClient := testEnv.APIClient()
+	rdr, pullErr := apiClient.ImagePull(ctx, remote, client.ImagePullOptions{})
+	if rdr != nil {
+		defer rdr.Close()
+		body, err := io.ReadAll(rdr)
+		assert.NilError(t, err)
+		assert.Check(t, is.Contains(string(body), schema2.MediaTypePluginConfig))
+		assert.Check(t, is.Contains(string(body), "(plugin) when fetching"))
+		return
+	}
+
+	assert.Assert(t, pullErr != nil)
+	assert.Check(t, is.ErrorContains(pullErr, pluginConfigPullError))
+	assert.Check(t, is.ErrorType(pullErr, cerrdefs.IsInvalidArgument))
 }
 
 // TestImagePullNonExisting pulls non-existing images from the central registry, with different


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/50818

## Summary

Return the same unsupported remote media type error for Docker plugin config descriptors when pulling with the containerd image store, instead of downloading the content and failing later during unpack with a rootfs mismatch.

This keeps plugin pulls non-fatal to the daemon while surfacing the plugin media type as the real reason the pull cannot create an image.

Test verification (RED -> GREEN):

RED on upstream-base behavior with the new integration test:

```text
TestImagePullPluginConfigReturnsUnsupportedRemoteError
failed to unpack image on snapshotter native: mismatched image rootfs and manifest layers
```

GREEN after the fix:

```text
PASS daemon/containerd.TestCheckPullDescriptorMediaType
PASS amd64.usr.src.moby.integration.image.TestImagePullPluginConfigReturnsUnsupportedRemoteError
DONE 164 tests, 2 skipped
```

Additional local CI preflight:

```text
hack/ci-local-preflight --quick
build dev image: ok
unit tests: ok
validate-default: ok
validate-generate-files: ok
validate-swagger: ok
validate-swagger-gen: ok
binary dynbinary build: ok
```

## Release notes (optional)

None
