### PR TITLE
daemon/containerd: Add preliminary support for Mount Manager

### DIFF
--- a/daemon/containerd/image_snapshot.go
+++ b/daemon/containerd/image_snapshot.go
@@ -2,9 +2,12 @@ package containerd
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	c8dimages "github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/leases"
@@ -91,6 +94,7 @@ func (i *ImageService) createLayer(descriptor *ocispec.Descriptor, layerName str
 		id:              layerName,
 		snapshotterName: i.StorageDriver(),
 		snapshotter:     sn,
+		mountManager:    i.client.MountManager(),
 		refCountMounter: i.refCountMounter,
 		lease:           lease,
 	}, nil
@@ -140,6 +144,7 @@ type rwLayer struct {
 	id              string
 	snapshotter     snapshots.Snapshotter
 	snapshotterName string
+	mountManager    mount.Manager
 	refCountMounter snapshotter.Mounter
 	root            string
 	lease           leases.Lease
@@ -157,6 +162,27 @@ func (l *rwLayer) Mount(mountLabel string) (string, error) {
 	mounts, err := l.mounts(ctx)
 	if err != nil {
 		return "", err
+	}
+
+	activateOpts := []mount.ActivateOpt{
+		mount.WithLabels(map[string]string{
+			"containerd.io/gc.bref.snapshot." + l.snapshotterName: l.id,
+		}),
+	}
+	key := "moby-" + l.snapshotterName + "-sn-" + l.id
+	if active, err := l.mountManager.Activate(ctx, key, mounts, activateOpts...); err == nil {
+		mounts = active.System
+	} else if cerrdefs.IsAlreadyExists(err) {
+		// If creation of task with same identifier, use existing mount rather than forcing
+		// deactivation of the old one. The back reference will prevent racing between
+		// deactivation and re-use, as the container with the same ID would still exist.
+		active, err = l.mountManager.Info(ctx, key)
+		if err != nil {
+			return "", fmt.Errorf("failed to get info on already active mount: %w", err)
+		}
+		mounts = active.System
+	} else if !cerrdefs.IsNotImplemented(err) {
+		return "", fmt.Errorf("failed to activate mounts: %w", err)
 	}
 
 	var root string
@@ -211,6 +237,7 @@ func (i *ImageService) GetLayerByID(cid string) (container.RWLayer, error) {
 		id:              cid,
 		snapshotterName: i.StorageDriver(),
 		snapshotter:     sn,
+		mountManager:    i.client.MountManager(),
 		refCountMounter: i.refCountMounter,
 		lease:           lss[0],
 		root:            root,
@@ -271,6 +298,20 @@ func (i *ImageService) prepareInitLayer(ctx context.Context, id string, parent s
 	}
 
 	if setupInit != nil {
+		mm := i.client.MountManager()
+		var b [3]byte
+		// Ignore read failures, just decreases uniqueness
+		rand.Read(b[:])
+		mountkey := fmt.Sprintf("moby-init-%d-%s", time.Now().Nanosecond(), base64.URLEncoding.EncodeToString(b[:]))
+
+		active, err := mm.Activate(ctx, mountkey, mounts)
+		if err == nil {
+			defer mm.Deactivate(ctx, mountkey)
+			mounts = active.System
+		} else if !cerrdefs.IsNotImplemented(err) {
+			return fmt.Errorf("failed to activate mounts: %w", err)
+		}
+
 		if err := mount.WithTempMount(ctx, mounts, func(root string) error {
 			return setupInit(root)
 		}); err != nil {


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

Fix https://github.com/docker/desktop-feedback/issues/487

EROFS snapshotter has been switched into using new mount manager interfaces since containerd 2.2.

Adapt Mount Manager to moby project, so that EROFS snapshotter can be enabled on containerd 2.3+/2.2.7+/2.1+:
```json
{
  "features": {
    "containerd-snapshotter": true
  },
  "storage-driver": "erofs"
}
```

Note that the current containerd 2.2.6 lacks of https://github.com/containerd/containerd/pull/13823, so it needs to be tested with 2.3+ or the upcoming 2.2.7.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
