### PR TITLE
daemon/logger/fluentd: Drain no-ACK test connection

### DIFF
--- a/daemon/logger/fluentd/fluentd_test.go
+++ b/daemon/logger/fluentd/fluentd_test.go
@@ -1,8 +1,8 @@
 package fluentd
 
 import (
-	"bufio"
 	"context"
+	"io"
 	"maps"
 	"net"
 	"path/filepath"
@@ -297,9 +297,10 @@ func TestReadWriteTimeoutsAreEffective(t *testing.T) {
 				go func() {
 					// Log will hang forever if the read timeout is not set. Hence, we invoke that
 					// asynchronously so that we can timeout the test if something goes wrong.
+					// This timestamp contains a newline byte when encoded as MessagePack.
 					done <- f.Log(&logger.Message{
 						Line:      data,
-						Timestamp: time.Now(),
+						Timestamp: time.Unix(10, 0),
 					})
 				}()
 
@@ -329,7 +330,7 @@ func TestReadWriteTimeoutsAreEffective(t *testing.T) {
 
 			// This is to guard against potential run-away test scenario so that a future change
 			// doesn't cause the tests suite to timeout.
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			var connectedWG sync.WaitGroup
@@ -424,21 +425,15 @@ func blackholeConnectionHandler(ctx context.Context, conn net.Conn) {
 }
 
 func noAckConnectionHandler(ctx context.Context, conn net.Conn) {
-	// Create a buffered reader to read from the connection.
-	reader := bufio.NewReader(conn)
-	// Read data from the connection.
-	_, err := reader.ReadString('\n')
-	if err != nil {
-		// If there's an error reading from the connection, it means the connection is closed.
-		select {
-		case <-ctx.Done():
-			// If the context is canceled, there's nothing for us to do here.
-			return
-		default:
-			return
-		}
+	readDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, conn)
+		close(readDone)
+	}()
+
+	select {
+	case <-ctx.Done():
+	case <-readDone:
 	}
-	// Don't write an ack back. The fluent configuration is set to expect an ack from the server.
-	<-ctx.Done()
 	_ = conn.Close()
 }


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/51079
- replace/close: https://github.com/moby/moby/pull/53059

## Summary

Deflake `TestReadWriteTimeoutsAreEffective`.

The no-ACK test server previously used `ReadString('\n')` on a MessagePack stream. If the encoded timestamp contained `0x0a`, the server stopped reading before the 1 MiB payload completed.
The client then blocked in `Write` before reaching the configured ACK read timeout.

Drain the connection while withholding the ACK, and use a timestamp whose MessagePack encoding contains `0x0a` so the previous failure is tested deterministically.