### PR TITLE
renovate: Group Docker GitHub Actions updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,12 @@
       "matchDepNames": ["/^golang\\.org\\/x\\//"]
     },
     {
+      "matchManagers": ["github-actions"],
+      "groupName": "docker GitHub Actions",
+      "groupSlug": "docker-actions",
+      "matchDepNames": ["/^docker\\//"]
+    },
+    {
       // Keep all the google.golang.org/genproto modules at the same version.
       "matchManagers": ["gomod"],
       "groupName": "google.golang.org/genproto packages",


### PR DESCRIPTION
## Summary

Group actions published by the docker organization so Renovate opens one update pull request instead of a separate pull request for each action.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->



## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
