### PR TITLE
libn/networkdb: keep networks of failed nodes

### DIFF
--- a/daemon/libnetwork/networkdb/cluster.go
+++ b/daemon/libnetwork/networkdb/cluster.go
@@ -256,18 +256,25 @@ func (nDB *NetworkDB) triggerFunc(stagger time.Duration, C <-chan time.Time, f f
 func (nDB *NetworkDB) reapDeadNode() {
 	nDB.Lock()
 	defer nDB.Unlock()
-	for _, nodeMap := range []map[string]*node{
-		nDB.failedNodes,
-		nDB.leftNodes,
-	} {
-		for id, n := range nodeMap {
-			if n.reapTime > nodeReapPeriod {
-				n.reapTime -= nodeReapPeriod
-				continue
-			}
-			log.G(context.TODO()).Debugf("Garbage collect node %v", n.Name)
-			delete(nodeMap, id)
+	for id, n := range nDB.failedNodes {
+		if n.reapTime > nodeReapPeriod {
+			n.reapTime -= nodeReapPeriod
+			continue
 		}
+		log.G(context.TODO()).Debugf("Garbage collect node %v", n.Name)
+		// The node is not coming back: drop the attachments remembered for
+		// it along with any entries reapTableEntries has not aged out yet.
+		nDB.deleteNodeFromNetworks(n.Name)
+		nDB.deleteNodeTableEntries(n.Name)
+		delete(nDB.failedNodes, id)
+	}
+	for id, n := range nDB.leftNodes {
+		if n.reapTime > nodeReapPeriod {
+			n.reapTime -= nodeReapPeriod
+			continue
+		}
+		log.G(context.TODO()).Debugf("Garbage collect node %v", n.Name)
+		delete(nDB.leftNodes, id)
 	}
 }
 
@@ -361,8 +368,9 @@ func (nDB *NetworkDB) reconnectNode() {
 // For timing the entry deletion in the reaper APIs that doesn't use monotonic clock
 // source (time.Now, Sub etc.) should be avoided. Hence we use reapTime in every
 // entry which is set initially to reapInterval and decremented by reapPeriod every time
-// the reaper runs. NOTE nDB.reapTableEntries updates the reapTime with a readlock. This
-// is safe as long as no other concurrent path touches the reapTime field.
+// the reaper runs. NOTE reapTime is only written while holding the NetworkDB write
+// lock — by the reapers and by the paths which suspend and restore the entries of a
+// failed node — and only read while holding at least the read lock.
 func (nDB *NetworkDB) reapState() {
 	// The reapTableEntries leverage the presence of the network so garbage collect entries first
 	nDB.reapTableEntries()
@@ -411,7 +419,10 @@ func (nDB *NetworkDB) reapTableEntries() {
 		nDB.indexes[byNetwork].Root().WalkPrefix([]byte("/"+nid), func(path []byte, v *entry) bool {
 			// timeCompensation compensate in case the lock took some time to be released
 			timeCompensation := time.Since(cycleStart)
-			if !v.deleting {
+			// Entries remembered for a failed owner age out like tombstones,
+			// so that they cannot be restored after whatever would delete
+			// them expired.
+			if !v.deleting && !nDB.isNodeFailed(v.node) {
 				return false
 			}
 
@@ -496,7 +507,9 @@ func (nDB *NetworkDB) gossip() {
 			nDB.RUnlock()
 
 			if mnode == nil {
-				break
+				// The node stopped being an active peer since it was
+				// picked, therefore skip it.
+				continue
 			}
 
 			// Send the compound message
@@ -613,8 +626,18 @@ func (nDB *NetworkDB) bulkSyncNode(networks []string, node string, unsolicited b
 	nDB.RLock()
 	mnode := nDB.nodes[node]
 	if mnode == nil {
+		// The node is not an active peer: it either failed since it was
+		// picked from a peer list, or it sent us a bulk sync while
+		// memberlist considers it failed. Sync at the address last known
+		// for it anyway: it evidently could reach us, and it is waiting for
+		// our reply if the bulk sync we are answering was unsolicited.
+		mnode = nDB.failedNodes[node]
+	}
+	if mnode == nil {
 		nDB.RUnlock()
-		return nil
+		// Nothing is known about the node, so it cannot be reached. Report
+		// it so that the caller does not count this as a completed sync.
+		return fmt.Errorf("cannot bulk sync with unknown node %s", node)
 	}
 
 	for _, nid := range networks {

--- a/daemon/libnetwork/networkdb/delegate.go
+++ b/daemon/libnetwork/networkdb/delegate.go
@@ -3,7 +3,6 @@ package networkdb
 import (
 	"context"
 	"net"
-	"slices"
 	"time"
 
 	"github.com/containerd/log"
@@ -116,7 +115,9 @@ func (nDB *NetworkDB) handleNetworkEvent(nEvent *NetworkEvent) bool {
 
 		if nEvent.Type == NetworkEventTypeLeave {
 			nDB.deleteNetworkNode(nEvent.NetworkID, nEvent.NodeName)
-		} else {
+		} else if _, active := nDB.nodes[nEvent.NodeName]; active {
+			// Only an active node is a gossip peer. Otherwise, changeNodeState
+			// puts it back in the peer list if the node comes back.
 			nDB.addNetworkNode(nEvent.NetworkID, nEvent.NodeName)
 		}
 
@@ -152,14 +153,19 @@ func (nDB *NetworkDB) handleTableEvent(tEvent *TableEvent, isBulkSync bool) bool
 
 	// Ignore the table events for networks that are in the process of going away
 	network, ok := nDB.thisNodeNetworks[tEvent.NetworkID]
-	// Check if the owner of the event is still part of the network
-	nodes := nDB.networkNodes[tEvent.NetworkID]
-	nodePresent := slices.Contains(nodes, tEvent.NodeName)
-
-	if !ok || network.leaving || !nodePresent {
-		// I'm out of the network OR the event owner is not anymore part of the network so do not propagate
+	if !ok || network.leaving {
+		// I'm out of the network so do not propagate
 		return false
 	}
+
+	// Check if the owner of the event is still attached to the network. The
+	// attachments of a failed node are remembered, so its entries keep
+	// being accepted while it is down.
+	if !nDB.isNodeAttached(tEvent.NodeName, tEvent.NetworkID) {
+		return false
+	}
+
+	ownerFailed := nDB.isNodeFailed(tEvent.NodeName)
 
 	var entryPresent bool
 	prev, err := nDB.getEntry(tEvent.TableName, tEvent.NetworkID, tEvent.Key)
@@ -188,6 +194,11 @@ func (nDB *NetworkDB) handleTableEvent(tEvent *TableEvent, isBulkSync bool) bool
 			nDB.config.Hostname, nDB.config.NodeID, tEvent)
 		e.reapTime = nDB.config.reapEntryInterval
 	}
+	if !e.deleting && ownerFailed && e.reapTime == 0 {
+		// The sender believes the owner is active and sent no residual reap
+		// time, so bound the remembered entry's retention locally.
+		e.reapTime = nDB.config.reapEntryInterval
+	}
 	nDB.createOrUpdateEntry(tEvent.NetworkID, tEvent.TableName, tEvent.Key, e)
 
 	if !entryPresent && tEvent.Type == TableEventTypeDelete {
@@ -208,6 +219,13 @@ func (nDB *NetworkDB) handleTableEvent(tEvent *TableEvent, isBulkSync bool) bool
 
 		// log.G(ctx).Infof("exiting on delete not knowing the obj with rebroadcast:%t", network.inSync)
 		return isBulkSync && network.inSync && e.reapTime > nDB.config.reapEntryInterval/6
+	}
+
+	if ownerFailed {
+		// The entry is hidden while its owner is failed. Watchers saw it
+		// deleted when the owner failed and get it back if the owner
+		// returns. Keep the event flowing so the whole cluster remembers it.
+		return network.inSync
 	}
 
 	event := WatchEvent{

--- a/daemon/libnetwork/networkdb/networkdb.go
+++ b/daemon/libnetwork/networkdb/networkdb.go
@@ -61,7 +61,9 @@ type NetworkDB struct {
 	// synchronization.
 	estNodes atomic.Int32
 
-	// List of all peer nodes which have failed
+	// List of all peer nodes which have failed. The attachments and table
+	// entries of a failed node are remembered, hidden rather than dropped,
+	// and put back in place if the node returns before it is reaped.
 	failedNodes map[string]*node
 
 	// List of all peer nodes which have left
@@ -69,14 +71,17 @@ type NetworkDB struct {
 
 	// A multi-dimensional map of network/node attachments for peer nodes.
 	// The first key is a node name and the second key is a network ID for
-	// the network that node is participating in.
+	// the network that node is participating in. Attachments of a failed
+	// node are kept until it is reaped, so its table events keep being
+	// accepted and its peer-list membership can be restored if it returns.
 	networks map[string]map[string]*network
 
 	// A map of this node's network attachments.
 	thisNodeNetworks map[string]*thisNodeNetwork
 
-	// A map of nodes which are participating in a given
-	// network. The key is a network ID.
+	// The active peers participating in a given network, which gossip and
+	// bulk sync pick peers from, keyed by network ID. A node is taken out
+	// when it fails or leaves, and put back if it returns.
 	networkNodes map[string][]string
 
 	// A table of subscriptions for every node from which we are waiting for
@@ -260,8 +265,9 @@ type entry struct {
 	// the cluster for certain amount of time after deletion.
 	deleting bool
 
-	// Number of seconds still left before a deleted table entry gets
-	// removed from networkDB
+	// Time still left before the entry gets removed from networkDB. Set
+	// for deleted entries lingering as tombstones, and for entries hidden
+	// because their owner failed.
 	reapTime time.Duration
 }
 
@@ -397,6 +403,9 @@ func (nDB *NetworkDB) GetEntry(tname, nid, key string) ([]byte, error) {
 	if v != nil && v.deleting {
 		return nil, types.NotFoundErrorf("entry in table %s network id %s and key %s deleted and pending garbage collection", tname, nid, key)
 	}
+	if nDB.isNodeFailed(v.node) {
+		return nil, types.NotFoundErrorf("entry in table %s network id %s and key %s is owned by a failed node and hidden until it returns", tname, nid, key)
+	}
 
 	// note: this panics if a nil entry was stored in the table; after
 	// discussion, we decided to not gracefully handle this situation as
@@ -414,15 +423,39 @@ func (nDB *NetworkDB) getEntry(tname, nid, key string) (*entry, error) {
 	return e, nil
 }
 
+// isNodeFailed reports whether the node is a peer which memberlist has
+// declared failed. The state of a failed node is remembered, but hidden from
+// watchers and reads, until the node either comes back or is reaped.
+// Caller should hold the NetworkDB lock while calling this.
+func (nDB *NetworkDB) isNodeFailed(nodeName string) bool {
+	_, failed := nDB.failedNodes[nodeName]
+	return failed
+}
+
+// failedNodeSet returns the names of the currently failed nodes as a set,
+// for filtering entries after the lock has been released.
+// Caller should hold the NetworkDB lock while calling this.
+func (nDB *NetworkDB) failedNodeSet() map[string]bool {
+	if len(nDB.failedNodes) == 0 {
+		return nil
+	}
+	failed := make(map[string]bool, len(nDB.failedNodes))
+	for name := range nDB.failedNodes {
+		failed[name] = true
+	}
+	return failed
+}
+
 // CreateEntry creates a table entry in NetworkDB for given (network,
 // table, key) tuple and if the NetworkDB is part of the cluster
 // propagates this event to the cluster. It is an error to create an
 // entry for the same tuple for which there is already an existing
-// entry unless the current entry is deleting state.
+// entry, unless that entry is a tombstone or is hidden because its owner
+// is a failed node.
 func (nDB *NetworkDB) CreateEntry(tname, nid, key string, value []byte) error {
 	nDB.Lock()
 	oldEntry, err := nDB.getEntry(tname, nid, key)
-	if err == nil || (oldEntry != nil && !oldEntry.deleting) {
+	if err == nil && !oldEntry.deleting && !nDB.isNodeFailed(oldEntry.node) {
 		nDB.Unlock()
 		return fmt.Errorf("cannot create entry in table %s with network id %s and key %s, already exists", tname, nid, key)
 	}
@@ -446,10 +479,12 @@ func (nDB *NetworkDB) CreateEntry(tname, nid, key string, value []byte) error {
 // UpdateEntry updates a table entry in NetworkDB for given (network,
 // table, key) tuple and if the NetworkDB is part of the cluster
 // propagates this event to the cluster. It is an error to update a
-// non-existent entry.
+// non-existent entry, including an entry that is a tombstone or is
+// hidden because its owner is a failed node.
 func (nDB *NetworkDB) UpdateEntry(tname, nid, key string, value []byte) error {
 	nDB.Lock()
-	if _, err := nDB.getEntry(tname, nid, key); err != nil {
+	oldEntry, err := nDB.getEntry(tname, nid, key)
+	if err != nil || oldEntry.deleting || nDB.isNodeFailed(oldEntry.node) {
 		nDB.Unlock()
 		return fmt.Errorf("cannot update entry as the entry in table %s with network id %s and key %s does not exist", tname, nid, key)
 	}
@@ -481,10 +516,11 @@ type TableElem struct {
 func (nDB *NetworkDB) GetTableByNetwork(tname, nid string) map[string]*TableElem {
 	nDB.RLock()
 	root := nDB.indexes[byTable].Root()
+	failed := nDB.failedNodeSet()
 	nDB.RUnlock()
 	entries := make(map[string]*TableElem)
 	root.WalkPrefix(fmt.Appendf(nil, "/%s/%s", tname, nid), func(k []byte, v *entry) bool {
-		if v.deleting {
+		if v.deleting || failed[v.node] {
 			return false
 		}
 		key := string(k)
@@ -501,7 +537,7 @@ func (nDB *NetworkDB) GetTableByNetwork(tname, nid string) map[string]*TableElem
 func (nDB *NetworkDB) DeleteEntry(tname, nid, key string) error {
 	nDB.Lock()
 	oldEntry, err := nDB.getEntry(tname, nid, key)
-	if err != nil || oldEntry == nil || oldEntry.deleting {
+	if err != nil || oldEntry.deleting || nDB.isNodeFailed(oldEntry.node) {
 		nDB.Unlock()
 		return fmt.Errorf("cannot delete entry %s with network id %s and key %s "+
 			"does not exist or is already being deleted", tname, nid, key)
@@ -525,26 +561,95 @@ func (nDB *NetworkDB) DeleteEntry(tname, nid, key string) error {
 	return nil
 }
 
+// isNodeAttached reports whether the node has a non-leaving attachment for
+// the network. A failed node still counts if its attachment was remembered.
+// Caller should hold the NetworkDB lock while calling this.
+func (nDB *NetworkDB) isNodeAttached(nodeName, nid string) bool {
+	n, ok := nDB.networks[nodeName][nid]
+	return ok && !n.leaving
+}
+
+// deleteNodeFromNetworks stops the node from being a peer of any network and
+// forgets which ones it was attached to.
+// Caller should hold the NetworkDB lock while calling this.
 func (nDB *NetworkDB) deleteNodeFromNetworks(deletedNode string) {
-	for nid, nodes := range nDB.networkNodes {
-		updatedNodes := make([]string, 0, len(nodes))
-		for _, node := range nodes {
-			if node == deletedNode {
-				continue
-			}
-
-			updatedNodes = append(updatedNodes, node)
-		}
-
-		nDB.networkNodes[nid] = updatedNodes
-	}
-
+	nDB.suspendNodeInNetworks(deletedNode)
 	delete(nDB.networks, deletedNode)
+}
+
+// suspendNodeInNetworks stops the node from being a peer of any network,
+// while keeping its attachments for restoreNodeInNetworks.
+// Caller should hold the NetworkDB lock while calling this.
+func (nDB *NetworkDB) suspendNodeInNetworks(nodeName string) {
+	for nid := range nDB.networkNodes {
+		nDB.deleteNetworkNode(nid, nodeName)
+	}
+}
+
+// restoreNodeInNetworks makes the node a peer again of the networks it is
+// attached to.
+// Caller should hold the NetworkDB lock while calling this.
+func (nDB *NetworkDB) restoreNodeInNetworks(nodeName string) {
+	for nid, n := range nDB.networks[nodeName] {
+		if n.leaving {
+			continue
+		}
+		nDB.addNetworkNode(nid, nodeName)
+	}
+}
+
+// suspendNodeTableEntries hides all table entries owned by node from
+// watchers and reads while keeping them in the store, so that the freshest
+// state possible is already in place if the node comes back. The entries
+// age out on the entry reap timer.
+// Caller should hold the NetworkDB lock while calling this.
+func (nDB *NetworkDB) suspendNodeTableEntries(node string) {
+	nDB.indexes[byTable].Root().Walk(func(path []byte, e *entry) bool {
+		if e.node != node || e.deleting {
+			return false
+		}
+		params := strings.Split(string(path[1:]), "/")
+		tName, nwID, key := params[0], params[1], params[2]
+
+		e.reapTime = nDB.config.reapEntryInterval
+		nDB.broadcaster.Write(WatchEvent{
+			Table:     tName,
+			NetworkID: nwID,
+			Key:       key,
+			Prev:      e.value,
+		})
+		return false
+	})
+}
+
+// restoreNodeTableEntries makes the table entries which were remembered
+// across a failure of node visible again. What is published is the freshest
+// state this node remembered; a peer which holds newer relayed state
+// delivers it as a regular update afterwards.
+// Caller should hold the NetworkDB lock while calling this.
+func (nDB *NetworkDB) restoreNodeTableEntries(node string) {
+	nDB.indexes[byTable].Root().Walk(func(path []byte, e *entry) bool {
+		if e.node != node || e.deleting {
+			return false
+		}
+		params := strings.Split(string(path[1:]), "/")
+		tName, nwID, key := params[0], params[1], params[2]
+
+		e.reapTime = 0
+		nDB.broadcaster.Write(WatchEvent{
+			Table:     tName,
+			NetworkID: nwID,
+			Key:       key,
+			Value:     e.value,
+		})
+		return false
+	})
 }
 
 // deleteNodeNetworkEntries deletes all table entries for a network owned by
 // node from the local store.
 func (nDB *NetworkDB) deleteNodeNetworkEntries(nid, node string) {
+	hidden := nDB.isNodeFailed(node)
 	nDB.indexes[byNetwork].Root().WalkPrefix([]byte("/"+nid),
 		func(path []byte, oldEntry *entry) bool {
 			// Do nothing if the entry is owned by a remote node that is not leaving the network
@@ -557,8 +662,9 @@ func (nDB *NetworkDB) deleteNodeNetworkEntries(nid, node string) {
 
 			nDB.deleteEntry(nwID, tName, key)
 
-			// Notify to the upper layer only entries not already marked for deletion
-			if !oldEntry.deleting {
+			// Notify to the upper layer only entries not already marked for
+			// deletion, and not already hidden because their owner is failed.
+			if !oldEntry.deleting && !hidden {
 				nDB.broadcaster.Write(WatchEvent{
 					Table:     tName,
 					NetworkID: nwID,
@@ -571,10 +677,12 @@ func (nDB *NetworkDB) deleteNodeNetworkEntries(nid, node string) {
 }
 
 // deleteNodeTableEntries deletes all table entries owned by node from the local
-// store, across all networks.
-func (nDB *NetworkDB) deleteNodeTableEntries(node string) {
-	nDB.indexes[byTable].Root().Walk(func(path []byte, oldEntry *entry) bool {
-		if oldEntry.node != node {
+// store, across all networks. It returns the events for the entries which were
+// visible, for the caller to broadcast if their removal is to be observed.
+func (nDB *NetworkDB) deleteNodeTableEntries(node string) []WatchEvent {
+	var deleted []WatchEvent
+	nDB.indexes[byTable].Root().Walk(func(path []byte, e *entry) bool {
+		if e.node != node {
 			return false
 		}
 
@@ -583,30 +691,35 @@ func (nDB *NetworkDB) deleteNodeTableEntries(node string) {
 
 		nDB.deleteEntry(nwID, tName, key)
 
-		if !oldEntry.deleting {
-			nDB.broadcaster.Write(WatchEvent{
+		if !e.deleting {
+			deleted = append(deleted, WatchEvent{
 				Table:     tName,
 				NetworkID: nwID,
 				Key:       key,
-				Prev:      oldEntry.value,
+				Prev:      e.value,
 			})
 		}
 		return false
 	})
+	return deleted
 }
 
 // WalkTable walks a single table in NetworkDB and invokes the passed
 // function for each entry in the table passing the network, key,
 // value. The walk stops if the passed function returns a true.
+// Entries which are hidden because their owner is failed are reported as
+// deleted.
 func (nDB *NetworkDB) WalkTable(tname string, fn func(string, string, []byte, bool) bool) error {
 	nDB.RLock()
 	root := nDB.indexes[byTable].Root()
+	failed := nDB.failedNodeSet()
 	nDB.RUnlock()
 	root.WalkPrefix([]byte("/"+tname), func(path []byte, v *entry) bool {
 		params := strings.Split(string(path[1:]), "/")
 		nid := params[1]
 		key := params[2]
-		return fn(nid, key, v.value, v.deleting)
+		deleted := v.deleting || failed[v.node]
+		return fn(nid, key, v.value, deleted)
 	})
 
 	return nil
@@ -715,7 +828,10 @@ func (nDB *NetworkDB) LeaveNetwork(nid string) error {
 		} else {
 			nDB.deleteEntry(nwID, tName, key)
 		}
-		if !oldEntry.deleting {
+		// Do not notify watchers of entries already hidden from them
+		// because their owner is failed.
+		hidden := nDB.isNodeFailed(oldEntry.node)
+		if !oldEntry.deleting && !hidden {
 			nDB.broadcaster.Write(WatchEvent{
 				Table:     tName,
 				NetworkID: nwID,

--- a/daemon/libnetwork/networkdb/networkdb_test.go
+++ b/daemon/libnetwork/networkdb/networkdb_test.go
@@ -295,6 +295,72 @@ func TestNetworkDBCRUDTableEntry(t *testing.T) {
 	closeNetworkDBInstances(t, dbs)
 }
 
+// TestCreateEntryOverTombstone checks that a key can be created again while
+// the tombstone of its previous incarnation is still lingering in the store,
+// and that a live entry still holds its key against a create.
+func TestCreateEntryOverTombstone(t *testing.T) {
+	nDB := newNetworkDB(DefaultConfig())
+	nDB.networkBroadcasts = &memberlist.TransmitLimitedQueue{}
+	nDB.nodeBroadcasts = &memberlist.TransmitLimitedQueue{}
+	assert.NilError(t, nDB.JoinNetwork("network1"))
+
+	assert.NilError(t, nDB.CreateEntry("test_table", "network1", "test_key", []byte("v1")))
+	assert.NilError(t, nDB.DeleteEntry("test_table", "network1", "test_key"))
+
+	nDB.RLock()
+	tombstone, err := nDB.getEntry("test_table", "network1", "test_key")
+	nDB.RUnlock()
+	assert.NilError(t, err)
+	assert.Assert(t, tombstone.deleting, "the deleted entry should still be lingering as a tombstone")
+
+	assert.NilError(t, nDB.CreateEntry("test_table", "network1", "test_key", []byte("v2")))
+	v, err := nDB.GetEntry("test_table", "network1", "test_key")
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("v2", string(v)))
+
+	// The entry is live again, so it holds its key.
+	assert.Check(t, is.ErrorContains(
+		nDB.CreateEntry("test_table", "network1", "test_key", []byte("v3")), "already exists"))
+}
+
+// TestUpdateAndDeleteEntryOnTombstone checks that a tombstone counts as a
+// non-existent entry for the write API, matching what a read of it reports:
+// neither an update nor a delete of one succeeds, and a refused update does
+// not resurrect it. TestCreateEntryOverTombstone covers the create side, where
+// the key is instead free to be taken over.
+func TestUpdateAndDeleteEntryOnTombstone(t *testing.T) {
+	nDB := newNetworkDB(DefaultConfig())
+	nDB.networkBroadcasts = &memberlist.TransmitLimitedQueue{}
+	nDB.nodeBroadcasts = &memberlist.TransmitLimitedQueue{}
+	assert.NilError(t, nDB.JoinNetwork("network1"))
+
+	assert.NilError(t, nDB.CreateEntry("test_table", "network1", "test_key", []byte("v1")))
+	assert.NilError(t, nDB.DeleteEntry("test_table", "network1", "test_key"))
+
+	nDB.RLock()
+	tombstone, err := nDB.getEntry("test_table", "network1", "test_key")
+	nDB.RUnlock()
+	assert.NilError(t, err)
+	assert.Assert(t, tombstone.deleting, "the deleted entry should still be lingering as a tombstone")
+
+	// A read already reports the key as gone, so the writes must agree.
+	_, err = nDB.GetEntry("test_table", "network1", "test_key")
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
+	assert.Check(t, is.ErrorContains(
+		nDB.UpdateEntry("test_table", "network1", "test_key", []byte("v2")), "does not exist"))
+	assert.Check(t, is.ErrorContains(
+		nDB.DeleteEntry("test_table", "network1", "test_key"), "does not exist"))
+
+	// The refused update must not have resurrected the entry nor taken its key.
+	nDB.RLock()
+	after, err := nDB.getEntry("test_table", "network1", "test_key")
+	nDB.RUnlock()
+	assert.NilError(t, err)
+	assert.Check(t, after.deleting, "the tombstone should still be a tombstone")
+	assert.Check(t, is.Equal("v1", string(after.value)), "the tombstone's value should be untouched")
+	assert.Check(t, is.Equal(nDB.config.NodeID, after.node), "the tombstone's owner should be untouched")
+}
+
 func (nDB *NetworkDB) dumpTable(t *testing.T, tname string) {
 	t.Helper()
 	var b strings.Builder
@@ -463,6 +529,34 @@ func TestNetworkDBBulkSync(t *testing.T) {
 	}
 
 	closeNetworkDBInstances(t, dbs)
+}
+
+// TestBulkSyncWithFailedPeer checks that a bulk sync is still sent to a peer
+// which memberlist has declared failed: such a peer can well be reachable, and
+// waiting for a reply, before we learn that it is back. Only a peer nothing is
+// known about is reported as unreachable, so that the caller does not count the
+// sync as completed.
+func TestBulkSyncWithFailedPeer(t *testing.T) {
+	dbs := createNetworkDBInstances(t, 2, "node", DefaultConfig())
+	defer closeNetworkDBInstances(t, dbs)
+
+	assert.NilError(t, dbs[0].JoinNetwork("network1"))
+	dbs[1].verifyNetworkExistence(t, dbs[0].config.NodeID, "network1", true)
+	assert.NilError(t, dbs[1].JoinNetwork("network1"))
+	dbs[0].verifyNetworkExistence(t, dbs[1].config.NodeID, "network1", true)
+
+	// Make node0 consider node1 failed while node1 is still very much alive.
+	// Nothing moves it back to active: a node event for a peer which is not in
+	// the memberlist node list is ignored, and memberlist only notifies a join
+	// for a node it sees coming back.
+	dbs[0].Lock()
+	_, err := dbs[0].changeNodeState(dbs[1].config.NodeID, nodeFailedState)
+	dbs[0].Unlock()
+	assert.NilError(t, err)
+
+	assert.NilError(t, dbs[0].bulkSyncNode([]string{"network1"}, dbs[1].config.NodeID, false))
+	assert.Check(t, is.ErrorContains(
+		dbs[0].bulkSyncNode([]string{"network1"}, "nosuchnode", false), "unknown node"))
 }
 
 // Regression test for https://github.com/moby/moby/issues/51701

--- a/daemon/libnetwork/networkdb/nodefail_rejoin_test.go
+++ b/daemon/libnetwork/networkdb/nodefail_rejoin_test.go
@@ -1,0 +1,397 @@
+package networkdb
+
+import (
+	"maps"
+	"net"
+	"slices"
+	"testing"
+	"time"
+
+	cerrdefs "github.com/containerd/errdefs"
+	"github.com/docker/go-events"
+	"github.com/hashicorp/memberlist"
+	"github.com/hashicorp/serf/serf"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+// newTestNetworkDBWithPeer returns a NetworkDB which has joined network1, and
+// a peer node1 attached to it, along with the delegates needed to drive them.
+func newTestNetworkDBWithPeer(t *testing.T) (*NetworkDB, *eventDelegate, *memberlist.Node, func(ltime serf.LamportTime, typ TableEvent_Type, key string, value []byte)) {
+	t.Helper()
+	nDB := newNetworkDB(DefaultConfig())
+	nDB.networkBroadcasts = &memberlist.TransmitLimitedQueue{}
+	nDB.nodeBroadcasts = &memberlist.TransmitLimitedQueue{}
+	assert.NilError(t, nDB.JoinNetwork("network1"))
+
+	ed := &eventDelegate{nDB}
+	mn := &memberlist.Node{Name: "node1", Addr: net.IPv4(1, 2, 3, 4)}
+	ed.NotifyJoin(mn)
+	nDB.handleNetworkEvent(&NetworkEvent{
+		Type:      NetworkEventTypeJoin,
+		LTime:     1,
+		NodeName:  "node1",
+		NetworkID: "network1",
+	})
+
+	d := &delegate{nDB}
+	msgs := &messageBuffer{t: t}
+	appendTableEvent := tableEventHelper(msgs, "node1", "network1", "table1")
+	deliver := func(ltime serf.LamportTime, typ TableEvent_Type, key string, value []byte) {
+		t.Helper()
+		msgs.Reset()
+		appendTableEvent(ltime, typ, key, value)
+		d.NotifyMsg(msgs.Compound())
+	}
+	return nDB, ed, mn, deliver
+}
+
+// TestFailedNodeEntriesHiddenAndRestored checks that the state owned by a
+// failed node is hidden rather than dropped: the node stops being a peer of
+// the networks it was attached to and its entries stop being visible, but
+// both are remembered and put back as soon as it comes back, without anything
+// being re-sent.
+func TestFailedNodeEntriesHiddenAndRestored(t *testing.T) {
+	nDB, ed, mn, deliver := newTestNetworkDBWithPeer(t)
+
+	watch, cancel := nDB.Watch("table1", "network1")
+	defer cancel()
+
+	deliver(2, TableEventTypeCreate, "key1", []byte("v1"))
+	ed.NotifyLeave(mn)
+
+	// The entry must stop being visible, and the watchers must be told that
+	// it is gone: what it describes cannot be reached either.
+	_, err := nDB.GetEntry("table1", "network1", "key1")
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound), "entry owned by a failed node should not be visible")
+	assert.Check(t, is.Len(nDB.GetTableByNetwork("table1", "network1"), 0))
+	assert.Check(t, is.DeepEqual(drainChannel(watch.C), []events.Event{
+		WatchEvent{Table: "table1", NetworkID: "network1", Key: "key1", Value: []byte("v1")},
+		WatchEvent{Table: "table1", NetworkID: "network1", Key: "key1", Prev: []byte("v1")},
+	}))
+
+	// The entry is still in the store, aging out.
+	nDB.RLock()
+	e, rawErr := nDB.getEntry("table1", "network1", "key1")
+	nDB.RUnlock()
+	assert.NilError(t, rawErr)
+	assert.Check(t, is.Equal(nDB.config.reapEntryInterval, e.reapTime), "hidden entry should age out")
+
+	// The node must no longer be a peer, but the attachment must be
+	// remembered.
+	nDB.RLock()
+	nn := slices.Clone(nDB.networkNodes["network1"])
+	attachments := maps.Clone(nDB.networks["node1"])
+	nDB.RUnlock()
+	assert.Check(t, !slices.Contains(nn, "node1"), "node1 should not be a peer of network1 while failed")
+	assert.Check(t, is.Contains(attachments, "network1"), "node1's attachment to network1 should be remembered")
+
+	// Coming back must put it in the peer list again and publish the entry
+	// again, with nothing having to be re-sent.
+	ed.NotifyJoin(mn)
+
+	nDB.RLock()
+	nn = slices.Clone(nDB.networkNodes["network1"])
+	e, rawErr = nDB.getEntry("table1", "network1", "key1")
+	nDB.RUnlock()
+	assert.Check(t, is.Contains(nn, "node1"), "node1 should be a peer of network1 again")
+	assert.NilError(t, rawErr)
+	assert.Check(t, is.Equal(time.Duration(0), e.reapTime), "restored entry should no longer age")
+
+	v, err := nDB.GetEntry("table1", "network1", "key1")
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("v1", string(v)))
+	assert.Check(t, is.DeepEqual(drainChannel(watch.C), []events.Event{
+		WatchEvent{Table: "table1", NetworkID: "network1", Key: "key1", Value: []byte("v1")},
+	}))
+}
+
+// TestLeftNodeClearsNetworkMembership checks that a node which gracefully
+// leaves the cluster is removed from the peer lists for good: nothing is
+// remembered for it, unlike for a failed node.
+func TestLeftNodeClearsNetworkMembership(t *testing.T) {
+	nDB, _, _, deliver := newTestNetworkDBWithPeer(t)
+	deliver(2, TableEventTypeCreate, "key1", []byte("v1"))
+
+	watch, cancel := nDB.Watch("table1", "network1")
+	defer cancel()
+
+	nDB.Lock()
+	_, err := nDB.changeNodeState("node1", nodeLeftState)
+	nDB.Unlock()
+	assert.NilError(t, err)
+
+	nDB.RLock()
+	present := slices.Contains(nDB.networkNodes["network1"], "node1")
+	_, hasNetworks := nDB.networks["node1"]
+	_, rawErr := nDB.getEntry("table1", "network1", "key1")
+	nDB.RUnlock()
+	assert.Check(t, !present, "node1 should be removed from networkNodes after leave")
+	assert.Check(t, !hasNetworks, "node1's attachments should be forgotten after leave")
+	assert.Check(t, is.ErrorType(rawErr, cerrdefs.IsNotFound), "node1's entries should be deleted after leave")
+
+	// Watchers see the snapshot of the entry and then its deletion.
+	assert.Check(t, is.DeepEqual(drainChannel(watch.C), []events.Event{
+		WatchEvent{Table: "table1", NetworkID: "network1", Key: "key1", Value: []byte("v1")},
+		WatchEvent{Table: "table1", NetworkID: "network1", Key: "key1", Prev: []byte("v1")},
+	}))
+}
+
+// TestFailedNodeRelayedEventsRemembered checks that an update relayed by
+// another node on behalf of a failed owner is remembered while the owner is
+// down — hidden and with bounded retention — and is what gets published when
+// the owner is back.
+func TestFailedNodeRelayedEventsRemembered(t *testing.T) {
+	nDB, ed, mn, deliver := newTestNetworkDBWithPeer(t)
+
+	watch, cancel := nDB.Watch("table1", "network1")
+	defer cancel()
+
+	ed.NotifyLeave(mn)
+
+	// An update for the failed owner, relayed by a node which can still
+	// reach it.
+	deliver(2, TableEventTypeCreate, "key1", []byte("relayed"))
+
+	_, err := nDB.GetEntry("table1", "network1", "key1")
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound), "relayed update should not be visible while the owner is down")
+
+	// It is remembered, with bounded retention.
+	nDB.RLock()
+	e, rawErr := nDB.getEntry("table1", "network1", "key1")
+	nDB.RUnlock()
+	assert.NilError(t, rawErr)
+	assert.Check(t, is.Equal("relayed", string(e.value)))
+	assert.Check(t, is.Equal(nDB.config.reapEntryInterval, e.reapTime), "remembered entry should age out")
+
+	// A fresher relayed update replaces what is remembered.
+	deliver(3, TableEventTypeUpdate, "key1", []byte("fresher"))
+
+	// Nothing was published while the owner was down, and the freshest state
+	// remembered is what gets published when it returns.
+	ed.NotifyJoin(mn)
+	v, err := nDB.GetEntry("table1", "network1", "key1")
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("fresher", string(v)), "the freshest state known should be restored")
+	assert.Check(t, is.DeepEqual(drainChannel(watch.C), []events.Event{
+		WatchEvent{Table: "table1", NetworkID: "network1", Key: "key1", Value: []byte("fresher")},
+	}))
+}
+
+// TestFailedNodeRelayedDeleteKept checks that an entry deleted while its owner
+// was down does not come back when the owner does.
+func TestFailedNodeRelayedDeleteKept(t *testing.T) {
+	nDB, ed, mn, deliver := newTestNetworkDBWithPeer(t)
+	deliver(2, TableEventTypeCreate, "key1", []byte("v1"))
+
+	watch, cancel := nDB.Watch("table1", "network1")
+	defer cancel()
+
+	ed.NotifyLeave(mn)
+	deliver(3, TableEventTypeDelete, "key1", []byte("v1"))
+
+	ed.NotifyJoin(mn)
+	_, err := nDB.GetEntry("table1", "network1", "key1")
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound), "an entry deleted while its owner was down should stay deleted")
+	assert.Check(t, is.DeepEqual(drainChannel(watch.C), []events.Event{
+		WatchEvent{Table: "table1", NetworkID: "network1", Key: "key1", Value: []byte("v1")},
+		WatchEvent{Table: "table1", NetworkID: "network1", Key: "key1", Prev: []byte("v1")},
+	}), "watchers should see the delete once, and the entry should not come back")
+}
+
+// TestFailedThenLeftDropsRememberedState checks that a graceful leave of a
+// failed node drops what was remembered for it without notifying watchers a
+// second time.
+func TestFailedThenLeftDropsRememberedState(t *testing.T) {
+	nDB, ed, mn, deliver := newTestNetworkDBWithPeer(t)
+	deliver(2, TableEventTypeCreate, "key1", []byte("v1"))
+
+	watch, cancel := nDB.Watch("table1", "network1")
+	defer cancel()
+
+	ed.NotifyLeave(mn)
+
+	nDB.Lock()
+	_, err := nDB.changeNodeState("node1", nodeLeftState)
+	nDB.Unlock()
+	assert.NilError(t, err)
+
+	nDB.RLock()
+	_, rawErr := nDB.getEntry("table1", "network1", "key1")
+	_, hasNetworks := nDB.networks["node1"]
+	nDB.RUnlock()
+	assert.Check(t, is.ErrorType(rawErr, cerrdefs.IsNotFound), "remembered entry should be dropped on leave")
+	assert.Check(t, !hasNetworks, "attachments should be dropped on leave")
+
+	// Watchers were told once, when the node failed.
+	assert.Check(t, is.DeepEqual(drainChannel(watch.C), []events.Event{
+		WatchEvent{Table: "table1", NetworkID: "network1", Key: "key1", Value: []byte("v1")},
+		WatchEvent{Table: "table1", NetworkID: "network1", Key: "key1", Prev: []byte("v1")},
+	}))
+}
+
+// TestFailedNodeEntriesExpire checks that entries remembered for a failed node
+// age out, so that they cannot be restored after whatever would delete them
+// expired.
+func TestFailedNodeEntriesExpire(t *testing.T) {
+	nDB, ed, mn, deliver := newTestNetworkDBWithPeer(t)
+	deliver(2, TableEventTypeCreate, "key1", []byte("v1"))
+
+	watch, cancel := nDB.Watch("table1", "network1")
+	defer cancel()
+
+	ed.NotifyLeave(mn)
+
+	// Age the remembered entry past its retention.
+	nDB.Lock()
+	e, rawErr := nDB.getEntry("table1", "network1", "key1")
+	if rawErr == nil {
+		e.reapTime = time.Second
+	}
+	nDB.Unlock()
+	assert.NilError(t, rawErr)
+
+	nDB.reapTableEntries()
+
+	nDB.RLock()
+	_, rawErr = nDB.getEntry("table1", "network1", "key1")
+	nDB.RUnlock()
+	assert.Check(t, is.ErrorType(rawErr, cerrdefs.IsNotFound), "remembered entry should expire")
+
+	// Nothing is left to restore when the node returns.
+	ed.NotifyJoin(mn)
+	assert.Check(t, is.DeepEqual(drainChannel(watch.C), []events.Event{
+		WatchEvent{Table: "table1", NetworkID: "network1", Key: "key1", Value: []byte("v1")},
+		WatchEvent{Table: "table1", NetworkID: "network1", Key: "key1", Prev: []byte("v1")},
+	}), "nothing should be restored after the remembered entry expired")
+}
+
+// TestWatchSnapshotSkipsHiddenEntries checks that a watch created while a node
+// is failed does not receive synthesized create events for hidden entries.
+func TestWatchSnapshotSkipsHiddenEntries(t *testing.T) {
+	nDB, ed, mn, deliver := newTestNetworkDBWithPeer(t)
+
+	// A second, healthy remote node with an entry of its own.
+	ed.NotifyJoin(&memberlist.Node{Name: "node2", Addr: net.IPv4(1, 2, 3, 5)})
+	nDB.handleNetworkEvent(&NetworkEvent{
+		Type:      NetworkEventTypeJoin,
+		LTime:     2,
+		NodeName:  "node2",
+		NetworkID: "network1",
+	})
+
+	deliver(2, TableEventTypeCreate, "key1", []byte("hidden"))
+
+	d := &delegate{nDB}
+	msgs := messageBuffer{t: t}
+	appendNode2TableEvent := tableEventHelper(&msgs, "node2", "network1", "table1")
+	appendNode2TableEvent(3, TableEventTypeCreate, "key2", []byte("visible"))
+	d.NotifyMsg(msgs.Compound())
+
+	ed.NotifyLeave(mn)
+
+	watch, cancel := nDB.Watch("table1", "network1")
+	defer cancel()
+	assert.Check(t, is.DeepEqual(drainChannel(watch.C), []events.Event{
+		WatchEvent{Table: "table1", NetworkID: "network1", Key: "key2", Value: []byte("visible")},
+	}), "only the entry of the healthy node should be synthesized")
+}
+
+// TestBulkSyncFromInactiveNodeRemembered checks that a bulk sync from a node we
+// consider failed (as happens across an asymmetric partition) is merged and
+// remembered, hidden until the node returns.
+func TestBulkSyncFromInactiveNodeRemembered(t *testing.T) {
+	nDB, ed, mn, _ := newTestNetworkDBWithPeer(t)
+	ed.NotifyLeave(mn)
+
+	payload := &messageBuffer{t: t}
+	tableEventHelper(payload, "node1", "network1", "table1")(2, TableEventTypeCreate, "key1", []byte("synced"))
+
+	msgs := &messageBuffer{t: t}
+	msgs.Append(MessageTypeBulkSync, &BulkSyncMessage{
+		LTime:    2,
+		NodeName: "node1",
+		Networks: []string{"network1"},
+		Payload:  payload.Compound(),
+	})
+	(&delegate{nDB}).NotifyMsg(msgs.Compound())
+
+	nDB.RLock()
+	e, rawErr := nDB.getEntry("table1", "network1", "key1")
+	nDB.RUnlock()
+	assert.NilError(t, rawErr)
+	assert.Check(t, is.Equal("synced", string(e.value)))
+	_, err := nDB.GetEntry("table1", "network1", "key1")
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound), "the synced entry should stay hidden while its owner is inactive")
+}
+
+// TestHiddenEntriesDoNotExistForPublicAPI checks that the public write API
+// treats entries hidden for a failed owner the same way it treated the
+// deleted state before: a create takes the key over, and updates or deletes
+// of a hidden entry fail as if it did not exist.
+func TestHiddenEntriesDoNotExistForPublicAPI(t *testing.T) {
+	nDB, ed, mn, deliver := newTestNetworkDBWithPeer(t)
+	deliver(2, TableEventTypeCreate, "key1", []byte("remote"))
+	deliver(2, TableEventTypeCreate, "key2", []byte("remote"))
+	ed.NotifyLeave(mn)
+
+	// A hidden entry does not hold its key against the local node.
+	assert.NilError(t, nDB.CreateEntry("table1", "network1", "key1", []byte("local")))
+	v, err := nDB.GetEntry("table1", "network1", "key1")
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("local", string(v)))
+
+	// Updating or deleting a hidden entry fails as if it did not exist.
+	assert.Check(t, is.ErrorContains(nDB.UpdateEntry("table1", "network1", "key2", []byte("nope")), "does not exist"))
+	assert.Check(t, is.ErrorContains(nDB.DeleteEntry("table1", "network1", "key2"), "does not exist"))
+
+	// When the owner returns, only the entry it still owns is restored, and
+	// its stale re-send of the taken-over key is rejected.
+	ed.NotifyJoin(mn)
+	deliver(2, TableEventTypeCreate, "key1", []byte("remote"))
+	v, err = nDB.GetEntry("table1", "network1", "key1")
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("local", string(v)), "the taken-over key should not be reclaimed by a stale re-send")
+	v, err = nDB.GetEntry("table1", "network1", "key2")
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("remote", string(v)))
+}
+
+// TestReapFailedNodeClearsNetworkState checks that garbage collecting a node
+// which never came back drops the attachments and any entries still
+// remembered for it.
+func TestReapFailedNodeClearsNetworkState(t *testing.T) {
+	nDB, ed, mn, deliver := newTestNetworkDBWithPeer(t)
+	deliver(2, TableEventTypeCreate, "key1", []byte("v1"))
+
+	ed.NotifyLeave(mn)
+
+	// Make the node eligible for collection.
+	nDB.Lock()
+	nDB.failedNodes["node1"].reapTime = nodeReapPeriod
+	nDB.Unlock()
+
+	// The failure took node1 out of the peer list, so what is left for the
+	// reap to drop is the attachment and the entry remembered for it.
+	nDB.RLock()
+	inNetwork := slices.Contains(nDB.networkNodes["network1"], "node1")
+	attachments := maps.Clone(nDB.networks["node1"])
+	nDB.RUnlock()
+	assert.Check(t, !inNetwork, "node1 should already be out of the peer list before the reap")
+	assert.Assert(t, is.Contains(attachments, "network1"), "node1's attachment should still be remembered before the reap")
+
+	nDB.reapDeadNode()
+
+	nDB.RLock()
+	_, stillFailed := nDB.failedNodes["node1"]
+	_, hasNetworks := nDB.networks["node1"]
+	nDB.RUnlock()
+	assert.Check(t, !stillFailed, "node1 should be garbage collected from failedNodes")
+	assert.Check(t, !hasNetworks, "node1's network attachments should be removed when reaped")
+
+	err := nDB.WalkTable("table1", func(nw, key string, value []byte, deleted bool) bool {
+		t.Fatalf("expected no entries owned by the reaped node, found %s/%s", nw, key)
+		return false
+	})
+	assert.NilError(t, err)
+}

--- a/daemon/libnetwork/networkdb/nodemgmt.go
+++ b/daemon/libnetwork/networkdb/nodemgmt.go
@@ -58,6 +58,11 @@ func (nDB *NetworkDB) changeNodeState(nodeName string, newState nodeState) (bool
 		// reset the node reap time
 		n.reapTime = 0
 		nDB.nodes[nodeName] = n
+		// The node is reachable again, so put it back in the peer list of
+		// the networks it was attached to when it failed, and make the
+		// entries remembered across the failure visible again.
+		nDB.restoreNodeInNetworks(n.Name)
+		nDB.restoreNodeTableEntries(n.Name)
 	case nodeLeftState:
 		if currState == nodeLeftState {
 			return false, nil
@@ -86,11 +91,27 @@ func (nDB *NetworkDB) changeNodeState(nodeName string, newState nodeState) (bool
 		if n.reapTime == 0 {
 			n.reapTime = nodeReapInterval
 		}
-		// The node leave or fails, delete all the entries created by it.
-		// If the node was temporary down, deleting the entries will guarantee that the CREATE events will be accepted
-		// If the node instead left because was going down, then it makes sense to just delete all its state
-		nDB.deleteNodeFromNetworks(n.Name)
-		nDB.deleteNodeTableEntries(n.Name)
+		if newState == nodeLeftState {
+			// The node is gone for good: delete all the entries created by
+			// it along with the record of which networks it was attached to.
+			deletedEvents := nDB.deleteNodeTableEntries(n.Name)
+			if currState != nodeFailedState {
+				// The entries were still visible: tell the watchers they
+				// are gone. Had the node already failed, the watchers were
+				// told when it failed.
+				for _, ev := range deletedEvents {
+					nDB.broadcaster.Write(ev)
+				}
+			}
+			nDB.deleteNodeFromNetworks(n.Name)
+		} else {
+			// The node may only be temporarily down. Hide its entries and
+			// remember its attachments, so the freshest state possible can
+			// be put straight back if it returns. What is remembered ages
+			// out on the entry reap timer and is dropped by reapDeadNode.
+			nDB.suspendNodeTableEntries(n.Name)
+			nDB.suspendNodeInNetworks(n.Name)
+		}
 	}
 
 	return true, nil

--- a/daemon/libnetwork/networkdb/watch.go
+++ b/daemon/libnetwork/networkdb/watch.go
@@ -53,7 +53,8 @@ type NodeAddr struct {
 // filter is an empty string it acts as a wildcard for that
 // field. Watch returns a channel of events, where the events will be
 // sent. The watch channel is initialized with synthetic create events for all
-// the existing table entries not owned by this node which match the filters.
+// the existing table entries not owned by this node which match the filters,
+// except entries hidden because their owner is failed.
 func (nDB *NetworkDB) Watch(tname, nid string) (*events.Channel, func()) {
 	var matcher events.Matcher
 
@@ -93,7 +94,7 @@ func (nDB *NetworkDB) Watch(tname, nid string) (*events.Channel, func()) {
 			prefix = []byte("/")
 		}
 		nDB.indexes[byNetwork].Root().WalkPrefix(prefix, func(path []byte, v *entry) bool {
-			if !v.deleting && v.node != nDB.config.NodeID {
+			if !v.deleting && !nDB.isNodeFailed(v.node) && v.node != nDB.config.NodeID {
 				tuple := strings.SplitN(string(path[1:]), "/", 3)
 				if len(tuple) == 3 {
 					entryNid, entryTname, key := tuple[0], tuple[1], tuple[2]
@@ -113,7 +114,7 @@ func (nDB *NetworkDB) Watch(tname, nid string) (*events.Channel, func()) {
 			prefix = append(prefix, []byte(nid+"/")...)
 		}
 		nDB.indexes[byTable].Root().WalkPrefix(prefix, func(path []byte, v *entry) bool {
-			if !v.deleting && v.node != nDB.config.NodeID {
+			if !v.deleting && !nDB.isNodeFailed(v.node) && v.node != nDB.config.NodeID {
 				tuple := strings.SplitN(string(path[1:]), "/", 3)
 				if len(tuple) == 3 {
 					entryTname, entryNid, key := tuple[0], tuple[1], tuple[2]


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/53141

## Summary

When memberlist declares a peer failed, NetworkDB used to drop everything it knew about it: its table entries, its network attachments, and its place in the per-network peer lists. On surviving nodes this tears down the service discovery records, and because the peer is no longer recognized as attached to any network, the table events that would refill those records after it reconnects are rejected until its network memberships are relearned. Swarm DNS on healthy nodes then keeps returning NXDOMAIN for the affected services long after the node is back.

This PR suspends the state of a failed node instead of dropping it:

- On failure, the node's table entries are hidden from watchers and reads (watchers see deletes, so observable behavior is unchanged from delete-on-failure) but stay in the store, and its network attachments are remembered. The node is removed from the peer lists used for gossip and bulk-sync sampling.
- While it is down, events for/from it are still accepted (keyed on the remembered attachments), stored, and rebroadcast, and its entries are carried in bulk syncs — the remembered state stays as fresh as the rest of the cluster can make it.
- When it turns active again, its attachments are restored and its entries republished to watchers immediately, with nothing needing to be re-sent. This reduces the recovery time after a rejoin from one periodic-sync interval (~30s) to instant.
- On graceful leave, or when a failed node is reaped, all of its state is dropped as before.

Remembered entries age out on the entry reap timer (30min) rather than the node reap timer, so remembered state never outlives the owner's own tombstones — otherwise a delete that expired while the node was away could
be resurrected on rejoin with nothing left in the cluster to delete it again.

## Release notes (optional)

```markdown changelog
Fix Swarm service names failing to resolve on healthy nodes after a transient node failure.
```


## A picture of a cute animal (not mandatory but encouraged)
