### PR TITLE
daemon/kill: Preserve indefinite delayed-exit waits

### DIFF
--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -122,7 +122,15 @@ func (daemon *Daemon) killWithSignal(container *containerpkg.Container, stopSign
 				// So let's wait the container's stop timeout amount of time to see if the event is eventually processed.
 				// Doing this has the side effect that if no event was ever going to come we are waiting a longer period of time unnecessarily.
 				// But this prevents race conditions in processing the container.
-				ctx, cancel := context.WithTimeout(context.TODO(), time.Duration(container.StopTimeout())*time.Second)
+				stopTimeout := time.Duration(container.StopTimeout()) * time.Second
+				var ctx context.Context
+				var cancel context.CancelFunc
+				if stopTimeout >= 0 {
+					ctx, cancel = context.WithTimeout(context.TODO(), stopTimeout)
+				} else {
+					ctx, cancel = context.WithCancel(context.TODO())
+				}
+
 				defer cancel()
 				s := <-container.State.Wait(ctx, containertypes.WaitConditionNotRunning)
 				if s.Err() != nil {

--- a/daemon/kill_test.go
+++ b/daemon/kill_test.go
@@ -1,0 +1,64 @@
+package daemon
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"time"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	cerrdefs "github.com/containerd/errdefs"
+	containertypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/v2/daemon/container"
+	"github.com/moby/moby/v2/daemon/events"
+	libcontainerdtypes "github.com/moby/moby/v2/daemon/internal/libcontainerd/types"
+	"gotest.tools/v3/assert"
+)
+
+type notFoundKillTask struct {
+	libcontainerdtypes.Task
+	deleteCalled chan struct{}
+}
+
+func (t *notFoundKillTask) Pid() uint32 {
+	return 1
+}
+
+func (t *notFoundKillTask) Kill(context.Context, syscall.Signal) error {
+	return cerrdefs.ErrNotFound
+}
+
+func (t *notFoundKillTask) Delete(ctx context.Context) (*containerd.ExitStatus, error) {
+	close(t.deleteCalled)
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestKillWithSignalWaitsIndefinitelyForDelayedExit(t *testing.T) {
+	task := &notFoundKillTask{deleteCalled: make(chan struct{})}
+	ctr := container.NewBaseContainer(t.Name(), t.TempDir())
+	stopTimeout := -1
+	ctr.Config = &containertypes.Config{StopTimeout: &stopTimeout}
+	ctr.HostConfig = &containertypes.HostConfig{}
+	ctr.Lock()
+	ctr.State.SetRunning(nil, task, time.Now())
+	ctr.Unlock()
+
+	daemon := &Daemon{
+		EventsService: events.New(),
+		shutdown:      true,
+	}
+
+	err := daemon.killWithSignal(ctr, syscall.SIGKILL)
+	assert.NilError(t, err)
+
+	select {
+	case <-task.deleteCalled:
+		t.Fatal("fallback exit handling ran before the delayed exit event")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	ctr.Lock()
+	ctr.State.SetStopped(&container.ExitStatus{})
+	ctr.Unlock()
+}


### PR DESCRIPTION
The container API supports a negative StopTimeout, conventionally -1, to wait indefinitely without forcefully terminating the container.

The delayed-exit path passed this value to context.WithTimeout, which expired immediately and triggered fallback exit handling before the real exit event could be processed.

Use a cancel-only context for negative timeouts so this path preserves the existing API contract.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
