### PR TITLE
releases: Automate Docker version updates after tags

### DIFF
--- a/.github/workflows/open-version-bump-pr.yml
+++ b/.github/workflows/open-version-bump-pr.yml
@@ -1,0 +1,159 @@
+---
+name: Bump Docker version
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+permissions: {}
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  open-version-bump-pr:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        base_branch:
+          - master
+          - docker-29.x
+    steps:
+      - name: Set Docker version
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ "$TAG_NAME" =~ ^docker-v(29\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "version=${BASH_REMATCH[1]}" >>"$GITHUB_ENV"
+          else
+            echo "Skipping non-release 29.x Docker tag '$TAG_NAME'"
+            echo "skip=true" >>"$GITHUB_ENV"
+          fi
+
+      - name: Checkout release automation
+        if: env.skip != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: master
+
+      - name: Determine release branch
+        if: env.skip != 'true'
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          tag_commit=$(git rev-parse "refs/tags/$TAG_NAME^{commit}")
+          master_contains=false
+          release_contains=false
+
+          if git merge-base --is-ancestor "$tag_commit" origin/master; then
+            master_contains=true
+          fi
+          if git merge-base --is-ancestor "$tag_commit" origin/docker-29.x; then
+            release_contains=true
+          fi
+
+          case "$master_contains:$release_contains" in
+            true:false)
+              source_branch=master
+              ;;
+            false:true)
+              source_branch=docker-29.x
+              ;;
+            true:true)
+              # Master release tags are later synced into docker-29.x.
+              # Release-branch tags are not merged back into master.
+              source_branch=master
+              ;;
+            *)
+              echo "::error::$TAG_NAME is not reachable from master or docker-29.x"
+              exit 1
+              ;;
+          esac
+
+          echo "source_branch=$source_branch" >>"$GITHUB_ENV"
+          echo "$TAG_NAME was created from $source_branch"
+
+      - name: Preserve version bump script
+        if: env.skip != 'true'
+        run: cp releases/bump-version.sh "$RUNNER_TEMP/bump-version.sh"
+
+      - name: Checkout target branch
+        if: env.skip != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ matrix.base_branch }}
+
+      - name: Bump Docker version
+        if: env.skip != 'true'
+        env:
+          BASE_BRANCH: ${{ matrix.base_branch }}
+        run: |
+          if [ "$BASE_BRANCH" = "$source_branch" ]; then
+            if [ "$BASE_BRANCH" = master ]; then
+              "$RUNNER_TEMP/bump-version.sh" docker next-minor "$version"
+            else
+              "$RUNNER_TEMP/bump-version.sh" docker next "$version"
+            fi
+          elif [ "$source_branch" = master ]; then
+            "$RUNNER_TEMP/bump-version.sh" docker next "$version"
+          fi
+          "$RUNNER_TEMP/bump-version.sh" docker last "$version"
+
+      - name: Open version bump PR
+        if: env.skip != 'true'
+        env:
+          BASE_BRANCH: ${{ matrix.base_branch }}
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          if git diff --quiet -- releases/versions.yaml; then
+            echo "Skipping $BASE_BRANCH because version is unchanged"
+            exit 0
+          fi
+
+          branch="bump-docker-version-${version}-${BASE_BRANCH}"
+          milestone=$(yq -er '.docker.next' releases/versions.yaml)
+          title='releases: Bump Docker version'
+          if [ "$BASE_BRANCH" != master ]; then
+            title="[$BASE_BRANCH] $title"
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git switch -c "$branch"
+          git add releases/versions.yaml
+          git commit --signoff -m 'releases: Bump Docker version'
+
+          remote_sha=$(git ls-remote --heads origin "$branch")
+          remote_sha=$(awk '{ print $1 }' <<<"$remote_sha")
+          if [ -n "$remote_sha" ]; then
+            git push \
+              --force-with-lease="refs/heads/$branch:$remote_sha" \
+              origin "$branch"
+          else
+            git push origin "$branch"
+          fi
+
+          if gh pr view "$branch" --json number >/dev/null 2>&1; then
+            gh pr edit "$branch" \
+              --title "$title" \
+              --body "Automated Docker version bump after $TAG_NAME." \
+              --milestone "$milestone"
+            echo "PR for $branch already exists"
+            exit 0
+          fi
+
+          gh pr create \
+            --base "$BASE_BRANCH" \
+            --head "$branch" \
+            --title "$title" \
+            --body "Automated Docker version bump after $TAG_NAME." \
+            --milestone "$milestone"

--- a/releases/bump-version.sh
+++ b/releases/bump-version.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [ "$#" -ne 3 ]; then
+	printf 'usage: %s <component> <last|next|next-minor> <released-version>\n' "$0" >&2
+	exit 64
+fi
+
+component="$1"
+version_operation="$2"
+released_version="$3"
+
+versions_file="releases/versions.yaml"
+version_pattern='^([0-9]+)\.([0-9]+)\.([0-9]+)$'
+
+version_is_greater() {
+	local left_major left_minor left_patch
+	local right_major right_minor right_patch
+
+	IFS=. read -r left_major left_minor left_patch <<< "$1"
+	IFS=. read -r right_major right_minor right_patch <<< "$2"
+
+	if ((10#$left_major != 10#$right_major)); then
+		((10#$left_major > 10#$right_major))
+		return
+	fi
+	if ((10#$left_minor != 10#$right_minor)); then
+		((10#$left_minor > 10#$right_minor))
+		return
+	fi
+	((10#$left_patch > 10#$right_patch))
+}
+
+read_version() {
+	local field="$1"
+	local version
+
+	if ! version=$(yq -er ".${component}.${field}" "$versions_file"); then
+		printf 'could not find %s.%s in %s\n' \
+			"$component" "$field" "$versions_file" >&2
+		return 1
+	fi
+	if [[ ! "$version" =~ $version_pattern ]]; then
+		printf 'invalid %s.%s version %q in %s\n' \
+			"$component" "$field" "$version" "$versions_file" >&2
+		return 1
+	fi
+	printf '%s\n' "$version"
+}
+
+if [[ ! "$released_version" =~ $version_pattern ]]; then
+	printf 'invalid released version %q\n' "$released_version" >&2
+	exit 64
+fi
+
+major=${BASH_REMATCH[1]}
+minor=${BASH_REMATCH[2]}
+patch=${BASH_REMATCH[3]}
+
+case "$version_operation" in
+	last)
+		version_field=last
+		target_version="$released_version"
+		;;
+	next)
+		version_field=next
+		target_version="$major.$minor.$((10#$patch + 1))"
+		;;
+	next-minor)
+		version_field=next
+		target_version="$major.$((10#$minor + 1)).0"
+		;;
+	*)
+		printf 'invalid version operation %q, expected last, next, or next-minor\n' \
+			"$version_operation" >&2
+		exit 64
+		;;
+esac
+
+last_version=$(read_version last)
+next_version=$(read_version next)
+
+if ! version_is_greater "$next_version" "$last_version"; then
+	printf 'invalid %s versions in %s: next %s must be newer than last %s\n' \
+		"$component" "$versions_file" "$next_version" "$last_version" >&2
+	exit 1
+fi
+
+case "$version_field" in
+	last)
+		current_version="$last_version"
+		;;
+	next)
+		current_version="$next_version"
+		;;
+esac
+
+if ! version_is_greater "$target_version" "$current_version"; then
+	printf 'Leaving %s.%s at %s because target version %s is not newer\n' \
+		"$component" "$version_field" "$current_version" "$target_version"
+	exit 0
+fi
+
+if [[ "$version_field" == last ]] \
+	&& ! version_is_greater "$next_version" "$target_version"; then
+	printf 'Leaving %s.last at %s because target version %s is not older than next %s\n' \
+		"$component" "$last_version" "$target_version" "$next_version"
+	exit 0
+fi
+
+if ! COMPONENT="$component" VERSION_FIELD="$version_field" TARGET_VERSION="$target_version" \
+	yq eval -i \
+	'.[env(COMPONENT)][env(VERSION_FIELD)] = strenv(TARGET_VERSION)' \
+	"$versions_file"; then
+	printf 'failed to update %s.%s in %s\n' "$component" "$version_field" "$versions_file" >&2
+	exit 1
+fi
+
+printf 'Bumped %s.%s from %s to %s\n' \
+	"$component" "$version_field" "$current_version" "$target_version"


### PR DESCRIPTION
## Summary

Automate version bump pull requests after final `docker-v29.*.*` tags.

The workflow:

- Detects the source branch from tag reachability, preferring `master` when both branches contain the tag and failing when neither does.
- Updates `docker.last` and advances `docker.next` on the source branch.
- Synchronizes the other branch when compatible, without violating `docker.last < docker.next`.
- Ignores duplicate and older versions, and rejects inconsistent metadata.
- Opens signed-off pull requests with the required title and milestone.
  

Examples:


| Tag | Source branch | `master` before → after | `docker-29.x` before → after |
|---|---|---|---|
| `29.6.5` | `docker-29.x` | `29.7.0 / 29.7.1` → unchanged | `29.6.4 / 29.6.5` → `29.6.5 / 29.6.6` |
| `29.7.1` | `master` | `29.7.0 / 29.7.1` → `29.7.1 / 29.7.2` | `29.6.4 / 29.6.5` → unchanged |
| `29.7.1` | `master` | `29.7.0 / 29.7.1` → `29.7.1 / 29.7.2` | `29.7.0 / 29.7.1` → `29.7.1 / 29.7.2` |
| `29.6.5` | `docker-29.x` | `29.6.4 / 29.7.0` → `29.6.5 / 29.7.0` | `29.6.4 / 29.6.5` → `29.6.5 / 29.6.6` |
| Duplicate `29.6.5` | `docker-29.x` | No change | No change |
| Older `29.6.4` | `docker-29.x` | No change | No change |
 