### PR TITLE
daemon: Add configurable default container stop timeout

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1470,9 +1470,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default (`default-stop-timeout`) is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |

--- a/client/container_restart.go
+++ b/client/container_restart.go
@@ -16,7 +16,8 @@ type ContainerRestartOptions struct {
 	// Timeout (optional) is the timeout (in seconds) to wait for the container
 	// to stop gracefully before forcibly terminating it with SIGKILL.
 	//
-	// - Use nil to use the default timeout (10 seconds).
+	// - Use nil to use the container's configured timeout, or the engine default
+	//   if the container has no configured timeout.
 	// - Use '-1' to wait indefinitely.
 	// - Use '0' to not wait for the container to exit gracefully, and
 	//   immediately proceeds to forcibly terminating the container.

--- a/client/container_stop.go
+++ b/client/container_stop.go
@@ -16,7 +16,8 @@ type ContainerStopOptions struct {
 	// Timeout (optional) is the timeout (in seconds) to wait for the container
 	// to stop gracefully before forcibly terminating it with SIGKILL.
 	//
-	// - Use nil to use the default timeout (10 seconds).
+	// - Use nil to use the container's configured timeout, or the engine default
+	//   if the container has no configured timeout.
 	// - Use '-1' to wait indefinitely.
 	// - Use '0' to not wait for the container to exit gracefully, and
 	//   immediately proceeds to forcibly terminating the container.

--- a/daemon/command/config.go
+++ b/daemon/command/config.go
@@ -63,6 +63,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.IntVar(&conf.MaxConcurrentUploads, "max-concurrent-uploads", conf.MaxConcurrentUploads, "Set the max concurrent uploads")
 	flags.IntVar(&conf.MaxDownloadAttempts, "max-download-attempts", conf.MaxDownloadAttempts, "Set the max download attempts for each pull")
 	flags.IntVar(&conf.ShutdownTimeout, "shutdown-timeout", conf.ShutdownTimeout, "Set the default shutdown timeout")
+	flags.IntVar(&conf.DefaultStopTimeout, "default-stop-timeout", conf.DefaultStopTimeout, "Set the default container stop timeout in seconds (0 to terminate immediately)")
 
 	flags.StringVar(&conf.SwarmDefaultAdvertiseAddr, "swarm-default-advertise-addr", "", "Set default address or interface for swarm advertised address")
 	flags.BoolVar(&conf.Experimental, "experimental", false, "Enable experimental features")

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -188,6 +188,13 @@ type DNSConfig struct {
 	HostGatewayIPs []netip.Addr `json:"host-gateway-ips,omitempty"`
 }
 
+// ContainerDefaults defines daemon defaults for containers.
+type ContainerDefaults struct {
+	// DefaultStopTimeout is the timeout, in seconds, used for containers that
+	// do not have a container-specific timeout set.
+	DefaultStopTimeout int `json:"default-stop-timeout,omitempty"`
+}
+
 // CommonConfig defines the configuration of a docker daemon which is
 // common across platforms.
 // It includes json tags to deserialize configuration from a file
@@ -258,6 +265,7 @@ type CommonConfig struct {
 	DaemonLogConfig         // DaemonLogConfig holds options for configuring the daemon's logging.
 	TLSOptions              // TLSOptions defines TLS configuration for the API server.
 	DNSConfig               // DNSConfig defines default DNS options for containers.
+	ContainerDefaults       // ContainerDefaults defines daemon defaults for containers.
 	LogConfig               // LogConfig defines default log configuration for containers.
 	BridgeConfig            // BridgeConfig holds bridge network specific configuration.
 	NetworkConfig           // NetworkConfig stores the daemon-wide networking configurations.
@@ -341,6 +349,9 @@ func New() (*Config, error) {
 	cfg := &Config{
 		CommonConfig: CommonConfig{
 			ShutdownTimeout: DefaultShutdownTimeout,
+			ContainerDefaults: ContainerDefaults{
+				DefaultStopTimeout: defaultStopTimeout,
+			},
 			LogConfig: LogConfig{
 				Type:   DefaultLogDriver,
 				Config: make(map[string]string),
@@ -476,8 +487,18 @@ func MergeDaemonConfigurations(flagsConfig *Config, flags *pflag.FlagSet, config
 	}
 
 	// merge flags configuration on top of the file configuration
+	//
+	// mergo does not distinguish "unset" from a zero value, so a
+	// "default-stop-timeout" of 0 in the config file would be overwritten by
+	// the (non-zero) default of the flag. Remember whether the file set the
+	// option, and restore its value after merging.
+	defaultStopTimeout := fileConfig.DefaultStopTimeout
+	defaultStopTimeoutSet := fileConfig.IsValueSet("default-stop-timeout")
 	if err := mergo.Merge(fileConfig, flagsConfig); err != nil {
 		return nil, err
+	}
+	if defaultStopTimeoutSet {
+		fileConfig.DefaultStopTimeout = defaultStopTimeout
 	}
 
 	// validate the merged fileConfig and flagsConfig
@@ -749,6 +770,9 @@ func Validate(config *Config) error {
 	}
 	if config.MaxDownloadAttempts < 0 {
 		return errors.Errorf("invalid max download attempts: %d", config.MaxDownloadAttempts)
+	}
+	if config.DefaultStopTimeout < 0 {
+		return errors.Errorf("invalid default stop timeout: %d", config.DefaultStopTimeout)
 	}
 	if config.NetworkDiagnosticPort < 0 || config.NetworkDiagnosticPort > 65535 {
 		return errors.Errorf("invalid network-diagnostic-port (%d): value must be between 0 and 65535", config.NetworkDiagnosticPort)

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -36,6 +36,8 @@ const (
 
 	// userlandProxyBinary is the name of the userland-proxy binary.
 	userlandProxyBinary = "docker-proxy"
+
+	defaultStopTimeout = 10
 )
 
 // BridgeConfig stores all the parameters for both the bridge driver and the default bridge network.

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -143,6 +143,42 @@ func TestDaemonConfigurationMergeConcurrentError(t *testing.T) {
 	assert.ErrorContains(t, err, `invalid max concurrent downloads: -1`)
 }
 
+func TestDefaultStopTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		config   string
+		expected int
+	}{
+		{
+			name:     "positive",
+			config:   `{"default-stop-timeout": 42}`,
+			expected: 42,
+		},
+		{
+			name:     "zero",
+			config:   `{"default-stop-timeout": 0}`,
+			expected: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			configFile := makeConfigFile(t, tc.config)
+			flagsConfig := &Config{
+				CommonConfig: CommonConfig{
+					ContainerDefaults: ContainerDefaults{
+						DefaultStopTimeout: 20,
+					},
+				},
+			}
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			flags.IntVar(&flagsConfig.DefaultStopTimeout, "default-stop-timeout", flagsConfig.DefaultStopTimeout, "")
+
+			merged, err := MergeDaemonConfigurations(flagsConfig, flags, configFile)
+			assert.NilError(t, err)
+			assert.Equal(t, merged.DefaultStopTimeout, tc.expected)
+		})
+	}
+}
+
 func TestDaemonConfigurationMergeConflictsWithInnerStructs(t *testing.T) {
 	configFile := makeConfigFile(t, `{"tlscacert": "/etc/certificates/ca.pem"}`)
 
@@ -314,6 +350,17 @@ func TestValidateConfigurationErrors(t *testing.T) {
 				},
 			},
 			expectedErr: "invalid max download attempts: -10",
+		},
+		{
+			name: "invalid default-stop-timeout",
+			config: &Config{
+				CommonConfig: CommonConfig{
+					ContainerDefaults: ContainerDefaults{
+						DefaultStopTimeout: -1,
+					},
+				},
+			},
+			expectedErr: "invalid default stop timeout: -1",
 		},
 		// TODO(thaJeztah) temporarily excluding this test as it assumes defaults are set before validating and applying updated configs
 		/*

--- a/daemon/config/config_windows.go
+++ b/daemon/config/config_windows.go
@@ -17,6 +17,8 @@ const (
 	StockRuntimeName = ""
 
 	WindowsV1RuntimeName = "com.docker.hcsshim.v1"
+
+	defaultStopTimeout = 30
 )
 
 // BridgeConfig is meant to store all the parameters for both the bridge driver and the default bridge network. On

--- a/daemon/container/container.go
+++ b/daemon/container/container.go
@@ -605,14 +605,6 @@ func (container *Container) StopSignal() syscall.Signal {
 	return stopSignal
 }
 
-// StopTimeout returns the timeout (in seconds) used to stop the container.
-func (container *Container) StopTimeout() int {
-	if container.Config.StopTimeout != nil {
-		return *container.Config.StopTimeout
-	}
-	return defaultStopTimeout
-}
-
 // InitDNSHostConfig ensures that the dns fields are never nil.
 // New containers don't ever have those fields nil,
 // but pre created containers can still have those nil values.

--- a/daemon/container/container_test.go
+++ b/daemon/container/container_test.go
@@ -33,22 +33,6 @@ func TestContainerStopSignal(t *testing.T) {
 	assert.Equal(t, s, defaultStopSignal)
 }
 
-func TestContainerStopTimeout(t *testing.T) {
-	c := &Container{
-		Config: &container.Config{},
-	}
-
-	s := c.StopTimeout()
-	assert.Equal(t, s, defaultStopTimeout)
-
-	stopTimeout := 15
-	c = &Container{
-		Config: &container.Config{StopTimeout: &stopTimeout},
-	}
-	s = c.StopTimeout()
-	assert.Equal(t, s, stopTimeout)
-}
-
 func TestContainerSecretReferenceDestTarget(t *testing.T) {
 	ref := &swarm.SecretReference{
 		File: &swarm.SecretReferenceFileTarget{

--- a/daemon/container/container_unix.go
+++ b/daemon/container/container_unix.go
@@ -21,10 +21,6 @@ import (
 )
 
 const (
-	// defaultStopTimeout sets the default time, in seconds, to wait
-	// for the graceful container stop before forcefully terminating it.
-	defaultStopTimeout = 10
-
 	containerConfigMountPath = "/"
 	containerSecretMountPath = "/run/secrets"
 )

--- a/daemon/container/container_windows.go
+++ b/daemon/container/container_windows.go
@@ -17,9 +17,6 @@ const (
 	containerSecretMountPath         = `C:\ProgramData\Docker\secrets`
 	containerInternalSecretMountPath = `C:\ProgramData\Docker\internal\secrets`
 	containerInternalConfigsDirPath  = `C:\ProgramData\Docker\internal\configs`
-
-	// defaultStopTimeout is the timeout (in seconds) for the shutdown call on a container
-	defaultStopTimeout = 30
 )
 
 // UnmountIpcMount unmounts Ipc related mounts.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1494,7 +1494,10 @@ func (daemon *Daemon) shutdownTimeout(cfg *config.Config) int {
 
 	graceTimeout := 5
 	for _, c := range daemon.containers.List() {
-		stopTimeout := c.StopTimeout()
+		stopTimeout := cfg.DefaultStopTimeout
+		if c.Config.StopTimeout != nil {
+			stopTimeout = *c.Config.StopTimeout
+		}
 		if stopTimeout < 0 {
 			return -1
 		}

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -122,11 +122,14 @@ func (daemon *Daemon) killWithSignal(container *containerpkg.Container, stopSign
 				// So let's wait the container's stop timeout amount of time to see if the event is eventually processed.
 				// Doing this has the side effect that if no event was ever going to come we are waiting a longer period of time unnecessarily.
 				// But this prevents race conditions in processing the container.
-				stopTimeout := time.Duration(container.StopTimeout()) * time.Second
+				stopTimeout := daemon.config().DefaultStopTimeout
+				if container.Config.StopTimeout != nil {
+					stopTimeout = *container.Config.StopTimeout
+				}
 				var ctx context.Context
 				var cancel context.CancelFunc
 				if stopTimeout >= 0 {
-					ctx, cancel = context.WithTimeout(context.TODO(), stopTimeout)
+					ctx, cancel = context.WithTimeout(context.TODO(), time.Duration(stopTimeout)*time.Second)
 				} else {
 					ctx, cancel = context.WithCancel(context.TODO())
 				}

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -81,6 +81,7 @@ func (tx *reloadTxn) Rollback() error {
 // - Daemon max concurrent uploads
 // - Daemon max download attempts
 // - Daemon shutdown timeout (in seconds)
+// - Daemon default container stop timeout (in seconds)
 // - Cluster discovery (reconfigure and restart)
 // - Daemon labels
 // - Insecure registries
@@ -118,6 +119,7 @@ func (daemon *Daemon) Reload(conf *config.Config) error {
 		daemon.reloadMaxConcurrentDownloadsAndUploads,
 		daemon.reloadMaxDownloadAttempts,
 		daemon.reloadShutdownTimeout,
+		daemon.reloadDefaultStopTimeout,
 		daemon.reloadFeatures,
 		daemon.reloadLabels,
 		daemon.reloadRegistryConfig,
@@ -216,6 +218,18 @@ func (daemon *Daemon) reloadShutdownTimeout(_ *reloadTxn, newCfg *configStore, c
 
 	// prepare reload event attributes with updatable configurations
 	attributes["shutdown-timeout"] = strconv.Itoa(newCfg.ShutdownTimeout)
+	return nil
+}
+
+// reloadDefaultStopTimeout updates the default container stop timeout
+// and updates the passed attributes.
+func (daemon *Daemon) reloadDefaultStopTimeout(_ *reloadTxn, newCfg *configStore, conf *config.Config, attributes map[string]string) error {
+	if conf.IsValueSet("default-stop-timeout") {
+		newCfg.DefaultStopTimeout = conf.DefaultStopTimeout
+		log.G(context.TODO()).Debugf("Reset Default Stop Timeout: %d", newCfg.DefaultStopTimeout)
+	}
+
+	attributes["default-stop-timeout"] = strconv.Itoa(newCfg.DefaultStopTimeout)
 	return nil
 }
 

--- a/daemon/reload_test.go
+++ b/daemon/reload_test.go
@@ -305,6 +305,37 @@ func TestDaemonReloadNotAffectOthers(t *testing.T) {
 	}
 }
 
+func TestDaemonReloadDefaultStopTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		timeout int
+	}{
+		{name: "positive", timeout: 42},
+		{name: "zero", timeout: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			daemon := newDaemonForReloadT(t, &config.Config{
+				CommonConfig: config.CommonConfig{
+					ContainerDefaults: config.ContainerDefaults{
+						DefaultStopTimeout: 10,
+					},
+				},
+			})
+			newConfig := &config.Config{
+				CommonConfig: config.CommonConfig{
+					ContainerDefaults: config.ContainerDefaults{
+						DefaultStopTimeout: tc.timeout,
+					},
+					ValuesSet: map[string]any{"default-stop-timeout": tc.timeout},
+				},
+			}
+
+			assert.NilError(t, daemon.Reload(newConfig))
+			assert.Equal(t, daemon.config().DefaultStopTimeout, tc.timeout)
+		})
+	}
+}
+
 func TestDaemonReloadNetworkDiagnosticPort(t *testing.T) {
 	if os.Getuid() != 0 {
 		t.Skip("root required")

--- a/daemon/server/backend/backend.go
+++ b/daemon/server/backend/backend.go
@@ -130,7 +130,8 @@ type ContainerStopOptions struct {
 	// Timeout (optional) is the timeout (in seconds) to wait for the container
 	// to stop gracefully before forcibly terminating it with SIGKILL.
 	//
-	// - Use nil to use the default timeout (10 seconds).
+	// - Use nil to use the container's configured timeout, or the engine default
+	//   if the container has no configured timeout.
 	// - Use '-1' to wait indefinitely.
 	// - Use '0' to not wait for the container to exit gracefully, and
 	//   immediately proceeds to forcibly terminating the container.

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -53,10 +53,11 @@ func (daemon *Daemon) containerStop(ctx context.Context, ctr *container.Containe
 		return nil
 	}
 
-	var (
-		stopSignal  = ctr.StopSignal()
-		stopTimeout = ctr.StopTimeout()
-	)
+	stopSignal := ctr.StopSignal()
+	stopTimeout := daemon.config().DefaultStopTimeout
+	if ctr.Config.StopTimeout != nil {
+		stopTimeout = *ctr.Config.StopTimeout
+	}
 	if options.Signal != "" {
 		sig, err := signal.ParseSignal(options.Signal)
 		if err != nil {

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -24,6 +24,7 @@ dockerd - Enable daemon mode
 [**--default-runtime**[=*runc*]]
 [**--default-ipc-mode**=*MODE*]
 [**--default-shm-size**[=*64MiB*]]
+[**--default-stop-timeout**[=*seconds*]]
 [**--default-ulimit**[=*[]*]]
 [**--dns**[=*[]*]]
 [**--dns-opt**[=*[]*]]
@@ -193,6 +194,12 @@ Bridge networks will accept packets with this firewall mark/mask.
 
 **--default-shm-size**=*size*
   Set the daemon-wide default shm *size* for containers. Default is `64MiB`.
+
+**--default-stop-timeout**=*seconds*
+  Set the timeout, in seconds, used to stop containers without a
+  container-specific timeout. Default is **10** on non-Windows platforms and
+  **30** on Windows. A value of **0** does not wait before forcefully terminating
+  the container. Negative values are invalid.
 
 **--default-ulimit**=[]
   Default ulimits for containers.

--- a/vendor/github.com/moby/moby/client/container_restart.go
+++ b/vendor/github.com/moby/moby/client/container_restart.go
@@ -16,7 +16,8 @@ type ContainerRestartOptions struct {
 	// Timeout (optional) is the timeout (in seconds) to wait for the container
 	// to stop gracefully before forcibly terminating it with SIGKILL.
 	//
-	// - Use nil to use the default timeout (10 seconds).
+	// - Use nil to use the container's configured timeout, or the engine default
+	//   if the container has no configured timeout.
 	// - Use '-1' to wait indefinitely.
 	// - Use '0' to not wait for the container to exit gracefully, and
 	//   immediately proceeds to forcibly terminating the container.

--- a/vendor/github.com/moby/moby/client/container_stop.go
+++ b/vendor/github.com/moby/moby/client/container_stop.go
@@ -16,7 +16,8 @@ type ContainerStopOptions struct {
 	// Timeout (optional) is the timeout (in seconds) to wait for the container
 	// to stop gracefully before forcibly terminating it with SIGKILL.
 	//
-	// - Use nil to use the default timeout (10 seconds).
+	// - Use nil to use the container's configured timeout, or the engine default
+	//   if the container has no configured timeout.
 	// - Use '-1' to wait indefinitely.
 	// - Use '0' to not wait for the container to exit gracefully, and
 	//   immediately proceeds to forcibly terminating the container.


### PR DESCRIPTION
- relates to / addresses https://github.com/moby/moby/issues/52775
- relates to / addresses https://github.com/docker/desktop-feedback/issues/494

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

Daemon uses a fixed default stop timeout when a container does not specify `StopTimeout`: 10
seconds on non-Windows platforms and 30 seconds on Windows.
Administrators cannot currently change this default daemon-wide.

Add the `default-stop-timeout` daemon configuration option and corresponding `--default-stop-timeout` flag.
The existing platform defaults remain unchanged.

When stopping a container without an explicit `StopTimeout`, Docker reads the current daemon default.
The timeout is not stored in the container configuration, so reloading the daemon option also changes the fallback for existing containers.
Explicit container and API request timeouts remain authoritative.

A value of `0` skips the graceful wait and forcefully terminates the container immediately.
Negative values are rejected.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Add the `default-stop-timeout` daemon option to configure the stop timeout assigned to containers without an explicit timeout.
```

## A picture of a cute animal (not mandatory but encouraged)
