### PR TITLE
daemon/logger/awslogs: fix deadlock on container stop with non-blocking mode

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
-	"sync/atomic"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -78,7 +78,9 @@ type logStream struct {
 	client             api
 
 	messages *loggerutils.MessageQueue
-	closed   atomic.Bool
+
+	closeOnce sync.Once
+	closedCh  chan struct{}
 
 	sequenceToken *string
 }
@@ -150,6 +152,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		multilinePattern:   containerStreamConfig.multilinePattern,
 		client:             client,
 		messages:           loggerutils.NewMessageQueue(containerStreamConfig.maxBufferedEvents),
+		closedCh:           make(chan struct{}),
 	}
 
 	creationDone := make(chan bool)
@@ -157,23 +160,32 @@ func New(info logger.Info) (logger.Logger, error) {
 		const maxBackoff = 32
 		go func() {
 			backoff := 1
-			// We're done when the logger is closed
-			for !containerStream.closed.Load() {
-				if err := containerStream.create(); err == nil {
-					break
+			for {
+				err := containerStream.create()
+				if err == nil {
+					close(creationDone)
+					return
 				}
 
-				time.Sleep(time.Duration(backoff) * time.Second)
-				if backoff < maxBackoff {
-					backoff *= 2
-				}
 				log.G(context.TODO()).WithFields(log.Fields{
 					"error":          err,
 					"container-id":   info.ContainerID,
 					"container-name": info.ContainerName,
 				}).Error("Error while trying to initialize awslogs. Retrying in: ", backoff, " seconds")
+
+				// Wait for backoff duration or shutdown signal.
+				timer := time.NewTimer(time.Duration(backoff) * time.Second)
+				select {
+				case <-timer.C:
+				case <-containerStream.closedCh:
+					timer.Stop()
+					return
+				}
+
+				if backoff < maxBackoff {
+					backoff *= 2
+				}
 			}
-			close(creationDone)
 		}()
 	} else {
 		if err = containerStream.create(); err != nil {
@@ -430,8 +442,10 @@ func (l *logStream) Log(msg *logger.Message) error {
 
 // Close closes the instance of the awslogs logging driver
 func (l *logStream) Close() error {
-	l.closed.Store(true)
-	l.messages.Close()
+	l.closeOnce.Do(func() {
+		close(l.closedCh)
+		l.messages.Close()
+	})
 	return nil
 }
 
@@ -538,8 +552,30 @@ var newTicker = func(freq time.Duration) *time.Ticker {
 // Logs, the processEvents method is called.  If a multiline pattern is not
 // configured, log events are submitted to the processEvents method immediately.
 func (l *logStream) collectBatch(created chan bool) {
-	// Wait for the logstream/group to be created
-	<-created
+	// Drain and discard messages until the log stream has been created. This
+	// prevents writers from blocking without buffering messages outside the
+	// configured message queue.
+	chLogs := l.messages.Receiver()
+
+	select {
+	case <-created:
+		goto ready
+	default:
+	}
+
+	for {
+		select {
+		case <-created:
+			goto ready
+		case msg, more := <-chLogs:
+			if !more {
+				return
+			}
+			logger.PutMessage(msg)
+		}
+	}
+
+ready:
 	flushInterval := l.forceFlushInterval
 	if flushInterval <= 0 {
 		flushInterval = defaultForceFlushInterval
@@ -549,7 +585,6 @@ func (l *logStream) collectBatch(created chan bool) {
 	var eventBufferTimestamp int64
 	batch := newEventBatch()
 
-	chLogs := l.messages.Receiver()
 	for {
 		select {
 		case t := <-ticker.C:

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -358,6 +358,7 @@ func TestLogClosed(t *testing.T) {
 	stream := &logStream{
 		client:   mockClient,
 		messages: loggerutils.NewMessageQueue(0),
+		closedCh: make(chan struct{}),
 	}
 	stream.Close()
 	err := stream.Log(&logger.Message{})
@@ -555,6 +556,7 @@ func TestCollectBatchSimple(t *testing.T) {
 		logStreamName: streamName,
 		sequenceToken: aws.String(sequenceToken),
 		messages:      loggerutils.NewMessageQueue(0),
+		closedCh:      make(chan struct{}),
 	}
 	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
 	mockClient.putLogEventsFunc = func(ctx context.Context, input *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
@@ -602,6 +604,7 @@ func TestCollectBatchTicker(t *testing.T) {
 		logStreamName: streamName,
 		sequenceToken: aws.String(sequenceToken),
 		messages:      loggerutils.NewMessageQueue(0),
+		closedCh:      make(chan struct{}),
 	}
 	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
 	called := make(chan struct{}, 50)
@@ -670,6 +673,7 @@ func TestCollectBatchMultilinePattern(t *testing.T) {
 		multilinePattern: multilinePattern,
 		sequenceToken:    aws.String(sequenceToken),
 		messages:         loggerutils.NewMessageQueue(0),
+		closedCh:         make(chan struct{}),
 	}
 	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
 	called := make(chan struct{}, 50)
@@ -736,6 +740,7 @@ func BenchmarkCollectBatch(b *testing.B) {
 			logStreamName: streamName,
 			sequenceToken: aws.String(sequenceToken),
 			messages:      loggerutils.NewMessageQueue(0),
+			closedCh:      make(chan struct{}),
 		}
 		mockClient.putLogEventsFunc = func(ctx context.Context, input *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
 			return &cloudwatchlogs.PutLogEventsOutput{
@@ -769,6 +774,7 @@ func BenchmarkCollectBatchMultilinePattern(b *testing.B) {
 			multilinePattern: multilinePattern,
 			sequenceToken:    aws.String(sequenceToken),
 			messages:         loggerutils.NewMessageQueue(0),
+			closedCh:         make(chan struct{}),
 		}
 		mockClient.putLogEventsFunc = func(ctx context.Context, input *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
 			return &cloudwatchlogs.PutLogEventsOutput{
@@ -800,6 +806,7 @@ func TestCollectBatchMultilinePatternMaxEventAge(t *testing.T) {
 		multilinePattern: multilinePattern,
 		sequenceToken:    aws.String(sequenceToken),
 		messages:         loggerutils.NewMessageQueue(0),
+		closedCh:         make(chan struct{}),
 	}
 	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
 	called := make(chan struct{}, 50)
@@ -874,6 +881,7 @@ func TestCollectBatchMultilinePatternNegativeEventAge(t *testing.T) {
 		multilinePattern: multilinePattern,
 		sequenceToken:    aws.String(sequenceToken),
 		messages:         loggerutils.NewMessageQueue(0),
+		closedCh:         make(chan struct{}),
 	}
 	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
 	called := make(chan struct{}, 50)
@@ -931,6 +939,7 @@ func TestCollectBatchMultilinePatternMaxEventSize(t *testing.T) {
 		multilinePattern: multilinePattern,
 		sequenceToken:    aws.String(sequenceToken),
 		messages:         loggerutils.NewMessageQueue(0),
+		closedCh:         make(chan struct{}),
 	}
 	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
 	called := make(chan struct{}, 50)
@@ -991,6 +1000,7 @@ func TestCollectBatchClose(t *testing.T) {
 		logStreamName: streamName,
 		sequenceToken: aws.String(sequenceToken),
 		messages:      loggerutils.NewMessageQueue(0),
+		closedCh:      make(chan struct{}),
 	}
 	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
 	called := make(chan struct{}, 50)
@@ -1093,6 +1103,7 @@ func TestCollectBatchLineSplit(t *testing.T) {
 		logStreamName: streamName,
 		sequenceToken: aws.String(sequenceToken),
 		messages:      loggerutils.NewMessageQueue(0),
+		closedCh:      make(chan struct{}),
 	}
 	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
 	called := make(chan struct{}, 50)
@@ -1141,6 +1152,7 @@ func TestCollectBatchLineSplitWithBinary(t *testing.T) {
 		logStreamName: streamName,
 		sequenceToken: aws.String(sequenceToken),
 		messages:      loggerutils.NewMessageQueue(0),
+		closedCh:      make(chan struct{}),
 	}
 	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
 	called := make(chan struct{}, 50)
@@ -1189,6 +1201,7 @@ func TestCollectBatchMaxEvents(t *testing.T) {
 		logStreamName: streamName,
 		sequenceToken: aws.String(sequenceToken),
 		messages:      loggerutils.NewMessageQueue(0),
+		closedCh:      make(chan struct{}),
 	}
 	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
 	called := make(chan struct{}, 50)
@@ -1243,6 +1256,7 @@ func TestCollectBatchMaxTotalBytes(t *testing.T) {
 		logStreamName: streamName,
 		sequenceToken: aws.String(sequenceToken),
 		messages:      loggerutils.NewMessageQueue(0),
+		closedCh:      make(chan struct{}),
 	}
 	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
 	called := make(chan struct{}, 50)
@@ -1324,6 +1338,7 @@ func TestCollectBatchMaxTotalBytesWithBinary(t *testing.T) {
 		logStreamName: streamName,
 		sequenceToken: aws.String(sequenceToken),
 		messages:      loggerutils.NewMessageQueue(0),
+		closedCh:      make(chan struct{}),
 	}
 	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
 	called := make(chan struct{}, 50)
@@ -1398,6 +1413,7 @@ func TestCollectBatchWithDuplicateTimestamps(t *testing.T) {
 		logStreamName: streamName,
 		sequenceToken: aws.String(sequenceToken),
 		messages:      loggerutils.NewMessageQueue(0),
+		closedCh:      make(chan struct{}),
 	}
 	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
 	called := make(chan struct{}, 50)
@@ -1722,4 +1738,59 @@ func TestNewAWSLogsClientCredentialEndpointDetect(t *testing.T) {
 	assert.Check(t, is.Contains(actualAuthHeader, "AWS4-HMAC-SHA256 Credential=test-access-key-id/"))
 	assert.Check(t, is.Contains(actualAuthHeader, "us-west-2"))
 	assert.Check(t, is.Contains(actualAuthHeader, "Signature="))
+}
+
+// TestCloseWhileLogStreamCreationPending is a regression test for
+// https://github.com/moby/moby/issues/53143.
+//
+// Closing a non-blocking logger must not deadlock while log stream creation
+// is still pending and the awslogs message queue is full.
+func TestCloseWhileLogStreamCreationPending(t *testing.T) {
+	stream := &logStream{
+		client: &mockClient{
+			putLogEventsFunc: func(context.Context, *cloudwatchlogs.PutLogEventsInput, ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
+				return &cloudwatchlogs.PutLogEventsOutput{}, nil
+			},
+		},
+		messages: loggerutils.NewMessageQueue(1),
+		closedCh: make(chan struct{}),
+	}
+	creationDone := make(chan bool)
+	go stream.collectBatch(creationDone)
+
+	ring := logger.NewRingLogger(stream, logger.Info{}, 1024)
+
+	assert.NilError(t, ring.Log(&logger.Message{Line: []byte("first")}))
+	assert.NilError(t, ring.Log(&logger.Message{Line: []byte("second")}))
+	assert.NilError(t, ring.Log(&logger.Message{Line: []byte("third")}))
+
+	closed := make(chan struct{})
+	go func() {
+		_ = ring.Close()
+		close(closed)
+	}()
+
+	t.Cleanup(func() {
+		select {
+		case <-closed:
+			return
+		default:
+		}
+
+		// Allow collectBatch to start consuming messages, unblocking the
+		// ring logger and permitting Close to finish.
+		close(creationDone)
+
+		select {
+		case <-closed:
+		case <-time.After(time.Second):
+			t.Error("logger did not shut down during cleanup")
+		}
+	})
+
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("Close blocked while log stream creation was pending")
+	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

Fixes: https://github.com/moby/moby/issues/53143

## Summary

When the awslogs driver is used in non-blocking mode and the CloudWatch log group does not exist, stopping the container deadlocks. The `collectBatch` goroutine blocks on receiving from the `creationDone` channel (waiting for the log stream creation goroutine to complete), so it never drains the message queue. The ring logger's `run()` goroutine blocks trying to enqueue into the full queue, preventing `ringLogger.Close()` from completing. This holds the container state lock indefinitely, freezing all container-scoped API calls and preventing the host port from being released.

Fix this by restructuring `collectBatch` to drain and discard messages from the `MessageQueue` channel while log stream creation is pending, rather than blocking on `<-created` first. Once creation succeeds, `collectBatch` transitions to its normal batch-collection logic. If the log stream is never created and the driver is closed, any in-flight messages are discarded since the destination never existed. This breaks the deadlock because the `MessageQueue` channel is always being consumed, so `Enqueue` never blocks, and the ring logger's `run()` goroutine can always return.

Additionally, replace `time.Sleep` in the log stream creation goroutine with a select on a timer and a close-signal channel, so the goroutine exits promptly on shutdown rather than sleeping up to 32 seconds.

NOTE: If approved, I'd like to backport this to the 25.x branch as well.

## Testing

Updated mocked `logStream` in tests to initialize close-signal channel. All existing awslogs unit tests pass (`go test ./daemon/logger/awslogs/`).

Also manually verified on Ubuntu 24.04 (c5.2xlarge, Docker Engine 29.6.2, containerd v2.2.6, runc 1.3.6, Go 1.26.5) using steps from the issue. Confirmed repro and validity of solution. As you will see below, we are able to reliably remove a container that has an empty log group and free the attached port.

```
ubuntu@ip-172-31-26-234:~$ cat /etc/os-release | head -3
PRETTY_NAME="Ubuntu 24.04.4 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
ubuntu@ip-172-31-26-234:/tmp/moby$ aws logs describe-log-groups --log-group-name-prefix /repro/awslogs-deadlock-nogroup --region us-west-2
{
    "logGroups": []
}
ubuntu@ip-172-31-26-234:/tmp/moby$
ubuntu@ip-172-31-26-234:/tmp/moby$ sudo docker run -d --name nb-hi -p 3000:3000 \
>   --log-driver=awslogs \
>   --log-opt awslogs-region=us-west-2 \
>   --log-opt awslogs-group=/repro/awslogs-deadlock-nogroup \
>   --log-opt awslogs-stream=nb-hi \
>   --log-opt mode=non-blocking \
>   public.ecr.aws/amazonlinux/amazonlinux:2023 \
>   bash -c 'trap "" TERM; for i in $(seq 1 10000); do echo "log line $i"; done; while true; do sleep 3600; done'
c29cbbb915ac5d1c689a758582ad903f45dd2db33c369e2690fc03964dd29a77
ubuntu@ip-172-31-26-234:/tmp/moby$ sudo docker ps
CONTAINER ID   IMAGE                                         COMMAND                    CREATED         STATUS         PORTS                                         NAMES
c29cbbb915ac   public.ecr.aws/amazonlinux/amazonlinux:2023   "bash -c 'trap \"\" TE…"   7 seconds ago   Up 7 seconds   0.0.0.0:3000->3000/tcp, [::]:3000->3000/tcp   nb-hi
ubuntu@ip-172-31-26-234:/tmp/moby$ grep 'ResourceNotFoundException\|Retrying' /tmp/dockerd.log | tail -5
time="2026-07-23T21:59:48.725696949Z" level=error msg="Error while trying to initialize awslogs. Retrying in: 2 seconds" container-id=c29cbbb915ac5d1c689a758582ad903f45dd2db33c369e2690fc03964dd29a77 container-name=/nb-hi error="<nil>"
time="2026-07-23T21:59:50.741514747Z" level=error msg="Failed to create log stream" errorCode=ResourceNotFoundException logGroupName=/repro/awslogs-deadlock-nogroup logStreamName=nb-hi message="The specified log group does not exist."
time="2026-07-23T21:59:50.741550381Z" level=error msg="Error while trying to initialize awslogs. Retrying in: 4 seconds" container-id=c29cbbb915ac5d1c689a758582ad903f45dd2db33c369e2690fc03964dd29a77 container-name=/nb-hi error="<nil>"
time="2026-07-23T21:59:54.757063682Z" level=error msg="Failed to create log stream" errorCode=ResourceNotFoundException logGroupName=/repro/awslogs-deadlock-nogroup logStreamName=nb-hi message="The specified log group does not exist."
time="2026-07-23T21:59:54.757097955Z" level=error msg="Error while trying to initialize awslogs. Retrying in: 8 seconds" container-id=c29cbbb915ac5d1c689a758582ad903f45dd2db33c369e2690fc03964dd29a77 container-name=/nb-hi error="<nil>"
ubuntu@ip-172-31-26-234:/tmp/moby$
ubuntu@ip-172-31-26-234:/tmp/moby$ time sudo docker stop nb-hi
nb-hi

real	0m10.154s
user	0m0.001s
sys	0m0.006s
ubuntu@ip-172-31-26-234:/tmp/moby$ sudo docker ps
CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
ubuntu@ip-172-31-26-234:/tmp/moby$  sudo ss -ltnp | grep 3000 || echo "port 3000 free"
port 3000 free
ubuntu@ip-172-31-26-234:/tmp/moby$ sudo docker rm nb-hi
nb-hi
```


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Fix a deadlock when stopping a container using the awslogs logging driver in non-blocking mode with a missing CloudWatch log group.
```

## A picture of a cute animal (not mandatory but encouraged)
🪿
