### PR TITLE
jsonmessage: clamp progress percentage to avoid panic on negative Current

### DIFF
--- a/client/pkg/jsonmessage/jsonmessage.go
+++ b/client/pkg/jsonmessage/jsonmessage.go
@@ -56,7 +56,8 @@ func RenderTUIProgress(p jsonstream.Progress, width uint16) string {
 		}
 	}
 
-	percentage := min(int(float64(p.Current)/float64(p.Total)*100)/2, 50)
+	// percentage can't be negative gh#7136
+	percentage := min(max(int(float64(p.Current)/float64(p.Total)*100)/2, 0), 50)
 	if width > 110 {
 		// this number can't be negative gh#7136
 		numSpaces := max(50-percentage, 0)

--- a/client/pkg/jsonmessage/jsonmessage_test.go
+++ b/client/pkg/jsonmessage/jsonmessage_test.go
@@ -111,6 +111,14 @@ func TestRenderTUIProgress(t *testing.T) {
 	}
 }
 
+func TestRenderTUIProgress_negativeCurrent(t *testing.T) {
+	// Current can be negative on a decoded stream; the "=" repeat count must
+	// stay non-negative or strings.Repeat panics (companion to gh#7136, which
+	// clamped the trailing spaces but not the "=" run). A panic fails the test.
+	out := RenderTUIProgress(jsonstream.Progress{Current: -100, Total: 100}, 200)
+	assert.Assert(t, !strings.Contains(out, "="), "negative progress should clamp the bar; got %q", out)
+}
+
 func TestDisplay(t *testing.T) {
 	messages := map[jsonstream.Message][]string{
 		// Empty


### PR DESCRIPTION
## Summary

`RenderTUIProgress` derives `percentage` from `Progress.Current / Total` and passes it to `strings.Repeat("=", percentage)`. `Current` is an `int64` decoded straight from a JSON stream, so it can be negative — driving `percentage` negative and panicking with `strings: negative Repeat count`. gh#7136 clamped the trailing spaces (`numSpaces`) but not the `"="` run.

This clamps `percentage` to `[0, 50]` and adds a regression test.

- Related to: https://github.com/moby/moby/pull/7136

## Reproduce

```go
RenderTUIProgress(jsonstream.Progress{Current: -100, Total: 100}, 200) // panics on master
```
Fails on `master` (`panic: strings: negative Repeat count`), passes with this change; `go test ./pkg/jsonmessage/` is green (verified in a `golang:1.25` container).

## Release notes

Fix a panic in progress-bar rendering when a JSON stream reports a negative progress `current` value.

Created with: Claude Code (Anthropic)