### PR TITLE
daemon/graphdriver: Avoid recursive ownership changes

### DIFF
--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -78,7 +78,7 @@ func Init(home string, options []string, idMap user.IdentityMapping) (graphdrive
 	}
 
 	_, gid := idMap.RootPair()
-	if err := user.MkdirAllAndChown(home, 0o710, os.Getuid(), gid); err != nil {
+	if err := user.MkdirAndChown(home, 0o710, os.Getuid(), gid); err != nil {
 		return nil, err
 	}
 

--- a/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
+++ b/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
@@ -84,10 +84,10 @@ func Init(home string, options []string, idMap user.IdentityMapping) (graphdrive
 
 	cuid := os.Getuid()
 	_, gid := idMap.RootPair()
-	if err := user.MkdirAllAndChown(home, 0o710, cuid, gid); err != nil {
+	if err := user.MkdirAndChown(home, 0o710, cuid, gid); err != nil {
 		return nil, err
 	}
-	if err := user.MkdirAllAndChown(path.Join(home, linkDir), 0o700, cuid, os.Getegid()); err != nil {
+	if err := user.MkdirAndChown(path.Join(home, linkDir), 0o700, cuid, os.Getegid()); err != nil {
 		return nil, err
 	}
 

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -348,9 +348,6 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) (retErr
 
 	cuid := os.Getuid()
 	uid, gid := d.idMap.RootPair()
-	if err := user.MkdirAllAndChown(path.Dir(dir), 0o710, cuid, gid); err != nil {
-		return err
-	}
 	if err := user.MkdirAndChown(dir, 0o710, cuid, gid); err != nil {
 		return err
 	}

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -167,10 +167,10 @@ func Init(home string, options []string, idMap user.IdentityMapping) (graphdrive
 
 	cuid := os.Getuid()
 	_, gid := idMap.RootPair()
-	if err := user.MkdirAllAndChown(home, 0o710, cuid, gid); err != nil {
+	if err := user.MkdirAndChown(home, 0o710, cuid, gid); err != nil {
 		return nil, err
 	}
-	if err := user.MkdirAllAndChown(path.Join(home, linkDir), 0o700, cuid, os.Getegid()); err != nil {
+	if err := user.MkdirAndChown(path.Join(home, linkDir), 0o700, cuid, os.Getegid()); err != nil {
 		return nil, err
 	}
 

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -172,9 +172,6 @@ func (d *Driver) create(id, parent string, size uint64) error {
 	dir := d.dir(id)
 	uid, gid := d.idMapping.RootPair()
 
-	if err := user.MkdirAllAndChown(filepath.Dir(dir), 0o710, os.Getuid(), gid); err != nil {
-		return err
-	}
 	if err := user.MkdirAndChown(dir, 0o755, uid, gid); err != nil {
 		return err
 	}

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -40,7 +40,10 @@ func Init(home string, options []string, idMap user.IdentityMapping) (graphdrive
 	}
 
 	_, gid := d.idMapping.RootPair()
-	if err := user.MkdirAllAndChown(home, 0o710, os.Getuid(), gid); err != nil {
+	if err := user.MkdirAndChown(home, 0o710, os.Getuid(), gid); err != nil {
+		return nil, err
+	}
+	if err := user.MkdirAndChown(filepath.Join(home, "dir"), 0o710, os.Getuid(), gid); err != nil {
 		return nil, err
 	}
 

--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -106,7 +106,7 @@ func Init(base string, opt []string, idMap user.IdentityMapping) (graphdriver.Dr
 	}
 
 	_, gid := idMap.RootPair()
-	if err := user.MkdirAllAndChown(base, 0o710, os.Getuid(), gid); err != nil {
+	if err := user.MkdirAndChown(base, 0o710, os.Getuid(), gid); err != nil {
 		return nil, fmt.Errorf("Failed to create '%s': %v", base, err)
 	}
 

--- a/daemon/internal/layer/migration_test.go
+++ b/daemon/internal/layer/migration_test.go
@@ -49,7 +49,7 @@ func TestLayerMigrationNoTarsplit(t *testing.T) {
 		newTestFile("/root/.bashrc", []byte("# Updated configuration"), 0o644),
 	}
 
-	graph, err := newVFSGraphDriver(filepath.Join(tempDir, "graphdriver-"))
+	graph, err := newVFSGraphDriver(tempDir)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- follow up to: https://github.com/moby/moby/pull/53134

## Summary


Avoid recursive ownership changes when initializing graphdriver directories.

Graphdriver home directories already have an existing parent under the daemon root, so create only the driver-owned directory instead of recursively creating and changing its parents.
Overlay2 and VFS now also create their layer parent directories during initialization, which removes repeated parent ownership changes from each layer creation.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
