### PR TITLE
integration: Replace flaky TestRunAttachDetachFromInvalidFlag

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -205,41 +205,6 @@ func (s *DockerCLIRunSuite) TestRunAttachDetachFromFlag(c *testing.T) {
 	assert.Equal(c, running, "true", "expected container to still be running")
 }
 
-// TestRunAttachDetachFromInvalidFlag checks attaching and detaching with the escape sequence specified via flags.
-func (s *DockerCLIRunSuite) TestRunAttachDetachFromInvalidFlag(c *testing.T) {
-	const name = "attach-detach"
-	cli.DockerCmd(c, "run", "--name", name, "-itd", "busybox", "top")
-	cli.WaitRun(c, name)
-
-	// specify an invalid detach key, container will ignore it and use default
-	cmd := exec.Command(dockerBinary, "attach", "--detach-keys=ctrl-A,a", name)
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		c.Fatal(err)
-	}
-	cpty, tty, err := pty.Open()
-	if err != nil {
-		c.Fatal(err)
-	}
-	defer cpty.Close()
-	cmd.Stdin = tty
-	if err := cmd.Start(); err != nil {
-		c.Fatal(err)
-	}
-	go cmd.Wait()
-
-	bufReader := bufio.NewReader(stderr)
-	out, err := bufReader.ReadString('\n')
-	if err != nil {
-		c.Fatal(err)
-	}
-	// it should print a warning to indicate the detach key flag is invalid
-	// FIXME(thaJeztah): this is a regression: current versions of docker (cli) don't print the error message
-	// errStr := "Invalid detach keys (ctrl-A,a) provided"
-	errStr := "unable to upgrade to tcp, received 400"
-	assert.Equal(c, strings.TrimSpace(out), errStr)
-}
-
 // TestRunAttachDetachFromConfig checks attaching and detaching with the escape sequence specified via config file.
 func (s *DockerCLIRunSuite) TestRunAttachDetachFromConfig(c *testing.T) {
 	keyCtrlA := []byte{1}

--- a/integration/container/attach_test.go
+++ b/integration/container/attach_test.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 	systemutil "github.com/moby/moby/v2/integration/internal/system"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/daemon"
+	"github.com/moby/moby/v2/internal/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/poll"
@@ -61,6 +64,40 @@ func TestAttach(t *testing.T) {
 			assert.Check(t, is.Equal(mediaType, tc.expectedMediaType))
 		})
 	}
+}
+
+func TestAttachRejectsInvalidDetachKeys(t *testing.T) {
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	resp, err := apiClient.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Config: &container.Config{
+			Image: "busybox",
+			Cmd:   []string{"top"},
+			Tty:   true,
+		},
+		HostConfig:       &container.HostConfig{},
+		NetworkingConfig: &network.NetworkingConfig{},
+	})
+	assert.NilError(t, err)
+
+	query := url.Values{"detachKeys": {"ctrl-A,a"}}
+	res, body, err := request.Post(ctx, "/containers/"+resp.ID+"/attach?"+query.Encode(),
+		request.With(func(req *http.Request) error {
+			req.Header.Set("Connection", "Upgrade")
+			req.Header.Set("Upgrade", "tcp")
+			return nil
+		}),
+	)
+	if body != nil {
+		defer func() { _ = body.Close() }()
+	}
+	assert.NilError(t, err)
+	assert.Equal(t, res.StatusCode, http.StatusBadRequest)
+
+	out, err := request.ReadBody(body)
+	assert.NilError(t, err)
+	assert.Check(t, is.Contains(string(out), "Invalid detach keys"))
 }
 
 // Regression test for #37182


### PR DESCRIPTION
- fix: https://github.com/moby/moby/issues/44128
- addresses https://github.com/moby/moby/issues/50159

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

The legacy test raced cmd.Wait against reads from its stderr pipe and only asserted the bundled CLI's generic HTTP upgrade error.

Rewrite it into a pure API integration test.
The cli side is already covered by
`TestNewAttachCommandErrors/invalid-detach-keys` test in docker/cli.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
