### PR TITLE
test: fix flaky TestUsernsCommit

### DIFF
--- a/integration/image/commit_test.go
+++ b/integration/image/commit_test.go
@@ -61,6 +61,10 @@ func TestUsernsCommit(t *testing.T) {
 	ctx := context.Background()
 	dUserRemap := daemon.New(t, daemon.WithUserNsRemap("default"))
 	dUserRemap.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false")
+	t.Cleanup(func() {
+		dUserRemap.Stop(t)
+		dUserRemap.Cleanup(t)
+	})
 	clientUserRemap := dUserRemap.NewClientT(t)
 	defer clientUserRemap.Close()
 


### PR DESCRIPTION
## What

Fix intermittent failure of `TestUsernsCommit`.

## Why

The test creates a userns-remapped daemon but only closes the API client (`clientUserRemap.Close()`), never stopping or cleaning up the daemon itself. With userns remapping active, the daemon mounts overlay2 union filesystems under `root/165536.165536/` in the bundle directory. These mounts remain live after the test completes, causing `EPERM` / "Permission denied" errors during bundle cleanup in **100% of all 31 userns CI runs** in the last 500 workflow runs.

## How

Add a `t.Cleanup` call immediately after `StartWithBusybox` to properly stop and clean up the daemon. This ensures all overlay2 mounts are unmounted before the test completes, following the same pattern already used correctly in `integration/build/build_userns_linux_test.go`.

## Verification

This change addresses the flakiness identified in #48118. The fix was proposed by automated analysis of CI logs and source code.

Closes #48118