### PR TITLE
vendor: cyphar.com/go-pathrs v0.2.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/longrunning v1.0.0 // indirect
 	code.cloudfoundry.org/clock v1.60.0 // indirect
-	cyphar.com/go-pathrs v0.2.1 // indirect
+	cyphar.com/go-pathrs v0.2.5 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ cloud.google.com/go/longrunning v1.0.0 h1:lwzWEYD8+NkYV7dhexOz6kmlvajZA70+bW/xMh
 cloud.google.com/go/longrunning v1.0.0/go.mod h1:8nqFBPOO1U/XkhWl0I19AMZEphrHi73VNABIpKYaTwM=
 code.cloudfoundry.org/clock v1.60.0 h1:X47eUg0qVXhzGnGSo6TTQtWKfT1vjMfomP7a3sXi2lo=
 code.cloudfoundry.org/clock v1.60.0/go.mod h1:aIq+ZIUPz32B/Mr8QQlPtEksMKRDKnWOxy+b9d9D7i8=
-cyphar.com/go-pathrs v0.2.1 h1:9nx1vOgwVvX1mNBWDu93+vaceedpbsDqo+XuBGL40b8=
-cyphar.com/go-pathrs v0.2.1/go.mod h1:y8f1EMG7r+hCuFf/rXsKqMJrJAUoADZGNh5/vZPKcGc=
+cyphar.com/go-pathrs v0.2.5 h1:SnX9FBvnoyn3lUs1dkMgZ52bAETpirNu3FTRh5HlRik=
+cyphar.com/go-pathrs v0.2.5/go.mod h1:y8f1EMG7r+hCuFf/rXsKqMJrJAUoADZGNh5/vZPKcGc=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=

--- a/vendor/cyphar.com/go-pathrs/.golangci.yml
+++ b/vendor/cyphar.com/go-pathrs/.golangci.yml
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # libpathrs: safe path resolution on Linux
-# Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
 # Copyright (C) 2019-2025 SUSE LLC
+# Copyright (C) 2026 Aleksa Sarai <cyphar@cyphar.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/vendor/cyphar.com/go-pathrs/doc.go
+++ b/vendor/cyphar.com/go-pathrs/doc.go
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 /*
  * libpathrs: safe path resolution on Linux
- * Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
  * Copyright (C) 2019-2025 SUSE LLC
+ * Copyright (C) 2026 Aleksa Sarai <cyphar@cyphar.com>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/vendor/cyphar.com/go-pathrs/handle_linux.go
+++ b/vendor/cyphar.com/go-pathrs/handle_linux.go
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: MPL-2.0
 /*
  * libpathrs: safe path resolution on Linux
- * Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
  * Copyright (C) 2019-2025 SUSE LLC
+ * Copyright (C) 2026 Aleksa Sarai <cyphar@cyphar.com>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -16,6 +16,8 @@ package pathrs
 import (
 	"fmt"
 	"os"
+
+	"golang.org/x/sys/unix"
 
 	"cyphar.com/go-pathrs/internal/fdutils"
 	"cyphar.com/go-pathrs/internal/libpathrs"
@@ -30,11 +32,9 @@ import (
 // you can try to use [Root.Open] or [Root.OpenFile].
 //
 // It is critical that perform all relevant operations through this [Handle]
-// (rather than fetching the file descriptor yourself with [Handle.IntoRaw]),
+// (rather than fetching the underlying [os.File] yourself with [Handle.IntoFile]),
 // because the security properties of libpathrs depend on users doing all
 // relevant filesystem operations through libpathrs.
-//
-// [os.File]: https://pkg.go.dev/os#File
 type Handle struct {
 	inner *os.File
 }
@@ -43,7 +43,7 @@ type Handle struct {
 // handle will be copied by this method, so the original handle should still be
 // freed by the caller.
 //
-// This is effectively the inverse operation of [Handle.IntoRaw], and is used
+// This is effectively the inverse operation of [Handle.IntoFile], and is used
 // for "deserialising" pathrs root handles.
 func HandleFromFile(file *os.File) (*Handle, error) {
 	newFile, err := fdutils.DupFile(file)
@@ -58,11 +58,11 @@ func HandleFromFile(file *os.File) (*Handle, error) {
 // and can be opened multiple times.
 //
 // The handle returned is only usable for reading, and this is method is
-// shorthand for [Handle.OpenFile] with os.O_RDONLY.
+// shorthand for [Handle.OpenFile] with [unix.O_RDONLY].
 //
 // TODO: Rename these to "Reopen" or something.
 func (h *Handle) Open() (*os.File, error) {
-	return h.OpenFile(os.O_RDONLY)
+	return h.OpenFile(unix.O_RDONLY)
 }
 
 // OpenFile creates an "upgraded" file handle to the file referenced by the
@@ -73,7 +73,7 @@ func (h *Handle) Open() (*os.File, error) {
 // handle.
 //
 // TODO: Rename these to "Reopen" or something.
-func (h *Handle) OpenFile(flags int) (*os.File, error) {
+func (h *Handle) OpenFile(flags uint64) (*os.File, error) {
 	return fdutils.WithFileFd(h.inner, func(fd uintptr) (*os.File, error) {
 		newFd, err := libpathrs.Reopen(fd, flags)
 		if err != nil {
@@ -92,8 +92,6 @@ func (h *Handle) OpenFile(flags int) (*os.File, error) {
 // calling [Handle.Close] will also close any copies of the returned [os.File].
 // If you want to get an independent copy, use [Handle.Clone] followed by
 // [Handle.IntoFile] on the cloned [Handle].
-//
-// [os.File]: https://pkg.go.dev/os#File
 func (h *Handle) IntoFile() *os.File {
 	// TODO: Figure out if we really don't want to make a copy.
 	// TODO: We almost certainly want to clear r.inner here, but we can't do

--- a/vendor/cyphar.com/go-pathrs/internal/fdutils/fd_linux.go
+++ b/vendor/cyphar.com/go-pathrs/internal/fdutils/fd_linux.go
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: MPL-2.0
 /*
  * libpathrs: safe path resolution on Linux
- * Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
  * Copyright (C) 2019-2025 SUSE LLC
+ * Copyright (C) 2026 Aleksa Sarai <cyphar@cyphar.com>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/vendor/cyphar.com/go-pathrs/internal/libpathrs/error_unix.go
+++ b/vendor/cyphar.com/go-pathrs/internal/libpathrs/error_unix.go
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: MPL-2.0
 /*
  * libpathrs: safe path resolution on Linux
- * Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
  * Copyright (C) 2019-2025 SUSE LLC
+ * Copyright (C) 2026 Aleksa Sarai <cyphar@cyphar.com>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/vendor/cyphar.com/go-pathrs/internal/libpathrs/libpathrs_linux.go
+++ b/vendor/cyphar.com/go-pathrs/internal/libpathrs/libpathrs_linux.go
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: MPL-2.0
 /*
  * libpathrs: safe path resolution on Linux
- * Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
  * Copyright (C) 2019-2025 SUSE LLC
+ * Copyright (C) 2026 Aleksa Sarai <cyphar@cyphar.com>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -60,8 +60,8 @@ func OpenRoot(path string) (uintptr, error) {
 }
 
 // Reopen wraps pathrs_reopen.
-func Reopen(fd uintptr, flags int) (uintptr, error) {
-	newFd := C.pathrs_reopen(C.int(fd), C.int(flags))
+func Reopen(fd uintptr, flags uint64) (uintptr, error) {
+	newFd := C.pathrs_reopen(C.int(fd), C.uint64_t(flags))
 	return uintptr(newFd), fetchError(newFd)
 }
 
@@ -84,11 +84,11 @@ func InRootResolveNoFollow(rootFd uintptr, path string) (uintptr, error) {
 }
 
 // InRootOpen wraps pathrs_inroot_open.
-func InRootOpen(rootFd uintptr, path string, flags int) (uintptr, error) {
+func InRootOpen(rootFd uintptr, path string, flags uint64) (uintptr, error) {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))
 
-	fd := C.pathrs_inroot_open(C.int(rootFd), cPath, C.int(flags))
+	fd := C.pathrs_inroot_open(C.int(rootFd), cPath, C.uint64_t(flags))
 	return uintptr(fd), fetchError(fd)
 }
 
@@ -100,7 +100,7 @@ func InRootReadlink(rootFd uintptr, path string) (string, error) {
 	size := 128
 	for {
 		linkBuf := make([]byte, size)
-		n := C.pathrs_inroot_readlink(C.int(rootFd), cPath, C.cast_ptr(unsafe.Pointer(&linkBuf[0])), C.ulong(len(linkBuf)))
+		n := C.pathrs_inroot_readlink(C.int(rootFd), cPath, C.cast_ptr(unsafe.Pointer(&linkBuf[0])), C.size_t(len(linkBuf)))
 		switch {
 		case int(n) < C.__PATHRS_MAX_ERR_VALUE:
 			return "", fetchError(n)
@@ -145,23 +145,23 @@ func InRootRemoveAll(rootFd uintptr, path string) error {
 }
 
 // InRootCreat wraps pathrs_inroot_creat.
-func InRootCreat(rootFd uintptr, path string, flags int, mode uint32) (uintptr, error) {
+func InRootCreat(rootFd uintptr, path string, flags uint64, mode uint32) (uintptr, error) {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))
 
-	fd := C.pathrs_inroot_creat(C.int(rootFd), cPath, C.int(flags), C.uint(mode))
+	fd := C.pathrs_inroot_creat(C.int(rootFd), cPath, C.uint64_t(flags), C.uint(mode))
 	return uintptr(fd), fetchError(fd)
 }
 
 // InRootRename wraps pathrs_inroot_rename.
-func InRootRename(rootFd uintptr, src, dst string, flags uint) error {
-	cSrc := C.CString(src)
-	defer C.free(unsafe.Pointer(cSrc))
+func InRootRename(oldRootFd uintptr, oldPath string, newRootFd uintptr, newPath string, flags uint64) error {
+	cOldPath := C.CString(oldPath)
+	defer C.free(unsafe.Pointer(cOldPath))
 
-	cDst := C.CString(dst)
-	defer C.free(unsafe.Pointer(cDst))
+	cNewPath := C.CString(newPath)
+	defer C.free(unsafe.Pointer(cNewPath))
 
-	err := C.pathrs_inroot_rename(C.int(rootFd), cSrc, cDst, C.uint(flags))
+	err := C.pathrs_inroot_rename(C.int(oldRootFd), cOldPath, C.int(newRootFd), cNewPath, C.uint64_t(flags))
 	return fetchError(err)
 }
 
@@ -193,26 +193,26 @@ func InRootMknod(rootFd uintptr, path string, mode uint32, dev uint64) error {
 }
 
 // InRootSymlink wraps pathrs_inroot_symlink.
-func InRootSymlink(rootFd uintptr, path, target string) error {
-	cPath := C.CString(path)
-	defer C.free(unsafe.Pointer(cPath))
+func InRootSymlink(target string, rootFd uintptr, linkpath string) error {
+	cLinkpath := C.CString(linkpath)
+	defer C.free(unsafe.Pointer(cLinkpath))
 
 	cTarget := C.CString(target)
 	defer C.free(unsafe.Pointer(cTarget))
 
-	err := C.pathrs_inroot_symlink(C.int(rootFd), cPath, cTarget)
+	err := C.pathrs_inroot_symlink(cTarget, C.int(rootFd), cLinkpath)
 	return fetchError(err)
 }
 
 // InRootHardlink wraps pathrs_inroot_hardlink.
-func InRootHardlink(rootFd uintptr, path, target string) error {
-	cPath := C.CString(path)
-	defer C.free(unsafe.Pointer(cPath))
+func InRootHardlink(oldRootFd uintptr, oldPath string, newRootFd uintptr, newPath string, flags uint64) error {
+	cNewPath := C.CString(newPath)
+	defer C.free(unsafe.Pointer(cNewPath))
 
-	cTarget := C.CString(target)
-	defer C.free(unsafe.Pointer(cTarget))
+	cOldPath := C.CString(oldPath)
+	defer C.free(unsafe.Pointer(cOldPath))
 
-	err := C.pathrs_inroot_hardlink(C.int(rootFd), cPath, cTarget)
+	err := C.pathrs_inroot_hardlink(C.int(oldRootFd), cOldPath, C.int(newRootFd), cNewPath, C.uint64_t(flags))
 	return fetchError(err)
 }
 
@@ -277,13 +277,13 @@ func init() {
 func ProcPid(pid uint32) ProcBase { return ProcBaseTypePid | ProcBase(pid) }
 
 // ProcOpenat wraps pathrs_proc_openat.
-func ProcOpenat(procRootFd int, base ProcBase, path string, flags int) (uintptr, error) {
+func ProcOpenat(procRootFd int, base ProcBase, path string, flags uint64) (uintptr, error) {
 	cBase := C.pathrs_proc_base_t(base)
 
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))
 
-	fd := C.pathrs_proc_openat(C.int(procRootFd), cBase, cPath, C.int(flags))
+	fd := C.pathrs_proc_openat(C.int(procRootFd), cBase, cPath, C.uint64_t(flags))
 	return uintptr(fd), fetchError(fd)
 }
 
@@ -301,7 +301,7 @@ func ProcReadlinkat(procRootFd int, base ProcBase, path string) (string, error) 
 		linkBuf := make([]byte, size)
 		n := C.pathrs_proc_readlinkat(
 			C.int(procRootFd), cBase, cPath,
-			C.cast_ptr(unsafe.Pointer(&linkBuf[0])), C.ulong(len(linkBuf)))
+			C.cast_ptr(unsafe.Pointer(&linkBuf[0])), C.size_t(len(linkBuf)))
 		switch {
 		case int(n) < C.__PATHRS_MAX_ERR_VALUE:
 			return "", fetchError(n)
@@ -334,4 +334,32 @@ func (how *ProcfsOpenHow) Flags() *C.uint64_t { return &how.flags }
 func ProcfsOpen(how *ProcfsOpenHow) (uintptr, error) {
 	fd := C.pathrs_procfs_open((*C.pathrs_procfs_open_how)(how), C.size_t(unsafe.Sizeof(*how)))
 	return uintptr(fd), fetchError(fd)
+}
+
+// VersionInfo is a Go-friendly form of pathrs_version_info_t (struct).
+type VersionInfo struct {
+	VersionString string
+}
+
+// versionInfo is pathrs_version_info_t (struct).
+type versionInfo C.pathrs_version_info_t
+
+// Version is pathrs_version_info_t (sizeof(version) is passed automatically).
+func Version() (*VersionInfo, error) {
+	var rawVersion versionInfo
+	size := C.pathrs_version((*C.pathrs_version_info_t)(&rawVersion), C.size_t(unsafe.Sizeof(rawVersion)))
+	switch {
+	case size < 0:
+		return nil, fetchError(size)
+	case size > 0:
+		// TODO(log): Logging?
+		fallthrough
+	default:
+		// TODO(log): Add a log statement if sizeof(rawVersion) is bigger than
+		// the number of fields we store in VersionInfo. Otherwise a rebuild
+		// will mask that Go callers cannot see any new fields.
+		return &VersionInfo{
+			VersionString: C.GoString(rawVersion.version_string),
+		}, nil
+	}
 }

--- a/vendor/cyphar.com/go-pathrs/procfs/procfs_linux.go
+++ b/vendor/cyphar.com/go-pathrs/procfs/procfs_linux.go
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: MPL-2.0
 /*
  * libpathrs: safe path resolution on Linux
- * Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
  * Copyright (C) 2019-2025 SUSE LLC
+ * Copyright (C) 2026 Aleksa Sarai <cyphar@cyphar.com>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -56,16 +56,15 @@ var (
 //     *before* you call wait(2)or any equivalent method that could reap
 //     zombies).
 func ProcPid(pid int) ProcBase {
-	if pid < 0 || pid >= 1<<31 {
+	if pid < 0 || uint64(pid) >= 1<<31 {
 		panic("invalid ProcBasePid value") // TODO: should this be an error?
 	}
-	return ProcBase{inner: libpathrs.ProcPid(uint32(pid))}
+	pid32 := uint32(pid) //nolint:gosec // G115 false positive <https://github.com/securego/gosec/issues/1212>
+	return ProcBase{inner: libpathrs.ProcPid(pid32)}
 }
 
 // ThreadCloser is a callback that needs to be called when you are done
 // operating on an [os.File] fetched using [Handle.OpenThreadSelf].
-//
-// [os.File]: https://pkg.go.dev/os#File
 type ThreadCloser func()
 
 // Handle is a wrapper around an *os.File handle to "/proc", which can be
@@ -128,7 +127,7 @@ func (proc *Handle) fd() int {
 }
 
 // TODO: Should we expose open?
-func (proc *Handle) open(base ProcBase, path string, flags int) (_ *os.File, Closer ThreadCloser, Err error) {
+func (proc *Handle) open(base ProcBase, path string, flags uint64) (_ *os.File, Closer ThreadCloser, Err error) {
 	var closer ThreadCloser
 	if base == ProcThreadSelf {
 		runtime.LockOSThread()
@@ -155,7 +154,7 @@ func (proc *Handle) open(base ProcBase, path string, flags int) (_ *os.File, Clo
 // (such as /proc/cpuinfo) or information about other processes (such as
 // /proc/1). Accessing your own process information should be done using
 // [Handle.OpenSelf] or [Handle.OpenThreadSelf].
-func (proc *Handle) OpenRoot(path string, flags int) (*os.File, error) {
+func (proc *Handle) OpenRoot(path string, flags uint64) (*os.File, error) {
 	file, closer, err := proc.open(ProcRoot, path, flags)
 	if closer != nil {
 		// should not happen
@@ -181,9 +180,7 @@ func (proc *Handle) OpenRoot(path string, flags int) (*os.File, error) {
 // Unlike [Handle.OpenThreadSelf], this method does not involve locking
 // the goroutine to the current OS thread and so is simpler to use and
 // theoretically has slightly less overhead.
-//
-// [runtime.LockOSThread]: https://pkg.go.dev/runtime#LockOSThread
-func (proc *Handle) OpenSelf(path string, flags int) (*os.File, error) {
+func (proc *Handle) OpenSelf(path string, flags uint64) (*os.File, error) {
 	file, closer, err := proc.open(ProcSelf, path, flags)
 	if closer != nil {
 		// should not happen
@@ -201,7 +198,7 @@ func (proc *Handle) OpenSelf(path string, flags int) (*os.File, error) {
 // Be aware that due to PID recycling, using this is generally not safe except
 // in certain circumstances. See the documentation of [ProcPid] for more
 // details.
-func (proc *Handle) OpenPid(pid int, path string, flags int) (*os.File, error) {
+func (proc *Handle) OpenPid(pid int, path string, flags uint64) (*os.File, error) {
 	file, closer, err := proc.open(ProcPid(pid), path, flags)
 	if closer != nil {
 		// should not happen
@@ -228,11 +225,7 @@ func (proc *Handle) OpenPid(pid int, path string, flags int) (*os.File, error) {
 // callback MUST be called AFTER you have finished using the returned
 // [os.File]. This callback is completely separate to [os.File.Close], so it
 // must be called regardless of how you close the handle.
-//
-// [runtime.LockOSThread]: https://pkg.go.dev/runtime#LockOSThread
-// [os.File]: https://pkg.go.dev/os#File
-// [os.File.Close]: https://pkg.go.dev/os#File.Close
-func (proc *Handle) OpenThreadSelf(path string, flags int) (*os.File, ThreadCloser, error) {
+func (proc *Handle) OpenThreadSelf(path string, flags uint64) (*os.File, ThreadCloser, error) {
 	return proc.open(ProcThreadSelf, path, flags)
 }
 

--- a/vendor/cyphar.com/go-pathrs/root_linux.go
+++ b/vendor/cyphar.com/go-pathrs/root_linux.go
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: MPL-2.0
 /*
  * libpathrs: safe path resolution on Linux
- * Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
  * Copyright (C) 2019-2025 SUSE LLC
+ * Copyright (C) 2026 Aleksa Sarai <cyphar@cyphar.com>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -19,6 +19,8 @@ import (
 	"os"
 	"syscall"
 
+	"golang.org/x/sys/unix"
+
 	"cyphar.com/go-pathrs/internal/fdutils"
 	"cyphar.com/go-pathrs/internal/libpathrs"
 )
@@ -27,7 +29,7 @@ import (
 // purpose of this "root handle" is to perform operations within the directory
 // tree, or to get a [Handle] to inodes within the directory tree.
 //
-// At time of writing, it is considered a *VERY BAD IDEA* to open a [Root]
+// At time of writing, it is considered a *VERY BAD IDEA* to open a Root
 // inside a possibly-attacker-controlled directory tree. While we do have
 // protections that should defend against it, it's far more dangerous than just
 // opening a directory tree which is not inside a potentially-untrusted
@@ -54,8 +56,6 @@ func OpenRoot(path string) (*Root, error) {
 // still be closed by the caller.
 //
 // This is effectively the inverse operation of [Root.IntoFile].
-//
-// [os.File]: https://pkg.go.dev/os#File
 func RootFromFile(file *os.File) (*Root, error) {
 	newFile, err := fdutils.DupFile(file)
 	if err != nil {
@@ -70,7 +70,7 @@ func RootFromFile(file *os.File) (*Root, error) {
 //
 // All symlinks (including trailing symlinks) are followed, but they are
 // resolved within the rootfs. If you wish to open a handle to the symlink
-// itself, use [ResolveNoFollow].
+// itself, use [Root.ResolveNoFollow].
 func (r *Root) Resolve(path string) (*Handle, error) {
 	return fdutils.WithFileFd(r.inner, func(rootFd uintptr) (*Handle, error) {
 		handleFd, err := libpathrs.InRootResolve(rootFd, path)
@@ -85,10 +85,10 @@ func (r *Root) Resolve(path string) (*Handle, error) {
 	})
 }
 
-// ResolveNoFollow is effectively an O_NOFOLLOW version of [Resolve]. Their
-// behaviour is identical, except that *trailing* symlinks will not be
-// followed. If the final component is a trailing symlink, an O_PATH|O_NOFOLLOW
-// handle to the symlink itself is returned.
+// ResolveNoFollow is effectively an [unix.O_NOFOLLOW] version of
+// [Root.Resolve]. Their behaviour is identical, except that *trailing*
+// symlinks will not be followed. If the final component is a trailing symlink,
+// an [unix.O_PATH]|[unix.O_NOFOLLOW] handle to the symlink itself is returned.
 func (r *Root) ResolveNoFollow(path string) (*Handle, error) {
 	return fdutils.WithFileFd(r.inner, func(rootFd uintptr) (*Handle, error) {
 		handleFd, err := libpathrs.InRootResolveNoFollow(rootFd, path)
@@ -103,33 +103,29 @@ func (r *Root) ResolveNoFollow(path string) (*Handle, error) {
 	})
 }
 
-// Open is effectively shorthand for [Resolve] followed by [Handle.Open], but
-// can be slightly more efficient (it reduces CGo overhead and the number of
-// syscalls used when using the openat2-based resolver) and is arguably more
+// Open is effectively shorthand for [Root.Resolve] followed by [Handle.Open],
+// but can be slightly more efficient (it reduces CGo overhead and the number
+// of syscalls used when using the openat2-based resolver) and is arguably more
 // ergonomic to use.
 //
 // This is effectively equivalent to [os.Open].
-//
-// [os.Open]: https://pkg.go.dev/os#Open
 func (r *Root) Open(path string) (*os.File, error) {
-	return r.OpenFile(path, os.O_RDONLY)
+	return r.OpenFile(path, unix.O_RDONLY)
 }
 
-// OpenFile is effectively shorthand for [Resolve] followed by
+// OpenFile is effectively shorthand for [Root.Resolve] followed by
 // [Handle.OpenFile], but can be slightly more efficient (it reduces CGo
 // overhead and the number of syscalls used when using the openat2-based
 // resolver) and is arguably more ergonomic to use.
 //
-// However, if flags contains os.O_NOFOLLOW and the path is a symlink, then
+// However, if flags contains [unix.O_NOFOLLOW] and the path is a symlink, then
 // OpenFile's behaviour will match that of openat2. In most cases an error will
-// be returned, but if os.O_PATH is provided along with os.O_NOFOLLOW then a
-// file equivalent to [ResolveNoFollow] will be returned instead.
+// be returned, but if [unix.O_PATH] is provided along with [unix.O_NOFOLLOW]
+// then a file equivalent to [Root.ResolveNoFollow] will be returned instead.
 //
-// This is effectively equivalent to [os.OpenFile], except that os.O_CREAT is
-// not supported.
-//
-// [os.OpenFile]: https://pkg.go.dev/os#OpenFile
-func (r *Root) OpenFile(path string, flags int) (*os.File, error) {
+// This is effectively equivalent to [os.OpenFile], except that [unix.O_CREAT]
+// is not supported.
+func (r *Root) OpenFile(path string, flags uint64) (*os.File, error) {
 	return fdutils.WithFileFd(r.inner, func(rootFd uintptr) (*os.File, error) {
 		fd, err := libpathrs.InRootOpen(rootFd, path, flags)
 		if err != nil {
@@ -145,9 +141,7 @@ func (r *Root) OpenFile(path string, flags int) (*os.File, error) {
 //
 // Unlike [os.Create], if the file already exists an error is created rather
 // than the file being opened and truncated.
-//
-// [os.Create]: https://pkg.go.dev/os#Create
-func (r *Root) Create(path string, flags int, mode os.FileMode) (*os.File, error) {
+func (r *Root) Create(path string, flags uint64, mode os.FileMode) (*os.File, error) {
 	unixMode, err := toUnixMode(mode, false)
 	if err != nil {
 		return nil, err
@@ -163,9 +157,9 @@ func (r *Root) Create(path string, flags int, mode os.FileMode) (*os.File, error
 
 // Rename two paths within a [Root]'s directory tree. The flags argument is
 // identical to the RENAME_* flags to the renameat2(2) system call.
-func (r *Root) Rename(src, dst string, flags uint) error {
+func (r *Root) Rename(src, dst string, flags uint64) error {
 	_, err := fdutils.WithFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
-		err := libpathrs.InRootRename(rootFd, src, dst, flags)
+		err := libpathrs.InRootRename(rootFd, src, rootFd, dst, flags)
 		return struct{}{}, err
 	})
 	return err
@@ -194,8 +188,6 @@ func (r *Root) RemoveFile(path string) error {
 // directory tree.
 //
 // This is effectively equivalent to [os.Remove].
-//
-// [os.Remove]: https://pkg.go.dev/os#Remove
 func (r *Root) Remove(path string) error {
 	// In order to match os.Remove's implementation we need to also do both
 	// syscalls unconditionally and adjust the error based on whether
@@ -219,8 +211,6 @@ func (r *Root) Remove(path string) error {
 // RemoveAll recursively deletes a path and all of its children.
 //
 // This is effectively equivalent to [os.RemoveAll].
-//
-// [os.RemoveAll]: https://pkg.go.dev/os#RemoveAll
 func (r *Root) RemoveAll(path string) error {
 	_, err := fdutils.WithFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
 		err := libpathrs.InRootRemoveAll(rootFd, path)
@@ -233,8 +223,6 @@ func (r *Root) RemoveAll(path string) error {
 // mode is used for the new directory (the process's umask applies).
 //
 // This is effectively equivalent to [os.Mkdir].
-//
-// [os.Mkdir]: https://pkg.go.dev/os#Mkdir
 func (r *Root) Mkdir(path string, mode os.FileMode) error {
 	unixMode, err := toUnixMode(mode, false)
 	if err != nil {
@@ -253,8 +241,6 @@ func (r *Root) Mkdir(path string, mode os.FileMode) error {
 // directories created by this function (the process's umask applies).
 //
 // This is effectively equivalent to [os.MkdirAll].
-//
-// [os.MkdirAll]: https://pkg.go.dev/os#MkdirAll
 func (r *Root) MkdirAll(path string, mode os.FileMode) (*Handle, error) {
 	unixMode, err := toUnixMode(mode, false)
 	if err != nil {
@@ -278,9 +264,7 @@ func (r *Root) MkdirAll(path string, mode os.FileMode) (*Handle, error) {
 // directory tree. The provided mode is used for the new directory (the
 // process's umask applies).
 //
-// This is effectively equivalent to [unix.Mknod].
-//
-// [unix.Mknod]: https://pkg.go.dev/golang.org/x/sys/unix#Mknod
+// This is effectively equivalent to [golang.org/x/sys/unix.Mknod].
 func (r *Root) Mknod(path string, mode os.FileMode, dev uint64) error {
 	unixMode, err := toUnixMode(mode, true)
 	if err != nil {
@@ -295,30 +279,26 @@ func (r *Root) Mknod(path string, mode os.FileMode, dev uint64) error {
 }
 
 // Symlink creates a symlink within a [Root]'s directory tree. The symlink is
-// created at path and is a link to target.
+// created at newname and is a link to oldname.
 //
 // This is effectively equivalent to [os.Symlink].
-//
-// [os.Symlink]: https://pkg.go.dev/os#Symlink
-func (r *Root) Symlink(path, target string) error {
+func (r *Root) Symlink(oldname, newname string) error {
 	_, err := fdutils.WithFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
-		err := libpathrs.InRootSymlink(rootFd, path, target)
+		err := libpathrs.InRootSymlink(oldname, rootFd, newname)
 		return struct{}{}, err
 	})
 	return err
 }
 
 // Hardlink creates a hardlink within a [Root]'s directory tree. The hardlink
-// is created at path and is a link to target. Both paths are within the
+// is created at newname and is a link to oldname. Both paths are within the
 // [Root]'s directory tree (you cannot hardlink to a different [Root] or the
 // host).
 //
 // This is effectively equivalent to [os.Link].
-//
-// [os.Link]: https://pkg.go.dev/os#Link
-func (r *Root) Hardlink(path, target string) error {
+func (r *Root) Hardlink(oldname, newname string) error {
 	_, err := fdutils.WithFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
-		err := libpathrs.InRootHardlink(rootFd, path, target)
+		err := libpathrs.InRootHardlink(rootFd, oldname, rootFd, newname, 0)
 		return struct{}{}, err
 	})
 	return err
@@ -327,8 +307,6 @@ func (r *Root) Hardlink(path, target string) error {
 // Readlink returns the target of a symlink with a [Root]'s directory tree.
 //
 // This is effectively equivalent to [os.Readlink].
-//
-// [os.Readlink]: https://pkg.go.dev/os#Readlink
 func (r *Root) Readlink(path string) (string, error) {
 	return fdutils.WithFileFd(r.inner, func(rootFd uintptr) (string, error) {
 		return libpathrs.InRootReadlink(rootFd, path)
@@ -345,8 +323,6 @@ func (r *Root) Readlink(path string) (string, error) {
 // calling [Root.Close] will also close any copies of the returned [os.File].
 // If you want to get an independent copy, use [Root.Clone] followed by
 // [Root.IntoFile] on the cloned [Root].
-//
-// [os.File]: https://pkg.go.dev/os#File
 func (r *Root) IntoFile() *os.File {
 	// TODO: Figure out if we really don't want to make a copy.
 	// TODO: We almost certainly want to clear r.inner here, but we can't do

--- a/vendor/cyphar.com/go-pathrs/utils_linux.go
+++ b/vendor/cyphar.com/go-pathrs/utils_linux.go
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: MPL-2.0
 /*
  * libpathrs: safe path resolution on Linux
- * Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
  * Copyright (C) 2019-2025 SUSE LLC
+ * Copyright (C) 2026 Aleksa Sarai <cyphar@cyphar.com>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/vendor/cyphar.com/go-pathrs/version_linux.go
+++ b/vendor/cyphar.com/go-pathrs/version_linux.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+// SPDX-License-Identifier: MPL-2.0
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2026 Aleksa Sarai <cyphar@cyphar.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package pathrs
+
+import (
+	"cyphar.com/go-pathrs/internal/libpathrs"
+)
+
+// LibraryVersionInfo contains information about the version and features
+// supported by the underlying libpathrs.so library at runtime.
+type LibraryVersionInfo = libpathrs.VersionInfo
+
+// LibraryVersion returns information about the version and features supported
+// by the underlying libpathrs.so library at runtime.
+func LibraryVersion() (*LibraryVersionInfo, error) {
+	return libpathrs.Version()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -43,7 +43,7 @@ cloud.google.com/go/longrunning/internal
 ## explicit; go 1.24.9
 code.cloudfoundry.org/clock
 code.cloudfoundry.org/clock/fakeclock
-# cyphar.com/go-pathrs v0.2.1
+# cyphar.com/go-pathrs v0.2.5
 ## explicit; go 1.18
 cyphar.com/go-pathrs
 cyphar.com/go-pathrs/internal/fdutils


### PR DESCRIPTION
full diff: https://github.com/cyphar/libpathrs/compare/v0.2.1...v0.2.5

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
