### PR TITLE
api/types/network: accept legacy CIDR gateway

### DIFF
--- a/api/types/network/ipam.go
+++ b/api/types/network/ipam.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"encoding/json"
 	"net/netip"
 )
 
@@ -17,6 +18,48 @@ type IPAMConfig struct {
 	IPRange    netip.Prefix          `json:"IPRange,omitzero"`
 	Gateway    netip.Addr            `json:"Gateway,omitzero"`
 	AuxAddress map[string]netip.Addr `json:"AuxiliaryAddresses,omitempty"`
+}
+
+// UnmarshalJSON accepts legacy daemon responses that encoded Gateway as a
+// prefix, while keeping strict parsing for all non-legacy invalid addresses.
+func (c *IPAMConfig) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Subnet     netip.Prefix          `json:"Subnet"`
+		IPRange    netip.Prefix          `json:"IPRange"`
+		Gateway    *string               `json:"Gateway"`
+		AuxAddress map[string]netip.Addr `json:"AuxiliaryAddresses"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if raw.Gateway != nil {
+		gateway, err := parseGatewayAddr(*raw.Gateway)
+		if err != nil {
+			return err
+		}
+		c.Gateway = gateway
+	}
+
+	c.Subnet = raw.Subnet
+	c.IPRange = raw.IPRange
+	c.AuxAddress = raw.AuxAddress
+	return nil
+}
+
+func parseGatewayAddr(value string) (netip.Addr, error) {
+	if value == "" {
+		return netip.Addr{}, nil
+	}
+	addr, addrErr := netip.ParseAddr(value)
+	if addrErr == nil {
+		return addr, nil
+	}
+	prefix, err := netip.ParsePrefix(value)
+	if err != nil {
+		return netip.Addr{}, addrErr
+	}
+	return prefix.Addr(), nil
 }
 
 type SubnetStatuses = map[netip.Prefix]SubnetStatus

--- a/api/types/network/ipam_test.go
+++ b/api/types/network/ipam_test.go
@@ -1,0 +1,28 @@
+package network
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestIPAMConfigUnmarshalJSONAcceptsLegacyCIDRPrefixedGateway(t *testing.T) {
+	const (
+		legacyGatewayConfig = `{"Subnet":"fd05:d0ca:2::/112","Gateway":"fd05:d0ca:2::1/112"}`
+		expectedGateway     = "fd05:d0ca:2::1"
+	)
+
+	var config IPAMConfig
+	assert.NilError(t, json.Unmarshal([]byte(legacyGatewayConfig), &config))
+	assert.Check(t, is.Equal(config.Gateway, netip.MustParseAddr(expectedGateway)))
+}
+
+func TestIPAMConfigUnmarshalJSONRejectsInvalidGateway(t *testing.T) {
+	const invalidGatewayConfig = `{"Gateway":"not-an-address"}`
+
+	var config IPAMConfig
+	assert.Check(t, is.ErrorContains(json.Unmarshal([]byte(invalidGatewayConfig), &config), "unable to parse IP"))
+}

--- a/client/network_inspect_test.go
+++ b/client/network_inspect_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"net/http"
+	"net/netip"
 	"strings"
 	"testing"
 
@@ -86,4 +87,24 @@ func TestNetworkInspect(t *testing.T) {
 		_, err := client.NetworkInspect(t.Context(), "test-500-response", NetworkInspectOptions{})
 		assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 	})
+}
+
+func TestNetworkInspectAcceptsLegacyCIDRPrefixedGateway(t *testing.T) {
+	const (
+		expectedURL                  = "/networks/" + legacyNetworkName
+		legacyNetworkInspectResponse = `{"Name":"` + legacyNetworkName + `","Driver":"bridge","IPAM":{"Config":[{"Subnet":"` + legacyNetworkSubnet + `","Gateway":"` + legacyCIDRPrefixedGateway + `"}]}}`
+	)
+
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
+		}
+		return mockResponse(http.StatusOK, http.Header{"Content-Type": {networkResponseContent}}, legacyNetworkInspectResponse)(req)
+	}))
+	assert.NilError(t, err)
+
+	res, err := client.NetworkInspect(t.Context(), legacyNetworkName, NetworkInspectOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, is.Len(res.Network.IPAM.Config, 1))
+	assert.Check(t, is.Equal(res.Network.IPAM.Config[0].Gateway, netip.MustParseAddr(legacyNetworkGateway)))
 }

--- a/client/network_list_test.go
+++ b/client/network_list_test.go
@@ -3,12 +3,21 @@ package client
 import (
 	"fmt"
 	"net/http"
+	"net/netip"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/network"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+)
+
+const (
+	legacyCIDRPrefixedGateway = "fd05:d0ca:2::1/112"
+	legacyNetworkGateway      = "fd05:d0ca:2::1"
+	legacyNetworkName         = "test-ipv6"
+	legacyNetworkSubnet       = "fd05:d0ca:2::/112"
+	networkResponseContent    = "application/json"
 )
 
 func TestNetworkListError(t *testing.T) {
@@ -77,4 +86,25 @@ func TestNetworkList(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, is.Len(res.Items, 1))
 	}
+}
+
+func TestNetworkListAcceptsLegacyCIDRPrefixedGateway(t *testing.T) {
+	const (
+		expectedURL               = "/networks"
+		legacyNetworkListResponse = `[{"Name":"` + legacyNetworkName + `","Driver":"bridge","IPAM":{"Config":[{"Subnet":"` + legacyNetworkSubnet + `","Gateway":"` + legacyCIDRPrefixedGateway + `"}]}}]`
+	)
+
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
+		}
+		return mockResponse(http.StatusOK, http.Header{"Content-Type": {networkResponseContent}}, legacyNetworkListResponse)(req)
+	}))
+	assert.NilError(t, err)
+
+	res, err := client.NetworkList(t.Context(), NetworkListOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, is.Len(res.Items, 1))
+	assert.Assert(t, is.Len(res.Items[0].IPAM.Config, 1))
+	assert.Check(t, is.Equal(res.Items[0].IPAM.Config[0].Gateway, netip.MustParseAddr(legacyNetworkGateway)))
 }


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/52991
Follow up to: https://github.com/moby/moby/pull/53005

## Summary

The Docker API client currently rejects network list and inspect responses from legacy daemons that encode `IPAM.Config[].Gateway` as a CIDR-prefixed address, for example `fd05:d0ca:2::1/112`.

This updates `api/types/network.IPAMConfig` unmarshalling to accept that legacy gateway shape by parsing it as a prefix and keeping only the address. Invalid non-prefix gateway values still return an error. `AuxiliaryAddresses` remain strictly parsed as addresses.

This deliberately differs from the closed #53005 attempt: the regression tests exercise the actual client response paths (`NetworkList` and `NetworkInspect`) instead of only direct type unmarshalling, and the implementation does not silently coerce arbitrary invalid addresses.

## Test verification (RED -> GREEN)

RED on upstream `origin/master` with only the new client repro tests:

```text
--- FAIL: TestNetworkInspectAcceptsLegacyCIDRPrefixedGateway (0.00s)
    network_inspect_test.go:108: assertion failed: error is not nil: ParseAddr("fd05:d0ca:2::1/112"): unexpected character, want colon (at "/112")
--- FAIL: TestNetworkListAcceptsLegacyCIDRPrefixedGateway (0.00s)
    network_list_test.go:99: assertion failed: error is not nil: ParseAddr("fd05:d0ca:2::1/112"): unexpected character, want colon (at "/112")
FAIL    github.com/moby/moby/client    0.008s
```

GREEN after the fix:

```text
$ ./run-ci.sh
ok      github.com/moby/moby/api/types/network    0.013s
ok      github.com/moby/moby/client               0.145s
```

## Release notes (optional)

```markdown changelog
- Accept legacy CIDR-suffixed network gateway addresses in API responses for backwards compatibility.
```

## A picture of a cute animal (not mandatory but encouraged)

N/A

