### PR TITLE
integration: fix flaky TestStopContainerWithTimeout by adding readiness barrier

### DIFF
--- a/integration/container/stop_test.go
+++ b/integration/container/stop_test.go
@@ -67,7 +67,7 @@ func TestStopContainerWithTimeout(t *testing.T) {
 		forcefulKillExitCode = 0x40010004
 	}
 
-	testCmd := container.WithCmd("sh", "-c", "sleep 10 && exit 42")
+	testCmd := container.WithCmd("sh", "-c", "echo ready; sleep 10; exit 42")
 	testData := []struct {
 		doc              string
 		timeout          int
@@ -107,6 +107,7 @@ func TestStopContainerWithTimeout(t *testing.T) {
 			// TODO(vvoland): Investigate why it helps
 			// t.Parallel()
 			id := container.Run(ctx, t, apiClient, testCmd)
+			poll.WaitOn(t, logsContains(ctx, apiClient, id, "ready"))
 
 			_, err := apiClient.ContainerStop(ctx, id, client.ContainerStopOptions{Timeout: &tc.timeout})
 			assert.NilError(t, err)


### PR DESCRIPTION
## Summary

Fix intermittent failure of `TestStopContainerWithTimeout` in `integration/container/stop_test.go`.

The test command is `sh -c "sleep 10 && exit 42"`. `container.Run()` returns as soon as the API acknowledges `ContainerStart` — it does NOT wait for PID 1 to reach the `sleep` instruction. If `ContainerStop`'s SIGTERM arrives before `sh` has forked `sleep`, the shell itself exits immediately without executing `exit 42`, producing exit code 2 instead of 42. This race is particularly observable in rootless mode where RootlessKit namespace setup adds startup latency.

The fix adds a readiness barrier: the test command is updated to `sh -c "echo ready; sleep 10; exit 42"` and a `poll.WaitOn(t, logsContains(ctx, apiClient, id, "ready"))` call is added after `container.Run()` and before `ContainerStop()`. This pattern mirrors the fix already applied to the sibling test `TestStopContainerWithTimeoutCancel` in `integration/container/stop_linux_test.go`.

Closes #49206

## Release notes

```markdown changelog
```

## Note for maintainers

If you are not the author of this commit, please make sure to add a DCO sign-off to this PR by adding a commit with `git commit --signoff`, or by adding a `Signed-off-by` trailer to the commit message. See https://github.com/moby/moby/blob/master/CONTRIBUTING.md#sign-your-work for more details.

## A picture of a cute animal

![A cute red panda](https://upload.wikimedia.org/wikipedia/commons/thumb/5/50/RedPandaFullBody.JPG/800px-RedPandaFullBody.JPG)