### PR TITLE
libnetwork: clarify dropLegacyFilterDirectAccess TODO

### DIFF
--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/port.go
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/port.go
@@ -193,7 +193,7 @@ func filterPortMappedOnLoopback(ctx context.Context, b types.PortBinding, hostIP
 // then, all packets addressed directly to the container's ports were dropped
 // by the filter-FORWARD rules.
 //
-// Since 28.0.2, direct routed packets sent to a container's address are all
+// Since 28.2.0, direct routed packets sent to a container's address are all
 // dropped in a raw-PREROUTING rule - it doesn't need to be per-port (so, fewer
 // rules), and it can be created along with the endpoint (so directly-routed
 // packets are dropped at the same point whether or not the endpoint is currently
@@ -203,7 +203,7 @@ func filterPortMappedOnLoopback(ctx context.Context, b types.PortBinding, hostIP
 // It still is. but now always deletes the rule if it might have been created
 // by an older version of the daemon.
 //
-// TODO(robmry) - remove this once there's no upgrade path from 28.0.x or 28.1.x.
+// TODO(robmry) - remove this in v30 or once we expect no upgrade paths from 28.0.x or 28.1.x to 28.2.0 or newer.
 func (n *network) dropLegacyFilterDirectAccess(ctx context.Context, b types.PortBinding) error {
 	if rawRulesDisabled(ctx) {
 		return nil


### PR DESCRIPTION
- follow-up https://github.com/moby/moby/pull/49829

Correct the version referenced in the comment describing the migration performed by Network.dropLegacyFilterDirectAccess.

The migration was introduced in v28.2.0, not v28.0.2. Also update the TODO to clarify that the migration can be removed once we no longer expect upgrades from v28.0.x or v28.1.x directly to a release that includes the migration.

Refs: a0ff0a361e876d4cf48b235677918a2255029c9e ("libnetwork: drop legacy direct access filter rules")

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
