### PR TITLE
integration/networking: increase FirewalldReload poll timeout

### DIFF
--- a/integration/internal/testutils/networking/firewall.go
+++ b/integration/internal/testutils/networking/firewall.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/moby/moby/v2/internal/testutil/daemon"
 	"gotest.tools/v3/assert"
@@ -70,5 +71,5 @@ func FirewalldReload(t *testing.T, d *daemon.Daemon) {
 			return poll.Success()
 		}
 		return poll.Continue("firewalld reload not complete")
-	})
+	}, poll.WithTimeout(30*time.Second))
 }


### PR DESCRIPTION
## Summary

Increase the `poll.WaitOn` timeout in the `FirewalldReload` test helper from the `gotest.tools/v3` default of 10 seconds to 30 seconds.

`TestBridgeICC` calls `FirewalldReload` once per subtest and has 10 subtests that run sequentially. On a busy CI runner, the daemon can take longer than 10 s to acknowledge a reload after several consecutive reloads, causing the test to fail with:

    timeout hit after 10s: firewalld reload not complete

Increasing the timeout to 30 seconds gives slow CI runners more headroom without extending normal test runtime (a healthy runner typically completes the reload in under 1 s).

## Release notes

```markdown changelog

```

## Note for maintainers

A maintainer's `Signed-off-by` co-sign is needed before this PR can be merged, per the DCO policy discussion in
https://github.com/moby/moby/pull/53197. If you are approving this PR,
please amend the commit to add your own sign-off, or instruct Gordon to
add it on your behalf.

## A picture of a cute animal (not mandatory but encouraged)

🐢 Gordon the Turtle says hi