### PR TITLE
daemon/libnetwork: fix early DNS drop when ndots is explicitly set to 0

### DIFF
--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -2060,6 +2060,10 @@ func (n *Network) NdotsSet() bool {
 	return false
 }
 
+func (n *Network) Ndots() int {
+	return 0
+}
+
 // config-only network is looked up by name
 func (c *Controller) getConfigNetwork(name string) (*Network, error) {
 	var n *Network

--- a/daemon/libnetwork/resolver.go
+++ b/daemon/libnetwork/resolver.go
@@ -45,6 +45,8 @@ type DNSBackend interface {
 	ExecFunc(f func()) error
 	// NdotsSet queries the backends ndots dns option settings
 	NdotsSet() bool
+	// Ndots queries the backend ndots value
+	Ndots() int
 	// HandleQueryResp passes the name & IP from a response to the backend. backend
 	// can use it to maintain any required state about the resolution
 	HandleQueryResp(name string, ip net.IP)
@@ -463,7 +465,7 @@ func (r *Resolver) serveDNS(w dns.ResponseWriter, query *dns.Msg) {
 	// in the root domain don't forward it out. We will return
 	// failure and let the client retry with the search domain
 	// attached.
-	if (queryType == dns.TypeA || queryType == dns.TypeAAAA) && r.backend.NdotsSet() &&
+	if (queryType == dns.TypeA || queryType == dns.TypeAAAA) && r.backend.NdotsSet() && r.backend.Ndots() > 0 &&
 		!strings.Contains(strings.TrimSuffix(queryName, "."), ".") {
 		resp = createRespMsg(query)
 	} else {

--- a/daemon/libnetwork/resolver_test.go
+++ b/daemon/libnetwork/resolver_test.go
@@ -251,6 +251,7 @@ func (noopDNSBackend) ResolveName(_ context.Context, name string, ipType types.I
 func (noopDNSBackend) ExecFunc(f func()) error { f(); return nil }
 
 func (noopDNSBackend) NdotsSet() bool { return false }
+func (noopDNSBackend) Ndots() int     { return 0 }
 
 func (noopDNSBackend) HandleQueryResp(name string, ip net.IP) {}
 

--- a/daemon/libnetwork/sandbox.go
+++ b/daemon/libnetwork/sandbox.go
@@ -52,6 +52,7 @@ type Sandbox struct {
 	inDelete        bool
 	ingress         bool
 	ndotsSet        bool
+	ndots           int
 	oslTypes        []osl.SandboxType // slice of properties of this sandbox
 	loadBalancerNID string            // NID that this SB is a load balancer for
 	mu              sync.Mutex
@@ -673,4 +674,8 @@ func (ep *Endpoint) Less(epj *Endpoint) bool {
 
 func (sb *Sandbox) NdotsSet() bool {
 	return sb.ndotsSet
+}
+
+func (sb *Sandbox) Ndots() int {
+	return sb.ndots
 }

--- a/daemon/libnetwork/sandbox_dns_unix.go
+++ b/daemon/libnetwork/sandbox_dns_unix.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/containerd/log"
@@ -318,7 +319,12 @@ func (sb *Sandbox) rebuildDNS() error {
 	}
 
 	// Work out whether ndots has been set from host config or overrides.
-	_, sb.ndotsSet = rc.Option("ndots")
+	if val, set := rc.Option("ndots"); set {
+		sb.ndotsSet = true
+		if n, err := strconv.Atoi(val); err == nil {
+			sb.ndots = n
+		}
+	}
 	// Swap nameservers for the internal one, and make sure the required options are set.
 	var extNameServers []resolvconf.ExtDNSEntry
 	extNameServers, err = rc.TransformForIntNS(intNS, sb.resolver.ResolverOptions())


### PR DESCRIPTION
<!--
Fixes: https://github.com/moby/moby/issues/53104
-->

## Summary

When a user explicitly sets `ndots:0` (for example, in a container within DinD), `NdotsSet()` correctly returns `true`. However, because `NdotsSet()` was the only check before dropping single-label root domain DNS queries to force client-side search domains, requests with `ndots:0` were incorrectly dropped as well.

This PR:
- Introduces an `Ndots() int` method to the internal `DNSBackend` interface.
- Populates the `ndots` value by parsing the resolv.conf ndots option inside `Sandbox`.
- Modifies the resolver check to also verify that `Ndots() > 0` before dropping single-label DNS queries.

This correctly allows containers with `ndots:0` to resolve single-label names directly from upstream DNS, fixing the `DinD` resolution bug reported in #53104.

## Release notes

<!-- No changelog required for this bug fix -->

## A picture of a cute animal (not mandatory but encouraged)

![A cute dog programming](https://images.unsplash.com/photo-1517849845537-4d257902454a?auto=format&fit=crop&q=80&w=400)
