### PR TITLE
ci: buildkit: align registry version with Dockerfile

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -230,7 +230,7 @@ jobs:
               ${{ env.TEST_IMAGE_NAME }} hack\make.ps1 -Daemon -Client
           go install "github.com/distribution/distribution/v3/cmd/registry@${{ env.REGISTRY_VERSION }}"
         env:
-          REGISTRY_VERSION: "v3.0.0"
+          REGISTRY_VERSION: "v3.1.1"
 
       - name: Checkout BuildKit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/52324
- https://github.com/moby/moby/pull/52322
- https://github.com/moby/moby/issues/52320

Commit 00840cd39cb436c94e5054b8d9f4a52e265f7060 pinned the registry version as used by the BuildKit tests to not use "latest", because there was a regression in registry v3.1.0 but it was not updated when we updated the Dockerfile to use v3.1.1 in d5951a317db2755dbfaef185a276325221962c07

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
