### PR TITLE
integration-cli: fix IsAmd64() to accept x86_64 architecture string

### DIFF
--- a/integration-cli/docker_cli_swarm_unix_test.go
+++ b/integration-cli/docker_cli_swarm_unix_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/v2/integration-cli/checker"
@@ -97,8 +96,6 @@ func (s *DockerSwarmSuite) TestSwarmNetworkPluginV2(c *testing.T) {
 	// disable plugin on worker
 	_, err = d2.Cmd("plugin", "disable", "-f", pluginName)
 	assert.NilError(c, err)
-
-	time.Sleep(20 * time.Second)
 
 	const imgName = "busybox:latest"
 	// create a new global service again.

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -41,7 +41,10 @@ func OnlyDefaultNetworks(ctx context.Context) bool {
 }
 
 func IsAmd64() bool {
-	return testEnv.DaemonInfo.Architecture == "amd64"
+	arch := testEnv.DaemonInfo.Architecture
+	// DaemonInfo.Architecture is populated from uname(2) on Linux, which returns
+	// "x86_64" rather than the Go GOARCH name "amd64". Accept both conventions.
+	return arch == "amd64" || arch == "x86_64"
 }
 
 func NotPpc64le() bool {


### PR DESCRIPTION
## Summary

Fix `IsAmd64()` in `integration-cli/requirements_test.go` to accept both `"amd64"` and `"x86_64"` architecture strings. On Linux x86_64 systems, the Docker daemon reports `DaemonInfo.Architecture` as `"x86_64"` (from `uname(2)`) rather than `"amd64"` (Go GOARCH). This mismatch caused `testRequires(c, IsAmd64)` to always evaluate to false, permanently skipping `TestSwarmNetworkPluginV2` (and any other test gated on `IsAmd64`) on all Linux x86_64 CI runners.

Also removes the hard-coded 20-second `time.Sleep` in `TestSwarmNetworkPluginV2` in a separate commit, since `plugin disable --force` is synchronous.

## Release notes

<!--
Write your release notes below; the release notes team will use this section as the base for the release notes.
-->

```markdown changelog
```

## Note for maintainers

<!--
As a reminder, contributors who do not have write access to the repository sign off on commits to acknowledge they read and agreed to
the [Developer Certificate of Origin](https://developercertificate.org/). This is done by adding a `Signed-off-by` trailer to commit messages.

Since this PR was opened by an automated bot (GordonTheTurtle), please add a Co-authored-by or Signed-off-by if you agree with the change:

   Co-authored-by: GordonTheTurtle <GordonTheTurtle@users.noreply.github.com>
-->

Please add a `Signed-off-by` or `Co-authored-by` trailer to acknowledge the DCO for commits made by the GordonTheTurtle bot:

   Co-authored-by: GordonTheTurtle <GordonTheTurtle@users.noreply.github.com>

## A picture of a cute animal

🐢 Gordon the turtle approves this fix!