### PR TITLE
builder: Use base platform for cache lookup

### DIFF
--- a/daemon/builder/builder.go
+++ b/daemon/builder/builder.go
@@ -96,6 +96,7 @@ type Image interface {
 	RunConfig() *container.Config
 	MarshalJSON() ([]byte, error)
 	OperatingSystem() string
+	Platform() ocispec.Platform
 }
 
 // ROLayer is a reference to image rootfs layer

--- a/daemon/builder/dockerfile/dispatchers.go
+++ b/daemon/builder/dockerfile/dispatchers.go
@@ -256,11 +256,18 @@ func (d *dispatchRequest) getImageOrStage(ctx context.Context, name string, plat
 		}
 
 		// TODO: scratch should not have an os. It should be nil image.
-		imageImage := &image.Image{}
-		if platform != nil {
-			imageImage.OS = platform.OS
-		} else {
-			imageImage.OS = runtime.GOOS
+		if platform == nil {
+			p := platforms.DefaultSpec()
+			platform = &p
+		}
+		imageImage := &image.Image{
+			V1Image: image.V1Image{
+				OS:           platform.OS,
+				Architecture: platform.Architecture,
+				Variant:      platform.Variant,
+			},
+			OSVersion:  platform.OSVersion,
+			OSFeatures: platform.OSFeatures,
 		}
 		return builder.Image(imageImage), nil
 	}

--- a/daemon/builder/dockerfile/dispatchers_test.go
+++ b/daemon/builder/dockerfile/dispatchers_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/moby/moby/v2/daemon/pkg/oci"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/daemon/server/buildbackend"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -114,6 +115,14 @@ func TestLabel(t *testing.T) {
 
 func TestFromScratch(t *testing.T) {
 	b := newBuilderWithMockBackend(t)
+	expectedPlatform := ocispec.Platform{
+		OS:           runtime.GOOS,
+		Architecture: "foreign-architecture",
+		OSVersion:    "test-version",
+		OSFeatures:   []string{"feature-a", "feature-b"},
+		Variant:      "v1",
+	}
+	b.platform = &expectedPlatform
 	sb := newDispatchRequest(b, '\\', nil, NewBuildArgs(make(map[string]*string)), newStagesBuildResults())
 	cmd := &instructions.Stage{
 		BaseName: "scratch",
@@ -128,9 +137,42 @@ func TestFromScratch(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, sb.state.hasFromImage())
 	assert.Check(t, is.Equal(sb.state.imageID, ""))
+	assert.DeepEqual(t, sb.state.platform, expectedPlatform)
+	assert.DeepEqual(t, b.getPlatform(sb.state), expectedPlatform)
 	// TODO(thaJeztah): use github.com/moby/buildkit/util/system.DefaultPathEnv() once https://github.com/moby/buildkit/pull/3158 is resolved.
 	expected := []string{"PATH=" + oci.DefaultPathEnv(runtime.GOOS)}
 	assert.Check(t, is.DeepEqual(sb.state.runConfig.Env, expected))
+}
+
+func TestCacheProbeUsesBaseImagePlatform(t *testing.T) {
+	expected := ocispec.Platform{
+		OS:           runtime.GOOS,
+		Architecture: "foreign-architecture",
+		Variant:      "v1",
+	}
+	b := newBuilderWithMockBackend(t)
+	mockBackend := b.docker.(*MockBackend)
+	mockBackend.getImageFunc = func(string) (builder.Image, builder.ROLayer, error) {
+		return &mockImage{id: "base", platform: expected}, nil, nil
+	}
+	mockBackend.makeImageCacheFunc = func([]string) builder.ImageCache {
+		return &mockImageCache{
+			getCacheFunc: func(_ string, _ *container.Config, platform ocispec.Platform) (string, error) {
+				assert.DeepEqual(t, platform, expected)
+				return "", nil
+			},
+		}
+	}
+	sb := newDispatchRequest(b, '\\', nil, NewBuildArgs(nil), newStagesBuildResults())
+
+	err := initializeStage(t.Context(), sb, &instructions.Stage{
+		BaseName: "base",
+		Platform: runtime.GOOS + "/foreign-architecture/v1",
+	})
+	assert.NilError(t, err)
+	hit, err := b.probeCache(sb.state, &container.Config{})
+	assert.NilError(t, err)
+	assert.Assert(t, !hit)
 }
 
 func TestFromWithArg(t *testing.T) {
@@ -449,7 +491,7 @@ func TestRunWithBuildArgs(t *testing.T) {
 	cachedCmd := append(envVars, cmdWithShell...)
 
 	imageCache := &mockImageCache{
-		getCacheFunc: func(parentID string, cfg *container.Config) (string, error) {
+		getCacheFunc: func(parentID string, cfg *container.Config, _ ocispec.Platform) (string, error) {
 			// Check the runConfig.Cmd sent to probeCache()
 			assert.Check(t, is.DeepEqual(cfg.Cmd, cachedCmd))
 			assert.Check(t, is.Nil(cfg.Entrypoint))
@@ -522,7 +564,7 @@ func TestRunIgnoresHealthcheck(t *testing.T) {
 	origCmd := []string{"cmd", "in", "from", "image"}
 
 	imageCache := &mockImageCache{
-		getCacheFunc: func(parentID string, cfg *container.Config) (string, error) {
+		getCacheFunc: func(parentID string, cfg *container.Config, _ ocispec.Platform) (string, error) {
 			return "", nil
 		},
 	}

--- a/daemon/builder/dockerfile/evaluator.go
+++ b/daemon/builder/dockerfile/evaluator.go
@@ -32,6 +32,7 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/image"
 	"github.com/moby/moby/v2/daemon/pkg/oci"
 	"github.com/moby/moby/v2/errdefs"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -114,6 +115,7 @@ type dispatchState struct {
 	stageName       string
 	buildArgs       *BuildArgs
 	operatingSystem string
+	platform        ocispec.Platform
 }
 
 func newDispatchState(baseArgs *BuildArgs) *dispatchState {
@@ -217,6 +219,7 @@ func (s *dispatchState) beginStage(stageName string, img builder.Image) error {
 	s.stageName = stageName
 	s.imageID = img.ImageID()
 	s.operatingSystem = img.OperatingSystem()
+	s.platform = img.Platform()
 	if err := image.CheckOS(s.operatingSystem); err != nil {
 		return err
 	}

--- a/daemon/builder/dockerfile/imagecontext.go
+++ b/daemon/builder/dockerfile/imagecontext.go
@@ -86,11 +86,15 @@ func (m *imageSources) Add(im *imageMount, platform *ocispec.Platform) {
 			os = "linux"
 		}
 
-		im.image = &dockerimage.Image{V1Image: dockerimage.V1Image{
-			OS:           os,
-			Architecture: platform.Architecture,
-			Variant:      platform.Variant,
-		}}
+		im.image = &dockerimage.Image{
+			V1Image: dockerimage.V1Image{
+				OS:           os,
+				Architecture: platform.Architecture,
+				Variant:      platform.Variant,
+			},
+			OSVersion:  platform.OSVersion,
+			OSFeatures: platform.OSFeatures,
+		}
 	default:
 		m.byImageID[im.image.ImageID()] = im
 	}

--- a/daemon/builder/dockerfile/imagecontext_test.go
+++ b/daemon/builder/dockerfile/imagecontext_test.go
@@ -47,6 +47,8 @@ func TestAddFromScratchPopulatesPlatform(t *testing.T) {
 		{
 			OS:           "linux",
 			Architecture: "amd64",
+			OSVersion:    "test-version",
+			OSFeatures:   []string{"feature-a", "feature-b"},
 		},
 		{
 			OS:           "linux",
@@ -63,6 +65,8 @@ func TestAddFromScratchPopulatesPlatform(t *testing.T) {
 		assert.Assert(t, ok)
 		assert.Equal(t, image.OS, platform.OS)
 		assert.Equal(t, image.Architecture, platform.Architecture)
+		assert.Equal(t, image.OSVersion, platform.OSVersion)
+		assert.DeepEqual(t, image.OSFeatures, platform.OSFeatures)
 		assert.Equal(t, image.Variant, platform.Variant)
 	}
 }

--- a/daemon/builder/dockerfile/internals.go
+++ b/daemon/builder/dockerfile/internals.go
@@ -81,6 +81,8 @@ func (b *Builder) exportImage(ctx context.Context, state *dispatchState, layer b
 	platform := &ocispec.Platform{
 		OS:           parentImage.OS,
 		Architecture: parentImage.Architecture,
+		OSVersion:    parentImage.OSVersion,
+		OSFeatures:   parentImage.OSFeatures,
 		Variant:      parentImage.Variant,
 	}
 
@@ -380,6 +382,9 @@ func (b *Builder) getPlatform(state *dispatchState) ocispec.Platform {
 	out := platforms.DefaultSpec()
 	if b.platform != nil {
 		out = *b.platform
+	}
+	if state.platform.Architecture != "" {
+		out = state.platform
 	}
 
 	if state.operatingSystem != "" {

--- a/daemon/builder/dockerfile/mockbackend_test.go
+++ b/daemon/builder/dockerfile/mockbackend_test.go
@@ -83,8 +83,9 @@ func (m *MockBackend) CreateImage(ctx context.Context, config []byte, parent str
 }
 
 type mockImage struct {
-	id     string
-	config *container.Config
+	id       string
+	config   *container.Config
+	platform ocispec.Platform
 }
 
 func (i *mockImage) ImageID() string {
@@ -96,7 +97,20 @@ func (i *mockImage) RunConfig() *container.Config {
 }
 
 func (i *mockImage) OperatingSystem() string {
+	if i.platform.OS != "" {
+		return i.platform.OS
+	}
 	return runtime.GOOS
+}
+
+func (i *mockImage) Platform() ocispec.Platform {
+	if i.platform.OS == "" {
+		i.platform.OS = runtime.GOOS
+	}
+	if i.platform.Architecture == "" {
+		i.platform.Architecture = runtime.GOARCH
+	}
+	return i.platform
 }
 
 func (i *mockImage) MarshalJSON() ([]byte, error) {
@@ -105,12 +119,12 @@ func (i *mockImage) MarshalJSON() ([]byte, error) {
 }
 
 type mockImageCache struct {
-	getCacheFunc func(parentID string, cfg *container.Config) (string, error)
+	getCacheFunc func(parentID string, cfg *container.Config, platform ocispec.Platform) (string, error)
 }
 
-func (mic *mockImageCache) GetCache(parentID string, cfg *container.Config, _ ocispec.Platform) (string, error) {
+func (mic *mockImageCache) GetCache(parentID string, cfg *container.Config, platform ocispec.Platform) (string, error) {
 	if mic.getCacheFunc != nil {
-		return mic.getCacheFunc(parentID, cfg)
+		return mic.getCacheFunc(parentID, cfg, platform)
 	}
 	return "", nil
 }


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/49947

## Summary

Use the loaded base image OCI platform when the classic builder probes its layer cache. This prevents a Dockerfile-level `FROM --platform` from falling back to the host architecture during cache lookup, while leaving the locally-built-image and platform-match security checks intact.

The change also records complete platform metadata for synthetic `scratch` images and adds a regression test that verifies the cache probe receives the base image platform.

## Release notes (optional)

```markdown changelog
Restore classic-builder cache hits for Dockerfiles that use a per-stage `FROM --platform`.
```

## Test plan

- `go test ./daemon/builder/dockerfile ./daemon/internal/image/cache`
- `go test ./daemon/builder/... ./daemon/images ./daemon/containerd`
- `go vet ./daemon/builder/... ./daemon/images ./daemon/containerd`

Created with: Codex