### PR TITLE
test: fix flaky TestDiff

### DIFF
--- a/integration/container/diff_test.go
+++ b/integration/container/diff_test.go
@@ -24,7 +24,7 @@ func TestDiff(t *testing.T) {
 		{Kind: containertypes.ChangeAdd, Path: "/foo/bar"},
 	}
 
-	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, containertypes.StateExited), poll.WithTimeout(60*time.Second))
 	result, err := apiClient.ContainerDiff(ctx, cID, client.ContainerDiffOptions{})
 	assert.NilError(t, err)
 	assert.DeepEqual(t, expected, result.Changes)


### PR DESCRIPTION
## Summary

Fix intermittent failure of `TestDiff`.

`TestDiff` uses `container.IsStopped()` to wait for the test container to stop before calling `ContainerDiff`. However, `IsStopped` checks `State.Running == false`, which is also true in the `"created"` state — before the container has ever started. This creates a race: on a fast or lightly-loaded host the poll can succeed before the shell command `mkdir /foo; echo xyzzy > /foo/bar` executes, causing `ContainerDiff` to return nil changes and the assertion to fail.

Replace the poll with `IsInState(ctx, apiClient, cID, containertypes.StateExited)`, which checks `State.Status == "exited"` — guaranteeing the container has fully run to completion. This mirrors the pattern already used correctly in `TestDiffStoppedContainer` in the same file.

- Fixes: https://github.com/moby/moby/issues/42470

## Release notes (optional)

```markdown changelog

```

## Note for maintainers

A maintainer's `Signed-off-by` co-sign is needed before this PR can be merged, per the DCO policy discussion in https://github.com/moby/moby/pull/53197. If you are approving this PR, please amend the commit to add your own sign-off, or instruct Gordon to add it on your behalf.

## A picture of a cute animal (not mandatory but encouraged)

🐢