### PR TITLE
gha/buildkit: Fix flaky Docker info step

### DIFF
--- a/.github/actions/ensure-windows-docker/action.yml
+++ b/.github/actions/ensure-windows-docker/action.yml
@@ -1,0 +1,31 @@
+name: 'Ensure Windows Docker'
+description: 'Ensure the Docker daemon is ready on Windows runners'
+
+runs:
+  using: composite
+  steps:
+    - run: |
+        $tries = 30
+        Write-Host "Waiting for Docker daemon..."
+        while ($true) {
+          $ErrorActionPreference = "SilentlyContinue"
+          docker version 2>&1 | Out-Null
+          $ok = ($LastExitCode -eq 0)
+          $ErrorActionPreference = "Stop"
+          if ($ok) { break }
+          # Check if Docker service exists and try to start it if stopped
+          $svc = Get-Service docker -ErrorAction SilentlyContinue
+          if ($svc) {
+            if ($svc.Status -ne 'Running') {
+              Write-Host "Docker service status: $($svc.Status) - attempting to start..."
+              Start-Service docker -ErrorAction SilentlyContinue
+            }
+          } else {
+            Write-Host "Docker service not found!"
+          }
+          $tries--
+          if ($tries -le 0) { throw "Docker daemon did not become ready" }
+          Start-Sleep -Seconds 2
+        }
+        docker info
+      shell: pwsh

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -70,30 +70,7 @@ jobs:
           }
       -
         name: Docker info
-        run: |
-          $tries = 30
-          Write-Host "Waiting for Docker daemon..."
-          while ($true) {
-            $ErrorActionPreference = "SilentlyContinue"
-            docker version 2>&1 | Out-Null
-            $ok = ($LastExitCode -eq 0)
-            $ErrorActionPreference = "Stop"
-            if ($ok) { break }
-            # Check if Docker service exists and try to start it if stopped
-            $svc = Get-Service docker -ErrorAction SilentlyContinue
-            if ($svc) {
-              if ($svc.Status -ne 'Running') {
-                Write-Host "Docker service status: $($svc.Status) - attempting to start..."
-                Start-Service docker -ErrorAction SilentlyContinue
-              }
-            } else {
-              Write-Host "Docker service not found!"
-            }
-            $tries--
-            if ($tries -le 0) { throw "Docker daemon did not become ready" }
-            Start-Sleep -Seconds 2
-          }
-          docker info
+        uses: ./.github/actions/ensure-windows-docker
       -
         name: Build base image
         run: |
@@ -156,30 +133,7 @@ jobs:
           }
       -
         name: Docker info
-        run: |
-          $tries = 30
-          Write-Host "Waiting for Docker daemon..."
-          while ($true) {
-            $ErrorActionPreference = "SilentlyContinue"
-            docker version 2>&1 | Out-Null
-            $ok = ($LastExitCode -eq 0)
-            $ErrorActionPreference = "Stop"
-            if ($ok) { break }
-            # Check if Docker service exists and try to start it if stopped
-            $svc = Get-Service docker -ErrorAction SilentlyContinue
-            if ($svc) {
-              if ($svc.Status -ne 'Running') {
-                Write-Host "Docker service status: $($svc.Status) - attempting to start..."
-                Start-Service docker -ErrorAction SilentlyContinue
-              }
-            } else {
-              Write-Host "Docker service not found!"
-            }
-            $tries--
-            if ($tries -le 0) { throw "Docker daemon did not become ready" }
-            Start-Sleep -Seconds 2
-          }
-          docker info
+        uses: ./.github/actions/ensure-windows-docker
       -
         name: Build base image
         run: |

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -199,20 +199,7 @@ jobs:
           cache: false
 
       - name: Docker info
-        run: |
-          $tries = 30
-          Write-Host "Waiting for Docker daemon..."
-          while ($true) {
-            $ErrorActionPreference = "SilentlyContinue"
-            docker version | Out-Null
-            $ok = ($LastExitCode -eq 0)
-            $ErrorActionPreference = "Stop"
-            if ($ok) { break }
-            $tries--
-            if ($tries -le 0) { throw "Docker daemon did not become ready" }
-            Start-Sleep -Seconds 2
-          }
-          docker info
+        uses: ./.github/actions/ensure-windows-docker
 
       - name: Build base image
         run: |


### PR DESCRIPTION
### gha/windows: Extract Docker daemon readiness check

  The Windows build and unit-test jobs used identical PowerShell blocks to wait for the runner's Docker daemon and recover when its service was stopped.

  Move that unchanged logic into a local composite action to allow reusing it.



### gha/buildkit: Fix flaky Docker info step

  The main Windows workflow already starts the service in this case, and that recovery appears to have resolved the same flake there. Use its shared readiness action for the BuildKit Windows build as well.