### PR TITLE
daemon: fix live-restore host-gateway nil sandbox options

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -84,7 +84,11 @@ func buildSandboxOptions(cfg *config.Config, ctr *container.Container) ([]libnet
 		// config variable
 		if ip == opts.HostGatewayName {
 			if len(cfg.HostGatewayIPs) == 0 {
-				return nil, errors.New("unable to derive the IP value for host-gateway")
+				log.G(context.TODO()).WithFields(log.Fields{
+					"extra_host": extraHost,
+					"container":  ctr.ID,
+				}).Warn("buildSandboxOptions: host-gateway IPs not configured, skipping host-gateway resolution")
+				continue
 			}
 			for _, gip := range cfg.HostGatewayIPs {
 				sboxOptions = append(sboxOptions, libnetwork.OptionExtraHost(host, gip.Unmap()))


### PR DESCRIPTION
### Description

Fixes #53089

When `live-restore` is enabled and `daemon.json` has no explicit `host-gateway-ips` configured, restarting dockerd while containers using `--add-host host.docker.internal:host-gateway` are running causes those containers to be restored with nil sandbox options.

**Root cause:** During daemon startup, `daemon.restore()` calls `buildSandboxOptions()` for running containers **before** `setHostGatewayIP()` has run. Since `cfg.HostGatewayIPs` is empty, `buildSandboxOptions()` returns an error (`"unable to derive the IP value for host-gateway"`). The restore function logs the warning but still registers the sandbox with nil options, causing `/var/lib/docker/network/files/<sandbox-id>/` to never be created. Any later `docker network connect` then fails with `open /var/lib/docker/network/files/<sandbox-id>/resolv.conf: no such file or directory`.

**Fix:** Instead of returning an error when `HostGatewayIPs` is empty, log a warning and skip the `host-gateway` extra host entry. The sandbox is created with valid options, and the container can be restored normally. The `host-gateway` resolution will be handled correctly after `setHostGatewayIP()` runs later in the startup sequence.

### Related issue

Closes #53089

### Wallet

fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT