### PR TITLE
fix: populate UsageData in Volume Inspect

### DIFF
--- a/daemon/server/router/volume/volume_routes.go
+++ b/daemon/server/router/volume/volume_routes.go
@@ -66,7 +66,7 @@ func (v *volumeRouter) getVolumeByName(ctx context.Context, w http.ResponseWrite
 	// we prefer to get volumes locally before attempting to get them from the
 	// cluster. Local volumes can only be looked up by name, but cluster
 	// volumes can also be looked up by ID.
-	vol, err := v.backend.Get(ctx, vars["name"], opts.WithGetResolveStatus)
+	vol, err := v.backend.Get(ctx, vars["name"], opts.WithGetResolveStatus, opts.WithGetResolveSize)
 
 	// if the volume is not found in the regular volume backend, and the client
 	// is using an API version greater than 1.42 (when cluster volumes were

--- a/daemon/volume/service/opts/opts.go
+++ b/daemon/volume/service/opts/opts.go
@@ -52,6 +52,7 @@ type GetConfig struct {
 	Driver        string
 	Reference     string
 	ResolveStatus bool
+	ResolveSize   bool
 }
 
 // GetOption is passed to the service `Get` add extra details on the get request
@@ -79,6 +80,12 @@ func WithGetReference(ref string) GetOption {
 // This can cause significant overhead in the volume lookup.
 func WithGetResolveStatus(cfg *GetConfig) {
 	cfg.ResolveStatus = true
+}
+
+// WithGetResolveSize indicates to `Get` to also calculate the volume size.
+// This can cause significant overhead in the volume lookup.
+func WithGetResolveSize(cfg *GetConfig) {
+	cfg.ResolveSize = true
 }
 
 // RemoveConfig is used by `RemoveOption` to store config options for remove

--- a/daemon/volume/service/service.go
+++ b/daemon/volume/service/service.go
@@ -105,6 +105,23 @@ func (s *VolumesService) Get(ctx context.Context, name string, getOpts ...opts.G
 	if cfg.ResolveStatus {
 		vol.Status = v.Status()
 	}
+
+	if cfg.ResolveSize {
+		if vol.Mountpoint == "" {
+			vol.Mountpoint = v.Path()
+		}
+		sz, err := directory.Size(ctx, vol.Mountpoint)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				log.G(ctx).WithFields(log.Fields{
+					"error":  err,
+					"volume": v.Name(),
+				}).Warn("Failed to determine size of volume")
+			}
+			sz = -1
+		}
+		vol.UsageData = &volumetypes.UsageData{Size: sz, RefCount: int64(s.vs.CountReferences(v))}
+	}
 	return &vol, nil
 }
 


### PR DESCRIPTION
When calling `VolumeInspect` (or `docker volume inspect`), the `UsageData` field is always `nil` because the `Get` method in the volume service never populates it. This is inconsistent with `List` (or `docker volume ls`), which does return `UsageData` when the `calcSize` option is set.

**Root cause**: The `VolumesService.Get` method calls `volumeToAPIType` which does not populate `UsageData`. The `volumesToAPI` method (used by `List`) supports a `calcSize` option, but `Get` has no equivalent.

**Fix**: Add `ResolveSize` option to `GetConfig` so the volume inspect handler can request size calculation:

1. `daemon/volume/service/opts/opts.go` — Added `ResolveSize bool` to `GetConfig` and `WithGetResolveSize` option function
2. `daemon/volume/service/service.go` — In `Get`, check `cfg.ResolveSize` and populate `UsageData` (size + ref count) when set
3. `daemon/server/router/volume/volume_routes.go` — Pass `opts.WithGetResolveSize` to the `Get` call

**Related**: https://github.com/moby/moby/issues/50782