### PR TITLE
daemon: report network stats for Windows containerd runtime

### DIFF
--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -11,6 +11,7 @@ import (
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/server/backend"
+	"github.com/pkg/errors"
 )
 
 // ContainerStats writes information about the container to the stream
@@ -124,8 +125,10 @@ func (daemon *Daemon) GetContainerStats(ctr *container.Container) (*containertyp
 		goto done
 	}
 
-	// We already have the network stats on Windows directly from HCS.
-	if !ctr.Config.NetworkDisabled && runtime.GOOS != "windows" {
+	// On Windows, the builtin (HCS) runtime already provides network stats
+	// embedded in the stats above; the containerd runtime does not, so query
+	// them separately when they're missing.
+	if !ctr.Config.NetworkDisabled && (runtime.GOOS != "windows" || len(stats.Networks) == 0) {
 		stats.Networks, err = daemon.getNetworkStats(ctr)
 	}
 
@@ -143,4 +146,19 @@ done:
 		return nil, err
 	}
 	return stats, nil
+}
+
+// getNetworkSandboxID resolves the network SandboxID, following the chain in
+// case the container reuses another container's network stack.
+func (daemon *Daemon) getNetworkSandboxID(c *container.Container) (string, error) {
+	curr := c
+	for curr.HostConfig.NetworkMode.IsContainer() {
+		containerID := curr.HostConfig.NetworkMode.ConnectedContainer()
+		connected, err := daemon.GetContainer(containerID)
+		if err != nil {
+			return "", errors.Wrapf(err, "Could not get container for %s", containerID)
+		}
+		curr = connected
+	}
+	return curr.NetworkSettings.SandboxID, nil
 }

--- a/daemon/stats_unix.go
+++ b/daemon/stats_unix.go
@@ -259,20 +259,6 @@ func (daemon *Daemon) statsV2(s *containertypes.StatsResponse, stats *statsV2.Me
 	return s, nil
 }
 
-// Resolve Network SandboxID in case the container reuse another container's network stack
-func (daemon *Daemon) getNetworkSandboxID(c *container.Container) (string, error) {
-	curr := c
-	for curr.HostConfig.NetworkMode.IsContainer() {
-		containerID := curr.HostConfig.NetworkMode.ConnectedContainer()
-		connected, err := daemon.GetContainer(containerID)
-		if err != nil {
-			return "", errors.Wrapf(err, "Could not get container for %s", containerID)
-		}
-		curr = connected
-	}
-	return curr.NetworkSettings.SandboxID, nil
-}
-
 func (daemon *Daemon) getNetworkStats(c *container.Container) (map[string]containertypes.NetworkStats, error) {
 	sandboxID, err := daemon.getNetworkSandboxID(c)
 	if err != nil {

--- a/daemon/stats_windows.go
+++ b/daemon/stats_windows.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"runtime"
 
+	"github.com/Microsoft/hcsshim"
 	cerrdefs "github.com/containerd/errdefs"
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/v2/daemon/container"
@@ -78,9 +79,55 @@ func (daemon *Daemon) stats(c *container.Container) (*containertypes.StatsRespon
 	return s, nil
 }
 
-// Windows network stats are obtained directly through HCS, hence this is a no-op.
+// getNetworkStats collects network statistics for a container. The builtin HCS
+// runtime already embeds these in the container stats, but the containerd
+// runtime does not, so they are queried here directly from HNS by endpoint.
 func (daemon *Daemon) getNetworkStats(c *container.Container) (map[string]containertypes.NetworkStats, error) {
-	return make(map[string]containertypes.NetworkStats), nil
+	sandboxID, err := daemon.getNetworkSandboxID(c)
+	if err != nil {
+		return nil, err
+	}
+
+	sb, err := daemon.netController.SandboxByID(sandboxID)
+	if err != nil {
+		return nil, err
+	}
+
+	stats := make(map[string]containertypes.NetworkStats)
+	for _, ep := range sb.Endpoints() {
+		info, err := ep.DriverInfo()
+		if err != nil {
+			return nil, err
+		}
+		hnsid, ok := info["hnsid"].(string)
+		if !ok || hnsid == "" {
+			continue
+		}
+
+		epStats, err := hcsshim.GetHNSEndpointStats(hnsid)
+		if err != nil {
+			return nil, err
+		}
+
+		stats[epStats.EndpointID] = hnsStatsToNetworkStats(epStats)
+	}
+	return stats, nil
+}
+
+// hnsStatsToNetworkStats maps HNS endpoint statistics onto the API network stats
+// shape. Errors are not reported by HNS, so RxErrors/TxErrors are left zeroed
+// (matching the builtin HCS path, which also does not populate them on Windows).
+func hnsStatsToNetworkStats(epStats *hcsshim.HNSEndpointStats) containertypes.NetworkStats {
+	return containertypes.NetworkStats{
+		RxBytes:    epStats.BytesReceived,
+		RxPackets:  epStats.PacketsReceived,
+		RxDropped:  epStats.DroppedPacketsIncoming,
+		TxBytes:    epStats.BytesSent,
+		TxPackets:  epStats.PacketsSent,
+		TxDropped:  epStats.DroppedPacketsOutgoing,
+		EndpointID: epStats.EndpointID,
+		InstanceID: epStats.InstanceID,
+	}
 }
 
 // getSystemCPUUsage returns the host system's cpu usage in

--- a/daemon/stats_windows_test.go
+++ b/daemon/stats_windows_test.go
@@ -1,0 +1,37 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/Microsoft/hcsshim"
+	containertypes "github.com/moby/moby/api/types/container"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestHNSStatsToNetworkStats(t *testing.T) {
+	in := &hcsshim.HNSEndpointStats{
+		EndpointID:             "endpoint-1",
+		InstanceID:             "instance-1",
+		BytesReceived:          100,
+		PacketsReceived:        10,
+		DroppedPacketsIncoming: 1,
+		BytesSent:              200,
+		PacketsSent:            20,
+		DroppedPacketsOutgoing: 2,
+	}
+
+	got := hnsStatsToNetworkStats(in)
+
+	assert.Check(t, is.DeepEqual(got, containertypes.NetworkStats{
+		RxBytes:    100,
+		RxPackets:  10,
+		RxDropped:  1,
+		TxBytes:    200,
+		TxPackets:  20,
+		TxDropped:  2,
+		EndpointID: "endpoint-1",
+		InstanceID: "instance-1",
+		// RxErrors/TxErrors are not reported by HNS and remain zero.
+	}))
+}

--- a/integration/container/stats_test.go
+++ b/integration/container/stats_test.go
@@ -101,8 +101,6 @@ func TestStatsContainerNotFound(t *testing.T) {
 }
 
 func TestStatsNetworkStats(t *testing.T) {
-	// FIXME(thaJeztah): Broken on Windows + containerd combination, see https://github.com/moby/moby/pull/41479
-	skip.If(t, testEnv.RuntimeIsWindowsContainerd(), "FIXME: Broken on Windows + containerd combination")
 	skip.If(t, testEnv.IsRootless() && testEnv.DaemonInfo.CgroupVersion == "1", "Rootless Mode does not support cgroups v1 stats")
 	skip.If(t, testEnv.IsRemoteDaemon(), "Test requires a local daemon")
 


### PR DESCRIPTION
<!--
- Follow up to: https://github.com/moby/moby/pull/53101
- Related to: https://github.com/moby/moby/issues/51643
-->

## Summary

`docker stats` reported empty network stats (`0B` NET I/O) for running Windows
containers under the containerd runtime. On Windows, network stats were only
available via the builtin HCS runtime, which embeds them in the container
statistics; the containerd runtime (runhcs shim) reports no network data, so
`StatsResponse.Networks` came back empty. As a result `TestStatsNetworkStats`
was skipped for the Windows + containerd combination.

This follows up on #53101, which fixed CPU/memory/storage for the same runtime.

### Changes

- Implement `getNetworkStats` on Windows (previously a no-op) to query network
  statistics directly from HNS: for each of the container's endpoints, resolve
  the HNS endpoint id via the libnetwork driver info and call
  `GetHNSEndpointStats`, mapping the result onto the API network stats.
- `GetContainerStats` falls back to this on Windows only when the stats don't
  already carry `Networks`, so the builtin runtime is unchanged.
- Move `getNetworkSandboxID` to the cross-platform `stats.go` so both platforms
  share it.
- Un-skip `TestStatsNetworkStats` on Windows + containerd and add a unit test
  for the HNS-to-API stats conversion.

### Testing

- Unit test covers the HNS-to-API network stats conversion.
- Verified manually: `docker stats` now reports non-zero NET I/O, and Rx/Tx
  packet counts increase after pinging a running container on a
  containerd-runtime daemon.
- `TestStatsNetworkStats` passes on Windows CI across all containerd legs:
  graphdriver+socket, snapshotter+socket, and snapshotter+embedded.

## Release notes (optional)

```markdown changelog
Fix `docker stats` reporting empty network stats for running Windows containers when using the containerd runtime.
```
