### PR TITLE
fix: add timeout to shim kill/resume RPC calls to prevent indefinite blocking

### DIFF
--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -108,7 +108,9 @@ func (daemon *Daemon) killWithSignal(container *containerpkg.Container, stopSign
 		return nil
 	}
 
-	if err := task.Kill(context.Background(), stopSignal); err != nil {
+	killCtx, killCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer killCancel()
+	if err := task.Kill(killCtx, stopSignal); err != nil {
 		if cerrdefs.IsNotFound(err) {
 			unpause = false
 			log.G(context.TODO()).WithFields(log.Fields{
@@ -153,7 +155,9 @@ func (daemon *Daemon) killWithSignal(container *containerpkg.Container, stopSign
 
 	if unpause {
 		// above kill signal will be sent once resume is finished
-		if err := task.Resume(context.Background()); err != nil {
+		resumeCtx, resumeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer resumeCancel()
+		if err := task.Resume(resumeCtx); err != nil {
 			log.G(context.TODO()).WithFields(log.Fields{
 				"error":     err,
 				"container": container.ID,


### PR DESCRIPTION
Fixes moby/moby#53189

## Description

When `containerd-shim-runc-v2` enters a degenerate state (alive with zero children, stuck on `futex_wait_queue`), the Docker daemon blocks indefinitely on all API calls to affected containers. This is because `task.Kill()` and `task.Resume()` RPC calls use `context.Background()` which has no timeout or cancellation.

This fix adds a 30-second timeout context to both `task.Kill()` and `task.Resume()` calls in `daemon/kill.go`, preventing the daemon from blocking forever when the shim is unresponsive.

## Changes

- **`daemon/kill.go`**: Changed `task.Kill(context.Background(), stopSignal)` to use a `context.WithTimeout` with a 30-second deadline
- **`daemon/kill.go`**: Changed `task.Resume(context.Background())` to use a `context.WithTimeout` with a 30-second deadline

## How it works

When the shim is healthy, the 30-second timeout is never reached — the kill/resume completes normally within milliseconds. When the shim is in a degenerate state (zombie shim with no children), the context deadline triggers after 30 seconds, the gRPC call is cancelled, and the daemon returns an error to the caller (e.g., `docker stop`, `docker kill`) instead of blocking indefinitely.

The existing error handling path already handles this correctly — if `task.Kill()` returns an error (including a context deadline exceeded), it falls through to the `else` branch and returns `errors.Wrapf(err, "Cannot kill container %s", container.ID)`.

## Related

- moby/moby#53189 — Docker daemon blocks indefinitely on API calls to containers with zombie containerd-shim
- containerd/containerd#13849 — containerd-shim-runc-v2 root cause