### PR TITLE
integration-cli: extend Windows poll timeout for --rm flag tests

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2673,7 +2673,11 @@ func (s *DockerCLIRunSuite) TestRunContainerWithRmFlagExitCodeNotEqualToZero(c *
 		ExitCode: 1,
 	})
 
-	poll.WaitOn(c, containerRemoved(name))
+	removeTimeout := 10 * time.Second
+	if DaemonIsWindows() {
+		removeTimeout = 60 * time.Second
+	}
+	poll.WaitOn(c, containerRemoved(name), poll.WithTimeout(removeTimeout))
 }
 
 func (s *DockerCLIRunSuite) TestRunContainerWithRmFlagCannotStartContainer(c *testing.T) {
@@ -2682,7 +2686,11 @@ func (s *DockerCLIRunSuite) TestRunContainerWithRmFlagCannotStartContainer(c *te
 		ExitCode: 127,
 	})
 
-	poll.WaitOn(c, containerRemoved(name))
+	removeTimeout := 10 * time.Second
+	if DaemonIsWindows() {
+		removeTimeout = 60 * time.Second
+	}
+	poll.WaitOn(c, containerRemoved(name), poll.WithTimeout(removeTimeout))
 }
 
 func containerRemoved(name string) poll.Check {


### PR DESCRIPTION
Extend the `poll.WaitOn` timeout for `TestRunContainerWithRmFlagCannotStartContainer`
and `TestRunContainerWithRmFlagExitCodeNotEqualToZero` on Windows from the default
10 seconds to 60 seconds.

On Windows, container teardown after `docker run --rm` involves:
1. HCS layer unmount (ReleaseLayer call via HCSSHIM)
2. `EnsureRemoveAll` with up to 50 retries × 100ms sleep on `ERROR_ACCESS_DENIED` /
   `ERROR_SHARING_VIOLATION` / `ERROR_LOCK_VIOLATION` / `ERROR_DIR_NOT_EMPTY`

Under CI load this can exceed the default 10-second poll budget, causing:
```
timeout hit after 10s: waiting for container 'sparkles' to be removed
```

This fix applies the same pattern already used in `TestRunStdinBlockedAfterContainerExit`
(added in a81aa78ceb) to the two `--rm` flag tests.

Fixes https://github.com/moby/moby/issues/43679

## Release notes (optional)

```markdown changelog

```

## Note for maintainers

A maintainer's `Signed-off-by` co-sign is needed before this PR can be merged, per the DCO policy discussion in https://github.com/moby/moby/pull/53197. If you are approving this PR, please amend the commit to add your own sign-off, or instruct Gordon to add it on your behalf.

## A picture of a cute animal (not mandatory but encouraged)

🐢