### PR TITLE
fix: prevent path traversal in Plugin.ScopedPath via PropagatedMount

### DIFF
--- a/daemon/pkg/plugin/v2/plugin.go
+++ b/daemon/pkg/plugin/v2/plugin.go
@@ -50,7 +50,14 @@ func (e ErrInadequateCapability) Error() string {
 func (p *Plugin) ScopedPath(s string) string {
 	if p.PluginObj.Config.PropagatedMount != "" && strings.HasPrefix(s, p.PluginObj.Config.PropagatedMount) {
 		// re-scope to the propagated mount path on the host
-		return filepath.Join(filepath.Dir(p.Rootfs), "propagated-mount", strings.TrimPrefix(s, p.PluginObj.Config.PropagatedMount))
+		base := filepath.Join(filepath.Dir(p.Rootfs), "propagated-mount")
+		result := filepath.Join(base, strings.TrimPrefix(s, p.PluginObj.Config.PropagatedMount))
+		// Clean the path to resolve any .. components and verify the result
+		// doesn't escape the base directory (path traversal prevention)
+		if !strings.HasPrefix(result, base) {
+			return filepath.Join(p.Rootfs, s)
+		}
+		return result
 	}
 	return filepath.Join(p.Rootfs, s)
 }


### PR DESCRIPTION
## What

Fixes #53023

 validates plugin-returned mountpoints with , but then builds the host-side path with . Since  normalizes  components, a plugin can return a mountpoint like  which passes the prefix check but escapes the intended  root after normalization.

## Root cause

The path traversal check only verified the prefix of the raw input string, but  resolves  components after the check. A malicious or compromised plugin could read/write files outside the propagated mount directory.

## Fix

The fix verifies the final resolved path after  normalization. If the result doesn't start with the expected base directory, the function falls back to the unscoped path to prevent the escape.

## Security

This is a defense-in-depth fix. Exploiting this requires a malicious or compromised v2 volume plugin, which is already a privileged component. However, preventing path traversal from an untrusted or buggy plugin is the correct behavior.