### PR TITLE
daemon/events: Events.loadBufferedEvent: avoid quadratic copies

### DIFF
--- a/daemon/events/events.go
+++ b/daemon/events/events.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"slices"
 	"sync"
 	"time"
 
@@ -119,9 +120,8 @@ func (e *Events) SubscribersCount() int {
 // It uses `time.Unix(seconds, nanoseconds)` to generate valid dates with those arguments.
 // It filters those buffered messages with a topic function if it's not nil, otherwise it adds all messages.
 func (e *Events) loadBufferedEvents(since, until time.Time, topic func(any) bool) []eventtypes.Message {
-	var buffered []eventtypes.Message
 	if since.IsZero() && until.IsZero() {
-		return buffered
+		return nil
 	}
 
 	var sinceNanoUnix int64
@@ -134,21 +134,22 @@ func (e *Events) loadBufferedEvents(since, until time.Time, topic func(any) bool
 		untilNanoUnix = until.UnixNano()
 	}
 
-	for i := len(e.events) - 1; i >= 0; i-- {
-		ev := e.events[i]
-
+	// Let append grow the result based on actual matches; the time range and topic
+	// filter may exclude most or all buffered events. If dense results prove more
+	// common, cloning and filtering the candidate range in place may be cheaper.
+	var buffered []eventtypes.Message
+	for _, ev := range slices.Backward(e.events) {
 		if ev.TimeNano < sinceNanoUnix {
 			break
 		}
-
 		if untilNanoUnix > 0 && ev.TimeNano > untilNanoUnix {
 			continue
 		}
-
 		if topic == nil || topic(ev) {
-			buffered = append([]eventtypes.Message{ev}, buffered...)
+			buffered = append(buffered, ev)
 		}
 	}
+	slices.Reverse(buffered)
 	return buffered
 }
 

--- a/daemon/events/events_test.go
+++ b/daemon/events/events_test.go
@@ -196,3 +196,26 @@ func TestIgnoreBufferedWhenNoTimes(t *testing.T) {
 	messages := evts.loadBufferedEvents(since, until, nil)
 	assert.Assert(t, is.Len(messages, 0))
 }
+
+func BenchmarkLoadBufferedEvents(b *testing.B) {
+	const eventCount = 256
+
+	evts := make([]events.Message, eventCount)
+	for i := range evts {
+		evts[i].TimeNano = int64(i + 1)
+	}
+
+	e := &Events{events: evts}
+
+	for _, matches := range []int{0, 1, 64, eventCount} {
+		b.Run("matches="+strconv.Itoa(matches), func(b *testing.B) {
+			since := time.Unix(0, int64(eventCount-matches+1))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_ = e.loadBufferedEvents(since, time.Time{}, nil)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Iterate over buffered events in reverse using slices.Backward and append matching events to the result. Reverse the result once before returning it to preserve chronological ordering.

The previous implementation prepended every matching event by allocating a new slice and copying the accumulated result. This made loading n matching events O(n²), with up to two allocations per match.

Appending while iterating backwards is amortized O(n), and slices.Reverse performs one additional O(n) in-place pass.

Before:

    pkg: github.com/moby/moby/v2/daemon/events
    BenchmarkLoadBufferedEvents
    BenchmarkLoadBufferedEvents/matches=0-10     332257917         3.615 ns/op       0 B/op    0 allocs/op
    BenchmarkLoadBufferedEvents/matches=1-10      26875524        45.78 ns/op       96 B/op    1 allocs/op
    BenchmarkLoadBufferedEvents/matches=64-10        14054     86242 ns/op      201651 B/op  127 allocs/op
    BenchmarkLoadBufferedEvents/matches=256-10         835   1470292 ns/op     3073765 B/op  511 allocs/op
    PASS

After:

    pkg: github.com/moby/moby/v2/daemon/events
    BenchmarkLoadBufferedEvents
    BenchmarkLoadBufferedEvents/matches=0-10     313992554         3.796 ns/op       0 B/op   0 allocs/op
    BenchmarkLoadBufferedEvents/matches=1-10      27586550        41.82 ns/op       96 B/op   1 allocs/op
    BenchmarkLoadBufferedEvents/matches=64-10       232579      5293 ns/op       12144 B/op   7 allocs/op
    BenchmarkLoadBufferedEvents/matches=256-10       64315     20377 ns/op       49008 B/op   9 allocs/op
    PASS

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
