### PR TITLE
*: don't manually call Events.Evict() in tests

### DIFF
--- a/daemon/cluster/executor/container/health_test.go
+++ b/daemon/cluster/executor/container/health_test.go
@@ -17,10 +17,6 @@ import (
 
 func TestHealthStates(t *testing.T) {
 	// set up environment: events, task, container ....
-	e := events.New()
-	_, l, _ := e.Subscribe()
-	defer e.Evict(l)
-
 	task := &api.Task{
 		ID:        "id",
 		ServiceID: "sid",
@@ -38,7 +34,7 @@ func TestHealthStates(t *testing.T) {
 	}
 
 	daemon := &daemon.Daemon{
-		EventsService: e,
+		EventsService: events.New(),
 	}
 
 	ctrlr, err := newController(daemon, nil, nil, task, nil, nil)

--- a/daemon/events/events_test.go
+++ b/daemon/events/events_test.go
@@ -14,10 +14,10 @@ import (
 
 func TestEventsLog(t *testing.T) {
 	e := New()
-	_, l1, _ := e.Subscribe()
-	_, l2, _ := e.Subscribe()
-	defer e.Evict(l1)
-	defer e.Evict(l2)
+	_, l1, cancel1 := e.Subscribe()
+	defer cancel1()
+	_, l2, cancel2 := e.Subscribe()
+	defer cancel2()
 	subscriberCount := e.SubscribersCount()
 	assert.Check(t, is.Equal(subscriberCount, 2))
 
@@ -53,8 +53,8 @@ func TestEventsLog(t *testing.T) {
 
 func TestEventsLogTimeout(t *testing.T) {
 	e := New()
-	_, l, _ := e.Subscribe()
-	defer e.Evict(l)
+	_, _, cancel := e.Subscribe()
+	defer cancel()
 
 	c := make(chan struct{})
 	go func() {
@@ -82,7 +82,8 @@ func TestLogEvents(t *testing.T) {
 		})
 	}
 	time.Sleep(50 * time.Millisecond)
-	current, l, _ := e.Subscribe()
+	current, l, cancel := e.Subscribe()
+	defer cancel()
 	for i := range 10 {
 		num := strconv.Itoa(i + eventsLimit + 16)
 		e.Log(events.Action("action_"+num), events.ContainerEventType, events.Actor{

--- a/daemon/events_test.go
+++ b/daemon/events_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestLogContainerEventCopyLabels(t *testing.T) {
 	e := events.New()
-	_, l, _ := e.Subscribe()
-	defer e.Evict(l)
+	_, l, cancel := e.Subscribe()
+	defer cancel()
 
 	ctr := &container.Container{
 		ID:   "container_id",
@@ -45,8 +45,8 @@ func TestLogContainerEventCopyLabels(t *testing.T) {
 
 func TestLogContainerEventWithAttributes(t *testing.T) {
 	e := events.New()
-	_, l, _ := e.Subscribe()
-	defer e.Evict(l)
+	_, l, cancel := e.Subscribe()
+	defer cancel()
 
 	ctr := &container.Container{
 		ID:   "container_id",

--- a/daemon/health_test.go
+++ b/daemon/health_test.go
@@ -47,8 +47,8 @@ func TestNoneHealthcheck(t *testing.T) {
 // FIXME(vdemeester) This takes around 3s… This is *way* too long
 func TestHealthStates(t *testing.T) {
 	e := events.New()
-	_, l, _ := e.Subscribe()
-	defer e.Evict(l)
+	_, l, cancel := e.Subscribe()
+	defer cancel()
 
 	expect := func(expected eventtypes.Action) {
 		select {


### PR DESCRIPTION
Events.Subscribe() returns a cancel func that can handle this.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
