### PR TITLE
daemon/cluster/executor/container: rename var that shadowed

### DIFF
--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -266,11 +266,10 @@ func (r *controller) Start(ctx context.Context) error {
 
 			switch event.Action {
 			case events.ActionDie: // exit on terminal events
-				ctnr, err := r.adapter.inspect(ctx)
-				if err != nil {
+				if ctr, err := r.adapter.inspect(ctx); err != nil {
 					return errors.Wrap(err, "die event received")
-				} else if ctnr.State.ExitCode != 0 {
-					return &exitError{code: ctnr.State.ExitCode, cause: healthErr}
+				} else if ctr.State.ExitCode != 0 {
+					return &exitError{code: ctr.State.ExitCode, cause: healthErr}
 				}
 
 				return nil


### PR DESCRIPTION

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
