### PR TITLE
daemon/cluster: close container event stream on shutdown

### DIFF
--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -400,12 +400,10 @@ func (c *containerAdapter) inspect(ctx context.Context) (containertypes.InspectR
 // events. The stream of events can be shutdown by cancelling the context.
 func (c *containerAdapter) events(ctx context.Context) <-chan events.Message {
 	swarmlog.G(ctx).Debugf("waiting on events")
-	buffer, l := c.backend.SubscribeToEvents(time.Time{}, time.Time{}, c.container.eventFilter())
-	eventsq := make(chan events.Message, len(buffer))
 
-	for _, event := range buffer {
-		eventsq <- event
-	}
+	// Discard buffered events; we don't provide since/until filters and use live events only.
+	_, l := c.backend.SubscribeToEvents(time.Time{}, time.Time{}, c.container.eventFilter())
+	eventsq := make(chan events.Message)
 
 	go func() {
 		defer c.backend.UnsubscribeFromEvents(l)

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -406,11 +406,16 @@ func (c *containerAdapter) events(ctx context.Context) <-chan events.Message {
 	eventsq := make(chan events.Message)
 
 	go func() {
+		defer close(eventsq)
 		defer c.backend.UnsubscribeFromEvents(l)
 
 		for {
 			select {
-			case ev := <-l:
+			case ev, ok := <-l:
+				if !ok {
+					return
+				}
+
 				jev, ok := ev.(events.Message)
 				if !ok {
 					swarmlog.G(ctx).Warnf("unexpected event message: %q", ev)


### PR DESCRIPTION
### daemon/cluster: remove unused event-buffer

backend.SubscribeToEvents is always called without since/until filters,
which means that we never receive historic events, only live events.


### daemon/cluster: close container event stream on shutdown

Close the returned event channel when the forwarding goroutine exits, allowing
consumers to detect that the event stream has stopped.

Also handle the backend subscription channel being closed. Previously, reads
from a closed channel returned nil repeatedly, causing the goroutine to log
unexpected messages and continue looping.


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
