### PR TITLE
d/libn/i/nftables: free nft_ctx when unreachable

### DIFF
--- a/daemon/libnetwork/internal/nftables/nft_cgo_linux.go
+++ b/daemon/libnetwork/internal/nftables/nft_cgo_linux.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"unsafe"
 
 	"github.com/containerd/log"
@@ -24,7 +25,13 @@ func preflight() error {
 	return nil
 }
 
-type nftCtx C.struct_nft_ctx
+// nftCtx owns a libnftables context. The context is freed by [nftCtx.Close],
+// or by a runtime cleanup if the nftCtx becomes unreachable without being
+// closed.
+type nftCtx struct {
+	handle  *C.struct_nft_ctx
+	cleanup runtime.Cleanup
+}
 
 // Apply calls libnftables to execute the nftables commands in nftCmd.
 func (h *nftCtx) Apply(ctx context.Context, nftCmd []byte) error {
@@ -34,9 +41,12 @@ func (h *nftCtx) Apply(ctx context.Context, nftCmd []byte) error {
 	cCmd := C.CString(string(nftCmd))
 	defer C.free(unsafe.Pointer(cCmd))
 
-	ret := C.nft_run_cmd_from_buffer((*C.struct_nft_ctx)(h), cCmd)
-	stdout := C.GoString(C.nft_ctx_get_output_buffer((*C.struct_nft_ctx)(h)))
-	stderr := C.GoString(C.nft_ctx_get_error_buffer((*C.struct_nft_ctx)(h)))
+	ret := C.nft_run_cmd_from_buffer(h.handle, cCmd)
+	stdout := C.GoString(C.nft_ctx_get_output_buffer(h.handle))
+	stderr := C.GoString(C.nft_ctx_get_error_buffer(h.handle))
+	// Keep h reachable until libnftables is done with its context, so that the
+	// cleanup can't free it out from under these calls.
+	runtime.KeepAlive(h)
 	if ret != 0 {
 		return fmt.Errorf("libnftables: failed to apply commands (code %d), stderr: %s", int(ret), stderr)
 	}
@@ -60,9 +70,22 @@ func newNftCtx() (_ *nftCtx, retErr error) {
 	if ret := C.nft_ctx_buffer_error(handle); ret != 0 {
 		return nil, fmt.Errorf("libnftables: failed to set error buffer (code %d)", int(ret))
 	}
-	return (*nftCtx)(handle), nil
+	h := &nftCtx{handle: handle}
+	h.cleanup = runtime.AddCleanup(h, func(handle *C.struct_nft_ctx) {
+		C.nft_ctx_free(handle)
+	}, handle)
+	return h, nil
 }
 
+// Close frees the libnftables context. It is idempotent, but h must not be used
+// for anything else after it's been closed.
 func (h *nftCtx) Close() {
-	C.nft_ctx_free((*C.struct_nft_ctx)(h))
+	h.cleanup.Stop()
+	if h.handle != nil {
+		C.nft_ctx_free(h.handle)
+		h.handle = nil
+	}
+	// Stop only cancels the cleanup if h hasn't already become unreachable, so h
+	// must be kept alive across the call to avoid a double free.
+	runtime.KeepAlive(h)
 }

--- a/daemon/libnetwork/internal/nftables/nft_cgo_linux.go
+++ b/daemon/libnetwork/internal/nftables/nft_cgo_linux.go
@@ -35,6 +35,10 @@ type nftCtx struct {
 
 // Apply calls libnftables to execute the nftables commands in nftCmd.
 func (h *nftCtx) Apply(ctx context.Context, nftCmd []byte) error {
+	if h.handle == nil {
+		return errors.New("libnftables: context is closed")
+	}
+
 	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".nftApply.cgo")
 	defer span.End()
 


### PR DESCRIPTION
## Summary

The libnftables context owned by `nftCtx` is C-allocated memory, freed only when
`nftCtx.Close()` is called. Attach a `runtime.AddCleanup` so a context which is
dropped without being closed is freed once it becomes unreachable, instead of
being leaked for the lifetime of the process.

`runtime.AddCleanup` needs a pointer to a Go-heap object to attach to, so the
libnftables handle is now wrapped in a Go struct rather than `nftCtx` being a
type definition of the C struct. Two `runtime.KeepAlive` calls come along with
that, and neither is decoration:

- in `Apply()`, the receiver is only mentioned while loading `h.handle` for the
  C calls, and a receiver may become unreachable at its last mention — without
  the `KeepAlive` the cleanup could free the context while
  `nft_run_cmd_from_buffer()` is still using it;
- in `Close()`, `runtime.Cleanup.Stop()` has no effect once the cleanup has been
  queued for execution, so `h` has to stay reachable across the `Stop()` call or
  the context could be freed twice.

`Close()` is now also idempotent — it nils out the handle after freeing, since
`nft_ctx_free()` dereferences its argument and so can't be handed a nil pointer.

This code is only compiled with the (opt-in) `libnftables` build tag, so it is
not in official binaries.

Verified by building, vetting and running the package's tests with
`-tags libnftables` in a container with `libnftables-dev` installed, plus a
throwaway test (not part of this PR) asserting that the cleanup does run for a
dropped `nftCtx`, that `Close()` followed by GC does not double-free, and that a
context freed by the cleanup doesn't disturb a live one.

## Release notes (optional)

```markdown changelog

```

---

Created with: Claude Code (Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
