### PR TITLE
daemon/libnetwork/osl: fix panic on repeated interface removal

### DIFF
--- a/daemon/libnetwork/osl/interface_linux.go
+++ b/daemon/libnetwork/osl/interface_linux.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -92,7 +93,13 @@ func newInterface(ns *Namespace, srcName, dstPrefix, dstName string, options ...
 // host namespace to DstName in a different net namespace with the appropriate
 // network settings.
 type Interface struct {
-	stopCh      chan struct{} // stopCh is closed before the interface is deleted.
+	// stopCh is closed before the interface is deleted, to stop background tasks
+	// that outlive [Namespace.AddInterface] (the unsolicited ARP/NA sends). Close
+	// it via stop(), removal can be attempted more than once for the same
+	// Interface.
+	stopCh   chan struct{}
+	stopOnce sync.Once
+
 	srcName     string
 	dstPrefix   string
 	dstName     string
@@ -170,6 +177,12 @@ func (i *Interface) Routes() []*net.IPNet {
 func (i *Interface) Remove() error {
 	nameSpace := i.ns
 	return nameSpace.RemoveInterface(i)
+}
+
+// stop stops the interface's background tasks. It is safe to call more than
+// once, and from multiple goroutines.
+func (i *Interface) stop() {
+	i.stopOnce.Do(func() { close(i.stopCh) })
 }
 
 // Statistics returns the sandbox's side veth interface statistics.
@@ -818,8 +831,14 @@ func (n *Namespace) prepAdvertiseAddrs(ctx context.Context, i *Interface, ifInde
 
 // RemoveInterface removes an interface from the namespace by renaming to
 // original name and moving it out of the sandbox.
+//
+// On failure, i is left in the Namespace's list of interfaces - the interface
+// may still be present in the namespace, and its name is still reserved. So,
+// callers that iterate over [Namespace.Interfaces] will try to remove i again
+// during a later teardown. RemoveInterface must therefore tolerate being called
+// more than once for the same Interface.
 func (n *Namespace) RemoveInterface(i *Interface) error {
-	close(i.stopCh)
+	i.stop()
 
 	// Find the network interface identified by the DstName attribute.
 	iface, err := n.nlHandle.LinkByName(i.DstName())

--- a/daemon/libnetwork/osl/interface_linux_test.go
+++ b/daemon/libnetwork/osl/interface_linux_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestGenerateIfaceName(t *testing.T) {
@@ -90,4 +91,54 @@ func TestAddInterfaceInParallel(t *testing.T) {
 
 	sort.Strings(eths)
 	assert.DeepEqual(t, eths, []string{"eth0", "eth1", "eth2", "eth3", "eth4", "eth5", "eth6", "eth7", "eth8", "eth9"})
+}
+
+// TestRemoveInterfaceTwice checks that a second attempt to remove an interface
+// returns an error instead of panicking.
+//
+// A failed RemoveInterface leaves the Interface in the Namespace. Callers
+// tear interfaces down by iterating over [Namespace.Interfaces], so the same
+// *Interface is passed to RemoveInterface again during a later teardown - for
+// example, by the rollback in libnetwork's Endpoint.sbJoin after a failed
+// re-join.
+func TestRemoveInterfaceTwice(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	nsh, err := netns.NewNamed(t.Name())
+	assert.NilError(t, err)
+	defer netns.DeleteNamed(t.Name())
+	defer nsh.Close()
+
+	nlh, err := nlwrap.NewHandleAt(nsh)
+	assert.NilError(t, err)
+	defer nlh.Close()
+
+	ns := &Namespace{
+		path:     "/run/netns/" + t.Name(),
+		nlHandle: nlh,
+	}
+
+	assert.NilError(t, nlh.LinkAdd(&netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{Name: "dummy0"},
+	}))
+	assert.NilError(t, ns.AddInterface(context.Background(), "dummy0", "eth", "", WithCreatedInContainer(true)))
+
+	ifaces := ns.Interfaces()
+	assert.Assert(t, is.Len(ifaces, 1))
+
+	// Delete the link so that the first removal fails part-way through, like the
+	// failures seen in CI ("LinkSetNsFd failed for interface vethc9f9c7d: bad
+	// file descriptor").
+	link, err := nlh.LinkByName(ifaces[0].DstName())
+	assert.NilError(t, err)
+	assert.NilError(t, nlh.LinkDel(link))
+
+	assert.Assert(t, ns.RemoveInterface(ifaces[0]) != nil)
+	// The interface is still in the Namespace, so it'll be removed again later.
+	remaining := ns.Interfaces()
+	assert.Assert(t, is.Len(remaining, 1))
+	assert.Equal(t, remaining[0], ifaces[0])
+
+	assert.Assert(t, ns.RemoveInterface(ifaces[0]) != nil)
 }


### PR DESCRIPTION
## Summary

`osl.Namespace.RemoveInterface` closes the `Interface`'s `stopCh` up-front, to stop the goroutine sending unsolicited ARP/NA messages, but only unregisters the `Interface` from the `Namespace` once the removal has completed. Several failure exits sit in between, so a removal that fails part-way leaves the `Interface` registered with an already-closed `stopCh`.

Callers tear interfaces down by iterating over `Namespace.Interfaces` (`releaseOSSboxResources`, and the overlay driver), so the same `*Interface` is handed back to `RemoveInterface` during a later teardown, and the second `close` panics — taking down the API request being served:

```
http: panic serving @: close of closed channel
```

Observed in CI (docker-py `LinkTest.test_remove_link`) on an unrelated PR, https://github.com/moby/moby/actions/runs/30479093900/job/90669110647:

```
osl.(*Namespace).RemoveInterface      interface_linux.go:822
osl.(*Interface).Remove               interface_linux.go:172
libnetwork.releaseOSSboxResources     sandbox_linux.go:22
libnetwork.(*Endpoint).sbLeave        endpoint.go:820
libnetwork.(*Endpoint).sbJoin.func1   endpoint.go:516  (deferred rollback)
libnetwork.(*Endpoint).sbJoin         endpoint.go:589
libnetwork.(*Sandbox).Refresh         sandbox.go:270
daemon.(*Daemon).updateNetwork        container_operations.go:260
daemon.(*Daemon).rmLink               delete.go:80
```

Immediately before the panic, the daemon logged for the same veth:

```
LinkSetNsFd failed for interface vethc9f9c7d: bad file descriptor
Remove interface vethc9f9c7d failed: bad file descriptor
```

So `Sandbox.Refresh` detached the endpoint, and that first `RemoveInterface` closed `stopCh` and renamed the link back to its source name, but then failed to move it out of the container's netns. The link was therefore no longer where the following re-join expected to find it, `sbJoin` failed, and its deferred rollback ran `sbLeave` → `releaseOSSboxResources` over the same still-registered `*Interface`.

The unguarded `close` was introduced in eaa84bc8f4 ("Send unsolicited ARP/NA requests when bringing up interfaces"), added to a function that already had, and still has, several failure exits before it completes. Before that, a repeated `RemoveInterface` simply returned "link not found".

### The fix

Close `stopCh` through a `sync.Once`. That keeps the guarantee the channel exists for — the ARP/NA sender is stopped whether or not the netlink teardown succeeds — while tolerating repeated, and concurrent, removal attempts. A `select`-guarded close would not be safe against concurrent callers, and deferring the close until the removal succeeds would leak the goroutine on exactly the failure paths that motivate this change.

A failed `RemoveInterface` still leaves the `Interface` registered in the `Namespace`. Besides allowing a retry, the entry is a name reservation: `generateIfaceName` derives the next `ethN` from `n.iFaces`, so if the removal failed before the rename the link is still present under its `dstName`, and dropping the entry would let the next `AddInterface` pick the same name and fail with `EEXIST`.

### Testing

`TestRemoveInterfaceTwice` forces the first removal to fail after `stopCh` has been closed, asserts the `Interface` is still registered, then removes it again. Against the unfixed code it reproduces the CI failure directly:

```
panic: close of closed channel [recovered, repanicked]
osl.(*Namespace).RemoveInterface   interface_linux.go:841
osl.TestRemoveInterfaceTwice       interface_linux_test.go:143
```

The underlying `EBADF` from `LinkSetNsFd` is a separate defect and is not addressed here — it is a race, with no reproducer, and it only exposed this panic rather than causing it.

## Release notes (optional)

```markdown changelog
Fix a daemon panic when cleanup of a container's network interface fails while the container is being disconnected from a network.
```

Created with: Claude Opus 5
