### PR TITLE
integration/networking: fix flaky TestNatNetworkICC cleanup

### DIFF
--- a/integration/networking/nat_windows_test.go
+++ b/integration/networking/nat_windows_test.go
@@ -48,16 +48,22 @@ func TestNatNetworkICC(t *testing.T) {
 				defer network.RemoveNoError(ctx, t, c, tc.netName)
 			}
 
-			const ctr1Name = "ctr1"
+			ctr1Name := tc.name + "-ctr1"
 			id1 := container.Run(ctx, t, c,
 				container.WithName(ctr1Name),
 				container.WithNetworkMode(tc.netName),
 			)
-			defer c.ContainerRemove(ctx, id1, client.ContainerRemoveOptions{Force: true})
+			t.Cleanup(func() {
+				c.ContainerRemove(context.Background(), id1, client.ContainerRemoveOptions{Force: true}) //nolint:errcheck
+			})
 
 			pingCmd := []string{"ping", "-n", "1", "-w", "3000", ctr1Name}
 
-			const ctr2Name = "ctr2"
+			ctr2Name := tc.name + "-ctr2"
+			// Register cleanup before RunAttach so it fires even if RunAttach exits via t.FailNow.
+			t.Cleanup(func() {
+				c.ContainerRemove(context.Background(), ctr2Name, client.ContainerRemoveOptions{Force: true}) //nolint:errcheck
+			})
 			attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 			defer cancel()
 			res := container.RunAttach(attachCtx, t, c,
@@ -65,7 +71,6 @@ func TestNatNetworkICC(t *testing.T) {
 				container.WithCmd(pingCmd...),
 				container.WithNetworkMode(tc.netName),
 			)
-			defer c.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
 
 			assert.Check(t, is.Equal(res.ExitCode, 0))
 			assert.Check(t, is.Equal(res.Stderr.Len(), 0))

--- a/integration/networking/nat_windows_test.go
+++ b/integration/networking/nat_windows_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"net/netip"
+	"strings"
 	"testing"
 	"time"
 
@@ -48,7 +49,8 @@ func TestNatNetworkICC(t *testing.T) {
 				defer network.RemoveNoError(ctx, t, c, tc.netName)
 			}
 
-			ctr1Name := tc.name + "-ctr1"
+			safeName := strings.ReplaceAll(tc.name, " ", "_")
+			ctr1Name := safeName + "-ctr1"
 			id1 := container.Run(ctx, t, c,
 				container.WithName(ctr1Name),
 				container.WithNetworkMode(tc.netName),
@@ -59,7 +61,7 @@ func TestNatNetworkICC(t *testing.T) {
 
 			pingCmd := []string{"ping", "-n", "1", "-w", "3000", ctr1Name}
 
-			ctr2Name := tc.name + "-ctr2"
+			ctr2Name := safeName + "-ctr2"
 			// Register cleanup before RunAttach so it fires even if RunAttach exits via t.FailNow.
 			t.Cleanup(func() {
 				c.ContainerRemove(context.Background(), ctr2Name, client.ContainerRemoveOptions{Force: true}) //nolint:errcheck

--- a/integration/networking/nat_windows_test.go
+++ b/integration/networking/nat_windows_test.go
@@ -46,7 +46,9 @@ func TestNatNetworkICC(t *testing.T) {
 				network.CreateNoError(ctx, t, c, tc.netName,
 					network.WithDriver("nat"),
 				)
-				defer network.RemoveNoError(ctx, t, c, tc.netName)
+				t.Cleanup(func() {
+					network.RemoveNoError(context.Background(), t, c, tc.netName)
+				})
 			}
 
 			safeName := strings.ReplaceAll(tc.name, " ", "_")


### PR DESCRIPTION
## Summary

Fix intermittent failure of `TestNatNetworkICC`.

The test had three structural bugs causing flakiness on Windows CI:
1. Hardcoded container names (`"ctr1"`, `"ctr2"`) collided across subtests, causing "container name already in use" errors when the first subtest failed and orphaned containers
2. The ctr2 cleanup defer was registered after `RunAttach`, which could exit via `t.FailNow()` before the defer fired, orphaning ctr2
3. Cleanup used the test context `ctx`, which could be cancelled on timeout, causing silent cleanup failures

This fix:
- Makes container names unique per subtest by prefixing with `tc.name`
- Replaces `defer` cleanup with `t.Cleanup()` using `context.Background()` so cleanup always runs with a valid context
- Registers ctr2 cleanup *before* `RunAttach` so it fires even if `RunAttach` exits early

- Relates: https://github.com/moby/moby/issues/48882

## Release notes (optional)

```markdown changelog

```

## Note for maintainers

A maintainer's `Signed-off-by` co-sign is needed before this PR can be merged, per the DCO policy discussion in https://github.com/moby/moby/pull/53197. If you are approving this PR, please amend the commit to add your own sign-off, or instruct Gordon to add it on your behalf.

## A picture of a cute animal (not mandatory but encouraged)

🐢