### PR TITLE
daemon/events: Events.Subscribe: make cancelFn idempotent

### DIFF
--- a/daemon/events/events.go
+++ b/daemon/events/events.go
@@ -34,18 +34,16 @@ func New() *Events {
 // last events, a channel in which you can expect new events (in form
 // of interface{}, so you need type assertion), and a function to call
 // to stop the stream of events.
-func (e *Events) Subscribe() ([]eventtypes.Message, chan any, func()) {
-	metrics.EventSubscribers.Inc()
+func (e *Events) Subscribe() (buf []eventtypes.Message, evts chan any, cancel func()) {
+	// Hold e.mu while loading buffered events and registering the subscriber so
+	// that an event cannot fall between the buffered snapshot and the live stream.
 	e.mu.Lock()
-	current := make([]eventtypes.Message, len(e.events))
-	copy(current, e.events)
-	l := e.pub.Subscribe()
-	e.mu.Unlock()
+	defer metrics.EventSubscribers.Inc()
+	defer e.mu.Unlock()
 
-	cancel := func() {
-		e.Evict(l)
-	}
-	return current, l, cancel
+	buf = slices.Clone(e.events)
+	ch := e.pub.Subscribe()
+	return buf, ch, sync.OnceFunc(func() { e.unsubscribe(ch) })
 }
 
 // SubscribeTopic adds new listener to events, returns slice of 256 stored
@@ -75,9 +73,15 @@ func (e *Events) SubscribeTopic(since, until time.Time, ef *Filter) ([]eventtype
 }
 
 // Evict evicts listener from pubsub
+//
+// TODO(thaJeztah): make all Subscribe methods return a cancelFn and remove this.
 func (e *Events) Evict(l chan any) {
+	e.unsubscribe(l)
+}
+
+func (e *Events) unsubscribe(ch chan any) {
+	e.pub.Evict(ch)
 	metrics.EventSubscribers.Dec()
-	e.pub.Evict(l)
 }
 
 // Log creates a local scope message and publishes it


### PR DESCRIPTION
We should avoid calling Evict manually, and make all Subscribe methods have a cancel function. Events.Evict is not idempotent, and calling it multiple times would double-decrement metrics.EventSubscribers.

Unfortunately, pubsub.Evict does not indicate whether a subscriber was found (no "ok" return), so we cannot easily discover this through other means.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
