### PR TITLE
api/docs: sync API docs v1.25 - v1.55

### DIFF
--- a/api/docs/v1.25.yaml
+++ b/api/docs/v1.25.yaml
@@ -871,9 +871,11 @@ definitions:
         type: "string"
         default: "SIGTERM"
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
+        x-nullable: true
       Shell:
         description: "Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell."
         type: "array"
@@ -2055,6 +2057,30 @@ definitions:
       - "shutdown"
       - "failed"
       - "rejected"
+
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -2114,6 +2140,13 @@ definitions:
                 type: "integer"
       DesiredState:
         $ref: "#/definitions/TaskState"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.26.yaml
+++ b/api/docs/v1.26.yaml
@@ -871,9 +871,11 @@ definitions:
         type: "string"
         default: "SIGTERM"
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
+        x-nullable: true
       Shell:
         description: "Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell."
         type: "array"
@@ -2059,6 +2061,30 @@ definitions:
       - "shutdown"
       - "failed"
       - "rejected"
+
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -2118,6 +2144,13 @@ definitions:
                 type: "integer"
       DesiredState:
         $ref: "#/definitions/TaskState"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.27.yaml
+++ b/api/docs/v1.27.yaml
@@ -884,9 +884,11 @@ definitions:
         type: "string"
         default: "SIGTERM"
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
+        x-nullable: true
       Shell:
         description: "Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell."
         type: "array"
@@ -2139,6 +2141,30 @@ definitions:
       - "shutdown"
       - "failed"
       - "rejected"
+
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -2194,6 +2220,13 @@ definitions:
                 type: "integer"
       DesiredState:
         $ref: "#/definitions/TaskState"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.28.yaml
+++ b/api/docs/v1.28.yaml
@@ -890,9 +890,11 @@ definitions:
         type: "string"
         default: "SIGTERM"
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
+        x-nullable: true
       Shell:
         description: "Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell."
         type: "array"
@@ -2192,6 +2194,30 @@ definitions:
       - "shutdown"
       - "failed"
       - "rejected"
+
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -2247,6 +2273,13 @@ definitions:
                 type: "integer"
       DesiredState:
         $ref: "#/definitions/TaskState"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.29.yaml
+++ b/api/docs/v1.29.yaml
@@ -896,9 +896,11 @@ definitions:
         type: "string"
         default: "SIGTERM"
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
+        x-nullable: true
       Shell:
         description: "Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell."
         type: "array"
@@ -2213,6 +2215,30 @@ definitions:
       - "shutdown"
       - "failed"
       - "rejected"
+
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -2268,6 +2294,13 @@ definitions:
                 type: "integer"
       DesiredState:
         $ref: "#/definitions/TaskState"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.30.yaml
+++ b/api/docs/v1.30.yaml
@@ -905,9 +905,11 @@ definitions:
         type: "string"
         default: "SIGTERM"
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
+        x-nullable: true
       Shell:
         description: "Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell."
         type: "array"
@@ -2393,6 +2395,30 @@ definitions:
       - "shutdown"
       - "failed"
       - "rejected"
+
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -2448,6 +2474,13 @@ definitions:
                 type: "integer"
       DesiredState:
         $ref: "#/definitions/TaskState"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.31.yaml
+++ b/api/docs/v1.31.yaml
@@ -905,9 +905,11 @@ definitions:
         type: "string"
         default: "SIGTERM"
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
+        x-nullable: true
       Shell:
         description: "Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell."
         type: "array"
@@ -2422,6 +2424,30 @@ definitions:
       - "shutdown"
       - "failed"
       - "rejected"
+
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -2477,6 +2503,13 @@ definitions:
                 type: "integer"
       DesiredState:
         $ref: "#/definitions/TaskState"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.32.yaml
+++ b/api/docs/v1.32.yaml
@@ -971,9 +971,11 @@ definitions:
         type: "string"
         default: "SIGTERM"
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
+        x-nullable: true
       Shell:
         description: "Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell."
         type: "array"
@@ -2879,6 +2881,29 @@ definitions:
       - "failed"
       - "rejected"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -2936,6 +2961,13 @@ definitions:
                 type: "integer"
       DesiredState:
         $ref: "#/definitions/TaskState"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.33.yaml
+++ b/api/docs/v1.33.yaml
@@ -975,9 +975,11 @@ definitions:
         type: "string"
         default: "SIGTERM"
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
+        x-nullable: true
       Shell:
         description: "Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell."
         type: "array"
@@ -2883,6 +2885,29 @@ definitions:
       - "failed"
       - "rejected"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -2940,6 +2965,13 @@ definitions:
                 type: "integer"
       DesiredState:
         $ref: "#/definitions/TaskState"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.34.yaml
+++ b/api/docs/v1.34.yaml
@@ -985,9 +985,11 @@ definitions:
         type: "string"
         default: "SIGTERM"
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
+        x-nullable: true
       Shell:
         description: "Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell."
         type: "array"
@@ -2893,6 +2895,29 @@ definitions:
       - "failed"
       - "rejected"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -2950,6 +2975,13 @@ definitions:
                 type: "integer"
       DesiredState:
         $ref: "#/definitions/TaskState"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.35.yaml
+++ b/api/docs/v1.35.yaml
@@ -982,9 +982,11 @@ definitions:
         type: "string"
         default: "SIGTERM"
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
+        x-nullable: true
       Shell:
         description: "Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell."
         type: "array"
@@ -2897,6 +2899,29 @@ definitions:
       - "failed"
       - "rejected"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -2954,6 +2979,13 @@ definitions:
                 type: "integer"
       DesiredState:
         $ref: "#/definitions/TaskState"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.36.yaml
+++ b/api/docs/v1.36.yaml
@@ -986,9 +986,11 @@ definitions:
         type: "string"
         default: "SIGTERM"
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
+        x-nullable: true
       Shell:
         description: "Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell."
         type: "array"
@@ -2914,6 +2916,29 @@ definitions:
       - "failed"
       - "rejected"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -2971,6 +2996,13 @@ definitions:
                 type: "integer"
       DesiredState:
         $ref: "#/definitions/TaskState"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.37.yaml
+++ b/api/docs/v1.37.yaml
@@ -989,9 +989,11 @@ definitions:
         type: "string"
         default: "SIGTERM"
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
+        x-nullable: true
       Shell:
         description: "Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell."
         type: "array"
@@ -2919,6 +2921,29 @@ definitions:
       - "remove"
       - "orphaned"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -2976,6 +3001,13 @@ definitions:
                 type: "integer"
       DesiredState:
         $ref: "#/definitions/TaskState"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.38.yaml
+++ b/api/docs/v1.38.yaml
@@ -996,9 +996,11 @@ definitions:
         type: "string"
         default: "SIGTERM"
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
+        x-nullable: true
       Shell:
         description: "Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell."
         type: "array"
@@ -2969,6 +2971,29 @@ definitions:
       - "remove"
       - "orphaned"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -3026,6 +3051,13 @@ definitions:
                 type: "integer"
       DesiredState:
         $ref: "#/definitions/TaskState"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.39.yaml
+++ b/api/docs/v1.39.yaml
@@ -1275,9 +1275,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4012,6 +4013,29 @@ definitions:
       - "remove"
       - "orphaned"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -4069,6 +4093,13 @@ definitions:
                 type: "integer"
       DesiredState:
         $ref: "#/definitions/TaskState"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.40.yaml
+++ b/api/docs/v1.40.yaml
@@ -1338,9 +1338,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4141,6 +4142,29 @@ definitions:
       - "remove"
       - "orphaned"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -4198,6 +4222,13 @@ definitions:
                 type: "integer"
       DesiredState:
         $ref: "#/definitions/TaskState"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.41.yaml
+++ b/api/docs/v1.41.yaml
@@ -1369,9 +1369,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4306,6 +4307,29 @@ definitions:
       - "remove"
       - "orphaned"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -4369,6 +4393,13 @@ definitions:
           the JobIteration of the Service this Task was created for. Absent if
           the Task was created for a Replicated or Global Service.
         $ref: "#/definitions/ObjectVersion"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.42.yaml
+++ b/api/docs/v1.42.yaml
@@ -1373,9 +1373,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4318,6 +4319,29 @@ definitions:
       - "remove"
       - "orphaned"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -4381,6 +4405,13 @@ definitions:
           the JobIteration of the Service this Task was created for. Absent if
           the Task was created for a Replicated or Global Service.
         $ref: "#/definitions/ObjectVersion"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.43.yaml
+++ b/api/docs/v1.43.yaml
@@ -1380,9 +1380,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4349,6 +4350,29 @@ definitions:
       - "remove"
       - "orphaned"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -4412,6 +4436,13 @@ definitions:
           the JobIteration of the Service this Task was created for. Absent if
           the Task was created for a Replicated or Global Service.
         $ref: "#/definitions/ObjectVersion"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.44.yaml
+++ b/api/docs/v1.44.yaml
@@ -1399,9 +1399,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4439,6 +4440,29 @@ definitions:
       PortStatus:
         $ref: "#/definitions/PortStatus"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -4483,6 +4507,13 @@ definitions:
           the JobIteration of the Service this Task was created for. Absent if
           the Task was created for a Replicated or Global Service.
         $ref: "#/definitions/ObjectVersion"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.45.yaml
+++ b/api/docs/v1.45.yaml
@@ -1400,9 +1400,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4425,6 +4426,29 @@ definitions:
       PortStatus:
         $ref: "#/definitions/PortStatus"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -4469,6 +4493,13 @@ definitions:
           the JobIteration of the Service this Task was created for. Absent if
           the Task was created for a Replicated or Global Service.
         $ref: "#/definitions/ObjectVersion"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.46.yaml
+++ b/api/docs/v1.46.yaml
@@ -1415,9 +1415,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4478,6 +4479,29 @@ definitions:
       PortStatus:
         $ref: "#/definitions/PortStatus"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -4522,6 +4546,13 @@ definitions:
           the JobIteration of the Service this Task was created for. Absent if
           the Task was created for a Replicated or Global Service.
         $ref: "#/definitions/ObjectVersion"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.47.yaml
+++ b/api/docs/v1.47.yaml
@@ -1415,9 +1415,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4496,6 +4497,29 @@ definitions:
       PortStatus:
         $ref: "#/definitions/PortStatus"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -4540,6 +4564,13 @@ definitions:
           the JobIteration of the Service this Task was created for. Absent if
           the Task was created for a Replicated or Global Service.
         $ref: "#/definitions/ObjectVersion"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.48.yaml
+++ b/api/docs/v1.48.yaml
@@ -1465,9 +1465,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4635,6 +4636,29 @@ definitions:
       PortStatus:
         $ref: "#/definitions/PortStatus"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -4679,6 +4703,13 @@ definitions:
           the JobIteration of the Service this Task was created for. Absent if
           the Task was created for a Replicated or Global Service.
         $ref: "#/definitions/ObjectVersion"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.49.yaml
+++ b/api/docs/v1.49.yaml
@@ -1465,9 +1465,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4635,6 +4636,29 @@ definitions:
       PortStatus:
         $ref: "#/definitions/PortStatus"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -4679,6 +4703,13 @@ definitions:
           the JobIteration of the Service this Task was created for. Absent if
           the Task was created for a Replicated or Global Service.
         $ref: "#/definitions/ObjectVersion"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.50.yaml
+++ b/api/docs/v1.50.yaml
@@ -1465,9 +1465,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4479,6 +4480,29 @@ definitions:
       PortStatus:
         $ref: "#/definitions/PortStatus"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -4523,6 +4547,13 @@ definitions:
           the JobIteration of the Service this Task was created for. Absent if
           the Task was created for a Replicated or Global Service.
         $ref: "#/definitions/ObjectVersion"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.51.yaml
+++ b/api/docs/v1.51.yaml
@@ -1468,9 +1468,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4498,6 +4499,29 @@ definitions:
       PortStatus:
         $ref: "#/definitions/PortStatus"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -4542,6 +4566,13 @@ definitions:
           the JobIteration of the Service this Task was created for. Absent if
           the Task was created for a Replicated or Global Service.
         $ref: "#/definitions/ObjectVersion"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -1470,9 +1470,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4723,6 +4724,29 @@ definitions:
       PortStatus:
         $ref: "#/definitions/PortStatus"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -4767,6 +4791,13 @@ definitions:
           the JobIteration of the Service this Task was created for. Absent if
           the Task was created for a Replicated or Global Service.
         $ref: "#/definitions/ObjectVersion"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.53.yaml
+++ b/api/docs/v1.53.yaml
@@ -1470,9 +1470,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4969,6 +4970,29 @@ definitions:
       PortStatus:
         $ref: "#/definitions/PortStatus"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -5013,6 +5037,13 @@ definitions:
           the JobIteration of the Service this Task was created for. Absent if
           the Task was created for a Replicated or Global Service.
         $ref: "#/definitions/ObjectVersion"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.54.yaml
+++ b/api/docs/v1.54.yaml
@@ -1470,9 +1470,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4969,6 +4970,29 @@ definitions:
       PortStatus:
         $ref: "#/definitions/PortStatus"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -5013,6 +5037,13 @@ definitions:
           the JobIteration of the Service this Task was created for. Absent if
           the Task was created for a Replicated or Global Service.
         $ref: "#/definitions/ObjectVersion"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/docs/v1.55.yaml
+++ b/api/docs/v1.55.yaml
@@ -1470,9 +1470,10 @@ definitions:
         example: "SIGTERM"
         x-nullable: true
       StopTimeout:
-        description: "Timeout to stop a container in seconds."
+        description: |
+          Timeout to stop a container in seconds. If omitted, the daemon-wide
+          default (`default-stop-timeout`) is used.
         type: "integer"
-        default: 10
         x-nullable: true
       Shell:
         description: |
@@ -4969,6 +4970,29 @@ definitions:
       PortStatus:
         $ref: "#/definitions/PortStatus"
 
+  NetworkAttachment:
+    description: |
+      Specifies how a task is attached to a network, and the addresses the
+      task was assigned on that network.
+    type: "object"
+    properties:
+      Network:
+        $ref: "#/definitions/Network"
+      Addresses:
+        description: |
+          The IP addresses (in CIDR notation) assigned to the task on this
+          network. To maintain backward compatibility this field accepts CIDR
+          notation, but only the IP address is used.
+        type: "array"
+        items:
+          type: "string"
+          format: "cidr"
+    example:
+      Network:
+        ID: "4qvuz4ko70xaltuqbt8956gd1"
+      Addresses:
+        - "10.255.0.10/16"
+
   Task:
     type: "object"
     properties:
@@ -5013,6 +5037,13 @@ definitions:
           the JobIteration of the Service this Task was created for. Absent if
           the Task was created for a Replicated or Global Service.
         $ref: "#/definitions/ObjectVersion"
+      NetworksAttachments:
+        description: |
+          The networks that this task is attached to, and the addresses the
+          task was assigned on each of them.
+        type: "array"
+        items:
+          $ref: "#/definitions/NetworkAttachment"
     example:
       ID: "0kzzo1i0y4jz6027t0k7aezc7"
       Version:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4986,6 +4986,7 @@ definitions:
         type: "array"
         items:
           type: "string"
+          format: "cidr"
     example:
       Network:
         ID: "4qvuz4ko70xaltuqbt8956gd1"


### PR DESCRIPTION
follow-up to;

- https://github.com/moby/moby/pull/53082#issuecomment-4996097864
- https://github.com/moby/moby/pull/53146

### api/swagger: document CIDR format for NetworkAttachment.Addresses

### api/docs: sync API docs v1.25 - v1.55

Update older versions of the API docs with the changes made in
37302166e03d4a442804f8ba83085f4c48ac12c9 (api: document
Task.NetworksAttachments in the swagger definition) and
99c1a9c77898108ad06e61b8a221d8dd4dece698 (daemon: Add
configurable default container stop timeout).

For older API versions I slightly adjusted the wording for the
timeout to not mention `default-stop-timeout`, because that option
is not present on older daemons, so I kept it to "daemon defaults".




## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
