### PR TITLE
libnetwork: Add service mesh tests

### DIFF
--- a/daemon/libnetwork/firewall_linux_test.go
+++ b/daemon/libnetwork/firewall_linux_test.go
@@ -26,6 +26,8 @@ const (
 )
 
 func TestUserChain(t *testing.T) {
+	skip.If(t, iptables.UsingFirewalld(), "firewalld is running in the host netns, it can't modify rules in the test's netns")
+
 	const testName = "TestUserChain"
 	iptable4 := iptables.GetIptable(iptables.IPv4)
 	iptable6 := iptables.GetIptable(iptables.IPv6)
@@ -87,7 +89,7 @@ func TestUserChain(t *testing.T) {
 				golden.Assert(t, getRules(t, iptable6, bridge.DockerForwardChain),
 					fmt.Sprintf("%s/iptables-%v_append-%v_dockerfwdinit6.golden", testName, tc.iptables, tc.append))
 			} else {
-				assert.Check(t, !iptables.GetIptable(iptables.IPv4).ExistChain(bridge.DockerForwardChain, fwdChainName),
+				assert.Check(t, !iptables.GetIptable(iptables.IPv4).ExistChain(bridge.DockerForwardChain, iptables.Filter),
 					"Chain %s should not exist", bridge.DockerForwardChain)
 			}
 
@@ -109,7 +111,7 @@ func TestUserChain(t *testing.T) {
 				golden.Assert(t, getRules(t, iptable6, bridge.DockerForwardChain),
 					fmt.Sprintf("%s/iptables-%v_append-%v_dockerfwdafter6.golden", testName, tc.iptables, tc.append))
 			} else {
-				assert.Check(t, !iptables.GetIptable(iptables.IPv4).ExistChain(bridge.DockerForwardChain, fwdChainName),
+				assert.Check(t, !iptables.GetIptable(iptables.IPv4).ExistChain(bridge.DockerForwardChain, iptables.Filter),
 					"Chain %s should not exist", bridge.DockerForwardChain)
 			}
 

--- a/integration/service/network_linux_test.go
+++ b/integration/service/network_linux_test.go
@@ -334,3 +334,96 @@ func TestRestoreIngressRulesOnFirewalldReload(t *testing.T) {
 	// It takes a while before this works ...
 	poll.WaitOn(t, checkHTTP, poll.WithTimeout(30*time.Second))
 }
+
+// TestServiceVIPAcrossRollingUpdate checks that a service's VIP keeps carrying
+// connections while the task behind it is replaced. Start-first ordering makes
+// the replacement task run before the one it replaces stops, which is what
+// leaves the load balancer holding both backends and having to keep the VIP
+// serving through the handover.
+func TestServiceVIPAcrossRollingUpdate(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support Swarm-mode")
+	skip.If(t, strings.HasPrefix(testEnv.FirewallBackendDriver(), "nftables"), "swarm cannot be used with nftables")
+	ctx := setupTest(t)
+
+	d := swarm.NewSwarm(ctx, t, testEnv, daemon.WithSwarmIptables(true))
+	defer d.Stop(t)
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	const netName = "svipu-net"
+	netID := net.CreateNoError(ctx, t, c, netName,
+		net.WithDriver("overlay"),
+		// Attachable so a plain container can join and address the VIP.
+		net.WithAttachable(),
+	)
+
+	serviceID := swarm.CreateService(ctx, t, d,
+		swarm.ServiceWithName("test-svipu"),
+		swarm.ServiceWithCommand([]string{"httpd", "-f"}),
+		swarm.ServiceWithNetwork(netName),
+		func(spec *swarmtypes.ServiceSpec) {
+			// Start the replacement task before stopping the one it replaces, so the
+			// load balancer holds both backends at once and has to keep the VIP
+			// serving through the handover. Under the default stop-first order the
+			// old backend is gone before the new one arrives, and the VIP is
+			// briefly backed by nothing at all - a weaker thing to assert.
+			spec.UpdateConfig = &swarmtypes.UpdateConfig{Order: swarmtypes.UpdateOrderStartFirst}
+		},
+	)
+	defer func() {
+		_, err := c.ServiceRemove(ctx, serviceID, client.ServiceRemoveOptions{})
+		assert.NilError(t, err)
+	}()
+	t.Log("Waiting for the service to start")
+	poll.WaitOn(t, swarm.RunningTasksCount(ctx, c, serviceID, 1), swarm.ServicePoll)
+
+	svc := getService(ctx, t, c, serviceID)
+	var vip string
+	for _, v := range svc.Endpoint.VirtualIPs {
+		if v.NetworkID == netID {
+			vip = v.Addr.Addr().String()
+		}
+	}
+	assert.Assert(t, vip != "", "no VIP allocated on %s: %+v", netName, svc.Endpoint.VirtualIPs)
+	t.Log("Service VIP is", vip)
+
+	clientID := container.Run(ctx, t, c, container.WithNetworkMode(netName))
+	defer c.ContainerRemove(ctx, clientID, client.ContainerRemoveOptions{Force: true})
+
+	// The tasks run httpd with nothing to serve, so a "404 Not Found" is the proof
+	// that the request reached one through the VIP - anything short of a task
+	// answering is a connection error instead.
+	checkVIP := func(_ poll.LogT) poll.Result {
+		res, err := container.Exec(ctx, c, clientID,
+			[]string{"wget", "-T1", "-t1", "-O-", "http://" + vip + "/"})
+		if err != nil {
+			return poll.Error(err)
+		}
+		if !strings.Contains(res.Combined(), "404 Not Found") {
+			return poll.Continue("404 Not Found not found in: %s", res.Combined())
+		}
+		return poll.Success()
+	}
+
+	t.Log("Checking VIP access before the update")
+	poll.WaitOn(t, checkVIP, poll.WithTimeout(30*time.Second))
+
+	// Roll the task without changing anything else about the service. Nothing here
+	// depends on what triggered the rollout, only that one task replaces another
+	// under the VIP.
+	t.Log("Forcing a rolling update")
+	svc.Spec.TaskTemplate.ForceUpdate++
+	_, err := c.ServiceUpdate(ctx, serviceID, client.ServiceUpdateOptions{
+		Version: svc.Version,
+		Spec:    svc.Spec,
+	})
+	assert.NilError(t, err)
+	poll.WaitOn(t, serviceIsUpdated(ctx, c, serviceID), swarm.ServicePoll)
+	poll.WaitOn(t, swarm.RunningTasksCount(ctx, c, serviceID, 1), swarm.ServicePoll)
+
+	// Back to one running task, and it is not the one that answered above. The VIP
+	// has to resolve to the replacement.
+	t.Log("Checking VIP access after the update")
+	poll.WaitOn(t, checkVIP, poll.WithTimeout(30*time.Second))
+}

--- a/integration/service/network_linux_test.go
+++ b/integration/service/network_linux_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	stdnet "net"
 	"net/netip"
 	"strings"
@@ -426,4 +427,146 @@ func TestServiceVIPAcrossRollingUpdate(t *testing.T) {
 	// has to resolve to the replacement.
 	t.Log("Checking VIP access after the update")
 	poll.WaitOn(t, checkVIP, poll.WithTimeout(30*time.Second))
+}
+
+// checkIngressPort returns a poll check that a service's published port is
+// accessible from host. The tasks run httpd with nothing to serve, so a "404 Not
+// Found" is the proof that the request reached one - anything short of a task
+// answering is a connection error instead.
+func checkIngressPort(t *testing.T, host networking.Host, hostAddr, port string) func(poll.LogT) poll.Result {
+	return func(_ poll.LogT) poll.Result {
+		var res *icmd.Result
+		// This is called from inside a "Do()" thread in the docker host's netns, but it
+		// uses poll.WaitOn - which runs the command in a different goroutine.
+		host.Do(t, func() {
+			res = icmd.RunCommand("wget", "-T1", "-t1", "-O-",
+				"http://"+stdnet.JoinHostPort(hostAddr, port))
+		})
+		if !strings.Contains(res.Stderr(), "404 Not Found") {
+			return poll.Continue("404 Not Found not found in: %s", res.Stderr())
+		}
+		return poll.Success()
+	}
+}
+
+// ingressPortSpec is an endpoint spec publishing each of published on the ingress
+// network, every one of them mapped to target port 80.
+func ingressPortSpec(published ...uint32) *swarmtypes.EndpointSpec {
+	spec := &swarmtypes.EndpointSpec{}
+	for _, p := range published {
+		spec.Ports = append(spec.Ports, swarmtypes.PortConfig{
+			Protocol:      "tcp",
+			TargetPort:    80,
+			PublishedPort: p,
+			PublishMode:   swarmtypes.PortConfigPublishModeIngress,
+		})
+	}
+	return spec
+}
+
+// createIngressService creates a service publishing endpoint's ports, and waits
+// for replicas of its tasks to be running.
+func createIngressService(ctx context.Context, t *testing.T, d *daemon.Daemon, c *client.Client, name string, replicas uint64, endpoint *swarmtypes.EndpointSpec) string {
+	t.Helper()
+	id := swarm.CreateService(ctx, t, d,
+		swarm.ServiceWithName(name),
+		swarm.ServiceWithCommand([]string{"httpd", "-f"}),
+		swarm.ServiceWithEndpoint(endpoint),
+		swarm.ServiceWithReplicas(replicas),
+		func(spec *swarmtypes.ServiceSpec) {
+			// Start the replacement task before stopping the one it replaces, so that an
+			// update to the published-port set really does have both generations of the
+			// service - and so both claims on a port they share - bound at once. Under
+			// the default stop-first order the old binding can be gone before the new
+			// one arrives, leaving nothing shared to get wrong.
+			spec.UpdateConfig = &swarmtypes.UpdateConfig{Order: swarmtypes.UpdateOrderStartFirst}
+		},
+	)
+	t.Log("Waiting for service", name, "to start")
+	poll.WaitOn(t, swarm.RunningTasksCount(ctx, c, id, replicas), swarm.ServicePoll)
+	return id
+}
+
+// TestIngressPortsAcrossServiceUpdate follows a service's host-published ingress
+// ports through the two events that change which host-port reservations it holds:
+// a published-port change, which leaves two generations of the service alive at
+// once, and the service's removal, which has to release the reservations for good.
+//
+// Those reservations are ref-counted, and both ways of getting the count wrong are
+// silent. Releasing too eagerly takes down a port the surviving generation is
+// still serving; not releasing at all leaves the count non-zero, and the next
+// service to publish that port is told there is nothing to plumb and never becomes
+// reachable. Neither shows up as an error from any API call, which is why this
+// drives the ports over the wire rather than inspecting the daemon's bookkeeping.
+func TestIngressPortsAcrossServiceUpdate(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support Swarm-mode")
+	skip.If(t, testEnv.FirewallBackendDriver() == "nftables")
+	skip.If(t, networking.FirewalldRunning(), "can't use firewalld in host netns to add rules in L3Segment")
+	ctx := setupTest(t)
+
+	// Run the test in its own netns, to avoid interfering with iptables on the test
+	// host - and so that the host ports it publishes are its own.
+	const hostAddr = "192.168.112.222"
+	const l3SegHost = "ipsu"
+	l3 := networking.NewL3Segment(t, "test-"+l3SegHost)
+	defer l3.Destroy(t)
+	l3.AddHost(t, l3SegHost, "ns-"+l3SegHost, "eth0", netip.MustParsePrefix(hostAddr+"/24"))
+
+	checkHTTP := func(port string) func(poll.LogT) poll.Result {
+		return checkIngressPort(t, l3.Hosts[l3SegHost], hostAddr, port)
+	}
+
+	l3.Hosts[l3SegHost].Do(t, func() {
+		d := swarm.NewSwarm(ctx, t, testEnv, daemon.WithSwarmIptables(true))
+		defer d.Stop(t)
+		c := d.NewClientT(t)
+		defer c.Close()
+
+		createService := func(name string, endpoint *swarmtypes.EndpointSpec) string {
+			return createIngressService(ctx, t, d, c, name, 1, endpoint)
+		}
+
+		serviceID := createService("test-"+l3SegHost, ingressPortSpec(8080))
+		t.Log("Checking http access on the initial published port")
+		poll.WaitOn(t, checkHTTP("8080"), poll.WithTimeout(30*time.Second))
+
+		// Publish a second port. The service's port set is part of its identity in
+		// libnetwork, so two services are bound on the ingress network, both
+		// publishing 8080, for as long as the rollout takes. Only one of them may
+		// hold that reservation, and the old one draining must not release it.
+		t.Log("Adding a published port")
+		svc := getService(ctx, t, c, serviceID)
+		svc.Spec.EndpointSpec = ingressPortSpec(8080, 9090)
+		_, err := c.ServiceUpdate(ctx, serviceID, client.ServiceUpdateOptions{
+			Version: svc.Version,
+			Spec:    svc.Spec,
+		})
+		assert.NilError(t, err)
+		poll.WaitOn(t, serviceIsUpdated(ctx, c, serviceID), swarm.ServicePoll)
+		poll.WaitOn(t, swarm.RunningTasksCount(ctx, c, serviceID, 1), swarm.ServicePoll)
+
+		t.Log("Checking http access on the added published port")
+		poll.WaitOn(t, checkHTTP("9090"), poll.WithTimeout(30*time.Second))
+		t.Log("Checking http access on the port that spanned the update")
+		poll.WaitOn(t, checkHTTP("8080"), poll.WithTimeout(30*time.Second))
+
+		// Remove the service, then have a fresh one publish the same two ports. It
+		// can only reach them if the first service released both its reservation and
+		// the underlying host-port binding, so this stands in for the unpublishing
+		// that has no observable output of its own.
+		t.Log("Removing the service")
+		_, err = c.ServiceRemove(ctx, serviceID, client.ServiceRemoveOptions{})
+		assert.NilError(t, err)
+		poll.WaitOn(t, swarm.NoTasksForService(ctx, c, serviceID), swarm.ServicePoll)
+
+		successor := createService("test-"+l3SegHost+"-2", ingressPortSpec(8080, 9090))
+		defer func() {
+			_, err := c.ServiceRemove(ctx, successor, client.ServiceRemoveOptions{})
+			assert.NilError(t, err)
+		}()
+		t.Log("Checking http access to the successor service's published ports")
+		poll.WaitOn(t, checkHTTP("8080"), poll.WithTimeout(30*time.Second))
+		poll.WaitOn(t, checkHTTP("9090"), poll.WithTimeout(30*time.Second))
+	})
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- Relates to: https://github.com/moby/moby/pull/51657

## Summary

Three test-only commits for the Swarm service mesh. No production code changes. These fell out of work on #53118 and #53125 but are independent of both and apply to master as-is.

### Regression coverage for #51657

That fix merged without a test. The new `TestIngressPortsAcrossServiceUpdate` follows a service's host-published ports through the two events that change which host-port reservations it holds — a published-port change, which leaves two generations of the service alive at once, and the service's removal, which has to release the reservations for good. With #51657 reverted the test fails on the port added by the update, because the arriving generation finds the VIP alias already present and gives up before publishing. Reservations are ref-counted and both ways of miscounting are silent — releasing too eagerly takes down a port still being served, never releasing leaves the next service to claim that port unreachable — and neither surfaces as an API error, so the test drives the ports over the wire.

`TestIngressPortsAcrossServiceUpdate` was verified to fail when #51657 is reverted.

### A service VIP was not exercised anywhere

Workloads on an overlay network reach load-balanced services on the same network by the service's Virtual IP. The existing published-port tests reach the load-balancer sandbox on the gwbridge address, matched by l4proto and port, so they pass whether the VIP plumbing works or not — a regression in the IPVS service keyed by fwmark, or in the /32 alias that makes the VIP locally deliverable, would go unnoticed. `TestServiceVIPAcrossRollingUpdate` drives it from a container on the network, before and after the task behind it is replaced, with the rollout forced via `TaskTemplate.ForceUpdate` so the spec is otherwise untouched and start-first ordering so the load balancer has to hold both backends through the handover.

`TestServiceVIPAcrossRollingUpdate` was checked to fail when what it guards is broken, not merely to pass today:

| Mutation | Result |
| --- | --- |
| VIP `/32` alias never added | `TestServiceVIPAcrossRollingUpdate` fails the first check |
| VIP alias released on every backend removal, not the last | fails only the check *after* the update |

That last one also confirms the forced update really does overlap the two tasks —
were the handover not concurrent, it would stop failing.

### A `TestUserChain` assertion was vacuously true.

`ExistChain`'s second parameter is a table name, and the checks passed `"FORWARD"`. There is no table by that name, so "DOCKER-FORWARD is absent" always held. Corrected to check the filter table, as intended, and the assertion still passes.





## Release notes (optional)

```markdown changelog

```

Created with: Claude Code (Claude Opus 5)

<!-- branch-stack-start -->

-------------------------
- master
  - **libnetwork: Add service mesh tests** :point_left:

<sup>[Stack](https://www.git-town.com/how-to/proposal-breadcrumb.html) generated by [Git Town](https://github.com/git-town/git-town)</sup>

<!-- branch-stack-end -->
