### PR TITLE
integration, integration-cli: assorted cleanups

### DIFF
--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -343,7 +343,7 @@ func (s *DockerCLIPluginsSuite) TestPluginInspectOnWindows(c *testing.T) {
 }
 
 func (ps *DockerPluginSuite) TestPluginIDPrefix(c *testing.T) {
-	name := "test"
+	const name = "test-plugin-id-prefix"
 	apiClient := testEnv.APIClient()
 
 	ctx, cancel := context.WithTimeout(testutil.GetContext(c), 60*time.Second)
@@ -404,7 +404,7 @@ func (ps *DockerPluginSuite) TestPluginListDefaultFormat(c *testing.T) {
 	err = os.WriteFile(filepath.Join(config, "config.json"), []byte(`{"pluginsFormat": "raw"}`), 0o644)
 	assert.NilError(c, err)
 
-	name := "test:latest"
+	const name = "plugin-list-test:latest"
 	apiClient := testEnv.APIClient()
 
 	ctx, cancel := context.WithTimeout(testutil.GetContext(c), 60*time.Second)
@@ -471,7 +471,7 @@ func (s *DockerCLIPluginsSuite) TestPluginMetricsCollector(c *testing.T) {
 	// plugin listens on localhost:19393 and proxies the metrics
 	resp, err := http.Get("http://localhost:19393/metrics")
 	assert.NilError(c, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	b, err := io.ReadAll(resp.Body)
 	assert.NilError(c, err)

--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -160,7 +160,7 @@ func (s *DockerCLIPluginsSuite) TestPluginInstallDisableVolumeLs(c *testing.T) {
 }
 
 func (ps *DockerPluginSuite) TestPluginSet(c *testing.T) {
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	name := "test"
 	ctx, cancel := context.WithTimeout(testutil.GetContext(c), 60*time.Second)
@@ -171,7 +171,7 @@ func (ps *DockerPluginSuite) TestPluginSet(c *testing.T) {
 	devPath := "/dev/bar"
 
 	// Create a new plugin with extra settings
-	err := plugin.Create(ctx, client, name, func(cfg *plugin.Config) {
+	err := plugin.Create(ctx, apiClient, name, func(cfg *plugin.Config) {
 		cfg.Env = []plugintypes.Env{{Name: "DEBUG", Value: &initialValue, Settable: []string{"value"}}}
 		cfg.Mounts = []plugintypes.Mount{
 			{Name: "pmount1", Settable: []string{"source"}, Type: "none", Source: &mntSrc},
@@ -344,11 +344,11 @@ func (s *DockerCLIPluginsSuite) TestPluginInspectOnWindows(c *testing.T) {
 
 func (ps *DockerPluginSuite) TestPluginIDPrefix(c *testing.T) {
 	name := "test"
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	ctx, cancel := context.WithTimeout(testutil.GetContext(c), 60*time.Second)
 	initialValue := "0"
-	err := plugin.Create(ctx, client, name, func(cfg *plugin.Config) {
+	err := plugin.Create(ctx, apiClient, name, func(cfg *plugin.Config) {
 		cfg.Env = []plugintypes.Env{{Name: "DEBUG", Value: &initialValue, Settable: []string{"value"}}}
 	})
 	cancel()
@@ -405,11 +405,11 @@ func (ps *DockerPluginSuite) TestPluginListDefaultFormat(c *testing.T) {
 	assert.NilError(c, err)
 
 	name := "test:latest"
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	ctx, cancel := context.WithTimeout(testutil.GetContext(c), 60*time.Second)
 	defer cancel()
-	err = plugin.Create(ctx, client, name, func(cfg *plugin.Config) {
+	err = plugin.Create(ctx, apiClient, name, func(cfg *plugin.Config) {
 		cfg.Description = "test plugin"
 	})
 	assert.Assert(c, err == nil, "failed to create test plugin")

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3966,9 +3966,9 @@ func (s *DockerDaemonSuite) TestRunWithUlimitAndDaemonDefault(c *testing.T) {
 }
 
 func (s *DockerCLIRunSuite) TestRunStoppedLoggingDriverNoLeak(c *testing.T) {
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 	ctx := testutil.GetContext(c)
-	nroutines, err := getGoroutineNumber(ctx, client)
+	nroutines, err := getGoroutineNumber(ctx, apiClient)
 	assert.NilError(c, err)
 
 	out, _, err := dockerCmdWithError("run", "--name=fail", "--log-driver=splunk", "busybox", "true")
@@ -3976,7 +3976,7 @@ func (s *DockerCLIRunSuite) TestRunStoppedLoggingDriverNoLeak(c *testing.T) {
 	assert.Assert(c, strings.Contains(out, "failed to initialize logging driver"), "error should be about logging driver, got output %s", out)
 
 	// NGoroutines is not updated right away, so we need to wait before failing
-	waitForGoroutines(ctx, c, client, nroutines)
+	waitForGoroutines(ctx, c, apiClient, nroutines)
 }
 
 // Handles error conditions for --credentialspec. Validating E2E success cases

--- a/integration/build/build_traces_test.go
+++ b/integration/build/build_traces_test.go
@@ -37,8 +37,8 @@ func TestBuildkitHistoryTracePropagation(t *testing.T) {
 
 	ctx := testutil.StartSpan(baseContext, t)
 
-	c := testEnv.APIClient()
-	bc, err := client.New(ctx, c.DaemonHost())
+	apiClient := testEnv.APIClient()
+	bc, err := client.New(ctx, apiClient.DaemonHost())
 
 	assert.NilError(t, err)
 	defer bc.Close()

--- a/integration/container/cdi_test.go
+++ b/integration/container/cdi_test.go
@@ -43,7 +43,7 @@ func TestCreateWithCDIDevices(t *testing.T) {
 		container.WithCmd("/bin/sh", "-c", "env"),
 		container.WithCDIDevices("vendor1.com/device=foo"),
 	)
-	defer apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+	defer container.Remove(ctx, t, apiClient, id, client.ContainerRemoveOptions{Force: true})
 
 	res, err := apiClient.ContainerInspect(ctx, id, client.ContainerInspectOptions{})
 	assert.NilError(t, err)

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -489,10 +489,7 @@ func TestCreateTmpfsOverrideAnonymousVolume(t *testing.T) {
 		testContainer.WithCmd("/bin/sh", "-c", "mount | grep '/foo' | grep tmpfs && mount | grep '/bar' | grep tmpfs"),
 	)
 
-	defer func() {
-		_, err := apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
-		assert.NilError(t, err)
-	}()
+	defer testContainer.Remove(ctx, t, apiClient, id, client.ContainerRemoveOptions{Force: true})
 
 	inspect, err := apiClient.ContainerInspect(ctx, id, client.ContainerInspectOptions{})
 	assert.NilError(t, err)
@@ -822,7 +819,7 @@ func TestContainerdContainerImageInfo(t *testing.T) {
 		// busybox is the default (as of this writing) used by the test client, but lets be explicit here.
 		cfg.Config.Image = "busybox"
 	})
-	defer apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+	defer testContainer.Remove(ctx, t, apiClient, id, client.ContainerRemoveOptions{Force: true})
 
 	c8dClient, err := containerd.New(info.Containerd.Address, containerd.WithDefaultNamespace(info.Containerd.Namespaces.Containers))
 	assert.NilError(t, err)

--- a/integration/container/inspect_test.go
+++ b/integration/container/inspect_test.go
@@ -56,10 +56,9 @@ func TestNetworkAliasesAreEmpty(t *testing.T) {
 			ctr := container.Create(ctx, t, apiClient,
 				container.WithName("ctr-"+nwMode),
 				container.WithImage("busybox:latest"),
-				container.WithNetworkMode(nwMode))
-			defer apiClient.ContainerRemove(ctx, ctr, client.ContainerRemoveOptions{
-				Force: true,
-			})
+				container.WithNetworkMode(nwMode),
+			)
+			defer container.Remove(ctx, t, apiClient, ctr, client.ContainerRemoveOptions{Force: true})
 
 			inspect := container.Inspect(ctx, t, apiClient, ctr)
 			netAliases := inspect.NetworkSettings.Networks[nwMode].Aliases

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -88,7 +88,6 @@ func TestCreateWithIPv6WithoutEnableIPv6Flag(t *testing.T) {
 	defer d.Stop(t)
 
 	apiClient := d.NewClientT(t)
-	defer apiClient.Close()
 
 	const nwName = "testnetula"
 	network.CreateNoError(ctx, t, apiClient, nwName)
@@ -120,7 +119,7 @@ func TestDefaultIPvOptOverride(t *testing.T) {
 		"--default-network-opt=bridge=com.docker.network.enable_ipv6="+opt6,
 	)
 	defer d.Stop(t)
-	c := d.NewClientT(t)
+	apiClient := d.NewClientT(t)
 
 	t.Run("TestDefaultIPvOptOverride", func(t *testing.T) {
 		for _, override4 := range []bool{false, true} {
@@ -135,10 +134,10 @@ func TestDefaultIPvOptOverride(t *testing.T) {
 					if override6 {
 						nopts = append(nopts, network.WithIPv6())
 					}
-					network.CreateNoError(ctx, t, c, netName, nopts...)
-					defer network.RemoveNoError(ctx, t, c, netName)
+					network.CreateNoError(ctx, t, apiClient, netName, nopts...)
+					defer network.RemoveNoError(ctx, t, apiClient, netName)
 
-					res, err := c.NetworkInspect(ctx, netName, client.NetworkInspectOptions{})
+					res, err := apiClient.NetworkInspect(ctx, netName, client.NetworkInspectOptions{})
 					assert.NilError(t, err)
 					t.Log("override4", override4, "override6", override6, "->", res.Network.Options)
 
@@ -165,7 +164,7 @@ func TestDefaultIPvOptOverride(t *testing.T) {
 // in 64-bit and bigger subnets, with and without a gateway.
 func Test64BitIPRange(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	type kv struct{ k, v string }
 	subnets := []kv{
@@ -188,8 +187,8 @@ func Test64BitIPRange(t *testing.T) {
 				t.Run(sn.k+"/"+ipr.k+"/"+gw.k, func(t *testing.T) {
 					ctx := testutil.StartSpan(ctx, t)
 					const netName = "test64br"
-					network.CreateNoError(ctx, t, c, netName, network.WithIPv6(), ipamSetter)
-					defer network.RemoveNoError(ctx, t, c, netName)
+					network.CreateNoError(ctx, t, apiClient, netName, network.WithIPv6(), ipamSetter)
+					network.RemoveNoError(ctx, t, apiClient, netName)
 				})
 			}
 		}
@@ -200,7 +199,7 @@ func Test64BitIPRange(t *testing.T) {
 // allocate the last address in range that ends on a 64-bit boundary.
 func TestIPRangeAt64BitLimit(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	tests := []struct {
 		name    string
@@ -228,15 +227,15 @@ func TestIPRangeAt64BitLimit(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 			const netName = "test64bl"
-			network.CreateNoError(ctx, t, c, netName,
+			network.CreateNoError(ctx, t, apiClient, netName,
 				network.WithIPv6(),
 				network.WithIPAMRange(tc.subnet, tc.ipRange, ""),
 			)
-			defer network.RemoveNoError(ctx, t, c, netName)
+			defer network.RemoveNoError(ctx, t, apiClient, netName)
 
-			id := ctr.Create(ctx, t, c, ctr.WithNetworkMode(netName))
-			defer c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
-			_, err := c.ContainerStart(ctx, id, client.ContainerStartOptions{})
+			id := ctr.Create(ctx, t, apiClient, ctr.WithNetworkMode(netName))
+			defer ctr.Remove(ctx, t, apiClient, id, client.ContainerRemoveOptions{Force: true})
+			_, err := apiClient.ContainerStart(ctx, id, client.ContainerStartOptions{})
 			assert.NilError(t, err)
 		})
 	}
@@ -345,8 +344,7 @@ func TestFilterForwardPolicy(t *testing.T) {
 				d.StartWithBusybox(ctx, t, tc.daemonArgs...)
 				t.Cleanup(func() { d.Stop(t) })
 			})
-			c := d.NewClientT(t)
-			t.Cleanup(func() { c.Close() })
+			apiClient := d.NewClientT(t)
 
 			// If necessary, the IPv4 policy should have been updated when the default bridge network was created.
 			assert.Check(t, is.Equal(getFwdPolicy("iptables"), tc.expPolicy))
@@ -356,8 +354,8 @@ func TestFilterForwardPolicy(t *testing.T) {
 
 			// If necessary, creating an IPv6 network should update the sysctls and policy.
 			const netName = "testnetffp"
-			network.CreateNoError(ctx, t, c, netName, network.WithIPv6())
-			t.Cleanup(func() { network.RemoveNoError(ctx, t, c, netName) })
+			network.CreateNoError(ctx, t, apiClient, netName, network.WithIPv6())
+			t.Cleanup(func() { network.RemoveNoError(ctx, t, apiClient, netName) })
 			assert.Check(t, is.Equal(getFwdPolicy("iptables"), tc.expPolicy))
 			assert.Check(t, is.Equal(getFwdPolicy("ip6tables"), tc.expPolicy))
 			assert.Check(t, is.Equal(getSysctls(), sysctls{tc.expForwarding, tc.expForwarding, tc.expForwarding}))
@@ -376,7 +374,6 @@ func TestPointToPoint(t *testing.T) {
 	t.Cleanup(func() { d.Stop(t) })
 
 	apiClient := d.NewClientT(t)
-	t.Cleanup(func() { apiClient.Close() })
 
 	testcases := []struct {
 		name   string
@@ -409,7 +406,7 @@ func TestPointToPoint(t *testing.T) {
 				ctr.WithNetworkMode(netName),
 				ctr.WithName(ctrName),
 			)
-			defer apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+			defer ctr.Remove(ctx, t, apiClient, id, client.ContainerRemoveOptions{Force: true})
 
 			attachCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
@@ -417,7 +414,7 @@ func TestPointToPoint(t *testing.T) {
 				ctr.WithCmd([]string{"ping", "-c1", "-W3", ctrName}...),
 				ctr.WithNetworkMode(netName),
 			)
-			defer apiClient.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+			defer ctr.Remove(ctx, t, apiClient, res.ContainerID, client.ContainerRemoveOptions{Force: true})
 			assert.Check(t, is.Equal(res.ExitCode, 0))
 			assert.Check(t, is.Equal(res.Stderr.Len(), 0))
 			assert.Check(t, is.Contains(res.Stdout.String(), "1 packets transmitted, 1 packets received"))
@@ -436,7 +433,6 @@ func TestIsolated(t *testing.T) {
 	t.Cleanup(func() { d.Stop(t) })
 
 	apiClient := d.NewClientT(t)
-	t.Cleanup(func() { apiClient.Close() })
 
 	const netName = "testisol"
 	const bridgeName = "br-" + netName
@@ -461,7 +457,7 @@ func TestIsolated(t *testing.T) {
 		ctr.WithNetworkMode(netName),
 		ctr.WithName(ctrName),
 	)
-	defer apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+	defer ctr.Remove(ctx, t, apiClient, id, client.ContainerRemoveOptions{Force: true})
 
 	ping := func(t *testing.T, ipv string) {
 		t.Helper()
@@ -471,7 +467,7 @@ func TestIsolated(t *testing.T) {
 			ctr.WithCmd([]string{"ping", "-c1", "-W3", ipv, "ctr1"}...),
 			ctr.WithNetworkMode(netName),
 		)
-		defer apiClient.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+		defer ctr.Remove(ctx, t, apiClient, res.ContainerID, client.ContainerRemoveOptions{Force: true})
 		if ipv == "-6" && networking.FirewalldRunning() {
 			// FIXME(robmry) - this fails due to https://github.com/moby/moby/issues/49680
 			if res.ExitCode != 1 {
@@ -551,7 +547,6 @@ func TestAllPortMappingsAreReturned(t *testing.T) {
 	defer d.Stop(t)
 
 	apiClient := d.NewClientT(t)
-	defer apiClient.Close()
 
 	nwV4 := network.CreateNoError(ctx, t, apiClient, "testnetv4")
 	defer network.RemoveNoError(ctx, t, apiClient, nwV4)
@@ -588,24 +583,24 @@ func TestFirewalldReloadNoZombies(t *testing.T) {
 	d := daemon.New(t)
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)
-	c := d.NewClientT(t)
+	apiClient := d.NewClientT(t)
 
 	const bridgeName = "br-fwdreload"
 	removed := false
-	nw := network.CreateNoError(ctx, t, c, "testnet",
+	nw := network.CreateNoError(ctx, t, apiClient, "testnet",
 		network.WithOption(bridge.BridgeName, bridgeName))
 	defer func() {
 		if !removed {
-			network.RemoveNoError(ctx, t, c, nw)
+			network.RemoveNoError(ctx, t, apiClient, nw)
 		}
 	}()
 
-	cid := ctr.Run(ctx, t, c,
+	cid := ctr.Run(ctx, t, apiClient,
 		ctr.WithExposedPorts("80/tcp", "81/tcp"),
 		ctr.WithPortMap(networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {{HostPort: "8000"}}}))
 	defer func() {
 		if !removed {
-			ctr.Remove(ctx, t, c, cid, client.ContainerRemoveOptions{Force: true})
+			ctr.Remove(ctx, t, apiClient, cid, client.ContainerRemoveOptions{Force: true})
 		}
 	}()
 
@@ -620,8 +615,8 @@ func TestFirewalldReloadNoZombies(t *testing.T) {
 		"With container: expected rules for %s in: %s", bridgeName, resBeforeDel.Combined())
 
 	// Delete the container and its network.
-	ctr.Remove(ctx, t, c, cid, client.ContainerRemoveOptions{Force: true})
-	network.RemoveNoError(ctx, t, c, nw)
+	ctr.Remove(ctx, t, apiClient, cid, client.ContainerRemoveOptions{Force: true})
+	network.RemoveNoError(ctx, t, apiClient, nw)
 	removed = true
 
 	// Check the network does not appear in iptables rules.
@@ -656,18 +651,18 @@ func TestLegacyLink(t *testing.T) {
 	d := daemon.New(t)
 	d.StartWithBusybox(ctx, t, "--icc=false")
 	defer d.Stop(t)
-	c := d.NewClientT(t)
+	apiClient := d.NewClientT(t)
 
 	// Run an http server.
 	const svrName = "svr"
-	cid := ctr.Run(ctx, t, c,
+	cid := ctr.Run(ctx, t, apiClient,
 		ctr.WithExposedPorts("80/tcp"),
 		ctr.WithName(svrName),
 		ctr.WithCmd("httpd", "-f"),
 	)
 
-	defer ctr.Remove(ctx, t, c, cid, client.ContainerRemoveOptions{Force: true})
-	insp := ctr.Inspect(ctx, t, c, cid)
+	defer ctr.Remove(ctx, t, apiClient, cid, client.ContainerRemoveOptions{Force: true})
+	insp := ctr.Inspect(ctx, t, apiClient, cid)
 	svrAddr := insp.NetworkSettings.Networks["bridge"].IPAddress
 
 	const svrAlias = "thealias"
@@ -705,7 +700,7 @@ func TestLegacyLink(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
-			res := ctr.RunAttach(ctx, t, c,
+			res := ctr.RunAttach(ctx, t, apiClient,
 				ctr.WithLinks(tc.links...),
 				ctr.WithCmd("wget", "-T3", "http://"+tc.host),
 			)
@@ -732,47 +727,47 @@ func TestRemoveLegacyLink(t *testing.T) {
 	d := daemon.New(t)
 	d.StartWithBusybox(ctx, t, "--icc=false")
 	defer d.Stop(t)
-	c := d.NewClientT(t)
+	apiClient := d.NewClientT(t)
 
 	// Run an http server.
 	const svrName = "svr"
-	svrId := ctr.Run(ctx, t, c,
+	svrId := ctr.Run(ctx, t, apiClient,
 		ctr.WithExposedPorts("80/tcp"),
 		ctr.WithName(svrName),
 		ctr.WithCmd("httpd", "-f"),
 	)
-	defer ctr.Remove(ctx, t, c, svrId, client.ContainerRemoveOptions{Force: true})
+	defer ctr.Remove(ctx, t, apiClient, svrId, client.ContainerRemoveOptions{Force: true})
 
 	// Run a container linked to the http server.
 	const svrAlias = "thealias"
 	const clientName = "client"
-	clientId := ctr.Run(ctx, t, c,
+	clientId := ctr.Run(ctx, t, apiClient,
 		ctr.WithName(clientName),
 		ctr.WithLinks(svrName+":"+svrAlias),
 	)
-	defer ctr.Remove(ctx, t, c, clientId, client.ContainerRemoveOptions{Force: true})
+	defer ctr.Remove(ctx, t, apiClient, clientId, client.ContainerRemoveOptions{Force: true})
 
 	// Check the link works.
-	res := ctr.ExecT(ctx, t, c, clientId, []string{"wget", "-T3", "http://" + svrName})
+	res := ctr.ExecT(ctx, t, apiClient, clientId, []string{"wget", "-T3", "http://" + svrName})
 	assert.Check(t, is.Contains(res.Stderr(), "404 Not Found"))
 
 	// Remove the link ("docker rm --link client/thealias").
-	_, err := c.ContainerRemove(ctx, clientName+"/"+svrAlias, client.ContainerRemoveOptions{RemoveLinks: true})
+	_, err := apiClient.ContainerRemove(ctx, clientName+"/"+svrAlias, client.ContainerRemoveOptions{RemoveLinks: true})
 	assert.Check(t, err)
 
 	// Check both containers are still running.
-	inspSvr := ctr.Inspect(ctx, t, c, svrId)
+	inspSvr := ctr.Inspect(ctx, t, apiClient, svrId)
 	assert.Check(t, is.Equal(inspSvr.State.Running, true))
-	inspClient := ctr.Inspect(ctx, t, c, clientId)
+	inspClient := ctr.Inspect(ctx, t, apiClient, clientId)
 	assert.Check(t, is.Equal(inspClient.State.Running, true))
 
 	// Check the link's alias doesn't work.
-	res = ctr.ExecT(ctx, t, c, clientId, []string{"wget", "-T3", "http://" + svrName})
+	res = ctr.ExecT(ctx, t, apiClient, clientId, []string{"wget", "-T3", "http://" + svrName})
 	assert.Check(t, is.Contains(res.Stderr(), "bad address"))
 
 	// Check the icc=false rules now block access by address.
 	svrAddr := inspSvr.NetworkSettings.Networks["bridge"].IPAddress
-	res = ctr.ExecT(ctx, t, c, clientId, []string{"wget", "-T3", "http://" + svrAddr.String()})
+	res = ctr.ExecT(ctx, t, apiClient, clientId, []string{"wget", "-T3", "http://" + svrAddr.String()})
 	assert.Check(t, is.Contains(res.Stderr(), "download timed out"))
 }
 
@@ -787,10 +782,10 @@ func TestPortMappingRestore(t *testing.T) {
 	d := daemon.New(t)
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)
-	c := d.NewClientT(t)
+	apiClient := d.NewClientT(t)
 
 	const svrName = "svr"
-	cid := ctr.Run(ctx, t, c,
+	cid := ctr.Run(ctx, t, apiClient,
 		ctr.WithExposedPorts("80/tcp"),
 		// TODO(robmry): this test supplies an empty list of PortBindings.
 		// https://github.com/moby/moby/issues/51727 will break it.
@@ -799,16 +794,16 @@ func TestPortMappingRestore(t *testing.T) {
 		ctr.WithRestartPolicy(containertypes.RestartPolicyUnlessStopped),
 		ctr.WithCmd("httpd", "-f"),
 	)
-	defer func() { ctr.Remove(ctx, t, c, cid, client.ContainerRemoveOptions{Force: true}) }()
+	defer func() { ctr.Remove(ctx, t, apiClient, cid, client.ContainerRemoveOptions{Force: true}) }()
 
 	check := func() {
 		t.Helper()
-		insp := ctr.Inspect(ctx, t, c, cid)
+		insp := ctr.Inspect(ctx, t, apiClient, cid)
 		assert.Check(t, is.Equal(insp.State.Running, true))
 		if assert.Check(t, is.Contains(insp.NetworkSettings.Ports, networktypes.MustParsePort("80/tcp"))) &&
 			assert.Check(t, is.Len(insp.NetworkSettings.Ports[networktypes.MustParsePort("80/tcp")], 2)) {
 			hostPort := insp.NetworkSettings.Ports[networktypes.MustParsePort("80/tcp")][0].HostPort
-			res := ctr.RunAttach(ctx, t, c,
+			res := ctr.RunAttach(ctx, t, apiClient,
 				ctr.WithExtraHost("thehost:host-gateway"),
 				ctr.WithCmd("wget", "-T3", "http://"+net.JoinHostPort("thehost", hostPort)),
 			)
@@ -877,9 +872,8 @@ func TestFirewallBackendSwitch(t *testing.T) {
 			// and that risks leaving a container process running on the test host
 			// when things go wrong.)
 			if !networkCreated {
-				c := d.NewClientT(t)
-				defer c.Close()
-				_ = network.CreateNoError(ctx, t, c, "testnet",
+				apiClient := d.NewClientT(t)
+				_ = network.CreateNoError(ctx, t, apiClient, "testnet",
 					network.WithIPv6(),
 					network.WithIPAM("192.0.2.0/24", "192.0.2.1"),
 					network.WithIPAM("2001:db8::/64", "2001:db8::1"),
@@ -954,7 +948,7 @@ func TestEmptyPortBindingsBC(t *testing.T) {
 
 	createInspect := func(t *testing.T, version string, pbs []networktypes.PortBinding) (networktypes.PortMap, []string) {
 		apiClient := d.NewClientT(t, client.WithAPIVersion(version))
-		defer apiClient.Close()
+		defer func() { _ = apiClient.Close() }()
 
 		// Skip this subtest if the daemon doesn't support the client version.
 		// TODO(aker): drop this once the Engine supports API version >= 1.53
@@ -976,7 +970,7 @@ func TestEmptyPortBindingsBC(t *testing.T) {
 			Name:             config.Name,
 		})
 		assert.NilError(t, err)
-		defer apiClient.ContainerRemove(ctx, c.ID, client.ContainerRemoveOptions{Force: true})
+		defer ctr.Remove(ctx, t, apiClient, c.ID, client.ContainerRemoveOptions{Force: true})
 
 		// Inspect the container and return its port bindings, along with
 		// warnings returns on container create.
@@ -1047,12 +1041,13 @@ func TestPortBindingBackfillingForOlderContainers(t *testing.T) {
 	// daemon backfills the empty port bindings on ContainerCreate (e.g.,
 	// API < 1.53), the tampering will reinitialize the PortBindings slice to
 	// an empty list.
-	c := d.NewClientT(t)
+	apiClient := d.NewClientT(t)
 
-	cid := ctr.Create(ctx, t, c,
+	cid := ctr.Create(ctx, t, apiClient,
 		ctr.WithExposedPorts("80/tcp"),
-		ctr.WithPortMap(networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {}}))
-	defer c.ContainerRemove(ctx, cid, client.ContainerRemoveOptions{Force: true})
+		ctr.WithPortMap(networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {}}),
+	)
+	defer ctr.Remove(ctx, t, apiClient, cid, client.ContainerRemoveOptions{Force: true})
 
 	// Stop the daemon to safely tamper with the on-disk state.
 	d.Stop(t)
@@ -1066,7 +1061,7 @@ func TestPortBindingBackfillingForOlderContainers(t *testing.T) {
 	// Restart the daemon — it should backfill the empty port binding slice.
 	d.StartWithBusybox(ctx, t)
 
-	inspect := ctr.Inspect(ctx, t, c, cid)
+	inspect := ctr.Inspect(ctx, t, apiClient, cid)
 
 	expMappings := networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {
 		{}, // An empty PortBinding is backfilled
@@ -1080,13 +1075,13 @@ func TestBridgeIPAMStatus(t *testing.T) {
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)
 
-	c := d.NewClientT(t, client.WithAPIVersion("1.52"))
+	apiClient := d.NewClientT(t, client.WithAPIVersion("1.52"))
 
 	checkSubnets := func(
 		netName string, want networktypes.SubnetStatuses,
 	) bool {
 		t.Helper()
-		res, err := c.NetworkInspect(ctx, netName, client.NetworkInspectOptions{})
+		res, err := apiClient.NetworkInspect(ctx, netName, client.NetworkInspectOptions{})
 		if assert.Check(t, err) && assert.Check(t, res.Network.Status != nil) {
 			return assert.Check(t, is.DeepEqual(want, res.Network.Status.IPAM.Subnets))
 		}
@@ -1114,7 +1109,7 @@ func TestBridgeIPAMStatus(t *testing.T) {
 			cidrv6 = netip.MustParsePrefix("2001:db8:abcd::/64")
 		)
 
-		network.CreateNoError(ctx, t, c, netName,
+		network.CreateNoError(ctx, t, apiClient, netName,
 			network.WithIPv4(true),
 			network.WithIPAMConfig(networktypes.IPAMConfig{
 				Subnet:  cidrv4,
@@ -1136,7 +1131,7 @@ func TestBridgeIPAMStatus(t *testing.T) {
 				},
 			}),
 		)
-		defer c.NetworkRemove(ctx, netName, client.NetworkRemoveOptions{})
+		defer network.RemoveNoError(ctx, t, apiClient, netName)
 
 		checkSubnets(netName, map[netip.Prefix]networktypes.SubnetStatus{
 			cidrv4: {
@@ -1153,8 +1148,8 @@ func TestBridgeIPAMStatus(t *testing.T) {
 
 		func() {
 			// From IPRange pool: both counters should be changed by 1
-			id := ctr.Run(ctx, t, c, ctr.WithNetworkMode(netName))
-			defer c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+			id := ctr.Run(ctx, t, apiClient, ctr.WithNetworkMode(netName))
+			defer ctr.Remove(ctx, t, apiClient, id, client.ContainerRemoveOptions{Force: true})
 
 			checkSubnets(netName, map[netip.Prefix]networktypes.SubnetStatus{
 				cidrv4: {
@@ -1168,12 +1163,12 @@ func TestBridgeIPAMStatus(t *testing.T) {
 			})
 
 			// Out of IPRange pools: subnet counter should be changed by 1
-			id = ctr.Run(ctx, t, c,
+			id = ctr.Run(ctx, t, apiClient,
 				ctr.WithNetworkMode(netName),
 				ctr.WithIPv4(netName, prefIPv4OutOfRange),
 				ctr.WithIPv6(netName, prefIPv6OutOfRange),
 			)
-			defer c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+			defer ctr.Remove(ctx, t, apiClient, id, client.ContainerRemoveOptions{Force: true})
 
 			checkSubnets(netName, map[netip.Prefix]networktypes.SubnetStatus{
 				cidrv4: {
@@ -1209,14 +1204,14 @@ func TestBridgeIPAMStatus(t *testing.T) {
 	t.Run("IPv6", func(t *testing.T) {
 		const netName = "testipambridgev6"
 		cidr := netip.MustParsePrefix("2001:db8:abcd::/56")
-		network.CreateNoError(ctx, t, c, netName,
+		network.CreateNoError(ctx, t, apiClient, netName,
 			network.WithIPv4(false),
 			network.WithIPv6(),
 			network.WithIPAMConfig(networktypes.IPAMConfig{
 				Subnet: cidr,
 			}),
 		)
-		defer c.NetworkRemove(ctx, netName, client.NetworkRemoveOptions{})
+		defer network.RemoveNoError(ctx, t, apiClient, netName)
 
 		checkSubnets(netName, map[netip.Prefix]networktypes.SubnetStatus{
 			cidr: {
@@ -1237,72 +1232,72 @@ func TestJoinError(t *testing.T) {
 	d := daemon.New(t)
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)
-	c := d.NewClientT(t)
+	apiClient := d.NewClientT(t)
 
 	const intNet = "intnet"
 	const gwAddr = "192.168.123.1"
-	network.CreateNoError(ctx, t, c, intNet,
+	network.CreateNoError(ctx, t, apiClient, intNet,
 		network.WithInternal(),
 		network.WithIPAM("192.168.123.0/24", gwAddr),
 	)
-	defer network.RemoveNoError(ctx, t, c, intNet)
+	defer network.RemoveNoError(ctx, t, apiClient, intNet)
 
 	const extNet = "extnet"
-	network.CreateNoError(ctx, t, c, extNet)
-	defer network.RemoveNoError(ctx, t, c, extNet)
+	network.CreateNoError(ctx, t, apiClient, extNet)
+	defer network.RemoveNoError(ctx, t, apiClient, extNet)
 
-	cid := ctr.Run(ctx, t, c,
+	cid := ctr.Run(ctx, t, apiClient,
 		ctr.WithNetworkMode(intNet),
 		ctr.WithPrivileged(true),
 	)
-	defer c.ContainerRemove(ctx, cid, client.ContainerRemoveOptions{Force: true})
+	defer ctr.Remove(ctx, t, apiClient, cid, client.ContainerRemoveOptions{Force: true})
 
 	// Add a default route to the container, so that connecting extNet will fail to
 	// set up its own default route.
-	res := ctr.ExecT(ctx, t, c, cid, []string{"ip", "route", "add", "default", "via", gwAddr})
+	res := ctr.ExecT(ctx, t, apiClient, cid, []string{"ip", "route", "add", "default", "via", gwAddr})
 	assert.Equal(t, res.ExitCode, 0)
 
 	// Expect an error when connecting extNet.
-	_, err := c.NetworkConnect(ctx, extNet, client.NetworkConnectOptions{
+	_, err := apiClient.NetworkConnect(ctx, extNet, client.NetworkConnectOptions{
 		Container: cid,
 	})
 	assert.Check(t, is.ErrorContains(err, "failed to set gateway: file exists"))
 
 	// Only intNet should show up in container inspect.
-	ctrInsp := ctr.Inspect(ctx, t, c, cid)
+	ctrInsp := ctr.Inspect(ctx, t, apiClient, cid)
 	assert.Check(t, is.Len(ctrInsp.NetworkSettings.Networks, 1))
 	assert.Check(t, is.Contains(ctrInsp.NetworkSettings.Networks, intNet))
 
 	// extNet should not report any attached containers
-	extNetInsp, err := c.NetworkInspect(ctx, extNet, client.NetworkInspectOptions{})
+	extNetInsp, err := apiClient.NetworkInspect(ctx, extNet, client.NetworkInspectOptions{})
 	assert.Check(t, err)
 	assert.Check(t, is.Len(extNetInsp.Network.Containers, 0))
 
 	// The container should have an eth0, but no eth1.
-	res = ctr.ExecT(ctx, t, c, cid, []string{"ip", "link", "show", "eth0"})
+	res = ctr.ExecT(ctx, t, apiClient, cid, []string{"ip", "link", "show", "eth0"})
 	assert.Check(t, is.Equal(res.ExitCode, 0), "container should have an eth0")
-	res = ctr.ExecT(ctx, t, c, cid, []string{"ip", "link", "show", "eth1"})
+	res = ctr.ExecT(ctx, t, apiClient, cid, []string{"ip", "link", "show", "eth1"})
 	assert.Check(t, is.Contains(res.Stderr(), "can't find device"), "container should not have an eth1")
 
 	// Remove the dodgy route.
-	res = ctr.ExecT(ctx, t, c, cid, []string{"ip", "route", "del", "default", "via", gwAddr})
+	res = ctr.ExecT(ctx, t, apiClient, cid, []string{"ip", "route", "del", "default", "via", gwAddr})
 	assert.Equal(t, res.ExitCode, 0)
 
 	// Check network connect now succeeds.
-	_, err = c.NetworkConnect(ctx, extNet, client.NetworkConnectOptions{
+	_, err = apiClient.NetworkConnect(ctx, extNet, client.NetworkConnectOptions{
 		Container: cid,
 	})
 	assert.Check(t, err)
-	ctrInsp = ctr.Inspect(ctx, t, c, cid)
+	ctrInsp = ctr.Inspect(ctx, t, apiClient, cid)
 	assert.Check(t, is.Len(ctrInsp.NetworkSettings.Networks, 2))
 	assert.Check(t, is.Contains(ctrInsp.NetworkSettings.Networks, intNet))
 	assert.Check(t, is.Contains(ctrInsp.NetworkSettings.Networks, extNet))
-	extNetInsp, err = c.NetworkInspect(ctx, extNet, client.NetworkInspectOptions{})
+	extNetInsp, err = apiClient.NetworkInspect(ctx, extNet, client.NetworkInspectOptions{})
 	assert.Check(t, err)
 	assert.Check(t, is.Len(extNetInsp.Network.Containers, 1))
-	res = ctr.ExecT(ctx, t, c, cid, []string{"ip", "link", "show", "eth0"})
+	res = ctr.ExecT(ctx, t, apiClient, cid, []string{"ip", "link", "show", "eth0"})
 	assert.Check(t, is.Equal(res.ExitCode, 0), "container should have an eth0")
-	res = ctr.ExecT(ctx, t, c, cid, []string{"ip", "link", "show", "eth1"})
+	res = ctr.ExecT(ctx, t, apiClient, cid, []string{"ip", "link", "show", "eth1"})
 	assert.Check(t, is.Equal(res.ExitCode, 0), "container should have an eth1")
 }
 
@@ -1313,20 +1308,20 @@ func TestPreferredSubnetRestore(t *testing.T) {
 	d := daemon.New(t)
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)
-	c := d.NewClientT(t)
+	apiClient := d.NewClientT(t)
 
 	const v4netName = "testnetv4restore"
-	network.CreateNoError(ctx, t, c, v4netName,
+	network.CreateNoError(ctx, t, apiClient, v4netName,
 		network.WithIPv4(true),
 		network.WithIPAMConfig(networktypes.IPAMConfig{
 			Subnet: netip.MustParsePrefix("0.0.0.0/24"),
 		}),
 	)
 
-	defer func() { network.RemoveNoError(ctx, t, c, v4netName) }()
+	defer func() { network.RemoveNoError(ctx, t, apiClient, v4netName) }()
 
 	const v6netName = "testnetv6restore"
-	network.CreateNoError(ctx, t, c, v6netName,
+	network.CreateNoError(ctx, t, apiClient, v6netName,
 		network.WithIPv4(false),
 		network.WithIPv6(),
 		network.WithIPAMConfig(networktypes.IPAMConfig{
@@ -1334,10 +1329,10 @@ func TestPreferredSubnetRestore(t *testing.T) {
 		}),
 	)
 
-	defer func() { network.RemoveNoError(ctx, t, c, v6netName) }()
+	defer func() { network.RemoveNoError(ctx, t, apiClient, v6netName) }()
 
 	const dualStackNetName = "testnetdualrestore"
-	network.CreateNoError(ctx, t, c, dualStackNetName,
+	network.CreateNoError(ctx, t, apiClient, dualStackNetName,
 		network.WithIPv4(true),
 		network.WithIPv6(),
 		network.WithIPAMConfig(networktypes.IPAMConfig{
@@ -1347,21 +1342,21 @@ func TestPreferredSubnetRestore(t *testing.T) {
 		}),
 	)
 
-	defer func() { network.RemoveNoError(ctx, t, c, dualStackNetName) }()
+	defer func() { network.RemoveNoError(ctx, t, apiClient, dualStackNetName) }()
 
 	inspOpts := client.NetworkInspectOptions{}
 
-	v4Insp := network.InspectNoError(ctx, t, c, v4netName, inspOpts)
+	v4Insp := network.InspectNoError(ctx, t, apiClient, v4netName, inspOpts)
 	assert.Check(t, is.Len(v4Insp.Network.IPAM.Config, 1))
 	v4allocCidr := v4Insp.Network.IPAM.Config[0].Subnet
 	assert.Check(t, is.Equal(v4allocCidr.Addr().IsUnspecified(), false), "expected specific subnet")
 
-	v6Insp := network.InspectNoError(ctx, t, c, v6netName, inspOpts)
+	v6Insp := network.InspectNoError(ctx, t, apiClient, v6netName, inspOpts)
 	assert.Check(t, is.Len(v6Insp.Network.IPAM.Config, 1))
 	v6allocCidr := v6Insp.Network.IPAM.Config[0].Subnet
 	assert.Check(t, is.Equal(v6allocCidr.Addr().IsUnspecified(), false), "expected specific subnet")
 
-	dualStackInsp := network.InspectNoError(ctx, t, c, dualStackNetName, inspOpts)
+	dualStackInsp := network.InspectNoError(ctx, t, apiClient, dualStackNetName, inspOpts)
 	assert.Check(t, is.Len(dualStackInsp.Network.IPAM.Config, 2))
 	var dualv4, dualv6 netip.Prefix
 	if dualStackInsp.Network.IPAM.Config[0].Subnet.Addr().Is4() {
@@ -1376,15 +1371,15 @@ func TestPreferredSubnetRestore(t *testing.T) {
 
 	d.Restart(t)
 
-	v4Insp = network.InspectNoError(ctx, t, c, v4netName, inspOpts)
+	v4Insp = network.InspectNoError(ctx, t, apiClient, v4netName, inspOpts)
 	assert.Check(t, is.Len(v4Insp.Network.IPAM.Config, 1))
 	assert.Check(t, is.Equal(v4Insp.Network.IPAM.Config[0].Subnet, v4allocCidr))
 
-	v6Insp = network.InspectNoError(ctx, t, c, v6netName, inspOpts)
+	v6Insp = network.InspectNoError(ctx, t, apiClient, v6netName, inspOpts)
 	assert.Check(t, is.Len(v6Insp.Network.IPAM.Config, 1))
 	assert.Check(t, is.Equal(v6Insp.Network.IPAM.Config[0].Subnet, v6allocCidr))
 
-	dualStackInsp = network.InspectNoError(ctx, t, c, dualStackNetName, inspOpts)
+	dualStackInsp = network.InspectNoError(ctx, t, apiClient, dualStackNetName, inspOpts)
 	assert.Check(t, is.Len(dualStackInsp.Network.IPAM.Config, 2))
 	var dualv4after, dualv6after netip.Prefix
 	if dualStackInsp.Network.IPAM.Config[0].Subnet.Addr().Is4() {

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -165,7 +165,7 @@ func TestDefaultIPvOptOverride(t *testing.T) {
 // in 64-bit and bigger subnets, with and without a gateway.
 func Test64BitIPRange(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	type kv struct{ k, v string }
 	subnets := []kv{
@@ -188,8 +188,8 @@ func Test64BitIPRange(t *testing.T) {
 				t.Run(sn.k+"/"+ipr.k+"/"+gw.k, func(t *testing.T) {
 					ctx := testutil.StartSpan(ctx, t)
 					const netName = "test64br"
-					network.CreateNoError(ctx, t, c, netName, network.WithIPv6(), ipamSetter)
-					defer network.RemoveNoError(ctx, t, c, netName)
+					network.CreateNoError(ctx, t, apiClient, netName, network.WithIPv6(), ipamSetter)
+					defer network.RemoveNoError(ctx, t, apiClient, netName)
 				})
 			}
 		}
@@ -200,7 +200,7 @@ func Test64BitIPRange(t *testing.T) {
 // allocate the last address in range that ends on a 64-bit boundary.
 func TestIPRangeAt64BitLimit(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	tests := []struct {
 		name    string
@@ -228,15 +228,15 @@ func TestIPRangeAt64BitLimit(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 			const netName = "test64bl"
-			network.CreateNoError(ctx, t, c, netName,
+			network.CreateNoError(ctx, t, apiClient, netName,
 				network.WithIPv6(),
 				network.WithIPAMRange(tc.subnet, tc.ipRange, ""),
 			)
-			defer network.RemoveNoError(ctx, t, c, netName)
+			defer network.RemoveNoError(ctx, t, apiClient, netName)
 
-			id := ctr.Create(ctx, t, c, ctr.WithNetworkMode(netName))
-			defer c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
-			_, err := c.ContainerStart(ctx, id, client.ContainerStartOptions{})
+			id := ctr.Create(ctx, t, apiClient, ctr.WithNetworkMode(netName))
+			defer apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+			_, err := apiClient.ContainerStart(ctx, id, client.ContainerStartOptions{})
 			assert.NilError(t, err)
 		})
 	}

--- a/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
+++ b/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
@@ -302,8 +302,7 @@ func runTestNet(t *testing.T, ctx context.Context, bundlesDir string, section se
 }
 
 func createBridgeNetworks(ctx context.Context, t *testing.T, d *daemon.Daemon, section section) {
-	c := d.NewClientT(t)
-	defer c.Close()
+	apiClient := d.NewClientT(t)
 
 	for i, nw := range section.networks {
 		gwMode := nw.gwMode
@@ -321,29 +320,28 @@ func createBridgeNetworks(ctx context.Context, t *testing.T, d *daemon.Daemon, s
 		if nw.internal {
 			netOpts = append(netOpts, network.WithInternal())
 		}
-		network.CreateNoError(ctx, t, c, nw.name, netOpts...)
-		t.Cleanup(func() { network.RemoveNoError(ctx, t, c, nw.name) })
+		network.CreateNoError(ctx, t, apiClient, nw.name, netOpts...)
+		t.Cleanup(func() { network.RemoveNoError(ctx, t, apiClient, nw.name) })
 
 		for _, ctr := range nw.containers {
 			var exposedPorts []string
 			for ep := range ctr.portMappings {
 				exposedPorts = append(exposedPorts, ep.String())
 			}
-			id := container.Run(ctx, t, c,
+			id := container.Run(ctx, t, apiClient,
 				container.WithNetworkMode(nw.name),
 				container.WithExposedPorts(exposedPorts...),
 				container.WithPortMap(ctr.portMappings),
 			)
 			t.Cleanup(func() {
-				c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+				apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
 			})
 		}
 	}
 }
 
 func createServices(ctx context.Context, t *testing.T, d *daemon.Daemon, section section, host networking.Host) {
-	c := d.NewClientT(t)
-	defer c.Close()
+	apiClient := d.NewClientT(t)
 
 	for _, nw := range section.networks {
 		for _, ctr := range nw.containers {
@@ -375,7 +373,7 @@ func createServices(ctx context.Context, t *testing.T, d *daemon.Daemon, section
 			})
 			t.Cleanup(func() { d.RemoveService(ctx, t, id) })
 			poll.WaitOn(t, func(_ poll.LogT) poll.Result {
-				return pollService(ctx, t, c, host)
+				return pollService(ctx, t, apiClient, host)
 			}, poll.WithTimeout(10*time.Second), poll.WithDelay(100*time.Millisecond))
 		}
 	}

--- a/integration/network/bridge/netinit_linux_test.go
+++ b/integration/network/bridge/netinit_linux_test.go
@@ -46,25 +46,24 @@ func TestNetworkInitErrorUserDefined(t *testing.T) {
 		_ = d.StopWithError()
 	}()
 
-	c := d.NewClientT(t)
-	defer c.Close()
+	apiClient := d.NewClientT(t)
 
 	const netName = "testnet"
 	const brName = "br-" + netName
-	network.CreateNoError(ctx, t, c, netName,
+	network.CreateNoError(ctx, t, apiClient, netName,
 		network.WithOption(bridge.BridgeName, brName),
 	)
-	defer network.RemoveNoError(ctx, t, c, netName)
+	defer network.RemoveNoError(ctx, t, apiClient, netName)
 
 	d.SetEnvVar("DOCKER_TEST_BRIDGE_INIT_ERROR", brName)
 	d.Restart(t)
 
-	_, err := c.NetworkRemove(ctx, netName, client.NetworkRemoveOptions{})
+	_, err := apiClient.NetworkRemove(ctx, netName, client.NetworkRemoveOptions{})
 	assert.NilError(t, err)
 
 	d.SetEnvVar("DOCKER_TEST_BRIDGE_INIT_ERROR", "")
 	d.Restart(t)
-	network.CreateNoError(ctx, t, c, netName,
+	network.CreateNoError(ctx, t, apiClient, netName,
 		network.WithOption(bridge.BridgeName, brName),
 	)
 }
@@ -82,12 +81,11 @@ func TestNetworkCreateErrorNoBridge(t *testing.T) {
 	d.Start(t)
 	defer d.Stop(t)
 
-	c := d.NewClientT(t)
-	defer c.Close()
+	apiClient := d.NewClientT(t)
 
-	_, err := network.Create(ctx, c, netName, network.WithOption(bridge.BridgeName, brName))
+	_, err := network.Create(ctx, apiClient, netName, network.WithOption(bridge.BridgeName, brName))
 	if err == nil {
-		defer network.RemoveNoError(ctx, t, c, brName)
+		defer network.RemoveNoError(ctx, t, apiClient, brName)
 		t.Fatalf("expected an error creating the network")
 	}
 	assert.Check(t, is.ErrorContains(err, "DOCKER_TEST_BRIDGE_INIT_ERROR"))

--- a/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
+++ b/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
@@ -275,8 +275,7 @@ func runTestNet(t *testing.T, ctx context.Context, bundlesDir string, section se
 }
 
 func createBridgeNetworks(ctx context.Context, t *testing.T, d *daemon.Daemon, section section) {
-	c := d.NewClientT(t)
-	defer c.Close()
+	apiClient := d.NewClientT(t)
 
 	for i, nw := range section.networks {
 		gwMode := nw.gwMode
@@ -294,21 +293,21 @@ func createBridgeNetworks(ctx context.Context, t *testing.T, d *daemon.Daemon, s
 		if nw.internal {
 			netOpts = append(netOpts, network.WithInternal())
 		}
-		network.CreateNoError(ctx, t, c, nw.name, netOpts...)
-		t.Cleanup(func() { network.RemoveNoError(ctx, t, c, nw.name) })
+		network.CreateNoError(ctx, t, apiClient, nw.name, netOpts...)
+		t.Cleanup(func() { network.RemoveNoError(ctx, t, apiClient, nw.name) })
 
 		for _, ctr := range nw.containers {
 			var exposedPorts []string
 			for ep := range ctr.portMappings {
 				exposedPorts = append(exposedPorts, ep.String())
 			}
-			id := container.Run(ctx, t, c,
+			id := container.Run(ctx, t, apiClient,
 				container.WithNetworkMode(nw.name),
 				container.WithExposedPorts(exposedPorts...),
 				container.WithPortMap(ctr.portMappings),
 			)
 			t.Cleanup(func() {
-				c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+				apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
 			})
 		}
 	}

--- a/integration/network/nat/nat_windows_test.go
+++ b/integration/network/nat/nat_windows_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestWindowsNoDisableIPv4(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	_, err := network.Create(ctx, c, "ipv6only",
+	_, err := network.Create(ctx, apiClient, "ipv6only",
 		network.WithDriver("nat"),
 		network.WithIPv4(false),
 	)

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -2040,14 +2040,14 @@ func TestAdvertiseAddressesLiveRestore(t *testing.T) {
 // TestNetworkInspectGateway checks that gateways reported in inspect output are parseable as addresses.
 func TestNetworkInspectGateway(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	const netName = "test-inspgw"
-	nid, err := network.Create(ctx, c, netName, network.WithIPv6())
+	nid, err := network.Create(ctx, apiClient, netName, network.WithIPv6())
 	assert.NilError(t, err)
-	defer network.RemoveNoError(ctx, t, c, netName)
+	defer network.RemoveNoError(ctx, t, apiClient, netName)
 
-	res, err := c.NetworkInspect(ctx, nid, client.NetworkInspectOptions{})
+	res, err := apiClient.NetworkInspect(ctx, nid, client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	for _, ipamCfg := range res.Network.IPAM.Config {
 		assert.Check(t, ipamCfg.Gateway.IsValid())
@@ -2209,13 +2209,13 @@ func TestDNSNamesForNonSwarmScopedNetworks(t *testing.T) {
 // Regression test for https://github.com/moby/moby/issues/51569
 func TestSetIPWithNoConfiguredSubnet(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	const bridgeName = "subnet-from-pools"
-	network.CreateNoError(ctx, t, c, bridgeName, network.WithIPv6())
-	defer network.RemoveNoError(ctx, t, c, bridgeName)
+	network.CreateNoError(ctx, t, apiClient, bridgeName, network.WithIPv6())
+	defer network.RemoveNoError(ctx, t, apiClient, bridgeName)
 
-	insp := network.InspectNoError(ctx, t, c, bridgeName, client.NetworkInspectOptions{})
+	insp := network.InspectNoError(ctx, t, apiClient, bridgeName, client.NetworkInspectOptions{})
 	assert.Assert(t, is.Len(insp.Network.IPAM.Config, 2))
 	ip4 := insp.Network.IPAM.Config[0].Subnet.Addr().Next().Next().String()
 	ip6 := insp.Network.IPAM.Config[1].Subnet.Addr().Next().Next().String()
@@ -2223,7 +2223,7 @@ func TestSetIPWithNoConfiguredSubnet(t *testing.T) {
 		ip4, ip6 = ip6, ip4
 	}
 
-	res := container.RunAttach(ctx, t, c,
+	res := container.RunAttach(ctx, t, apiClient,
 		container.WithCmd("ip", "addr", "show", "eth0"),
 		container.WithNetworkMode(bridgeName),
 		container.WithIPv4(bridgeName, ip4),
@@ -2287,12 +2287,12 @@ func TestGatewayErrorOnNetDisconnect(t *testing.T) {
 // Regression test for https://github.com/moby/moby/issues/51620
 func TestPublishAllWithNilPortBindings(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	imgWithExpose := container.WithImage(build.Do(ctx, t, c,
+	imgWithExpose := container.WithImage(build.Do(ctx, t, apiClient,
 		fakecontext.New(t, "", fakecontext.WithDockerfile("FROM busybox\nEXPOSE 80/tcp\n")), client.ImageBuildOptions{}))
 
-	_ = container.Run(ctx, t, c,
+	_ = container.Run(ctx, t, apiClient,
 		container.WithAutoRemove,
 		container.WithPublishAllPorts(true),
 		imgWithExpose,

--- a/integration/networking/drivers_windows_test.go
+++ b/integration/networking/drivers_windows_test.go
@@ -25,7 +25,7 @@ import (
 // Tests: NAT, Transparent, and L2Bridge network drivers.
 func TestWindowsNetworkDrivers(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	testcases := []struct {
 		name   string
@@ -58,7 +58,7 @@ func TestWindowsNetworkDrivers(t *testing.T) {
 			netName := fmt.Sprintf("test-%s-%d", tc.driver, tcID)
 
 			// Create network with specified driver
-			netResp, err := c.NetworkCreate(ctx, netName, client.NetworkCreateOptions{
+			netResp, err := apiClient.NetworkCreate(ctx, netName, client.NetworkCreateOptions{
 				Driver: tc.driver,
 			})
 			if err != nil {
@@ -71,10 +71,10 @@ func TestWindowsNetworkDrivers(t *testing.T) {
 				}
 				t.Fatalf("Failed to create network with %s driver: %v", tc.driver, err)
 			}
-			defer network.RemoveNoError(ctx, t, c, netName)
+			defer network.RemoveNoError(ctx, t, apiClient, netName)
 
 			// Inspect network to validate driver is correctly set
-			netInfo, err := c.NetworkInspect(ctx, netResp.ID, client.NetworkInspectOptions{})
+			netInfo, err := apiClient.NetworkInspect(ctx, netResp.ID, client.NetworkInspectOptions{})
 			assert.NilError(t, err)
 			assert.Check(t, is.Equal(netInfo.Network.Driver, tc.driver), "Network driver mismatch")
 			assert.Check(t, is.Equal(netInfo.Network.Name, netName), "Network name mismatch")
@@ -85,7 +85,7 @@ func TestWindowsNetworkDrivers(t *testing.T) {
 // TestWindowsNATDriverPortMapping validates NAT port mapping by testing host connectivity.
 func TestWindowsNATDriverPortMapping(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	// Use default NAT network which supports port mapping
 	netName := "nat"
@@ -107,7 +107,7 @@ func TestWindowsNATDriverPortMapping(t *testing.T) {
 
 	// Create container with port mapping 80->8080
 	ctrName := "port-mapping-test"
-	id := container.Run(ctx, t, c,
+	id := container.Run(ctx, t, apiClient,
 		container.WithName(ctrName),
 		container.WithCmd("powershell", "-Command", psScript),
 		container.WithNetworkMode(netName),
@@ -116,10 +116,10 @@ func TestWindowsNATDriverPortMapping(t *testing.T) {
 			networktypes.MustParsePort("80"): {{HostIP: netip.IPv4Unspecified(), HostPort: "8080"}},
 		}),
 	)
-	defer c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+	defer apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
 
 	// Verify port mapping metadata
-	ctrInfo := container.Inspect(ctx, t, c, id)
+	ctrInfo := container.Inspect(ctx, t, apiClient, id)
 	portKey := networktypes.MustParsePort("80/tcp")
 	assert.Check(t, ctrInfo.NetworkSettings.Ports[portKey] != nil, "Port mapping not found")
 	assert.Check(t, len(ctrInfo.NetworkSettings.Ports[portKey]) > 0, "No host port binding")
@@ -151,7 +151,7 @@ func TestWindowsNATDriverPortMapping(t *testing.T) {
 // TestWindowsNetworkDNSResolution validates DNS resolution on Windows networks.
 func TestWindowsNetworkDNSResolution(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	testcases := []struct {
 		name       string
@@ -188,27 +188,27 @@ func TestWindowsNetworkDNSResolution(t *testing.T) {
 				}
 			}
 
-			network.CreateNoError(ctx, t, c, netName, netOpts...)
-			defer network.RemoveNoError(ctx, t, c, netName)
+			network.CreateNoError(ctx, t, apiClient, netName, netOpts...)
+			defer network.RemoveNoError(ctx, t, apiClient, netName)
 
 			// Create container and verify DNS resolution
 			ctrName := fmt.Sprintf("dns-test-%d", tcID)
-			id := container.Run(ctx, t, c,
+			id := container.Run(ctx, t, apiClient,
 				container.WithName(ctrName),
 				container.WithNetworkMode(netName),
 			)
-			defer c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+			defer apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
 
 			// Test DNS resolution by pinging container by name from another container
 			pingCmd := []string{"ping", "-n", "1", "-w", "3000", ctrName}
 
 			attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 			defer cancel()
-			res := container.RunAttach(attachCtx, t, c,
+			res := container.RunAttach(attachCtx, t, apiClient,
 				container.WithCmd(pingCmd...),
 				container.WithNetworkMode(netName),
 			)
-			defer c.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+			defer apiClient.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
 
 			assert.Check(t, is.Equal(res.ExitCode, 0), "DNS resolution failed")
 			assert.Check(t, is.Contains(res.Stdout.String(), "Sent = 1, Received = 1, Lost = 0"))
@@ -226,53 +226,53 @@ func TestWindowsNetworkLifecycle(t *testing.T) {
 		"Skipping test: fails on Containerd due to unsupported platform request error during NetworkConnect operations")
 
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	netName := "lifecycle-test-nat"
 
-	netID := network.CreateNoError(ctx, t, c, netName,
+	netID := network.CreateNoError(ctx, t, apiClient, netName,
 		network.WithDriver("nat"),
 	)
 
-	netInfo, err := c.NetworkInspect(ctx, netID, client.NetworkInspectOptions{})
+	netInfo, err := apiClient.NetworkInspect(ctx, netID, client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(netInfo.Network.Name, netName))
 
 	// Create container on network
 	ctrName := "lifecycle-ctr"
-	id := container.Run(ctx, t, c,
+	id := container.Run(ctx, t, apiClient,
 		container.WithName(ctrName),
 		container.WithNetworkMode(netName),
 	)
 
-	ctrInfo := container.Inspect(ctx, t, c, id)
+	ctrInfo := container.Inspect(ctx, t, apiClient, id)
 	assert.Check(t, ctrInfo.NetworkSettings.Networks[netName] != nil)
 
 	// Disconnect container from network
-	_, err = c.NetworkDisconnect(ctx, netID, client.NetworkDisconnectOptions{
+	_, err = apiClient.NetworkDisconnect(ctx, netID, client.NetworkDisconnectOptions{
 		Container: id,
 		Force:     false,
 	})
 	assert.NilError(t, err)
 
-	ctrInfo = container.Inspect(ctx, t, c, id)
+	ctrInfo = container.Inspect(ctx, t, apiClient, id)
 	assert.Check(t, ctrInfo.NetworkSettings.Networks[netName] == nil, "Container still connected after disconnect")
 
 	// Reconnect container to network
-	_, err = c.NetworkConnect(ctx, netID, client.NetworkConnectOptions{
+	_, err = apiClient.NetworkConnect(ctx, netID, client.NetworkConnectOptions{
 		Container:      id,
 		EndpointConfig: nil,
 	})
 	assert.NilError(t, err)
 
-	ctrInfo = container.Inspect(ctx, t, c, id)
+	ctrInfo = container.Inspect(ctx, t, apiClient, id)
 	assert.Check(t, ctrInfo.NetworkSettings.Networks[netName] != nil, "Container not reconnected")
 
-	c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+	apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
 
-	network.RemoveNoError(ctx, t, c, netName)
+	network.RemoveNoError(ctx, t, apiClient, netName)
 
-	_, err = c.NetworkInspect(ctx, netID, client.NetworkInspectOptions{})
+	_, err = apiClient.NetworkInspect(ctx, netID, client.NetworkInspectOptions{})
 	assert.Check(t, err != nil, "Network still exists after deletion")
 }
 
@@ -280,27 +280,27 @@ func TestWindowsNetworkLifecycle(t *testing.T) {
 // Ensures containers on different networks cannot communicate, validating Windows network driver isolation.
 func TestWindowsNetworkIsolation(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	// Create two separate NAT networks
 	net1Name := "isolation-net1"
 	net2Name := "isolation-net2"
 
-	network.CreateNoError(ctx, t, c, net1Name, network.WithDriver("nat"))
-	defer network.RemoveNoError(ctx, t, c, net1Name)
+	network.CreateNoError(ctx, t, apiClient, net1Name, network.WithDriver("nat"))
+	defer network.RemoveNoError(ctx, t, apiClient, net1Name)
 
-	network.CreateNoError(ctx, t, c, net2Name, network.WithDriver("nat"))
-	defer network.RemoveNoError(ctx, t, c, net2Name)
+	network.CreateNoError(ctx, t, apiClient, net2Name, network.WithDriver("nat"))
+	defer network.RemoveNoError(ctx, t, apiClient, net2Name)
 
 	// Create container on first network
 	ctr1Name := "isolated-ctr1"
-	id1 := container.Run(ctx, t, c,
+	id1 := container.Run(ctx, t, apiClient,
 		container.WithName(ctr1Name),
 		container.WithNetworkMode(net1Name),
 	)
-	defer c.ContainerRemove(ctx, id1, client.ContainerRemoveOptions{Force: true})
+	defer apiClient.ContainerRemove(ctx, id1, client.ContainerRemoveOptions{Force: true})
 
-	ctr1Info := container.Inspect(ctx, t, c, id1)
+	ctr1Info := container.Inspect(ctx, t, apiClient, id1)
 	ctr1IP := ctr1Info.NetworkSettings.Networks[net1Name].IPAddress
 	assert.Check(t, ctr1IP.IsValid(), "Container IP not assigned")
 
@@ -309,11 +309,11 @@ func TestWindowsNetworkIsolation(t *testing.T) {
 
 	attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	res := container.RunAttach(attachCtx, t, c,
+	res := container.RunAttach(attachCtx, t, apiClient,
 		container.WithCmd(pingCmd...),
 		container.WithNetworkMode(net2Name),
 	)
-	defer c.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+	defer apiClient.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
 
 	// Ping should fail, demonstrating network isolation
 	assert.Check(t, res.ExitCode != 0, "Ping succeeded unexpectedly - networks are not isolated")
@@ -338,11 +338,13 @@ func TestWindowsNetworkIsolation(t *testing.T) {
 // Tests that multiple containers can be created and managed on the same network.
 func TestWindowsNetworkEndpointManagement(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	netName := "endpoint-test-nat"
-	network.CreateNoError(ctx, t, c, netName, network.WithDriver("nat"))
-	defer network.RemoveNoError(ctx, t, c, netName)
+	network.CreateNoError(ctx, t, apiClient, netName, network.WithDriver("nat"))
+	t.Cleanup(func() {
+		network.RemoveNoError(ctx, t, apiClient, netName)
+	})
 
 	// Create multiple containers on the same network
 	const numContainers = 3
@@ -350,15 +352,17 @@ func TestWindowsNetworkEndpointManagement(t *testing.T) {
 
 	for i := range numContainers {
 		ctrName := fmt.Sprintf("endpoint-ctr-%d", i)
-		id := container.Run(ctx, t, c,
+		id := container.Run(ctx, t, apiClient,
 			container.WithName(ctrName),
 			container.WithNetworkMode(netName),
 		)
 		containerIDs[i] = id
-		defer c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+		t.Cleanup(func() {
+			container.Remove(ctx, t, apiClient, id, client.ContainerRemoveOptions{Force: true})
+		})
 	}
 
-	netInfo, err := c.NetworkInspect(ctx, netName, client.NetworkInspectOptions{})
+	netInfo, err := apiClient.NetworkInspect(ctx, netName, client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(len(netInfo.Network.Containers), numContainers),
 		"Expected %d containers, got %d", numContainers, len(netInfo.Network.Containers))
@@ -371,12 +375,14 @@ func TestWindowsNetworkEndpointManagement(t *testing.T) {
 		sourceName := fmt.Sprintf("endpoint-ctr-%d", i+1)
 		attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
-		res := container.RunAttach(attachCtx, t, c,
+		res := container.RunAttach(attachCtx, t, apiClient,
 			container.WithName(fmt.Sprintf("%s-pinger", sourceName)),
 			container.WithCmd(pingCmd...),
 			container.WithNetworkMode(netName),
 		)
-		defer c.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+		t.Cleanup(func() {
+			container.Remove(ctx, t, apiClient, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+		})
 
 		assert.Check(t, is.Equal(res.ExitCode, 0),
 			"Container %s failed to ping %s", sourceName, targetName)

--- a/integration/networking/drivers_windows_test.go
+++ b/integration/networking/drivers_windows_test.go
@@ -25,7 +25,7 @@ import (
 // Tests: NAT, Transparent, and L2Bridge network drivers.
 func TestWindowsNetworkDrivers(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	testcases := []struct {
 		name   string
@@ -58,7 +58,7 @@ func TestWindowsNetworkDrivers(t *testing.T) {
 			netName := fmt.Sprintf("test-%s-%d", tc.driver, tcID)
 
 			// Create network with specified driver
-			netResp, err := c.NetworkCreate(ctx, netName, client.NetworkCreateOptions{
+			netResp, err := apiClient.NetworkCreate(ctx, netName, client.NetworkCreateOptions{
 				Driver: tc.driver,
 			})
 			if err != nil {
@@ -71,10 +71,10 @@ func TestWindowsNetworkDrivers(t *testing.T) {
 				}
 				t.Fatalf("Failed to create network with %s driver: %v", tc.driver, err)
 			}
-			defer network.RemoveNoError(ctx, t, c, netName)
+			defer network.RemoveNoError(ctx, t, apiClient, netName)
 
 			// Inspect network to validate driver is correctly set
-			netInfo, err := c.NetworkInspect(ctx, netResp.ID, client.NetworkInspectOptions{})
+			netInfo, err := apiClient.NetworkInspect(ctx, netResp.ID, client.NetworkInspectOptions{})
 			assert.NilError(t, err)
 			assert.Check(t, is.Equal(netInfo.Network.Driver, tc.driver), "Network driver mismatch")
 			assert.Check(t, is.Equal(netInfo.Network.Name, netName), "Network name mismatch")
@@ -85,7 +85,7 @@ func TestWindowsNetworkDrivers(t *testing.T) {
 // TestWindowsNATDriverPortMapping validates NAT port mapping by testing host connectivity.
 func TestWindowsNATDriverPortMapping(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	// Use default NAT network which supports port mapping
 	netName := "nat"
@@ -107,7 +107,7 @@ func TestWindowsNATDriverPortMapping(t *testing.T) {
 
 	// Create container with port mapping 80->8080
 	ctrName := "port-mapping-test"
-	id := container.Run(ctx, t, c,
+	id := container.Run(ctx, t, apiClient,
 		container.WithName(ctrName),
 		container.WithCmd("powershell", "-Command", psScript),
 		container.WithNetworkMode(netName),
@@ -116,10 +116,10 @@ func TestWindowsNATDriverPortMapping(t *testing.T) {
 			networktypes.MustParsePort("80"): {{HostIP: netip.IPv4Unspecified(), HostPort: "8080"}},
 		}),
 	)
-	defer c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+	defer apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
 
 	// Verify port mapping metadata
-	ctrInfo := container.Inspect(ctx, t, c, id)
+	ctrInfo := container.Inspect(ctx, t, apiClient, id)
 	portKey := networktypes.MustParsePort("80/tcp")
 	assert.Check(t, ctrInfo.NetworkSettings.Ports[portKey] != nil, "Port mapping not found")
 	assert.Check(t, len(ctrInfo.NetworkSettings.Ports[portKey]) > 0, "No host port binding")
@@ -151,7 +151,7 @@ func TestWindowsNATDriverPortMapping(t *testing.T) {
 // TestWindowsNetworkDNSResolution validates DNS resolution on Windows networks.
 func TestWindowsNetworkDNSResolution(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	testcases := []struct {
 		name       string
@@ -188,27 +188,27 @@ func TestWindowsNetworkDNSResolution(t *testing.T) {
 				}
 			}
 
-			network.CreateNoError(ctx, t, c, netName, netOpts...)
-			defer network.RemoveNoError(ctx, t, c, netName)
+			network.CreateNoError(ctx, t, apiClient, netName, netOpts...)
+			defer network.RemoveNoError(ctx, t, apiClient, netName)
 
 			// Create container and verify DNS resolution
 			ctrName := fmt.Sprintf("dns-test-%d", tcID)
-			id := container.Run(ctx, t, c,
+			id := container.Run(ctx, t, apiClient,
 				container.WithName(ctrName),
 				container.WithNetworkMode(netName),
 			)
-			defer c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+			defer apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
 
 			// Test DNS resolution by pinging container by name from another container
 			pingCmd := []string{"ping", "-n", "1", "-w", "3000", ctrName}
 
 			attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 			defer cancel()
-			res := container.RunAttach(attachCtx, t, c,
+			res := container.RunAttach(attachCtx, t, apiClient,
 				container.WithCmd(pingCmd...),
 				container.WithNetworkMode(netName),
 			)
-			defer c.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+			defer apiClient.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
 
 			assert.Check(t, is.Equal(res.ExitCode, 0), "DNS resolution failed")
 			assert.Check(t, is.Contains(res.Stdout.String(), "Sent = 1, Received = 1, Lost = 0"))
@@ -226,53 +226,53 @@ func TestWindowsNetworkLifecycle(t *testing.T) {
 		"Skipping test: fails on Containerd due to unsupported platform request error during NetworkConnect operations")
 
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	netName := "lifecycle-test-nat"
 
-	netID := network.CreateNoError(ctx, t, c, netName,
+	netID := network.CreateNoError(ctx, t, apiClient, netName,
 		network.WithDriver("nat"),
 	)
 
-	netInfo, err := c.NetworkInspect(ctx, netID, client.NetworkInspectOptions{})
+	netInfo, err := apiClient.NetworkInspect(ctx, netID, client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(netInfo.Network.Name, netName))
 
 	// Create container on network
 	ctrName := "lifecycle-ctr"
-	id := container.Run(ctx, t, c,
+	id := container.Run(ctx, t, apiClient,
 		container.WithName(ctrName),
 		container.WithNetworkMode(netName),
 	)
 
-	ctrInfo := container.Inspect(ctx, t, c, id)
+	ctrInfo := container.Inspect(ctx, t, apiClient, id)
 	assert.Check(t, ctrInfo.NetworkSettings.Networks[netName] != nil)
 
 	// Disconnect container from network
-	_, err = c.NetworkDisconnect(ctx, netID, client.NetworkDisconnectOptions{
+	_, err = apiClient.NetworkDisconnect(ctx, netID, client.NetworkDisconnectOptions{
 		Container: id,
 		Force:     false,
 	})
 	assert.NilError(t, err)
 
-	ctrInfo = container.Inspect(ctx, t, c, id)
+	ctrInfo = container.Inspect(ctx, t, apiClient, id)
 	assert.Check(t, ctrInfo.NetworkSettings.Networks[netName] == nil, "Container still connected after disconnect")
 
 	// Reconnect container to network
-	_, err = c.NetworkConnect(ctx, netID, client.NetworkConnectOptions{
+	_, err = apiClient.NetworkConnect(ctx, netID, client.NetworkConnectOptions{
 		Container:      id,
 		EndpointConfig: nil,
 	})
 	assert.NilError(t, err)
 
-	ctrInfo = container.Inspect(ctx, t, c, id)
+	ctrInfo = container.Inspect(ctx, t, apiClient, id)
 	assert.Check(t, ctrInfo.NetworkSettings.Networks[netName] != nil, "Container not reconnected")
 
-	c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+	apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
 
-	network.RemoveNoError(ctx, t, c, netName)
+	network.RemoveNoError(ctx, t, apiClient, netName)
 
-	_, err = c.NetworkInspect(ctx, netID, client.NetworkInspectOptions{})
+	_, err = apiClient.NetworkInspect(ctx, netID, client.NetworkInspectOptions{})
 	assert.Check(t, err != nil, "Network still exists after deletion")
 }
 
@@ -280,27 +280,27 @@ func TestWindowsNetworkLifecycle(t *testing.T) {
 // Ensures containers on different networks cannot communicate, validating Windows network driver isolation.
 func TestWindowsNetworkIsolation(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	// Create two separate NAT networks
 	net1Name := "isolation-net1"
 	net2Name := "isolation-net2"
 
-	network.CreateNoError(ctx, t, c, net1Name, network.WithDriver("nat"))
-	defer network.RemoveNoError(ctx, t, c, net1Name)
+	network.CreateNoError(ctx, t, apiClient, net1Name, network.WithDriver("nat"))
+	defer network.RemoveNoError(ctx, t, apiClient, net1Name)
 
-	network.CreateNoError(ctx, t, c, net2Name, network.WithDriver("nat"))
-	defer network.RemoveNoError(ctx, t, c, net2Name)
+	network.CreateNoError(ctx, t, apiClient, net2Name, network.WithDriver("nat"))
+	defer network.RemoveNoError(ctx, t, apiClient, net2Name)
 
 	// Create container on first network
 	ctr1Name := "isolated-ctr1"
-	id1 := container.Run(ctx, t, c,
+	id1 := container.Run(ctx, t, apiClient,
 		container.WithName(ctr1Name),
 		container.WithNetworkMode(net1Name),
 	)
-	defer c.ContainerRemove(ctx, id1, client.ContainerRemoveOptions{Force: true})
+	defer apiClient.ContainerRemove(ctx, id1, client.ContainerRemoveOptions{Force: true})
 
-	ctr1Info := container.Inspect(ctx, t, c, id1)
+	ctr1Info := container.Inspect(ctx, t, apiClient, id1)
 	ctr1IP := ctr1Info.NetworkSettings.Networks[net1Name].IPAddress
 	assert.Check(t, ctr1IP.IsValid(), "Container IP not assigned")
 
@@ -309,11 +309,11 @@ func TestWindowsNetworkIsolation(t *testing.T) {
 
 	attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	res := container.RunAttach(attachCtx, t, c,
+	res := container.RunAttach(attachCtx, t, apiClient,
 		container.WithCmd(pingCmd...),
 		container.WithNetworkMode(net2Name),
 	)
-	defer c.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+	defer apiClient.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
 
 	// Ping should fail, demonstrating network isolation
 	assert.Check(t, res.ExitCode != 0, "Ping succeeded unexpectedly - networks are not isolated")
@@ -338,11 +338,11 @@ func TestWindowsNetworkIsolation(t *testing.T) {
 // Tests that multiple containers can be created and managed on the same network.
 func TestWindowsNetworkEndpointManagement(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	netName := "endpoint-test-nat"
-	network.CreateNoError(ctx, t, c, netName, network.WithDriver("nat"))
-	defer network.RemoveNoError(ctx, t, c, netName)
+	network.CreateNoError(ctx, t, apiClient, netName, network.WithDriver("nat"))
+	defer network.RemoveNoError(ctx, t, apiClient, netName)
 
 	// Create multiple containers on the same network
 	const numContainers = 3
@@ -350,15 +350,17 @@ func TestWindowsNetworkEndpointManagement(t *testing.T) {
 
 	for i := range numContainers {
 		ctrName := fmt.Sprintf("endpoint-ctr-%d", i)
-		id := container.Run(ctx, t, c,
+		id := container.Run(ctx, t, apiClient,
 			container.WithName(ctrName),
 			container.WithNetworkMode(netName),
 		)
 		containerIDs[i] = id
-		defer c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+		t.Cleanup(func() {
+			container.Remove(ctx, t, apiClient, id, client.ContainerRemoveOptions{Force: true})
+		})
 	}
 
-	netInfo, err := c.NetworkInspect(ctx, netName, client.NetworkInspectOptions{})
+	netInfo, err := apiClient.NetworkInspect(ctx, netName, client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(len(netInfo.Network.Containers), numContainers),
 		"Expected %d containers, got %d", numContainers, len(netInfo.Network.Containers))
@@ -371,12 +373,14 @@ func TestWindowsNetworkEndpointManagement(t *testing.T) {
 		sourceName := fmt.Sprintf("endpoint-ctr-%d", i+1)
 		attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
-		res := container.RunAttach(attachCtx, t, c,
+		res := container.RunAttach(attachCtx, t, apiClient,
 			container.WithName(fmt.Sprintf("%s-pinger", sourceName)),
 			container.WithCmd(pingCmd...),
 			container.WithNetworkMode(netName),
 		)
-		defer c.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+		t.Cleanup(func() {
+			defer container.Remove(ctx, t, apiClient, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+		})
 
 		assert.Check(t, is.Equal(res.ExitCode, 0),
 			"Container %s failed to ping %s", sourceName, targetName)

--- a/integration/networking/nat_windows_test.go
+++ b/integration/networking/nat_windows_test.go
@@ -53,19 +53,17 @@ func TestNatNetworkICC(t *testing.T) {
 				container.WithName(ctr1Name),
 				container.WithNetworkMode(tc.netName),
 			)
-			defer apiClient.ContainerRemove(ctx, id1, client.ContainerRemoveOptions{Force: true})
-
-			pingCmd := []string{"ping", "-n", "1", "-w", "3000", ctr1Name}
+			defer container.Remove(ctx, t, apiClient, id1, client.ContainerRemoveOptions{Force: true})
 
 			const ctr2Name = "ctr2"
 			attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 			defer cancel()
 			res := container.RunAttach(attachCtx, t, apiClient,
 				container.WithName(ctr2Name),
-				container.WithCmd(pingCmd...),
+				container.WithCmd("ping", "-n", "1", "-w", "3000", ctr1Name),
 				container.WithNetworkMode(tc.netName),
 			)
-			defer apiClient.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+			defer container.Remove(ctx, t, apiClient, res.ContainerID, client.ContainerRemoveOptions{Force: true})
 
 			assert.Check(t, is.Equal(res.ExitCode, 0))
 			assert.Check(t, is.Equal(res.Stderr.Len(), 0))
@@ -86,7 +84,7 @@ func TestFlakyPortMappedHairpinWindows(t *testing.T) {
 	conn, err := net.Dial("tcp4", "hub.docker.com:80")
 	assert.NilError(t, err)
 	hostAddr := conn.LocalAddr().(*net.TCPAddr).IP.String()
-	conn.Close()
+	_ = conn.Close()
 
 	const serverNetName = "servernet"
 	network.CreateNoError(ctx, t, apiClient, serverNetName, network.WithDriver("nat"))
@@ -101,7 +99,7 @@ func TestFlakyPortMappedHairpinWindows(t *testing.T) {
 		container.WithPortMap(networktypes.PortMap{networktypes.MustParsePort("80"): {{HostIP: netip.IPv4Unspecified()}}}),
 		container.WithCmd("httpd", "-f"),
 	)
-	defer apiClient.ContainerRemove(ctx, serverId, client.ContainerRemoveOptions{Force: true})
+	defer container.Remove(ctx, t, apiClient, serverId, client.ContainerRemoveOptions{Force: true})
 
 	inspect := container.Inspect(ctx, t, apiClient, serverId)
 	hostPort := inspect.NetworkSettings.Ports[networktypes.MustParsePort("80/tcp")][0].HostPort
@@ -112,6 +110,6 @@ func TestFlakyPortMappedHairpinWindows(t *testing.T) {
 		container.WithNetworkMode(clientNetName),
 		container.WithCmd("wget", "http://"+hostAddr+":"+hostPort),
 	)
-	defer apiClient.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+	defer container.Remove(ctx, t, apiClient, res.ContainerID, client.ContainerRemoveOptions{Force: true})
 	assert.Check(t, is.Contains(res.Stderr.String(), "404 Not Found"))
 }

--- a/integration/networking/nat_windows_test.go
+++ b/integration/networking/nat_windows_test.go
@@ -21,7 +21,7 @@ import (
 // Regression test for https://github.com/moby/moby/issues/47370
 func TestNatNetworkICC(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	testcases := []struct {
 		name    string
@@ -42,30 +42,30 @@ func TestNatNetworkICC(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 
 			if tc.netName != "nat" {
-				network.CreateNoError(ctx, t, c, tc.netName,
+				network.CreateNoError(ctx, t, apiClient, tc.netName,
 					network.WithDriver("nat"),
 				)
-				defer network.RemoveNoError(ctx, t, c, tc.netName)
+				defer network.RemoveNoError(ctx, t, apiClient, tc.netName)
 			}
 
 			const ctr1Name = "ctr1"
-			id1 := container.Run(ctx, t, c,
+			id1 := container.Run(ctx, t, apiClient,
 				container.WithName(ctr1Name),
 				container.WithNetworkMode(tc.netName),
 			)
-			defer c.ContainerRemove(ctx, id1, client.ContainerRemoveOptions{Force: true})
+			defer apiClient.ContainerRemove(ctx, id1, client.ContainerRemoveOptions{Force: true})
 
 			pingCmd := []string{"ping", "-n", "1", "-w", "3000", ctr1Name}
 
 			const ctr2Name = "ctr2"
 			attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 			defer cancel()
-			res := container.RunAttach(attachCtx, t, c,
+			res := container.RunAttach(attachCtx, t, apiClient,
 				container.WithName(ctr2Name),
 				container.WithCmd(pingCmd...),
 				container.WithNetworkMode(tc.netName),
 			)
-			defer c.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+			defer apiClient.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
 
 			assert.Check(t, is.Equal(res.ExitCode, 0))
 			assert.Check(t, is.Equal(res.Stderr.Len(), 0))
@@ -80,7 +80,7 @@ func TestNatNetworkICC(t *testing.T) {
 // FIXME: flaky test; see https://github.com/moby/moby/issues/48881
 func TestFlakyPortMappedHairpinWindows(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	// Find an address on the test host.
 	conn, err := net.Dial("tcp4", "hub.docker.com:80")
@@ -89,29 +89,29 @@ func TestFlakyPortMappedHairpinWindows(t *testing.T) {
 	conn.Close()
 
 	const serverNetName = "servernet"
-	network.CreateNoError(ctx, t, c, serverNetName, network.WithDriver("nat"))
-	defer network.RemoveNoError(ctx, t, c, serverNetName)
+	network.CreateNoError(ctx, t, apiClient, serverNetName, network.WithDriver("nat"))
+	defer network.RemoveNoError(ctx, t, apiClient, serverNetName)
 	const clientNetName = "clientnet"
-	network.CreateNoError(ctx, t, c, clientNetName, network.WithDriver("nat"))
-	defer network.RemoveNoError(ctx, t, c, clientNetName)
+	network.CreateNoError(ctx, t, apiClient, clientNetName, network.WithDriver("nat"))
+	defer network.RemoveNoError(ctx, t, apiClient, clientNetName)
 
-	serverId := container.Run(ctx, t, c,
+	serverId := container.Run(ctx, t, apiClient,
 		container.WithNetworkMode(serverNetName),
 		container.WithExposedPorts("80"),
 		container.WithPortMap(networktypes.PortMap{networktypes.MustParsePort("80"): {{HostIP: netip.IPv4Unspecified()}}}),
 		container.WithCmd("httpd", "-f"),
 	)
-	defer c.ContainerRemove(ctx, serverId, client.ContainerRemoveOptions{Force: true})
+	defer apiClient.ContainerRemove(ctx, serverId, client.ContainerRemoveOptions{Force: true})
 
-	inspect := container.Inspect(ctx, t, c, serverId)
+	inspect := container.Inspect(ctx, t, apiClient, serverId)
 	hostPort := inspect.NetworkSettings.Ports[networktypes.MustParsePort("80/tcp")][0].HostPort
 
 	attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	res := container.RunAttach(attachCtx, t, c,
+	res := container.RunAttach(attachCtx, t, apiClient,
 		container.WithNetworkMode(clientNetName),
 		container.WithCmd("wget", "http://"+hostAddr+":"+hostPort),
 	)
-	defer c.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+	defer apiClient.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
 	assert.Check(t, is.Contains(res.Stderr.String(), "404 Not Found"))
 }

--- a/integration/networking/resolvconf_test.go
+++ b/integration/networking/resolvconf_test.go
@@ -198,14 +198,14 @@ func TestNslookupWindows(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "windows")
 
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	res := container.RunAttach(attachCtx, t, c,
+	res := container.RunAttach(attachCtx, t, apiClient,
 		container.WithCmd("nslookup", "docker.com"),
 	)
-	defer c.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+	defer apiClient.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
 
 	assert.Check(t, is.Equal(res.ExitCode, 0))
 	// Current default is to forward requests to external servers, which

--- a/internal/testutil/fixtures/plugin/plugin.go
+++ b/internal/testutil/fixtures/plugin/plugin.go
@@ -118,15 +118,14 @@ func CreateInRegistry(ctx context.Context, repo string, auth *registry.AuthConfi
 		return err
 	}
 
-	managerConfig := plugin.ManagerConfig{
+	manager, err := plugin.NewManager(plugin.ManagerConfig{
 		Store:           plugin.NewStore(),
 		RegistryService: regService,
 		Root:            filepath.Join(tmpDir, "root"),
 		ExecRoot:        "/run/docker", // manager init fails if not set
 		CreateExecutor:  dummyExec,
 		LogPluginEvent:  func(id, name string, action events.Action) {}, // panics when not set
-	}
-	manager, err := plugin.NewManager(managerConfig)
+	})
 	if err != nil {
 		return errors.Wrap(err, "error creating plugin manager")
 	}


### PR DESCRIPTION
Some leftovers from branches I was working on.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
