### PR TITLE
c8d: protect content walks with a lease

### DIFF
--- a/daemon/containerd/handlers.go
+++ b/daemon/containerd/handlers.go
@@ -5,17 +5,45 @@ import (
 
 	"github.com/containerd/containerd/v2/core/content"
 	c8dimages "github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/leases"
 	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	"github.com/moby/moby/v2/errdefs"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // walkPresentChildren is a simple wrapper for c8dimages.Walk with presentChildrenHandler.
 // This is only a convenient helper to reduce boilerplate.
+//
+// The traversal is protected by a lease so content cannot be garbage-collected
+// while it is being inspected.
 func (i *ImageService) walkPresentChildren(ctx context.Context, target ocispec.Descriptor, f func(context.Context, ocispec.Descriptor) error) error {
-	return c8dimages.Walk(ctx, presentChildrenHandler(i.content, c8dimages.HandlerFunc(
+	ctx, release, err := i.client.WithLease(ctx)
+	if err != nil {
+		return errdefs.System(err)
+	}
+	defer func() {
+		if err := release(context.WithoutCancel(ctx)); err != nil {
+			log.G(ctx).WithError(err).Warn("failed to release content walk lease")
+		}
+	}()
+
+	lid, _ := leases.FromContext(ctx)
+	lm := i.client.LeasesService()
+	handler := presentChildrenHandler(i.content, c8dimages.HandlerFunc(
 		func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 			return nil, f(ctx, desc)
-		})), target)
+		}))
+
+	return c8dimages.Walk(ctx, c8dimages.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		if err := lm.AddResource(ctx, leases.Lease{ID: lid}, leases.Resource{
+			ID:   desc.Digest.String(),
+			Type: "content",
+		}); err != nil {
+			return nil, errdefs.System(err)
+		}
+		return handler(ctx, desc)
+	}), target)
 }
 
 // presentChildrenHandler is a handler wrapper which traverses all children

--- a/daemon/containerd/handlers_test.go
+++ b/daemon/containerd/handlers_test.go
@@ -1,0 +1,115 @@
+package containerd
+
+import (
+	"context"
+	"testing"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/leases"
+	cerrdefs "github.com/containerd/errdefs"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"gotest.tools/v3/assert"
+)
+
+type recordingContentStore struct {
+	content.Store
+	info func(context.Context, digest.Digest) (content.Info, error)
+}
+
+func (s recordingContentStore) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
+	return s.info(ctx, dgst)
+}
+
+type recordingLeaseManager struct {
+	noopLeasesManager
+	calls    *[]string
+	resource leases.Resource
+}
+
+func (m *recordingLeaseManager) Create(_ context.Context, opts ...leases.Opt) (leases.Lease, error) {
+	*m.calls = append(*m.calls, "create")
+	l := leases.Lease{ID: "content-walk"}
+	for _, opt := range opts {
+		if err := opt(&l); err != nil {
+			return leases.Lease{}, err
+		}
+	}
+	return l, nil
+}
+
+func (m *recordingLeaseManager) Delete(context.Context, leases.Lease, ...leases.DeleteOpt) error {
+	*m.calls = append(*m.calls, "delete")
+	return nil
+}
+
+func (m *recordingLeaseManager) AddResource(_ context.Context, _ leases.Lease, resource leases.Resource) error {
+	*m.calls = append(*m.calls, "lease")
+	m.resource = resource
+	return nil
+}
+
+func TestWalkPresentChildrenLeasesBeforeContentAccess(t *testing.T) {
+	var calls []string
+	lm := &recordingLeaseManager{calls: &calls}
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    digest.FromString(t.Name()),
+	}
+	store := recordingContentStore{
+		info: func(_ context.Context, dgst digest.Digest) (content.Info, error) {
+			calls = append(calls, "info")
+			return content.Info{Digest: dgst}, nil
+		},
+	}
+	client, err := containerd.New("", containerd.WithServices(
+		containerd.WithContentStore(store),
+		containerd.WithLeasesService(lm),
+	))
+	assert.NilError(t, err)
+	service := &ImageService{client: client, content: store}
+
+	err = service.walkPresentChildren(t.Context(), desc, func(context.Context, ocispec.Descriptor) error {
+		calls = append(calls, "handler")
+		return nil
+	})
+
+	assert.NilError(t, err)
+	assert.DeepEqual(t, calls, []string{"create", "lease", "info", "handler", "delete"})
+	assert.DeepEqual(t, lm.resource, leases.Resource{
+		ID:   desc.Digest.String(),
+		Type: "content",
+	})
+}
+
+func TestWalkPresentChildrenLeasesBeforeSkippingMissingContent(t *testing.T) {
+	var calls []string
+	lm := &recordingLeaseManager{calls: &calls}
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    digest.FromString(t.Name()),
+	}
+	store := recordingContentStore{
+		info: func(context.Context, digest.Digest) (content.Info, error) {
+			calls = append(calls, "info")
+			return content.Info{}, cerrdefs.ErrNotFound
+		},
+	}
+	client, err := containerd.New("", containerd.WithServices(
+		containerd.WithContentStore(store),
+		containerd.WithLeasesService(lm),
+	))
+	assert.NilError(t, err)
+	service := &ImageService{client: client, content: store}
+
+	var handlerCalled bool
+	err = service.walkPresentChildren(t.Context(), desc, func(context.Context, ocispec.Descriptor) error {
+		handlerCalled = true
+		return nil
+	})
+
+	assert.NilError(t, err)
+	assert.DeepEqual(t, calls, []string{"create", "lease", "info", "delete"})
+	assert.Check(t, !handlerCalled)
+}


### PR DESCRIPTION
Related to [**Better image traversal mode #52688**](https://github.com/moby/moby/issues/52688)

## Summary

**What changed**

Updated `walkPresentChildren` (`daemon/containerd/handlers.go`) to hold a containerd lease for the duration of each traversal.

Added each descriptor to the lease before checking or reading its content, and released the lease when the traversal completes.

Added tests in `daemon/containerd/handlers_test.go` to verify that descriptors are leased before content access, including when content is already missing.

**Why**

`presentChildrenHandler` checks that a blob exists before reading its children. During concurrent image operations, containerd garbage collection can remove the blob between those steps, causing the traversal to fail with `NotFound`.

Leasing each descriptor before accessing it keeps the content available for the duration of the walk. Existing missing-content handling still covers cases where removal completed before the descriptor was leased.

**Validation**

```text
go test ./daemon/containerd -run '^TestWalkPresentChildren' -count=100
```

## Release notes (optional)

```markdown changelog
Protect containerd image-content walks from concurrent garbage collection.
```

## A picture of a cute animal (not mandatory but encouraged)
