### PR TITLE
Fix ringLogger deadlock when driver Log() blocks indefinitely

### DIFF
--- a/daemon/logger/ring.go
+++ b/daemon/logger/ring.go
@@ -5,7 +5,12 @@ import (
 	"errors"
 	"sync"
 	"sync/atomic"
+	"time"
+
+	"github.com/containerd/log"
 )
+
+var ringLoggerTimeout = 15 * time.Second
 
 const (
 	defaultRingMaxSize = 1e6 // 1MB
@@ -19,6 +24,8 @@ type ringLogger struct {
 	logInfo   Info
 	closeFlag atomic.Bool
 	wg        sync.WaitGroup
+	closeOnce sync.Once
+	closedErr error
 }
 
 var (
@@ -92,11 +99,46 @@ func (r *ringLogger) setClosed() {
 	r.closeFlag.Store(true)
 }
 
+// closeUnderlying closes the underlying logger exactly once and caches the error.
+func (r *ringLogger) closeUnderlying() error {
+	r.closeOnce.Do(func() {
+		r.closedErr = r.l.Close()
+	})
+	return r.closedErr
+}
+
 // Close closes the logger
 func (r *ringLogger) Close() error {
 	r.setClosed()
 	r.buffer.Close()
-	r.wg.Wait()
+
+	done := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(done)
+	}()
+
+	// Wait for run() to exit so that we fulfill the io.Closer contract.
+	// We use a 15-second timeout (ample time for normal flush operations to complete)
+	// to forcefully close the underlying driver to interrupt blocked Log() calls.
+	//
+	// Note: We MUST wait for run() to exit to prevent use-after-return bugs
+	// where run() continues accessing ringLogger state. Therefore, if the
+	// underlying driver's Close() method does NOT unblock its Log() method
+	// (e.g., uninterruptible kernel I/O, or lock inversion), ringLogger.Close()
+	// will still hang indefinitely. This timeout is a targeted mitigation for
+	// drivers that support interruptible Close() semantics (such as awslogs).
+	timer := time.NewTimer(ringLoggerTimeout)
+	defer timer.Stop()
+
+	select {
+	case <-done:
+	case <-timer.C:
+		log.G(context.TODO()).WithField("logger", r.l.Name()).Warn("ringlogger: timed out waiting for logger flush; forcing underlying logger close (works only for drivers whose Close interrupts Log)")
+		go r.closeUnderlying()
+		<-done
+	}
+
 	// empty out the queue
 	var logErr bool
 	for _, msg := range r.buffer.Drain() {
@@ -113,7 +155,7 @@ func (r *ringLogger) Close() error {
 			logErr = true
 		}
 	}
-	return r.l.Close()
+	return r.closeUnderlying()
 }
 
 // run consumes messages from the ring buffer and forwards them to the underling

--- a/daemon/logger/ring_test.go
+++ b/daemon/logger/ring_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 )
@@ -46,6 +47,92 @@ func TestRingLogger(t *testing.T) {
 	case msg := <-mockLog.c:
 		t.Fatalf("expected no more messages in the queue, got: %q", string(msg.Line))
 	default:
+	}
+}
+
+type blockingMockLogger struct {
+	closeOnce      sync.Once
+	closed         chan struct{}
+	closeCnt       int
+	mu             sync.Mutex
+	startedLog     chan struct{}
+	startedLogOnce sync.Once
+}
+
+func newBlockingMockLogger() *blockingMockLogger {
+	return &blockingMockLogger{
+		closed:     make(chan struct{}),
+		startedLog: make(chan struct{}),
+	}
+}
+
+func (l *blockingMockLogger) Log(msg *Message) error {
+	// Signal that Log has been entered and is blocking
+	l.startedLogOnce.Do(func() {
+		close(l.startedLog)
+	})
+
+	select {
+	case <-l.closed: // block until Close is called
+		return errors.New("logger closed")
+	case <-time.After(5 * time.Second):
+		// fallback to avoid infinite hangs in bad tests
+		return errors.New("timeout")
+	}
+}
+
+func (l *blockingMockLogger) Name() string {
+	return "blockingMock"
+}
+
+func (l *blockingMockLogger) Close() error {
+	l.mu.Lock()
+	l.closeCnt++
+	l.mu.Unlock()
+	l.closeOnce.Do(func() {
+		close(l.closed)
+	})
+	return nil
+}
+
+func TestRingLoggerCloseTimeout(t *testing.T) {
+	origTimeout := ringLoggerTimeout
+	ringLoggerTimeout = 50 * time.Millisecond
+	defer func() { ringLoggerTimeout = origTimeout }()
+
+	mockLog := newBlockingMockLogger()
+	ring := newRingLogger(mockLog, Info{}, 1)
+
+	// Add a message to trigger the block in Log()
+	ring.Log(&Message{Line: []byte("1")})
+
+	// Wait for run() to actually enter Log() and block
+	<-mockLog.startedLog
+
+	// Now that run() is solidly blocked, trigger Close.
+	// This will hit the timeout, forcefully close the underlying driver,
+	// which unblocks Log(), allowing run() to exit naturally.
+	done := make(chan struct{})
+	go func() {
+		ring.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// ring.Close() cannot complete through its normal shutdown path because
+		// run() is blocked inside Log(). The only code path that can unblock Log()
+		// before run() exits is the timeout path, which force-closes the underlying
+		// logger. Therefore, successful completion of this test demonstrates that
+		// the timeout path executed.
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for ring.Close()")
+	}
+
+	mockLog.mu.Lock()
+	defer mockLog.mu.Unlock()
+	if mockLog.closeCnt != 1 {
+		t.Fatalf("expected Close to be called exactly once, got %d", mockLog.closeCnt)
 	}
 }
 


### PR DESCRIPTION
Fix ringLogger deadlock when driver Log() blocks indefinitely

**Fixes #53143**

When `ringLogger` wraps a logging driver in non-blocking mode, a background goroutine dequeues messages from the ring buffer and forwards them to the underlying driver's `Log()` method. During shutdown, `ringLogger.Close()` waits for that goroutine to exit before draining any remaining buffered messages and closing the underlying driver.

For `awslogs`, `Log()` can block indefinitely while the driver's internal queue is unable to make progress (for example, when initialization retries never succeed). In that situation, `ringLogger.Close()` waits forever for the background goroutine to exit, but the driver's `Close()` method—which would unblock the pending `Log()` call—is never reached, resulting in the deadlock described in #53143.

This change introduces a bounded wait during `ringLogger.Close()`. If the background goroutine does not exit within the timeout, `ringLogger` invokes the underlying driver's `Close()` to give interruptible drivers (such as `awslogs`) an opportunity to unblock the in-flight `Log()` call and allow shutdown to complete normally.

**Limitation**

This mitigation relies on the underlying driver's `Close()` implementation interrupting an in-flight `Log()` call. Drivers whose `Log()` cannot be interrupted by `Close()` are unaffected. In those cases, `ringLogger.Close()` continues to wait rather than returning while the background goroutine is still accessing `ringLogger` state.
