### PR TITLE
libnetwork/iptables: add firewalld skip guard and netns isolation to TestExistsRaw

### DIFF
--- a/daemon/libnetwork/iptables/iptables_test.go
+++ b/daemon/libnetwork/iptables/iptables_test.go
@@ -211,6 +211,9 @@ func TestCleanup(t *testing.T) {
 }
 
 func TestExistsRaw(t *testing.T) {
+	skip.If(t, UsingFirewalld(), "firewalld is running in the host netns, it can't modify rules in the test's netns")
+	defer netnsutils.SetupTestOSContext(t)()
+
 	const testChain1 = "ABCD"
 	const testChain2 = "EFGH"
 


### PR DESCRIPTION
## Problem

`TestExistsRaw` in `daemon/libnetwork/iptables/iptables_test.go` was missing the firewalld skip guard and network namespace isolation that sibling tests `TestRule` and `TestFlushChain` already use.

Without these guards, the test can produce a spurious failure on environments where firewalld is running:

1. `RawCombinedOutput()` routes rule additions through firewalld's D-Bus `direct.passthrough` interface when `firewalldRunning=true`
2. `exists(native=true, ...)` **always** bypasses firewalld and calls the `iptables` binary directly
3. This path asymmetry means the existence check may see the rule as absent before firewalld has committed it to the underlying iptables state

This was reported as a flaky failure on arm64 CI in https://github.com/moby/moby/issues/42469.

## Fix

Add the same guards already used by `TestRule` and `TestFlushChain`:

```go
skip.If(t, UsingFirewalld(), "firewalld is running in the host netns, it can't modify rules in the test's netns")
defer netnsutils.SetupTestOSContext(t)()
```

No new imports are needed — both `skip` and `netnsutils` are already imported in the file.

Fixes: #42469