### PR TITLE
integration/container: fix flaky TestCreateByImageID by removing t.Parallel() from subtests

### DIFF
--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -121,7 +121,6 @@ func TestCreateByImageID(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.doc, func(t *testing.T) {
-			t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)
 			resp, err := apiClient.ContainerCreate(ctx, client.ContainerCreateOptions{
 				Config: &container.Config{Image: tc.image},


### PR DESCRIPTION
## Summary

Fix intermittent failure of `TestCreateByImageID`.

`TestCreateByImageID` has 5 subtests that all call `t.Parallel()` and share a singleton `apiClient`. On Windows WCOW, each container creation triggers the Windows snapshotter to create a scratch VHD (`blank.vhdx → sandbox.vhdx`). This VHD copy happens **inside a boltdb write transaction** (`vendor/go.etcd.io/bbolt/db.go:847` — `db.rwlock.Lock()`), which serializes all 5 parallel subtests behind a mutex. Under CI load, each VHD copy takes 10–20 seconds, so 5 subtests × ~12s = ~60 seconds total. After 60s with no data on the Windows named pipe, the OS closes the connection and the client sees EOF.

The subtests are all testing different image reference formats on the same busybox image — they do not benefit from parallelism because they all serialize anyway via the boltdb write lock. Removing `t.Parallel()` eliminates the boltdb contention and prevents the 60-second cumulative wait that triggers the timeout.

- Fixes: https://github.com/moby/moby/issues/49348

## Release notes (optional)

```markdown changelog

```

## Note for maintainers

A maintainer's `Signed-off-by` co-sign is needed before this PR can be merged, per the DCO policy discussion in https://github.com/moby/moby/pull/53197. If you are approving this PR, please amend the commit to add your own sign-off, or instruct Gordon to add it on your behalf.

## A picture of a cute animal (not mandatory but encouraged)

🐢