### PR TITLE
daemon/logger/awslogs: fix container exit deadlock in non-blocking mode

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -154,26 +154,36 @@ func New(info logger.Info) (logger.Logger, error) {
 
 	creationDone := make(chan bool)
 	if logNonBlocking {
-		const maxBackoff = 32
+		const maxBackoff = 32 * time.Second
 		go func() {
-			backoff := 1
+			defer close(creationDone)
+
+			backoff := 1 * time.Second
 			// We're done when the logger is closed
 			for !containerStream.closed.Load() {
-				if err := containerStream.create(); err == nil {
-					break
+				err := containerStream.create()
+				if err == nil {
+					return
 				}
 
-				time.Sleep(time.Duration(backoff) * time.Second)
-				if backoff < maxBackoff {
-					backoff *= 2
-				}
 				log.G(context.TODO()).WithFields(log.Fields{
 					"error":          err,
 					"container-id":   info.ContainerID,
 					"container-name": info.ContainerName,
-				}).Error("Error while trying to initialize awslogs. Retrying in: ", backoff, " seconds")
+				}).Error("Error while trying to initialize awslogs. Retrying in: ", backoff)
+
+				select {
+				case <-time.After(backoff):
+				case <-containerStream.messages.Done():
+					// The logger was closed while waiting to retry. Stop here
+					// instead of keeping this goroutine (and the container's
+					// logger) alive for the remainder of the backoff.
+					return
+				}
+				if backoff < maxBackoff {
+					backoff *= 2
+				}
 			}
-			close(creationDone)
 		}()
 	} else {
 		if err = containerStream.create(); err != nil {
@@ -538,8 +548,13 @@ var newTicker = func(freq time.Duration) *time.Ticker {
 // Logs, the processEvents method is called.  If a multiline pattern is not
 // configured, log events are submitted to the processEvents method immediately.
 func (l *logStream) collectBatch(created chan bool) {
+	chLogs := l.messages.Receiver()
+
 	// Wait for the logstream/group to be created
-	<-created
+	if !l.waitCreated(created, chLogs) {
+		return
+	}
+
 	flushInterval := l.forceFlushInterval
 	if flushInterval <= 0 {
 		flushInterval = defaultForceFlushInterval
@@ -549,7 +564,6 @@ func (l *logStream) collectBatch(created chan bool) {
 	var eventBufferTimestamp int64
 	batch := newEventBatch()
 
-	chLogs := l.messages.Receiver()
 	for {
 		select {
 		case t := <-ticker.C:
@@ -596,6 +610,51 @@ func (l *logStream) collectBatch(created chan bool) {
 				l.processEvent(batch, line, msg.Timestamp.UnixNano()/int64(time.Millisecond))
 				logger.PutMessage(msg)
 			}
+		}
+	}
+}
+
+// waitCreated waits for the log stream to be created, discarding any messages
+// received in the meantime. It reports whether the log stream was created; a
+// false return means the driver was closed first and no batching should be
+// performed.
+//
+// Messages must keep being consumed while the log stream is being created. The
+// message queue is bounded and [logStream.Log] blocks once it is full, so a log
+// stream that takes a long time to create -- or that can never be created, such
+// as a log stream in a log group that does not exist, which is retried
+// indefinitely in non-blocking mode -- would otherwise block the caller
+// forever. That in turn blocks container exit, because the ring logger used for
+// non-blocking mode waits for its forwarding goroutine to return before closing
+// this driver, and closing this driver is what would unblock that goroutine.
+//
+// The messages are discarded because there is nowhere to put them until the log
+// stream exists, and buffering them is what fills the queue to begin with. This
+// also drops messages logged during the short window in which a log stream is
+// created successfully, which is a deliberate trade: this only applies to
+// non-blocking mode, which is lossy by definition, and the alternative is to
+// keep blocking the container.
+func (l *logStream) waitCreated(created <-chan bool, chLogs <-chan *logger.Message) bool {
+	for {
+		// Check whether the log stream exists before receiving a message, so
+		// that messages are only discarded for as long as there is nowhere to
+		// put them. A message that arrives at the same time as the log stream
+		// is created may still be discarded, which is acceptable: this only
+		// happens in non-blocking mode, which is lossy by definition.
+		select {
+		case <-created:
+			return true
+		default:
+		}
+
+		select {
+		case <-created:
+			return true
+		case msg, more := <-chLogs:
+			if !more {
+				return false
+			}
+			logger.PutMessage(msg)
 		}
 	}
 }

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -1029,6 +1029,139 @@ func TestCollectBatchClose(t *testing.T) {
 	assert.Equal(t, logline, *(argument.LogEvents[0].Message))
 }
 
+// TestCollectBatchLogDoesNotBlockBeforeStreamCreated verifies that messages are
+// consumed while the log stream is still being created.
+//
+// In non-blocking mode the log stream is created by a goroutine that retries
+// indefinitely, so a log group that does not exist keeps creation pending
+// forever. If nothing drained the message queue in the meantime, Log would
+// block once the queue filled up, which deadlocked container exit.
+func TestCollectBatchLogDoesNotBlockBeforeStreamCreated(t *testing.T) {
+	stream := &logStream{
+		client:        &mockClient{},
+		logGroupName:  groupName,
+		logStreamName: streamName,
+		sequenceToken: aws.String(sequenceToken),
+		messages:      loggerutils.NewMessageQueue(1),
+	}
+
+	// Never closed: the log stream is never created.
+	created := make(chan bool)
+	go stream.collectBatch(created)
+	defer stream.Close()
+
+	logged := make(chan struct{})
+	go func() {
+		defer close(logged)
+		// More messages than the queue can hold.
+		for range 100 {
+			stream.Log(&logger.Message{
+				Line:      []byte(logline),
+				Timestamp: time.Time{},
+			})
+		}
+	}()
+
+	select {
+	case <-logged:
+	case <-time.After(30 * time.Second):
+		t.Fatal("Log blocked while the log stream was still being created")
+	}
+}
+
+// TestCollectBatchCloseBeforeStreamCreated verifies that closing the driver
+// stops batching even if the log stream was never created. Otherwise the
+// goroutine outlives the container it logs for.
+func TestCollectBatchCloseBeforeStreamCreated(t *testing.T) {
+	stream := &logStream{
+		client:        &mockClient{},
+		logGroupName:  groupName,
+		logStreamName: streamName,
+		sequenceToken: aws.String(sequenceToken),
+		messages:      loggerutils.NewMessageQueue(1),
+	}
+
+	// Never closed: the log stream is never created.
+	created := make(chan bool)
+	collectDone := make(chan struct{})
+	go func() {
+		defer close(collectDone)
+		stream.collectBatch(created)
+	}()
+
+	stream.Log(&logger.Message{
+		Line:      []byte(logline),
+		Timestamp: time.Time{},
+	})
+	stream.Close()
+
+	select {
+	case <-collectDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("collectBatch did not return after the driver was closed")
+	}
+}
+
+// TestCollectBatchStreamCreatedLate verifies that batching resumes normally
+// once the log stream is created, after messages have been discarded while
+// creation was pending.
+func TestCollectBatchStreamCreatedLate(t *testing.T) {
+	mockClient := &mockClient{}
+	stream := &logStream{
+		client:        mockClient,
+		logGroupName:  groupName,
+		logStreamName: streamName,
+		sequenceToken: aws.String(sequenceToken),
+		messages:      loggerutils.NewMessageQueue(0),
+	}
+	var calls []*cloudwatchlogs.PutLogEventsInput
+	called := make(chan struct{}, 50)
+	mockClient.putLogEventsFunc = func(ctx context.Context, input *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
+		calls = append(calls, input)
+		called <- struct{}{}
+		return &cloudwatchlogs.PutLogEventsOutput{
+			NextSequenceToken: aws.String(nextSequenceToken),
+		}, nil
+	}
+	ticks := make(chan time.Time)
+	newTicker = func(_ time.Duration) *time.Ticker {
+		return &time.Ticker{
+			C: ticks,
+		}
+	}
+
+	created := make(chan bool)
+	go stream.collectBatch(created)
+
+	// The queue is unbuffered, so this returns once the message has been
+	// received, which can only be the goroutine discarding it while the log
+	// stream does not exist yet.
+	stream.Log(&logger.Message{
+		Line:      []byte("dropped while the log stream did not exist"),
+		Timestamp: time.Time{},
+	})
+
+	close(created)
+
+	// The batch is empty, so this tick publishes nothing. It only blocks until
+	// collectBatch has observed that the log stream was created and reached its
+	// main loop, so that the message below is batched instead of discarded.
+	ticks <- time.Time{}
+
+	stream.Log(&logger.Message{
+		Line:      []byte(logline),
+		Timestamp: time.Time{},
+	})
+	ticks <- time.Time{}
+
+	<-called
+	stream.Close()
+
+	assert.Assert(t, is.Len(calls, 1))
+	assert.Assert(t, is.Len(calls[0].LogEvents, 1))
+	assert.Equal(t, logline, aws.ToString(calls[0].LogEvents[0].Message))
+}
+
 func TestEffectiveLen(t *testing.T) {
 	tests := []struct {
 		str            string

--- a/daemon/logger/loggerutils/queue.go
+++ b/daemon/logger/loggerutils/queue.go
@@ -143,6 +143,21 @@ func (q *MessageQueue) Close() {
 	close(q.closeWait)
 }
 
+// Done returns a channel that is closed when [MessageQueue.Close] is called.
+//
+// Unlike the channel returned by [MessageQueue.Receiver], which stays open
+// until the queue has been drained, this channel is closed as soon as the queue
+// starts closing. It can be used to interrupt work that should not outlive the
+// queue.
+func (q *MessageQueue) Done() <-chan struct{} {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.init()
+
+	return q.closed
+}
+
 // Receiver returns a channel that can be used to dequeue messages
 // The channel will be closed when the message queue is closed but may have
 // messages buffered.


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/53143
Related to: https://github.com/moby/moby/issues/40063 (the same hang, fixed per-driver for `fluentd` in #42979)

## Summary

When the `awslogs` driver runs in non-blocking mode and the target CloudWatch log group does not exist, stopping the container deadlocks container exit: the container process is dead but stays `Up` in `docker ps`, its published host port is never released, and `docker inspect`/`stop`/`kill`/`rm` all block forever for that container.

This fixes the driver so that it can always be closed, which is what unwedges the exit path.

### Why it deadlocks

In non-blocking mode the log stream is created by a goroutine that retries indefinitely, so a missing log group keeps creation pending forever. `collectBatch` waited on that creation before it began receiving from the message queue:

```go
func (l *logStream) collectBatch(created chan bool) {
	// Wait for the logstream/group to be created
	<-created
	...
	chLogs := l.messages.Receiver()
```

So nothing consumed the queue while creation was pending. The queue is bounded (`awslogs-max-buffered-events`, 4096 by default), and `logStream.Log` blocks once it is full, so the chain from the issue's goroutine dump closes into a cycle:

1. `handleContainerExit` → `Container.Reset` → `ringLogger.Close` blocks on `wg.Wait()` for its forwarding goroutine (`daemon/logger/ring.go`).
2. That goroutine is blocked in `logStream.Log` → `MessageQueue.Enqueue`, because the queue is full.
3. The queue is full because `collectBatch` is parked on `<-created`.
4. `<-created` never fires because `CreateLogStream` keeps failing against a log group that does not exist.

The cycle closes at step 1: `ringLogger.Close` calls the driver's `Close()` — which closes the queue and *would* release the blocked `Enqueue` — only **after** `wg.Wait()` returns. The one thing that could break the deadlock is gated behind the wait it would satisfy.

Because `Container.Reset` holds the container `State` lock, every container-scoped API call for that container then blocks on the mutex, and the port stays in the daemon's accounting even though nothing is listening at the OS level.

This is why it only reproduces in non-blocking mode (blocking mode creates the stream synchronously in `New` and fails container start cleanly) and only with enough log volume to fill the queue.

### The fix

Keep consuming the queue while the log stream is being created, in a new `waitCreated` helper. `Log` then never blocks, so the driver can always be closed and the ring logger's goroutine can always return.

Messages received before the log stream exists are discarded. There is nowhere to put them, and buffering them is what fills the queue to begin with.

**Trade-off worth calling out:** this also drops messages logged during the brief window in which a log stream *is* created successfully, where they were previously buffered and delivered. This is deliberate — it only applies to non-blocking mode, which is lossy by definition, and the alternative is to keep blocking the container — but it is a behavior change, and happy to rework it if reviewers would rather preserve that buffering.

Two smaller things in the same code:

- **The retry backoff outlived the driver.** The goroutine slept up to 32s before re-checking `closed`, keeping a stopped container's logger alive for that long, and it could still create a log stream for a container that no longer exists. It now waits on the message queue being closed as well as on the timer, via a new `MessageQueue.Done()` in `loggerutils`.
- **The retry loop logged the wrong error.** `if err := containerStream.create(); err == nil` scopes `err` to the `if` statement, so the `error` field in `"Error while trying to initialize awslogs"` referred to the outer `err` from `newAWSLogsClient`, which is always `nil` at that point. The daemon log therefore reported `error=<nil>` instead of the `ResourceNotFoundException` that explains the retry — precisely the message needed to diagnose this issue. Introduced in be54c79.

### Scope

This fixes `awslogs`, matching how the analogous `fluentd` hang (#40063) was fixed per-driver in #42979.

It does not address the general defect that `ringLogger.Close` can block forever on any driver whose `Log()` does not return — that is the broader class tracked by #41827/#41828 and is a separate change.

## Testing

Three regression tests in `daemon/logger/awslogs`:

| test | asserts |
| --- | --- |
| `TestCollectBatchLogDoesNotBlockBeforeStreamCreated` | `Log` returns while stream creation is still pending, with more messages than the queue holds |
| `TestCollectBatchCloseBeforeStreamCreated` | `collectBatch` returns after `Close` when the stream was never created |
| `TestCollectBatchStreamCreatedLate` | batching and publishing resume normally once creation completes |

All three fail against the unfixed driver — the first two time out on the blocked `Log`/`collectBatch`, the third hangs until the test binary panics — and pass with it.

- `go test ./daemon/logger/awslogs/ ./daemon/logger/loggerutils/ ./daemon/logger/ ./daemon/logger/loggerutils/cache/` passes, including all 42 pre-existing `awslogs` tests
- `go test -race -count=5 -run TestCollectBatch ./daemon/logger/awslogs/` is clean
- `GOOS=linux go build ./daemon/logger/...`, `go vet`, `gofmt` clean

Not verified end-to-end against a live CloudWatch endpoint; the reproducer in the issue needs an EC2 instance role and a genuinely absent log group.

## Release notes (optional)

```markdown changelog
Fix the `awslogs` logging driver in non-blocking mode preventing a container from stopping, and its published ports from being released, when the CloudWatch log group does not exist.
```