### PR TITLE
integration-cli: fix flaky TestAPISwarmServicesFailedUpdate

### DIFF
--- a/integration-cli/docker_api_swarm_service_test.go
+++ b/integration-cli/docker_api_swarm_service_test.go
@@ -329,8 +329,7 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesFailedUpdate(c *testing.T) {
 
 	// should update 2 tasks and then pause
 	poll.WaitOn(c, pollCheck(c, daemons[0].CheckServiceUpdateState(ctx, id), checker.Equals(swarm.UpdateStatePaused)), poll.WithTimeout(defaultReconciliationTimeout))
-	v, _ := daemons[0].CheckServiceRunningTasks(ctx, id)(c)
-	assert.Assert(c, v == instances-2)
+	poll.WaitOn(c, pollCheck(c, daemons[0].CheckServiceRunningTasks(ctx, id), checker.Equals(instances-2)), poll.WithTimeout(defaultReconciliationTimeout))
 
 	// Roll back to the previous version. This uses the CLI because
 	// rollback used to be a client-side operation.


### PR DESCRIPTION
## Summary

Fix intermittent failure of `TestAPISwarmServicesFailedUpdate`.

After `poll.WaitOn` confirms the update is in `UpdateStatePaused` state, the test previously read the running-task count exactly once and asserted immediately with no retry. If any task was still transitioning at that moment, the assertion would fail spuriously.

Replace the single-shot check with a `poll.WaitOn` using the same `defaultReconciliationTimeout`, so the assertion retries until the Swarm scheduler has stabilised the expected number of running tasks.

- Fixes: https://github.com/moby/moby/issues/37408

## Release notes (optional)

```markdown changelog

```

## Note for maintainers

A maintainer's `Signed-off-by` co-sign is needed before this PR can be merged, per the DCO policy discussion in https://github.com/moby/moby/pull/53197. If you are approving this PR, please amend the commit to add your own sign-off, or instruct Gordon to add it on your behalf.

## A picture of a cute animal (not mandatory but encouraged)

🐢