### PR TITLE
daemon: notify container waiters before removing from registry in cleanupContainer

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -168,6 +168,13 @@ func (daemon *Daemon) cleanupContainer(ctr *container.Container, config backend.
 	if ctr.ProcessLabel != "" {
 		selinux.ReleaseLabel(ctr.ProcessLabel)
 	}
+	// Notify waiters that the container has been removed before deleting it
+	// from the in-memory registry. This closes a race where a ContainerWait
+	// call arriving after containers.Delete but before SetRemoved would get a
+	// 404 from GetContainer and return exit code 125 instead of the container's
+	// actual exit code.
+	ctr.State.SetRemoved()
+	metrics.StateCtr.Delete(ctr.ID)
 	daemon.containers.Delete(ctr.ID)
 	daemon.containersReplica.Delete(ctr)
 	if err := daemon.removeMountPoints(ctr, config.RemoveVolume); err != nil {
@@ -176,8 +183,6 @@ func (daemon *Daemon) cleanupContainer(ctr *container.Container, config backend.
 	for _, name := range linkNames {
 		daemon.releaseName(name)
 	}
-	ctr.State.SetRemoved()
-	metrics.StateCtr.Delete(ctr.ID)
 
 	daemon.LogContainerEvent(ctr, events.ActionDestroy)
 	return nil


### PR DESCRIPTION
## Summary

Fix intermittent failure of `TestStartReturnCorrectExitCode`.

### Root cause

The test `TestStartReturnCorrectExitCode` in `integration-cli/docker_cli_start_test.go` is flaky due to a race condition in `daemon/delete.go`. When a `--rm` container finishes, `cleanupContainer()` removes the container from the in-memory registry via `daemon.containers.Delete(ctr.ID)` **before** notifying waiters via `ctr.State.SetRemoved()`. A `ContainerWait` call arriving in that window hits `GetContainer` → 404 → exit code 125 instead of the expected exit code 12.

### Fix

This PR reorders the operations in `cleanupContainer()` to call `ctr.State.SetRemoved()` and `metrics.StateCtr.Delete(ctr.ID)` **before** `daemon.containers.Delete(ctr.ID)`. This ensures that any waiters are notified of the container's removal (and receive its exit code) before the container is removed from the registry.

- Closes: https://github.com/moby/moby/issues/38521

## Release notes (optional)

```markdown changelog

```

## Note for maintainers

A maintainer's `Signed-off-by` co-sign is needed before this PR can be merged, per the DCO policy discussion in https://github.com/moby/moby/pull/53197. If you are approving this PR, please amend the commit to add your own sign-off, or instruct Gordon to add it on your behalf.

## A picture of a cute animal (not mandatory but encouraged)

🐢