### PR TITLE
daemon/internal/image/tarexport: remove uses of moby/sys/sequential

### DIFF
--- a/daemon/internal/image/tarexport/load.go
+++ b/daemon/internal/image/tarexport/load.go
@@ -25,7 +25,6 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/progress"
 	"github.com/moby/moby/v2/daemon/internal/streamformatter"
 	"github.com/moby/moby/v2/daemon/internal/stringid"
-	"github.com/moby/sys/sequential"
 	"github.com/moby/sys/symlink"
 	"github.com/opencontainers/go-digest"
 )
@@ -212,8 +211,8 @@ func (l *tarexporter) loadLayer(ctx context.Context, filename string, rootFS ima
 	}()
 
 	// We use sequential file access to avoid depleting the standby list on Windows.
-	// On Linux, this equates to a regular os.Open.
-	rawTar, err := sequential.Open(filename)
+	// On non-Windows platforms this equates to a regular os.Open.
+	rawTar, err := os.OpenFile(filename, os.O_RDONLY|windows_O_FILE_FLAG_SEQUENTIAL_SCAN, 0)
 	if err != nil {
 		log.G(context.TODO()).Debugf("Error reading embedded tar: %v", err)
 		return nil, err

--- a/daemon/internal/image/tarexport/save.go
+++ b/daemon/internal/image/tarexport/save.go
@@ -25,7 +25,6 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/layer"
 	"github.com/moby/moby/v2/daemon/internal/system"
 	"github.com/moby/moby/v2/errdefs"
-	"github.com/moby/sys/sequential"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -550,12 +549,12 @@ func (s *saveSession) saveConfigAndLayer(ctx context.Context, id layer.ChainID, 
 		return distribution.Descriptor{}, err
 	}
 
-	// We use sequential file access to avoid depleting the standby list on
-	// Windows. On Linux, this equates to a regular os.Create.
 	if err := mkdirAllWithChtimes(filepath.Dir(layerPath), 0o755, ts, ts); err != nil {
 		return distribution.Descriptor{}, errors.Wrap(err, "could not create layer dir parent")
 	}
-	tarFile, err := sequential.Create(layerPath)
+	// We use sequential file access to avoid depleting the standby list on
+	// Windows. On non-Windows platforms this equates to a regular os.Create.
+	tarFile, err := os.OpenFile(layerPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|windows_O_FILE_FLAG_SEQUENTIAL_SCAN, 0o666)
 	if err != nil {
 		return distribution.Descriptor{}, errors.Wrap(err, "error creating layer file")
 	}

--- a/daemon/internal/image/tarexport/sequential_nowindows.go
+++ b/daemon/internal/image/tarexport/sequential_nowindows.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package tarexport
+
+const windows_O_FILE_FLAG_SEQUENTIAL_SCAN = 0

--- a/daemon/internal/image/tarexport/sequential_windows.go
+++ b/daemon/internal/image/tarexport/sequential_windows.go
@@ -1,0 +1,5 @@
+package tarexport
+
+import "golang.org/x/sys/windows"
+
+const windows_O_FILE_FLAG_SEQUENTIAL_SCAN = windows.O_FILE_FLAG_SEQUENTIAL_SCAN

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,6 @@ require (
 	github.com/moby/sys/mount v0.3.5
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/moby/sys/reexec v0.1.0
-	github.com/moby/sys/sequential v0.7.0
 	github.com/moby/sys/signal v0.7.1
 	github.com/moby/sys/symlink v0.3.0
 	github.com/moby/sys/user v0.4.1
@@ -241,6 +240,7 @@ require (
 	github.com/mdlayher/vsock v1.2.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/sys/capability v0.4.0 // indirect
+	github.com/moby/sys/sequential v0.7.0 // indirect
 	github.com/morikuni/aec v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/ulid/v2 v2.1.1 // indirect


### PR DESCRIPTION
go1.26 now natively supports O_FILE_FLAG_SEQUENTIAL_SCAN on Windows; the moby/sys/sequential package is now a very thin wrapper around stdlib and golang.org/x/sys/windows (for the flag value) when using go1.26.

Define a local, non-exported const for O_FILE_FLAG_SEQUENTIAL_SCAN, which is an alias for windows.O_FILE_FLAG_SEQUENTIAL_SCAN on Windows, and a zero-value for other platforms.

We still have moby/sys/sequential as an indirect dependency, but this will eventually go away.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
