### PR TITLE
daemon/config: TestDaemonBrokenConfiguration avoid string-matching

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -558,7 +558,7 @@ func getConflictFreeConfiguration(configFile string, flags *pflag.FlagSet) (*Con
 	if flags != nil {
 		var jsonConfig map[string]any
 		if err := json.Unmarshal(b, &jsonConfig); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("invalid JSON: %w", err)
 		}
 
 		configSet := configValuesSet(jsonConfig)
@@ -601,7 +601,7 @@ func getConflictFreeConfiguration(configFile string, flags *pflag.FlagSet) (*Con
 	}
 
 	if err := json.Unmarshal(b, &config); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
 
 	for _, mc := range migratedNamedConfig {

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -37,11 +38,13 @@ func TestDaemonConfigurationNotFound(t *testing.T) {
 	assert.Check(t, os.IsNotExist(err), "got: %[1]T: %[1]v", err)
 }
 
-func TestDaemonBrokenConfiguration(t *testing.T) {
-	configFile := makeConfigFile(t, `{"Debug": tru`)
+func TestDaemonConfigurationMalformedJSON(t *testing.T) {
+	configFile := makeConfigFile(t, `{"debug": tru`)
 
 	_, err := MergeDaemonConfigurations(&Config{}, nil, configFile)
-	assert.ErrorContains(t, err, `invalid character ' ' in literal true`)
+	assert.Check(t, is.ErrorContains(err, "invalid JSON"))
+	var syntaxErr *json.SyntaxError
+	assert.Check(t, errors.As(err, &syntaxErr), `got: %[1]T: %[1]v`, err)
 }
 
 // TestDaemonConfigurationUnicodeVariations feeds various variations of Unicode into the JSON parser, ensuring that we


### PR DESCRIPTION
- relates to / needed for https://github.com/moby/moby/pull/53279


This test was validating that we failed the daemon config because of malformed JSON, not any other error, but was depending on the error string, which changes in go1.27;

    === Failed
    === FAIL: daemon/config TestDaemonBrokenConfiguration (0.00s)
        config_test.go:44: assertion failed: expected error to contain "invalid character ' ' in literal true", got "unexpected end of JSON input"

Update the test to check for a json.SyntaxError instead, so that we don't depend on string-matching, and update the config code to decorate the error.

Also rename the test to TestDaemonConfigurationMalformedJSON, to have a common prefix with other tests.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
