### PR TITLE
daemon/pkg/opts: fix recursive NRI JSON decoding on go1.27 (JSON v2)

### DIFF
--- a/daemon/pkg/opts/nri_opts.go
+++ b/daemon/pkg/opts/nri_opts.go
@@ -19,11 +19,8 @@ type NRIOpts struct {
 func (c *NRIOpts) UnmarshalJSON(raw []byte) error {
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.DisallowUnknownFields()
-	type nc *NRIOpts // prevent recursion
-	if err := dec.Decode(nc(c)); err != nil {
-		return err
-	}
-	return nil
+	type nriOpts NRIOpts // prevent recursion
+	return dec.Decode((*nriOpts)(c))
 }
 
 // NamedNRIOpts is a NamedOption and flags.Value for NRI configuration parsing.


### PR DESCRIPTION
- relates to https://github.com/golang/go/issues/75361
- relates to / needed for https://github.com/moby/moby/pull/53279

Define the recursion-prevention type from NRIOpts instead of *NRIOpts.

The named pointer type was handled correctly by the legacy JSON decoder, but Go 1.27's new JSON implementation resolves NRIOpts.UnmarshalJSON through it, causing infinite recursion and eventually a stack overflow.

Using a distinct type with NRIOpts as its underlying type removes the method set while preserving the same fields and JSON representation.

Failure on go1.27 before this patch;

```console
=== FAIL: daemon/pkg/opts TestNRIOptsJSON (unknown)
--- PASS: TestNRIOptsJSON/no_config (0.00s)
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0x27fc55c003a0 stack=[0x27fc55c00000, 0x27fc75c00000]
fatal error: stack overflow

runtime stack:
runtime.throw({0x2c3dab?, 0x4eba8?})
	/usr/local/go/src/runtime/panic.go:1243 +0x38 fp=0xfffff210f4c0 sp=0xfffff210f490 pc=0x994f8
runtime.newstack()
	/usr/local/go/src/runtime/stack.go:1178 +0x480 fp=0xfffff210f5f0 sp=0xfffff210f4c0 pc=0x7ab40
runtime.morestack()
	/usr/local/go/src/runtime/asm_arm64.s:487 +0x70 fp=0xfffff210f5f0 sp=0xfffff210f5f0 pc=0x9e400

goroutine 127 gp=0x27fc353f21e0 m=0 mp=0x5f9440 [running]:
encoding/json/jsontext.(*decoderState).consumeObject(0x27fc4b28c280, 0x27fc55c00500, 0x0?, 0x1)
	/usr/local/go/src/encoding/json/jsontext/decode.go:971 +0xb44 fp=0x27fc55c003a0 sp=0x27fc55c003a0 pc=0x13cae4
encoding/json/jsontext.(*decoderState).consumeValue(0x27fc4b28c280, 0x27fc55c00500, 0x27fc55c00498?, 0x1)
	/usr/local/go/src/encoding/json/jsontext/decode.go:884 +0x38c fp=0x27fc55c00410 sp=0x27fc55c003a0 pc=0x13b9bc
encoding/json/jsontext.(*decoderState).ReadValue(0x27fc4b28c280, 0x27fc55c00500)
	/usr/local/go/src/encoding/json/jsontext/decode.go:730 +0x118 fp=0x27fc55c004a0 sp=0x27fc55c00410 pc=0x13a888
encoding/json/jsontext.(*Decoder).ReadValue(...)
	/usr/local/go/src/encoding/json/jsontext/decode.go:678
encoding/json/v2.makeMethodArshaler.func6(0x27fc4b28c280, {{0x5afb18?, 0x27fc3543c200?, 0x10?}, 0x10?}, 0x27fc4b28c340)
	/usr/local/go/src/encoding/json/v2/arshal_methods.go:291 +0x98 fp=0x27fc55c00570 sp=0x27fc55c004a0 pc=0x16a198
encoding/json/v2.unmarshalDecode(0x27fc4b28c280, {0x58d030?, 0x27fc3543c200?}, 0x27fc4b28c340, 0x1)
	/usr/local/go/src/encoding/json/v2/arshal.go:472 +0x190 fp=0x27fc55c00630 sp=0x27fc55c00570 pc=0x150100
encoding/json/v2.Unmarshal({0x27fc464d5380?, 0x27fc55c00700?, 0x27fc55c00728?}, {0x58d030, 0x27fc3543c200}, {0x27fc55c00718?, 0x5f1780?, 0x27fc464e85a0?})
	/usr/local/go/src/encoding/json/v2/arshal.go:391 +0x84 fp=0x27fc55c006b0 sp=0x27fc55c00630 pc=0x14feb4
encoding/json.(*Decoder).Decode(0x27fc464e85d0, {0x58d030, 0x27fc3543c200})
	/usr/local/go/src/encoding/json/v2_stream.go:90 +0x134 fp=0x27fc55c00730 sp=0x27fc55c006b0 pc=0x17ffa4
github.com/moby/moby/v2/daemon/pkg/opts.(*NRIOpts).UnmarshalJSON(0x27fc3543c200, {0x27fc464d5340, 0x10, 0x10})
	/usr/src/moby/daemon/pkg/opts/nri_opts.go:23 +0x114 fp=0x27fc55c00770 sp=0x27fc55c00730 pc=0x29ea94
encoding/json/v2.makeMethodArshaler.func6(0x27fc4b287b80, {{0x5afb18?, 0x27fc3543c200?, 0x10?}, 0x10?}, 0x27fc4b287c40)
	/usr/local/go/src/encoding/json/v2/arshal_methods.go:296 +0xec fp=0x27fc55c00840 sp=0x27fc55c00770 pc=0x16a1ec
encoding/json/v2.unmarshalDecode(0x27fc4b287b80, {0x58d030?, 0x27fc3543c200?}, 0x27fc4b287c40, 0x1)
	/usr/local/go/src/encoding/json/v2/arshal.go:472 +0x190 fp=0x27fc55c00900 sp=0x27fc55c00840 pc=0x150100
encoding/json/v2.Unmarshal({0x27fc464d5340?, 0x27fc55c009d0?, 0x27fc55c009f8?}, {0x58d030, 0x27fc3543c200}, {0x27fc55c009e8?, 0x5f1780?, 0x27fc464e8540?})
	/usr/local/go/src/encoding/json/v2/arshal.go:391 +0x84 fp=0x27fc55c00980 sp=0x27fc55c00900 pc=0x14feb4
encoding/json.(*Decoder).Decode(0x27fc464e8570, {0x58d030, 0x27fc3543c200})
	/usr/local/go/src/encoding/json/v2_stream.go:90 +0x134 fp=0x27fc55c00a00 sp=0x27fc55c00980 pc=0x17ffa4
goroutine 129 gp=0x27fc353f25a0 m=nil [GC worker (idle)]:
runtime.gopark(0x468f31640b?, 0x1?, 0x5d?, 0xba?, 0x0?)
	/usr/local/go/src/runtime/proc.go:474 +0xb8 fp=0x27fc35287f20 sp=0x27fc35287f00 pc=0x99608
runtime.gcBgMarkWorker(0x27fc3541b9d0)
	/usr/local/go/src/runtime/mgc.go:1807 +0xe0 fp=0x27fc35287fb0 sp=0x27fc35287f20 pc=0x3f190
runtime.gcBgMarkStartWorkers.gowrap1()
	/usr/local/go/src/runtime/mgc.go:1711 +0x20 fp=0x27fc35287fd0 sp=0x27fc35287fb0 pc=0x8f6d0
runtime.goexit({})
	/usr/local/go/src/runtime/asm_arm64.s:1039 +0x4 fp=0x27fc35287fd0 sp=0x27fc35287fd0 pc=0xa0204
created by runtime.gcBgMarkStartWorkers in goroutine 127
	/usr/local/go/src/runtime/mgc.go:1711 +0x130

goroutine 130 gp=0x27fc353f2780 m=nil [GC worker (idle)]:
runtime.gopark(0x468f03c0f7?, 0x3?, 0x99?, 0x46?, 0x0?)
	/usr/local/go/src/runtime/proc.go:474 +0xb8 fp=0x27fc35317f20 sp=0x27fc35317f00 pc=0x99608
runtime.gcBgMarkWorker(0x27fc3541b9d0)
	/usr/local/go/src/runtime/mgc.go:1807 +0xe0 fp=0x27fc35317fb0 sp=0x27fc35317f20 pc=0x3f190
runtime.gcBgMarkStartWorkers.gowrap1()
	/usr/local/go/src/runtime/mgc.go:1711 +0x20 fp=0x27fc35317fd0 sp=0x27fc35317fb0 pc=0x8f6d0
runtime.goexit({})
	/usr/local/go/src/runtime/asm_arm64.s:1039 +0x4 fp=0x27fc35317fd0 sp=0x27fc35317fd0 pc=0xa0204
created by runtime.gcBgMarkStartWorkers in goroutine 127
	/usr/local/go/src/runtime/mgc.go:1711 +0x130

goroutine 131 gp=0x27fc353f2960 m=nil [GC worker (idle)]:
runtime.gopark(0x468f3174c3?, 0x3?, 0x2c?, 0x73?, 0x0?)
	/usr/local/go/src/runtime/proc.go:474 +0xb8 fp=0x27fc35280f20 sp=0x27fc35280f00 pc=0x99608
runtime.gcBgMarkWorker(0x27fc3541b9d0)
	/usr/local/go/src/runtime/mgc.go:1807 +0xe0 fp=0x27fc35280fb0 sp=0x27fc35280f20 pc=0x3f190
runtime.gcBgMarkStartWorkers.gowrap1()
	/usr/local/go/src/runtime/mgc.go:1711 +0x20 fp=0x27fc35280fd0 sp=0x27fc35280fb0 pc=0x8f6d0
runtime.goexit({})
	/usr/local/go/src/runtime/asm_arm64.s:1039 +0x4 fp=0x27fc35280fd0 sp=0x27fc35280fd0 pc=0xa0204
created by runtime.gcBgMarkStartWorkers in goroutine 127
	/usr/local/go/src/runtime/mgc.go:1711 +0x130
```


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
