### PR TITLE
daemon: use mountinfo parser when cleaning up mounts

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1537,8 +1537,13 @@ func (daemon *Daemon) Shutdown(ctx context.Context) error {
 				logger.WithError(err).Error("failed to shut down container")
 				return
 			}
-			if mountid, err := daemon.imageService.GetLayerMountID(c.ID); err == nil {
-				daemon.cleanupMountsByID(mountid)
+			if mountID, err := daemon.imageService.GetLayerMountID(c.ID); err == nil {
+				if err := daemon.cleanupMountsByID(mountID); err != nil {
+					logger.WithFields(log.Fields{
+						"error":   err,
+						"mountid": mountID,
+					}).Warn("failed to clean up container mounts")
+				}
 			}
 			logger.Debugf("shut down container")
 		})
@@ -1546,7 +1551,7 @@ func (daemon *Daemon) Shutdown(ctx context.Context) error {
 
 	if daemon.volumes != nil {
 		if err := daemon.volumes.Shutdown(); err != nil {
-			log.G(ctx).Errorf("Error shutting down volume store: %v", err)
+			log.G(ctx).WithError(err).Error("error shutting down volume store")
 		}
 	}
 
@@ -1577,11 +1582,11 @@ func (daemon *Daemon) Shutdown(ctx context.Context) error {
 	}
 
 	if daemon.containerdClient != nil {
-		daemon.containerdClient.Close()
+		_ = daemon.containerdClient.Close()
 	}
 
 	if daemon.mdDB != nil {
-		daemon.mdDB.Close()
+		_ = daemon.mdDB.Close()
 	}
 
 	// At this point, everything has been shut down and no containers are
@@ -1589,7 +1594,7 @@ func (daemon *Daemon) Shutdown(ctx context.Context) error {
 	// '/events' endpoint, closing the EventsService should tear them down
 	// immediately.
 	if daemon.EventsService != nil {
-		daemon.EventsService.Close()
+		_ = daemon.EventsService.Close()
 	}
 
 	return daemon.cleanupMounts(cfg)

--- a/daemon/daemon_linux.go
+++ b/daemon/daemon_linux.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -18,7 +19,6 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork/resolvconf"
 	"github.com/moby/sys/mount"
 	"github.com/moby/sys/mountinfo"
-	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
@@ -46,7 +46,7 @@ func (daemon *Daemon) cleanupMountsFromReaderByID(reader io.Reader, id string, u
 	if daemon.root == "" {
 		return nil
 	}
-	var errs []string
+	var errs []error
 
 	regexps := getCleanPatterns(id)
 	sc := bufio.NewScanner(reader)
@@ -57,7 +57,7 @@ func (daemon *Daemon) cleanupMountsFromReaderByID(reader io.Reader, id string, u
 					if p.MatchString(mnt) {
 						if err := unmount(mnt); err != nil {
 							log.G(context.TODO()).Error(err)
-							errs = append(errs, err.Error())
+							errs = append(errs, err)
 						}
 					}
 				}
@@ -69,8 +69,8 @@ func (daemon *Daemon) cleanupMountsFromReaderByID(reader io.Reader, id string, u
 		return err
 	}
 
-	if len(errs) > 0 {
-		return fmt.Errorf("Error cleaning up mounts:\n%v", strings.Join(errs, "\n"))
+	if err := errors.Join(errs...); err != nil {
+		return fmt.Errorf("error cleaning up mounts:\n%w", err)
 	}
 
 	log.G(context.TODO()).Debugf("Cleaning up old mountid %v: done.", id)
@@ -85,7 +85,7 @@ func (daemon *Daemon) cleanupMounts(cfg *config.Config) error {
 
 	info, err := mountinfo.GetMounts(mountinfo.SingleEntryFilter(daemon.root))
 	if err != nil {
-		return errors.Wrap(err, "error reading mount table for cleanup")
+		return fmt.Errorf("error reading mount table for cleanup: %w", err)
 	}
 
 	if len(info) < 1 {

--- a/daemon/daemon_linux.go
+++ b/daemon/daemon_linux.go
@@ -32,14 +32,18 @@ func getPluginExecRoot(_ *config.Config) string {
 }
 
 func (daemon *Daemon) cleanupMountsByID(id string) error {
-	log.G(context.TODO()).Debugf("Cleaning up old mountid %s: start.", id)
+	log.G(context.TODO()).WithField("mountid", id).Debug("cleaning up old mount start")
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 
-	return daemon.cleanupMountsFromReaderByID(f, id, mount.Unmount)
+	if err := daemon.cleanupMountsFromReaderByID(f, id, mount.Unmount); err != nil {
+		return err
+	}
+	log.G(context.TODO()).WithField("mountid", id).Debug("cleaning up old mount done")
+	return nil
 }
 
 func (daemon *Daemon) cleanupMountsFromReaderByID(reader io.Reader, id string, unmount func(target string) error) error {
@@ -56,7 +60,10 @@ func (daemon *Daemon) cleanupMountsFromReaderByID(reader io.Reader, id string, u
 				for _, p := range regexps {
 					if p.MatchString(mnt) {
 						if err := unmount(mnt); err != nil {
-							log.G(context.TODO()).Error(err)
+							log.G(context.TODO()).WithFields(log.Fields{
+								"mountpoint": mnt,
+								"error":      err,
+							}).Error("error unmounting mountpoint")
 							errs = append(errs, err)
 						}
 					}
@@ -73,7 +80,6 @@ func (daemon *Daemon) cleanupMountsFromReaderByID(reader io.Reader, id string, u
 		return fmt.Errorf("error cleaning up mounts:\n%w", err)
 	}
 
-	log.G(context.TODO()).Debugf("Cleaning up old mountid %v: done.", id)
 	return nil
 }
 

--- a/daemon/daemon_linux.go
+++ b/daemon/daemon_linux.go
@@ -1,12 +1,12 @@
 package daemon
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -50,30 +50,42 @@ func (daemon *Daemon) cleanupMountsFromReaderByID(reader io.Reader, id string, u
 	if daemon.root == "" {
 		return nil
 	}
-	var errs []error
 
-	regexps := getCleanPatterns(id)
-	sc := bufio.NewScanner(reader)
-	for sc.Scan() {
-		if fields := strings.Fields(sc.Text()); len(fields) > 4 {
-			if mnt := fields[4]; strings.HasPrefix(mnt, daemon.root) {
-				for _, p := range regexps {
-					if p.MatchString(mnt) {
-						if err := unmount(mnt); err != nil {
-							log.G(context.TODO()).WithFields(log.Fields{
-								"mountpoint": mnt,
-								"error":      err,
-							}).Error("error unmounting mountpoint")
-							errs = append(errs, err)
-						}
-					}
-				}
-			}
-		}
+	root := filepath.Clean(daemon.root)
+	if !filepath.IsAbs(root) {
+		return fmt.Errorf("cannot clean up mounts with non-absolute daemon root %q", daemon.root)
+	}
+	if root == "/" {
+		return errors.New("cannot clean up mounts with daemon root set to /")
 	}
 
-	if err := sc.Err(); err != nil {
+	regexps := getCleanPatterns(id)
+	mounts, err := mountinfo.GetMountsFromReader(reader, func(m *mountinfo.Info) (skip, stop bool) {
+		// Mountinfo paths have no trailing slash. Append one to both paths to avoid
+		// matching sibling paths that merely share the daemon-root prefix.
+		if !strings.HasPrefix(m.Mountpoint+"/", root+"/") {
+			return true, false
+		}
+		for _, p := range regexps {
+			if p.MatchString(m.Mountpoint) {
+				return false, false
+			}
+		}
+		return true, false
+	})
+	if err != nil {
 		return err
+	}
+
+	var errs []error
+	for _, m := range mounts {
+		if err := unmount(m.Mountpoint); err != nil {
+			log.G(context.TODO()).WithFields(log.Fields{
+				"mountpoint": m.Mountpoint,
+				"error":      err,
+			}).Error("error unmounting mountpoint")
+			errs = append(errs, err)
+		}
 	}
 
 	if err := errors.Join(errs...); err != nil {
@@ -89,13 +101,23 @@ func (daemon *Daemon) cleanupMounts(cfg *config.Config) error {
 		return err
 	}
 
-	info, err := mountinfo.GetMounts(mountinfo.SingleEntryFilter(daemon.root))
+	if daemon.root == "" {
+		return nil
+	}
+	root := filepath.Clean(daemon.root)
+	if !filepath.IsAbs(root) {
+		return fmt.Errorf("cannot clean up mounts with non-absolute daemon root %q", daemon.root)
+	}
+	if root == "/" {
+		return errors.New("cannot clean up mounts with daemon root set to /")
+	}
+	info, err := mountinfo.GetMounts(mountinfo.SingleEntryFilter(root))
 	if err != nil {
 		return fmt.Errorf("error reading mount table for cleanup: %w", err)
 	}
 
-	if len(info) < 1 {
-		// no mount found, we're done here
+	if len(info) == 0 {
+		// No mount found; nothing to clean up.
 		return nil
 	}
 
@@ -104,7 +126,7 @@ func (daemon *Daemon) cleanupMounts(cfg *config.Config) error {
 	//   `mount --bind /daemon/root /daemon/root && mount --make-shared /daemon/root`
 	// This is only done when the daemon is started up and `/daemon/root` is not
 	// already on a shared mountpoint.
-	if !shouldUnmountRoot(daemon.root, info[0]) {
+	if !shouldUnmountRoot(root, info[0]) {
 		return nil
 	}
 
@@ -113,8 +135,8 @@ func (daemon *Daemon) cleanupMounts(cfg *config.Config) error {
 		return nil
 	}
 
-	log.G(context.TODO()).WithField("mountpoint", daemon.root).Debug("unmounting daemon root")
-	if err := mount.Unmount(daemon.root); err != nil {
+	log.G(context.TODO()).WithField("mountpoint", root).Debug("unmounting daemon root")
+	if err := mount.Unmount(root); err != nil {
 		return err
 	}
 	return os.Remove(unmountFile)

--- a/daemon/daemon_linux_test.go
+++ b/daemon/daemon_linux_test.go
@@ -135,6 +135,21 @@ func TestCleanupMounts(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, unmounted, 1, "Expected to unmount the shm (and the shm only)")
 	})
+
+	// Verify escaped mountpoint characters are decoded before matching and unmounting.
+	t.Run("escaped mountpoint", func(t *testing.T) {
+		const expected = "/var/lib/docker data/containers/404a7f860e600bfc144f7b5d9140d80bf3072fbb97659f98bc47039fd73d2695/mounts/shm"
+		const mountInfo = `123 456 0:42 / /var/lib/docker\040data/containers/404a7f860e600bfc144f7b5d9140d80bf3072fbb97659f98bc47039fd73d2695/mounts/shm rw,relatime - tmpfs tmpfs rw` //nolint:dupword
+
+		var unmounted string
+		d2 := &Daemon{root: "/var/lib/docker data"}
+		err := d2.cleanupMountsFromReaderByID(strings.NewReader(mountInfo), "", func(target string) error {
+			unmounted = target
+			return nil
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, unmounted, expected)
+	})
 }
 
 func TestCleanupMountsByID(t *testing.T) {

--- a/daemon/daemon_linux_test.go
+++ b/daemon/daemon_linux_test.go
@@ -111,31 +111,27 @@ func TestCleanupMounts(t *testing.T) {
 	}
 
 	t.Run("aufs", func(t *testing.T) {
-		expected := "/var/lib/docker/containers/d045dc441d2e2e1d5b3e328d47e5943811a40819fb47497c5f5a5df2d6d13c37/shm"
+		const expected = "/var/lib/docker/containers/d045dc441d2e2e1d5b3e328d47e5943811a40819fb47497c5f5a5df2d6d13c37/shm"
 		var unmounted int
-		unmount := func(target string) error {
+		err := d.cleanupMountsFromReaderByID(strings.NewReader(mountsFixture), "", func(target string) error {
 			if target == expected {
 				unmounted++
 			}
 			return nil
-		}
-
-		err := d.cleanupMountsFromReaderByID(strings.NewReader(mountsFixture), "", unmount)
+		})
 		assert.NilError(t, err)
 		assert.Equal(t, unmounted, 1, "Expected to unmount the shm (and the shm only)")
 	})
 
 	t.Run("overlay2", func(t *testing.T) {
-		expected := "/var/lib/docker/containers/404a7f860e600bfc144f7b5d9140d80bf3072fbb97659f98bc47039fd73d2695/mounts/shm"
+		const expected = "/var/lib/docker/containers/404a7f860e600bfc144f7b5d9140d80bf3072fbb97659f98bc47039fd73d2695/mounts/shm"
 		var unmounted int
-		unmount := func(target string) error {
+		err := d.cleanupMountsFromReaderByID(strings.NewReader(mountsFixtureOverlay2), "", func(target string) error {
 			if target == expected {
 				unmounted++
 			}
 			return nil
-		}
-
-		err := d.cleanupMountsFromReaderByID(strings.NewReader(mountsFixtureOverlay2), "", unmount)
+		})
 		assert.NilError(t, err)
 		assert.Equal(t, unmounted, 1, "Expected to unmount the shm (and the shm only)")
 	})
@@ -146,16 +142,15 @@ func TestCleanupMountsByID(t *testing.T) {
 		root: "/var/lib/docker/",
 	}
 	t.Run("overlay2", func(t *testing.T) {
-		expected := "/var/lib/docker/overlay2/3a4b807fcb98c208573f368c5654a6568545a7f92404a07d0045eb5c85acaf67/merged"
+		const mntID = "3a4b807fcb98c208573f368c5654a6568545a7f92404a07d0045eb5c85acaf67"
+		const expected = "/var/lib/docker/overlay2/3a4b807fcb98c208573f368c5654a6568545a7f92404a07d0045eb5c85acaf67/merged"
 		var unmounted int
-		unmount := func(target string) error {
+		err := d.cleanupMountsFromReaderByID(strings.NewReader(mountsFixtureOverlay2), mntID, func(target string) error {
 			if target == expected {
 				unmounted++
 			}
 			return nil
-		}
-
-		err := d.cleanupMountsFromReaderByID(strings.NewReader(mountsFixtureOverlay2), "3a4b807fcb98c208573f368c5654a6568545a7f92404a07d0045eb5c85acaf67", unmount)
+		})
 		assert.NilError(t, err)
 		assert.Equal(t, unmounted, 1, "Expected to unmount the root (and that only)")
 	})
@@ -165,15 +160,14 @@ func TestNotCleanupMounts(t *testing.T) {
 	d := &Daemon{
 		repository: "",
 	}
-	var unmounted bool
-	unmount := func(target string) error {
-		unmounted = true
+	var unmounted int
+	const mountInfo = `234 232 0:59 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k`
+	err := d.cleanupMountsFromReaderByID(strings.NewReader(mountInfo), "", func(target string) error {
+		unmounted++
 		return nil
-	}
-	mountInfo := `234 232 0:59 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k`
-	err := d.cleanupMountsFromReaderByID(strings.NewReader(mountInfo), "", unmount)
+	})
 	assert.NilError(t, err)
-	assert.Equal(t, unmounted, false, "Expected not to clean up /dev/shm")
+	assert.Equal(t, unmounted, 0, "Expected not to clean up /dev/shm")
 }
 
 func TestValidateContainerIsolationLinux(t *testing.T) {

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -268,34 +268,41 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 // Cleanup releases any network resources allocated to the container along with any rules
 // around how containers are linked together.  It also unmounts the container's root filesystem.
 func (daemon *Daemon) Cleanup(ctx context.Context, container *container.Container) {
+	logger := log.G(ctx).WithField("container", container.ID)
+
 	// Microsoft HCS containers get in a bad state if host resources are
 	// released while the container still exists.
 	if ctr, ok := container.State.C8dContainer(); ok {
-		if err := ctr.Delete(context.Background()); err != nil {
-			log.G(ctx).Errorf("%s cleanup: failed to delete container from containerd: %v", container.ID, err)
+		if err := ctr.Delete(context.WithoutCancel(ctx)); err != nil {
+			logger.WithError(err).Error("cleanup: failed to delete container from containerd")
 		}
 	}
 
 	daemon.releaseNetwork(ctx, container)
 
 	if err := container.UnmountIpcMount(); err != nil {
-		log.G(ctx).Warnf("%s cleanup: failed to unmount IPC: %s", container.ID, err)
+		logger.WithError(err).Warn("cleanup: failed to unmount IPC")
 	}
 
 	if err := daemon.conditionalUnmountOnCleanup(container); err != nil {
-		// FIXME: remove once reference counting for graphdrivers has been refactored
-		// Ensure that all the mounts are gone
-		if mountid, err := daemon.imageService.GetLayerMountID(container.ID); err == nil {
-			daemon.cleanupMountsByID(mountid)
+		// FIXME(tonistiigi): remove once reference counting for graphdrivers has been refactored https://github.com/moby/moby/pull/20662
+		// Ensure that all the mounts are gone.
+		if mountID, err := daemon.imageService.GetLayerMountID(container.ID); err == nil {
+			if err := daemon.cleanupMountsByID(mountID); err != nil {
+				logger.WithFields(log.Fields{
+					"error":   err,
+					"mountid": mountID,
+				}).Warn("cleanup: error while cleaning up container mounts")
+			}
 		}
 	}
 
 	if err := container.UnmountSecrets(); err != nil {
-		log.G(ctx).Warnf("%s cleanup: failed to unmount secrets: %s", container.ID, err)
+		logger.WithError(err).Warn("cleanup: error while unmounting secrets")
 	}
 
 	if err := recursiveUnmount(container.Root); err != nil {
-		log.G(ctx).WithError(err).WithField("container", container.ID).Warn("Error while cleaning up container resource mounts.")
+		logger.WithError(err).Warn("cleanup: error while cleaning up container resource mounts")
 	}
 
 	for _, eConfig := range container.ExecCommands.Commands() {
@@ -304,7 +311,7 @@ func (daemon *Daemon) Cleanup(ctx context.Context, container *container.Containe
 
 	if container.BaseFS != "" {
 		if err := container.UnmountVolumes(ctx, daemon.LogVolumeEvent); err != nil {
-			log.G(ctx).Warnf("%s cleanup: Failed to umount volumes: %v", container.ID, err)
+			logger.WithError(err).Warn("cleanup: error while unmounting volumes")
 		}
 	}
 


### PR DESCRIPTION
### daemon: use mountinfo parser when cleaning up mounts

Replace the manual parsing of `/proc/self/mountinfo` with
`moby/sys/mountinfo`.

The previous implementation split each line with `strings.Fields` and read
the mountpoint from a fixed field. Besides duplicating mountinfo parsing, this
left several subtle correctness issues:

* escaped mountpoint characters were not decoded before matching or unmounting;
* malformed entries with too few fields were silently ignored;
* the daemon root check used a plain string prefix, which could also match
  sibling paths with the same prefix.

Use `mountinfo.GetMountsFromReader` with a filter that selects mountpoints
below the daemon root and matching the cleanup patterns. This delegates
validation and mountpoint decoding to the shared parser and leaves the cleanup
loop responsible only for unmounting the selected entries.

Some minor other changes included in this PR;

-  daemon: Cleanup, Shutdown: use structured logs
-  daemon: cleanupMountsFromReaderByID: use errors.Join
-  daemon: cleanupMountsXXX: use structured logs
-  daemon: TestCleanupXXX: minor cleanups

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
