### PR TITLE
ci: validate-pr: limit checks to relevant events

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,9 +1,5 @@
 name: validate-pr
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 
@@ -13,6 +9,9 @@ on:
 
 jobs:
   check-labels:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-check-labels
+      cancel-in-progress: true
     if: >-
       ${{
         github.event.pull_request.state == 'open' &&
@@ -40,6 +39,9 @@ jobs:
         run: exit 0
 
   check-changelog:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-check-changelog
+      cancel-in-progress: true
     if: >-
       ${{
         github.event.pull_request.state == 'open' &&
@@ -92,6 +94,9 @@ jobs:
           echo "$desc"
 
   check-commit-references:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-check-commit-references
+      cancel-in-progress: true
     if: >-
       ${{
         github.event.pull_request.state == 'open' &&
@@ -116,6 +121,9 @@ jobs:
         run: bash hack/validate/pr-gh-references
 
   check-pr-branch:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-check-pr-branch
+      cancel-in-progress: true
     if: >-
       ${{
         github.event.pull_request.state == 'open' &&

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -13,9 +13,18 @@ on:
 
 jobs:
   check-labels:
-    if: ${{ github.event.pull_request.state == 'open' }}
+    if: >-
+      ${{
+        github.event.pull_request.state == 'open' &&
+        (
+          github.event.action == 'opened' ||
+          github.event.action == 'reopened' ||
+          github.event.action == 'labeled' ||
+          github.event.action == 'unlabeled'
+        )
+      }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 5
     steps:
       - name: Missing `area/` label
         if: always() && contains(join(github.event.pull_request.labels.*.name, ','), 'impact/') && !contains(join(github.event.pull_request.labels.*.name, ','), 'area/')
@@ -31,9 +40,22 @@ jobs:
         run: exit 0
 
   check-changelog:
-    if: ${{ github.event.pull_request.state == 'open' }}
+    if: >-
+      ${{
+        github.event.pull_request.state == 'open' &&
+        (
+          github.event.action == 'opened' ||
+          github.event.action == 'reopened' ||
+          github.event.action == 'labeled' ||
+          github.event.action == 'unlabeled' ||
+          (
+            github.event.action == 'edited' &&
+            github.event.changes.body != null
+          )
+        )
+      }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 5
     env:
       HAS_IMPACT_LABEL: ${{ contains(join(github.event.pull_request.labels.*.name, ','), 'impact/') }}
       PR_BODY: |
@@ -70,7 +92,15 @@ jobs:
           echo "$desc"
 
   check-commit-references:
-    if: ${{ github.event.pull_request.state == 'open' }}
+    if: >-
+      ${{
+        github.event.pull_request.state == 'open' &&
+        (
+          github.event.action == 'opened' ||
+          github.event.action == 'reopened' ||
+          github.event.action == 'synchronize'
+        )
+      }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -86,9 +116,23 @@ jobs:
         run: bash hack/validate/pr-gh-references
 
   check-pr-branch:
-    if: ${{ github.event.pull_request.state == 'open' }}
+    if: >-
+      ${{
+        github.event.pull_request.state == 'open' &&
+        (
+          github.event.action == 'opened' ||
+          github.event.action == 'reopened' ||
+          (
+            github.event.action == 'edited' &&
+            (
+              github.event.changes.title != null ||
+              github.event.changes.base != null
+            )
+          )
+        )
+      }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 5
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}
     steps:


### PR DESCRIPTION
Avoid rerunning validation jobs for pull-request events that cannot change their result. For example, changing labels does not affect commit-message validation, and synchronizing commits does not affect labels or the PR description.

Also reduce the guardrail timeout for the short validation jobs.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
