### PR TITLE
daemon/libnetwork: Avoid races while loading networks

### DIFF
--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -733,8 +733,10 @@ func (n *Network) UnmarshalJSON(b []byte) (err error) {
 	if v, ok := netMap["attachable"]; ok {
 		n.attachable = v.(bool)
 	}
-	if s, ok := netMap["scope"]; ok {
-		n.scope = s.(string)
+	if v, ok := netMap["scope"]; ok {
+		if s := v.(string); s != "" {
+			n.scope = s
+		}
 	}
 	if v, ok := netMap["inDelete"]; ok {
 		n.inDelete = v.(bool)

--- a/daemon/libnetwork/store.go
+++ b/daemon/libnetwork/store.go
@@ -23,18 +23,14 @@ func (c *Controller) getNetworkFromStore(nid string) (*Network, error) {
 func (c *Controller) getNetworks() ([]*Network, error) {
 	var nl []*Network
 
-	kvol, err := c.store.List(&Network{ctrlr: c})
+	kvol, err := c.store.List(&Network{ctrlr: c, scope: scope.Local})
 	if err != nil && !errors.Is(err, datastore.ErrKeyNotFound) {
 		return nil, fmt.Errorf("failed to get networks: %w", err)
 	}
 
 	for _, kvo := range kvol {
 		n := kvo.(*Network)
-		n.ctrlr = c
 		c.cacheNetwork(n)
-		if n.scope == "" {
-			n.scope = scope.Local
-		}
 		nl = append(nl, n)
 	}
 
@@ -44,7 +40,7 @@ func (c *Controller) getNetworks() ([]*Network, error) {
 func (c *Controller) getNetworksFromStore(ctx context.Context) []*Network { // FIXME: unify with c.getNetworks()
 	var nl []*Network
 
-	kvol, err := c.store.List(&Network{ctrlr: c})
+	kvol, err := c.store.List(&Network{ctrlr: c, scope: scope.Local})
 	if err != nil {
 		if !errors.Is(err, datastore.ErrKeyNotFound) {
 			log.G(ctx).Debugf("failed to get networks from store: %v", err)
@@ -54,12 +50,6 @@ func (c *Controller) getNetworksFromStore(ctx context.Context) []*Network { // F
 
 	for _, kvo := range kvol {
 		n := kvo.(*Network)
-		n.mu.Lock()
-		n.ctrlr = c
-		if n.scope == "" {
-			n.scope = scope.Local
-		}
-		n.mu.Unlock()
 		nl = append(nl, n)
 	}
 


### PR DESCRIPTION
related:

- https://github.com/moby/libnetwork/pull/594
- https://github.com/moby/libnetwork/pull/880
- https://github.com/moby/libnetwork/pull/1758

The datastore cache returns shared `Network` pointers. Store reads updated the controller and default scope after `List` returned, which raced with endpoint creation.

Commit 71e14dd52a3 made `List` construct networks through `Network.New`, which copies the controller from its prototype.
Commit 315004b575c added the same behavior for scope, while f626582c165 kept a local fallback for legacy records without a stored scope.

The later assignments were no longer needed to initialize loaded networks.

Supply both values through the `List` prototype instead. `Network.New` applies them before decoding and cache publication. Decoding replaces the scope only when the stored value is non-empty, so persisted global and swarm scopes still win while missing or empty legacy scopes remain local.
    

## Release notes (optional)

```markdown changelog
```

## A picture of a cute animal (not mandatory but encouraged)
