### PR TITLE
integration-cli: Keep Swarm cleanup failures from blocking tests

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"sync"
 	"syscall"
@@ -613,18 +614,24 @@ func (s *DockerSwarmSuite) AddDaemon(ctx context.Context, t *testing.T, joinSwar
 func (s *DockerSwarmSuite) TearDownTest(ctx context.Context, t *testing.T) {
 	testRequires(t, DaemonIsLinux)
 	s.daemonsLock.Lock()
-	for _, d := range s.daemons {
-		if d != nil {
-			if t.Failed() {
-				d.TailLogsT(t, 100)
-			}
-			d.Stop(t)
-			d.Cleanup(t)
-		}
-	}
+	daemons := slices.Clone(s.daemons)
 	s.daemons = nil
 	s.portIndex = 0
 	s.daemonsLock.Unlock()
+
+	testFailed := t.Failed()
+	for _, d := range daemons {
+		if d == nil {
+			continue
+		}
+		if testFailed {
+			d.TailLogsT(t, 100)
+		}
+		t.Run("stop-"+d.ID(), func(t *testing.T) {
+			d.Stop(t)
+		})
+		d.Cleanup(t)
+	}
 	s.ds.TearDownTest(ctx, t)
 }
 


### PR DESCRIPTION
Swarm suite teardown stopped daemons while holding daemonsLock. A nonzero daemon exit made Stop call Fatalf, so the test goroutine left the mutex locked and retained stale daemons for the next test.

Snapshot and clear suite state under the lock, then stop each daemon in its own cleanup subtest. A failed stop now releases suite state, cleanup still runs for that daemon, and teardown continues with the remaining daemons.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
