### PR TITLE
d/libn/i/nftables: add trailing semicolon

### DIFF
--- a/daemon/libnetwork/internal/nftables/incremental_update.nft.gotmpl
+++ b/daemon/libnetwork/internal/nftables/incremental_update.nft.gotmpl
@@ -34,7 +34,7 @@ table {{$family}} {{$tableName}} {
 	}
 	{{end}}
 	{{range .Chains}}{{if .MustFlush}}chain {{.Name}} {
-		{{if .ChainType}}type {{.ChainType}} hook {{.Hook}}{{if .Device}} device "{{.Device}}"{{end}} priority {{.Priority}}; policy {{.Policy}}{{end}}
+		{{if .ChainType}}type {{.ChainType}} hook {{.Hook}}{{if .Device}} device "{{.Device}}"{{end}} priority {{.Priority}}; policy {{.Policy}};{{end}}
 	} ; {{end}}{{end}}
 }
 {{if .MustFlush}}flush table {{$family}} {{$tableName}}{{end}}
@@ -52,7 +52,7 @@ table {{$family}} {{$tableName}} {
 {{end}}
 table {{$family}} {{$tableName}} {
 	{{range .Chains}}{{if .MustFlush}}chain {{.Name}} {
-		{{if .ChainType}}type {{.ChainType}} hook {{.Hook}}{{if .Device}} device "{{.Device}}"{{end}} priority {{.Priority}}; policy {{.Policy}}{{end}}
+		{{if .ChainType}}type {{.ChainType}} hook {{.Hook}}{{if .Device}} device "{{.Device}}"{{end}} priority {{.Priority}}; policy {{.Policy}};{{end}}
 		{{range .Rules}}{{.}}
 		{{end}}
 	}

--- a/daemon/libnetwork/internal/nftables/reload.nft.gotmpl
+++ b/daemon/libnetwork/internal/nftables/reload.nft.gotmpl
@@ -33,7 +33,7 @@ table {{$family}} {{$tableName}} {
 	}
 	{{end}}
 	{{range .Chains}}chain {{.Name}} {
-		{{if .ChainType}}type {{.ChainType}} hook {{.Hook}}{{if .Device}} device "{{.Device}}"{{end}} priority {{.Priority}}; policy {{.Policy}}{{end}}
+		{{if .ChainType}}type {{.ChainType}} hook {{.Hook}}{{if .Device}} device "{{.Device}}"{{end}} priority {{.Priority}}; policy {{.Policy}};{{end}}
 		{{range .Rules}}{{.}}
 		{{end}}
 	}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- Split from #53125 

## Summary
The syntax for specifying the parameters of a base chain is documented to have a mandatory semicolon terminating each parameter clause. In practice, nft sometimes accepts a chain definition with a newline instead of a semicolon after the terminal parameter, only to reject the rules that follow with strange errors. Add trailing semicolons to the policy parameters of base chain definitions to satisfy the parsers of all versions of nft we might encounter.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
- Improve compatibility with more nftables releases by terminating base-chain policies with a semicolon
```

## A picture of a cute animal (not mandatory but encouraged)
