### PR TITLE
daemon: prepare archive options before entering container filesystem

### DIFF
--- a/daemon/archive_tarcopyoptions_unix.go
+++ b/daemon/archive_tarcopyoptions_unix.go
@@ -14,24 +14,24 @@ import (
 	"github.com/moby/sys/user"
 )
 
-func (daemon *Daemon) tarCopyOptions(ctr *container.Container, allowOverwriteDirWithFile bool) (*archive.TarOptions, error) {
+func (daemon *Daemon) applyTarCopyUserOptions(ctr *container.Container, opts *archive.TarOptions) error {
 	if ctr.Config.User == "" {
-		return daemon.defaultTarCopyOptions(allowOverwriteDirWithFile), nil
+		return nil
 	}
 
 	uid, gid, err := getUIDGID(ctr.Config.User)
 	if err != nil {
-		return nil, errdefs.InvalidParameter(err)
+		return errdefs.InvalidParameter(err)
 	}
 	uid, gid, err = daemon.idMapping.ToHost(uid, gid)
 	if err != nil {
-		return nil, errdefs.InvalidParameter(err)
+		return errdefs.InvalidParameter(err)
 	}
 
-	return &archive.TarOptions{
-		NoOverwriteDirNonDir: !allowOverwriteDirWithFile,
-		ChownOpts:            &archive.ChownOpts{UID: uid, GID: gid},
-	}, nil
+	// ChownOpts overrides archive ownership, so avoid remapping header IDs.
+	opts.IDMap = user.IdentityMapping{}
+	opts.ChownOpts = &archive.ChownOpts{UID: uid, GID: gid}
+	return nil
 }
 
 // getUIDGID resolves the UID and GID of a given container's Config.User,

--- a/daemon/archive_unix.go
+++ b/daemon/archive_unix.go
@@ -102,6 +102,8 @@ func (daemon *Daemon) containerExtractToDir(container *container.Container, path
 	container.Lock()
 	defer container.Unlock()
 
+	options := daemon.defaultTarCopyOptions(allowOverwriteDirWithFile)
+
 	// Decompress the archive before switching into the container's
 	// filesystem to avoid executing decompression binaries (xz, unpigz)
 	// that may have been placed inside the container image.
@@ -141,18 +143,13 @@ func (daemon *Daemon) containerExtractToDir(container *container.Container, path
 			return err
 		}
 
-		options := daemon.defaultTarCopyOptions(allowOverwriteDirWithFile)
-
 		if copyUIDGID {
-			var err error
-			// tarCopyOptions will appropriately pull in the right uid/gid for the
-			// user/group and will set the options.
-			options, err = daemon.tarCopyOptions(container, allowOverwriteDirWithFile)
-			if err != nil {
+			// Resolve the container user and group from the container's filesystem,
+			// then apply the corresponding host-mapped ownership options.
+			if err := daemon.applyTarCopyUserOptions(container, options); err != nil {
 				return err
 			}
 		}
-
 		return archive.UntarUncompressed(decompressed, absPath, options)
 	})
 	if err != nil {


### PR DESCRIPTION
- relates to / needed for: https://github.com/moby/moby/pull/53305

Create the default archive options before entering the container filesystem,
and refactor container-specific ownership handling into
applyTarCopyOptions.

Keep user and group resolution inside the container filesystem so lookups
continue to use the container's passwd and group files.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
