### PR TITLE
daemon/libnetwork: Drop legacy network scope fallback

### DIFF
--- a/daemon/libnetwork/store.go
+++ b/daemon/libnetwork/store.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/libnetwork/datastore"
-	"github.com/moby/moby/v2/daemon/libnetwork/scope"
 	"go.opentelemetry.io/otel"
 )
 
@@ -30,11 +29,7 @@ func (c *Controller) getNetworks() ([]*Network, error) {
 
 	for _, kvo := range kvol {
 		n := kvo.(*Network)
-		n.ctrlr = c
 		c.cacheNetwork(n)
-		if n.scope == "" {
-			n.scope = scope.Local
-		}
 		nl = append(nl, n)
 	}
 
@@ -54,12 +49,6 @@ func (c *Controller) getNetworksFromStore(ctx context.Context) []*Network { // F
 
 	for _, kvo := range kvol {
 		n := kvo.(*Network)
-		n.mu.Lock()
-		n.ctrlr = c
-		if n.scope == "" {
-			n.scope = scope.Local
-		}
-		n.mu.Unlock()
 		nl = append(nl, n)
 	}
 


### PR DESCRIPTION
related:

- https://github.com/moby/libnetwork/pull/594
- https://github.com/moby/libnetwork/pull/880
- https://github.com/moby/libnetwork/pull/1758

- replace / close: https://github.com/moby/moby/pull/53291

## Summary



Network records have persisted a non-empty scope since January 2016. The store therefore no longer needs to replace a missing persisted value with `scope.Local`.

Load the persisted scope directly while still supplying the controller before the datastore publishes the network. The default for newly constructed networks remains in the driver path.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
