### PR TITLE
gha/windows: Share test daemon setup

### DIFF
--- a/.github/actions/setup-windows-test-daemon/action.yml
+++ b/.github/actions/setup-windows-test-daemon/action.yml
@@ -1,0 +1,121 @@
+name: 'Setup Windows test daemon'
+description: 'Set up the Windows test daemon as a service'
+
+inputs:
+  bin_out:
+    description: 'Path containing the Docker binaries'
+    required: true
+  containerd:
+    description: 'Containerd mode (embedded or external)'
+    required: true
+  runtime:
+    description: 'Runtime mode (containerd or legacy)'
+    required: true
+  storage:
+    description: 'Storage mode (snapshotter or graphdriver)'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    -
+      # Docker is not installed as a PackageManagement package, so remove its
+      # service directly to let the test daemon register under the same name.
+      name: Removing current daemon
+      shell: pwsh
+      run: |
+        if (Get-Service docker -ErrorAction SilentlyContinue) {
+          $dockerVersion = (docker version -f "{{.Server.Version}}")
+          Write-Host "Current installed Docker version: $dockerVersion"
+          # remove service
+          Stop-Service -Force -Name docker
+          Remove-Service -Name docker
+          # removes event log entry. we could use "Remove-EventLog -LogName -Source docker"
+          # but this cmd is not available atm
+          $ErrorActionPreference = "SilentlyContinue"
+          & reg delete "HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application\docker" /f 2>&1 | Out-Null
+          $ErrorActionPreference = "Stop"
+          Write-Host "Service removed"
+        }
+    -
+      name: Starting test daemon
+      shell: pwsh
+      env:
+        BIN_OUT: ${{ inputs.bin_out }}
+        INPUT_CONTAINERD: ${{ inputs.containerd }}
+        INPUT_RUNTIME: ${{ inputs.runtime }}
+        INPUT_STORAGE: ${{ inputs.storage }}
+      run: |
+        Write-Host "Creating service"
+        $args = @(
+          "--debug",
+          "--host=npipe:////./pipe/docker_engine", `
+          "--data-root=$env:TEMP\moby-root", `
+          "--exec-root=$env:TEMP\moby-exec", `
+          "--pidfile=$env:TEMP\docker.pid", `
+          "--register-service"
+        )
+        If ($env:INPUT_CONTAINERD -eq "embedded") {
+          $args += "--feature=embedded-containerd"
+        } ElseIf ($env:INPUT_RUNTIME -eq "containerd") {
+          $args += "--default-runtime=io.containerd.runhcs.v1"
+          echo "DOCKER_WINDOWS_CONTAINERD_RUNTIME=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+        }
+        if ($env:INPUT_STORAGE -eq "snapshotter") {
+          $args += "--feature=containerd-snapshotter"
+        }
+        New-Item -ItemType Directory "$env:TEMP\moby-root" -ErrorAction SilentlyContinue | Out-Null
+        New-Item -ItemType Directory "$env:TEMP\moby-exec" -ErrorAction SilentlyContinue | Out-Null
+        Start-Process -Wait -NoNewWindow "$env:BIN_OUT\dockerd" -ArgumentList $args
+        # Make the env-var visible to the service-managed dockerd, as there's no CLI flag for this option.
+        $dockerEnviron = @("DOCKER_MIN_API_VERSION=1.24")
+        $dockerEnviron += @(Get-Item Env:\OTEL_* -ErrorAction SilentlyContinue | ForEach-Object { "$($_.Name)=$($_.Value)" })
+        If ($env:INPUT_STORAGE -eq "graphdriver") {
+          $dockerEnviron += @("TEST_INTEGRATION_USE_GRAPHDRIVER=1")
+          echo "TEST_INTEGRATION_USE_GRAPHDRIVER=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+        }
+        If ($env:INPUT_CONTAINERD -eq "embedded") {
+          $dockerEnviron += @("TEST_INTEGRATION_CONTAINERD_EMBEDDED=1")
+          echo "TEST_INTEGRATION_CONTAINERD_EMBEDDED=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+        }
+        New-ItemProperty -Name "Environment" -Path "HKLM:\SYSTEM\CurrentControlSet\Services\docker" -PropertyType MultiString -Value $dockerEnviron
+        Write-Host "Starting service"
+        Start-Service -Name docker
+        Write-Host "Service started successfully!"
+    -
+      name: Waiting for test daemon to start
+      shell: pwsh
+      env:
+        BIN_OUT: ${{ inputs.bin_out }}
+        INPUT_CONTAINERD: ${{ inputs.containerd }}
+        INPUT_RUNTIME: ${{ inputs.runtime }}
+        DOCKER_HOST: npipe:////./pipe/docker_engine
+      run: |
+        $tries=20
+        Write-Host "Waiting for the test daemon to start..."
+        While ($true) {
+          $ErrorActionPreference = "SilentlyContinue"
+          & "$env:BIN_OUT\docker" version
+          $ErrorActionPreference = "Stop"
+          If ($LastExitCode -eq 0) {
+            break
+          }
+          $tries--
+          If ($tries -le 0) {
+            Throw "Failed to get a response from the daemon"
+          }
+          Write-Host -NoNewline "."
+          Start-Sleep -Seconds 1
+        }
+        Write-Host "Test daemon started and replied!"
+        If ($env:INPUT_CONTAINERD -eq "external" -and $env:INPUT_RUNTIME -eq "containerd") {
+          $containerdProcesses = Get-Process -Name containerd -ErrorAction:SilentlyContinue
+          If (-not $containerdProcesses) {
+            Throw "containerd process is not running"
+          } else {
+            foreach ($process in $containerdProcesses) {
+              $processPath = (Get-Process -Id $process.Id -FileVersionInfo).FileName
+              Write-Output "Running containerd instance binary Path: $($processPath)"
+            }
+          }
+        }

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -23,7 +23,7 @@ on:
       containerd:
         required: false
         type: string
-        default: "socket"
+        default: external
     secrets:
       CODECOV_TOKEN:
         required: false
@@ -308,102 +308,14 @@ jobs:
           $testName = ([System.BitConverter]::ToString((New-Object System.Security.Cryptography.SHA256Managed).ComputeHash([System.Text.Encoding]::UTF8.GetBytes($env:MATRIX_TEST))) -replace '-').ToLower()
           echo "TESTREPORTS_NAME=$testName" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
       -
-        # Docker is not installed as a PackageManagement package, so remove its
-        # service directly to let the test daemon register under the same name.
-        name: Removing current daemon
-        run: |
-          if (Get-Service docker -ErrorAction SilentlyContinue) {
-            $dockerVersion = (docker version -f "{{.Server.Version}}")
-            Write-Host "Current installed Docker version: $dockerVersion"
-            # remove service
-            Stop-Service -Force -Name docker
-            Remove-Service -Name docker
-            # removes event log entry. we could use "Remove-EventLog -LogName -Source docker"
-            # but this cmd is not available atm
-            $ErrorActionPreference = "SilentlyContinue"
-            & reg delete "HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application\docker" /f 2>&1 | Out-Null
-            $ErrorActionPreference = "Stop"
-            Write-Host "Service removed"
-          }
-      -
         name: Starting test daemon
         id: start-daemon
-        env:
-          INPUT_STORAGE: ${{ inputs.storage }}
-          INPUT_CONTAINERD: ${{ inputs.containerd }}
-          MATRIX_RUNTIME: ${{ matrix.runtime }}
-        run: |
-          Write-Host "Creating service"
-          $args = @(
-            "--debug",
-            "--host=npipe:////./pipe/docker_engine", `
-            "--data-root=$env:TEMP\moby-root", `
-            "--exec-root=$env:TEMP\moby-exec", `
-            "--pidfile=$env:TEMP\docker.pid", `
-            "--register-service"
-          )
-          If ($env:INPUT_CONTAINERD -eq "embedded") {
-            $args += "--feature=embedded-containerd"
-          } ElseIf ($env:MATRIX_RUNTIME -eq "containerd") {
-            $args += "--default-runtime=io.containerd.runhcs.v1"
-            echo "DOCKER_WINDOWS_CONTAINERD_RUNTIME=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-          }
-          if ($env:INPUT_STORAGE -eq "snapshotter") {
-            $args += "--feature=containerd-snapshotter"
-          }
-          New-Item -ItemType Directory "$env:TEMP\moby-root" -ErrorAction SilentlyContinue | Out-Null
-          New-Item -ItemType Directory "$env:TEMP\moby-exec" -ErrorAction SilentlyContinue | Out-Null
-          Start-Process -Wait -NoNewWindow "${{ env.BIN_OUT }}\dockerd" -ArgumentList $args
-          # Make the env-var visible to the service-managed dockerd, as there's no CLI flag for this option.
-          $dockerEnviron = @("DOCKER_MIN_API_VERSION=1.24")
-          $dockerEnviron += @(Get-Item Env:\OTEL_* | ForEach-Object { "$($_.Name)=$($_.Value)" })
-          If ($env:INPUT_STORAGE -eq "graphdriver") {
-            $dockerEnviron += @("TEST_INTEGRATION_USE_GRAPHDRIVER=1")
-            echo "TEST_INTEGRATION_USE_GRAPHDRIVER=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-          }
-          If ($env:INPUT_CONTAINERD -eq "embedded") {
-            $dockerEnviron += @("TEST_INTEGRATION_CONTAINERD_EMBEDDED=1")
-            echo "TEST_INTEGRATION_CONTAINERD_EMBEDDED=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-          }
-          New-ItemProperty -Name "Environment" -Path "HKLM:\SYSTEM\CurrentControlSet\Services\docker" -PropertyType MultiString -Value $dockerEnviron
-          Write-Host "Starting service"
-          Start-Service -Name docker
-          Write-Host "Service started successfully!"
-      -
-        name: Waiting for test daemon to start
-        env:
-          INPUT_CONTAINERD: ${{ inputs.containerd }}
-          MATRIX_RUNTIME: ${{ matrix.runtime }}
-          DOCKER_HOST: npipe:////./pipe/docker_engine
-        run: |
-          $tries=20
-          Write-Host "Waiting for the test daemon to start..."
-          While ($true) {
-            $ErrorActionPreference = "SilentlyContinue"
-            & "${{ env.BIN_OUT }}\docker" version
-            $ErrorActionPreference = "Stop"
-            If ($LastExitCode -eq 0) {
-              break
-            }
-            $tries--
-            If ($tries -le 0) {
-              Throw "Failed to get a response from the daemon"
-            }
-            Write-Host -NoNewline "."
-            Start-Sleep -Seconds 1
-          }
-          Write-Host "Test daemon started and replied!"
-          If ($env:INPUT_CONTAINERD -ne "embedded" -and $env:MATRIX_RUNTIME -eq "containerd") {
-            $containerdProcesses = Get-Process -Name containerd -ErrorAction:SilentlyContinue
-            If (-not $containerdProcesses) {
-              Throw "containerd process is not running"
-            } else {
-              foreach ($process in $containerdProcesses) {
-                $processPath = (Get-Process -Id $process.Id -FileVersionInfo).FileName
-                Write-Output "Running containerd instance binary Path: $($processPath)"
-              }
-            }
-          }
+        uses: ./.github/actions/setup-windows-test-daemon
+        with:
+          bin_out: ${{ env.BIN_OUT }}
+          containerd: ${{ inputs.containerd }}
+          runtime: ${{ matrix.runtime == 'containerd' && 'containerd' || 'legacy' }}
+          storage: ${{ inputs.storage }}
       -
         name: Docker info
         run: |

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -308,9 +308,8 @@ jobs:
           $testName = ([System.BitConverter]::ToString((New-Object System.Security.Cryptography.SHA256Managed).ComputeHash([System.Text.Encoding]::UTF8.GetBytes($env:MATRIX_TEST))) -replace '-').ToLower()
           echo "TESTREPORTS_NAME=$testName" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
       -
-        # removes docker service that is currently installed on the runner. we
-        # could use Uninstall-Package but not yet available on Windows runners.
-        # more info: https://github.com/actions/virtual-environments/blob/d3a5bad25f3b4326c5666bab0011ac7f1beec95e/images/win/scripts/Installers/Install-Docker.ps1#L11
+        # Docker is not installed as a PackageManagement package, so remove its
+        # service directly to let the test daemon register under the same name.
         name: Removing current daemon
         run: |
           if (Get-Service docker -ErrorAction SilentlyContinue) {

--- a/.github/workflows/windows-2022.yml
+++ b/.github/workflows/windows-2022.yml
@@ -26,9 +26,9 @@ jobs:
       matrix:
         include:
           - storage: graphdriver
-            containerd: socket
+            containerd: external
           - storage: snapshotter
-            containerd: socket
+            containerd: external
           - storage: snapshotter
             containerd: embedded
     with:

--- a/.github/workflows/windows-2025.yml
+++ b/.github/workflows/windows-2025.yml
@@ -31,9 +31,9 @@ jobs:
       matrix:
         include:
           - storage: graphdriver
-            containerd: socket
+            containerd: external
           - storage: snapshotter
-            containerd: socket
+            containerd: external
           - storage: snapshotter
             containerd: embedded
     with:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

Move the service removal, daemon registration, environment setup, and
readiness checks into a composite action.

Pass the containerd, runtime, and storage modes explicitly so other
Windows integration workflows can use the same daemon configuration.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
