### PR TITLE
Fix flaky TestHealthCheckProcessKilled on Windows

### DIFF
--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -100,15 +100,24 @@ func TestHealthCheckProcessKilled(t *testing.T) {
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 
+	// Note: Windows is much slower than Linux at getting the probe process to
+	// the point where it has written to stdout. With a 50ms timeout the probe
+	// is regularly killed before it has written anything, leaving the timeout
+	// message with no output to report.
+	probeTimeout := 50 * time.Millisecond
+	if testEnv.DaemonInfo.OSType == "windows" {
+		probeTimeout = 500 * time.Millisecond
+	}
+
 	cID := container.Run(ctx, t, apiClient, func(c *container.TestContainerConfig) {
 		c.Config.Healthcheck = &containertypes.HealthConfig{
 			Test:     []string{"CMD", "sh", "-c", `echo "logs1 logs2 logs3"; sleep 60`},
 			Interval: 100 * time.Millisecond,
-			Timeout:  50 * time.Millisecond,
+			Timeout:  probeTimeout,
 			Retries:  1,
 		}
 	})
-	poll.WaitOn(t, pollForHealthCheckLog(ctx, apiClient, cID, "Health check exceeded timeout (50ms): logs1 logs2 logs3\n"))
+	poll.WaitOn(t, pollForHealthCheckLog(ctx, apiClient, cID, fmt.Sprintf("Health check exceeded timeout (%v): logs1 logs2 logs3\n", probeTimeout)))
 }
 
 func TestHealthStartInterval(t *testing.T) {


### PR DESCRIPTION
- fixes #53267


**- What I did**

Fix the flaky `TestHealthCheckProcessKilled` on Windows reported in #53267.

**- How I did it**

The probe echoes to stdout and then sleeps. The test gives it a 50ms timeout and asserts that the timeout message carries the echoed output.

The 50ms clock starts in `daemon/health.go` when the exec request is accepted (`<-execConfig.Started`), not when the probe process is running. On Windows the process still has to be scheduled, `sh` has to initialize, `echo` has to run, and the bytes have to reach the daemon. That often exceeds 50ms, so the probe is killed having written nothing and the daemon reports the timeout without any output, which is the `out != ""` branch in `daemon/health.go`. The assertion then fails on the missing `logs1 logs2 logs3`.

The daemon behaves correctly here; the assertion is what does not hold on Windows. This raises the Windows probe timeout to 500ms and leaves Linux at 50ms, following the same reasoning as `TestHealthStartInterval` further down the file. The expected string is built from the same variable with `fmt.Sprintf`, so it cannot drift from the configured timeout.

Coverage is unchanged. The probe sleeps 60s, so it still exceeds the timeout, is still killed, and the output assertion still runs. Only the margin changes.

**- How to verify it**

Windows daemon built from `master` with no daemon changes, Hyper-V isolation, `servercore:ltsc2022`, 30 iterations per value:

| probe timeout | failures |
| --- | --- |
| 50ms (current) | 14/30 |
| 250ms | 0/30 |
| 500ms (this PR) | 0/30 |
| 2s | 0/30 |

Linux, via `TEST_REPEAT=5 TEST_FILTER=TestHealthCheckProcessKilled make test-integration`: unchanged, all pass in about 1s.

500ms leaves headroom over the lowest value that ran clean here. I am happy to raise it if the runners still flake.

Scope note: these runs used a Server 2022 kernel, since the host was Windows 11 23H2 (build 22631) and `ltsc2025` requires build 26100 or newer. The report was on Server 2025, which CI covers.

**- Description for the changelog**

n/a, test-only change.
