### PR TITLE
libnet/cnmallocator: don't fail OnGetNetwork if unallocated

### DIFF
--- a/daemon/libnetwork/cnmallocator/extra_status.go
+++ b/daemon/libnetwork/cnmallocator/extra_status.go
@@ -26,7 +26,8 @@ func (na *cnmNetworkAllocator) OnGetNetwork(ctx context.Context, swarmnet *api.N
 
 	n := na.getNetwork(swarmnet.ID)
 	if n == nil {
-		return fmt.Errorf("cnmallocator: network %s not found", swarmnet.ID)
+		// Unallocated networks have no operational status to report.
+		return nil
 	}
 
 	ipamdriver, _, _, err := na.resolveIPAM(swarmnet)

--- a/daemon/libnetwork/cnmallocator/extra_status_test.go
+++ b/daemon/libnetwork/cnmallocator/extra_status_test.go
@@ -1,0 +1,123 @@
+package cnmallocator
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+
+	gogotypes "github.com/gogo/protobuf/types"
+	"github.com/moby/moby/v2/daemon/cluster/convert/netextra"
+	"github.com/moby/swarmkit/v2/api"
+	"github.com/moby/swarmkit/v2/manager/allocator/networkallocator"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+// ipamStatusAppdata is the appdata a client sends to ask for IPAM status,
+// as [github.com/moby/moby/v2/daemon/cluster.Cluster] marshals it.
+func ipamStatusAppdata(t *testing.T) (typeurl string, appdata []byte) {
+	t.Helper()
+	msg, err := gogotypes.MarshalAny(&netextra.GetNetworkExtraOptions{WithIPAMStatus: true})
+	assert.NilError(t, err)
+	return msg.TypeUrl, msg.Value
+}
+
+func newOnGetNetworker(t *testing.T) networkallocator.OnGetNetworker {
+	t.Helper()
+	na, ok := newNetworkAllocator(t).(networkallocator.OnGetNetworker)
+	assert.Assert(t, ok, "allocator does not implement OnGetNetworker")
+	return na
+}
+
+// TestOnGetNetworkUnallocated asserts the [networkallocator.OnGetNetworker]
+// contract: "The network may not have been allocated at the time of the call.
+// Calling OnGetNetwork with an unallocated network should not be an error."
+//
+// An unallocated network is not hypothetical. It is the state a failed
+// allocation leaves behind - Allocate frees the pools and does not record the
+// network - and the allocator only logs the failure before parking the network
+// for a later retry. It is also the state of every network in the store that
+// the allocator has not restored yet during manager init.
+//
+// Erroring here does not merely lose one network's status. The hook is called
+// per-network over the whole store for a ListNetworks request with no filters,
+// which is how the daemon lists Swarm networks, so one unallocated network
+// would fail the response for all of them.
+func TestOnGetNetworkUnallocated(t *testing.T) {
+	na := newOnGetNetworker(t)
+	typeurl, appdata := ipamStatusAppdata(t)
+
+	// A network as it looks in the store when allocation failed: the spec is
+	// committed, but the allocator never filled in IPAM or the driver state.
+	n := &api.Network{
+		ID: "unallocatedID",
+		Spec: api.NetworkSpec{
+			Annotations:  api.Annotations{Name: "unallocated"},
+			DriverConfig: &api.Driver{Name: "overlay"},
+		},
+	}
+
+	assert.NilError(t, na.OnGetNetwork(context.Background(), n, typeurl, appdata))
+	// There is no status to report, rather than an empty one: a client cannot
+	// tell an absent Status from a manager too old to report any, and the
+	// unallocated condition is already visible in the empty IPAM config.
+	assert.Check(t, is.Nil(n.Extra))
+}
+
+// TestOnGetNetworkAllocated is the positive control for
+// [TestOnGetNetworkUnallocated]: returning no status for an unallocated
+// network is only correct if an allocated one still gets one.
+func TestOnGetNetworkAllocated(t *testing.T) {
+	na := newOnGetNetworker(t)
+	typeurl, appdata := ipamStatusAppdata(t)
+
+	subnet := netip.MustParsePrefix("10.144.0.0/24")
+	n := &api.Network{
+		ID: "allocatedID",
+		Spec: api.NetworkSpec{
+			Annotations:  api.Annotations{Name: "allocated"},
+			DriverConfig: &api.Driver{Name: "overlay"},
+			IPAM: &api.IPAMOptions{
+				Configs: []*api.IPAMConfig{{
+					Family: api.IPAMConfig_IPV4,
+					Subnet: subnet.String(),
+				}},
+			},
+		},
+	}
+	assert.NilError(t, na.(networkallocator.NetworkAllocator).Allocate(n))
+
+	assert.NilError(t, na.OnGetNetwork(context.Background(), n, typeurl, appdata))
+	assert.Assert(t, n.Extra != nil, "no status reported for an allocated network")
+
+	status, err := netextra.StatusFrom(n.Extra)
+	assert.NilError(t, err)
+	assert.Assert(t, status != nil)
+	st, ok := status.IPAM.Subnets[subnet]
+	assert.Assert(t, ok, "no IPAM status for subnet %s, only for %v", subnet, status.IPAM.Subnets)
+	// The gateway is allocated out of the subnet, so the counters are already
+	// non-trivial before anything attaches.
+	assert.Check(t, st.IPsInUse > 0, "IPsInUse is %d for a subnet with a gateway", st.IPsInUse)
+	assert.Check(t, st.DynamicIPsAvailable > 0, "no addresses available in a freshly allocated /24")
+}
+
+// TestOnGetNetworkWithoutStatusRequested checks that a request which did not
+// ask for status does not get any, whether or not the network is allocated.
+func TestOnGetNetworkWithoutStatusRequested(t *testing.T) {
+	na := newOnGetNetworker(t)
+
+	n := &api.Network{
+		ID: "nostatusID",
+		Spec: api.NetworkSpec{
+			Annotations:  api.Annotations{Name: "nostatus"},
+			DriverConfig: &api.Driver{Name: "overlay"},
+		},
+	}
+
+	assert.NilError(t, na.OnGetNetwork(context.Background(), n, "", nil))
+	assert.Check(t, is.Nil(n.Extra))
+
+	assert.NilError(t, na.(networkallocator.NetworkAllocator).Allocate(n))
+	assert.NilError(t, na.OnGetNetwork(context.Background(), n, "", nil))
+	assert.Check(t, is.Nil(n.Extra))
+}


### PR DESCRIPTION
- Follow up to: https://github.com/moby/moby/pull/50946

## Summary

`cnmNetworkAllocator.OnGetNetwork` returned an error when the network was not in the allocator's map of allocated networks. Its own interface contract forbids that:

```go
// The network may not have been allocated at the time of the call.
// Calling OnGetNetwork with an unallocated network should not be an
// error.
```

A network is in the store but unallocated in two ordinary situations:

- The allocator has yet to restore it. `allocateNetworks()` deliberately skips networks with no driver state or IPAM during manager init, so as not to hand out resources another network already holds.
- Its allocation failed. `allocateNetwork()` parks the network in `unallocatedNetworks` for a later retry and `doNetworkAlloc()` only logs `Failed allocation for network %s`. A VNI collision gets you here: pin a `com.docker.network.driver.overlay.vxlanid_list` that another network already holds and the overlay manager returns `could not assign vxlan id`. Allocation happens after the spec is committed to Raft, so `network create` has already returned success.

The consequence reached well past the one network. `Cluster.GetNetworks` requests every Swarm network with **no filters**, deliberately — the Engine API's filter semantics are richer than swarmkit's, so the matching has to happen client-side — and swarmkit runs the hook per network over that unfiltered listing. One unallocated network therefore failed the whole response. The `network inspect` route falls back to that listing to resolve a name and reports a failed lookup as `ErrNoSuchNetwork`, so:

```console
$ docker network inspect healthy-net
Error response from daemon: network healthy-net not found
```

...for a network that is perfectly healthy, because an unrelated one could not report status.

Report no status instead. An absent `Status` is already how "no status available" is expressed — it is what a manager whose IPAM driver does not implement `PoolStatuser` returns — and the unallocated condition stays visible in what the allocator never filled in: an empty IPAM config and no VNI echoed back.

### Scope

Only requests that ask for status reach the hook, so this affected **API v1.52 and later** only. Within that, the reachable paths are:

| Request | Before |
|---|---|
| `network inspect <name>`, no scope filter | **404**, even for a healthy network |
| `network inspect <unallocated>` | **404** |
| `network inspect <full-id>` / `--scope=swarm` | OK — resolved from a filtered lookup that never sees the unallocated network |
| `network ls` | OK — does not request status |

### Testing

`TestOnGetNetworkUnallocated` covers the contract directly, with `TestOnGetNetworkAllocated` as a positive control so it cannot pass by status reporting having stopped working altogether.

## Release notes (optional)

```markdown changelog
Fix `docker network inspect` failing to find a healthy Swarm network when another Swarm network could not be allocated.
```

## A picture of a cute animal (not mandatory but encouraged)

<!-- over to you -->

Created with: Claude Opus 5
