### PR TITLE
ci: validate-pr: validate commit messages through GitHub API

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,7 +1,7 @@
 name: validate-pr
 
 permissions:
-  contents: read
+  pull-requests: read
 
 on:
   pull_request:
@@ -109,16 +109,45 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-
       - name: Check GitHub references
         env:
-          VALIDATE_REPO: ${{ github.server_url }}/${{ github.repository }}.git
-          VALIDATE_BRANCH: ${{ github.event.pull_request.base.ref }}
-        run: bash hack/validate/pr-gh-references
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh api --paginate --slurp "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits" > "$RUNNER_TEMP/pr-commits.json"
+
+          # Number of commits, excluding merge commits.
+          commitCount="$(jq '[.[][] | select(.parents | length <= 1)] | length' "$RUNNER_TEMP/pr-commits.json")"
+          references="$(
+              jq -r '
+                  def ghref:
+                      "(^|[^[:alnum:]_])#[0-9]+"
+                      + "|(^|[^[:alnum:]_./-])[[:alnum:]_.-]+#[0-9]+"
+                      + "|(^|[^[:alnum:]_./-])[[:alnum:]_.-]+/[[:alnum:]_.-]+#[0-9]+"
+                      + "|https?://(www\\.)?github\\.com/[^[:space:]/]+/[^[:space:]/]+/(issues|pull)/[0-9]+";
+    
+                  .[][]
+                  # Skip merge commits.
+                  | select(.parents | length <= 1)
+                  | select(.commit.message | test(ghref))
+                  | .sha
+              ' "$RUNNER_TEMP/pr-commits.json"
+          )"
+
+          if [ -z "$references" ]; then
+            echo "Checked ${commitCount} commit(s); no GitHub issue or PR references found."
+            exit 0
+          fi
+
+          while read -r commit; do
+            echo "::error::commit ${commit} contains a GitHub issue or PR reference; use a commit hash instead if a reference is needed."
+          done <<< "$references"
+
+          echo
+          echo "Remove GitHub issue or PR references from commit messages."
+          echo "Use commit hashes instead if a reference is needed."
+          echo "Keep GitHub issue or PR references in GitHub-visible text, such as PR descriptions or comments."
+          exit 1
 
   check-pr-branch:
     concurrency:


### PR DESCRIPTION
### ci: validate-pr: validate commit messages through GitHub API

Use the pull request commits API to validate commit messages instead of
checking out the repository and inspecting the local Git history.

This avoids fetching the repository solely for commit metadata, making the
check lighter and faster. It also avoids executing validation scripts from
the PR checkout, reducing exposure to untrusted PR-controlled code.

While updating; also touched-up the messages slightly, and added a log
for successful checks (to verify the expected number of commits were
checked).

Before this patch, the check took 20-30 seconds; with this patch it's
1-2 seconds.

Failing check:

    Run Check GitHub references
      Run gh api --paginate --slurp "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits" > "$RUNNER_TEMP/pr-commits.json"
      Error: commit ea73f3de6fd7e88db036c24ebc178eecb3e58ad8 contains a GitHub issue or PR reference; use a commit hash instead if a reference is needed.

      Remove GitHub issue or PR references from commit messages.
      Use commit hashes instead if a reference is needed.
      Keep GitHub issue or PR references in GitHub-visible text, such as PR descriptions or comments.
      Error: Process completed with exit code 1.

Successful check:

    Run Check GitHub references
      Run gh api --paginate --slurp "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits" > "$RUNNER_TEMP/pr-commits.json"
      Checked 3 commit(s); no GitHub issue or PR references found.


Before:

<img width="559" height="325" alt="Screenshot 2026-08-07 at 14 02 02" src="https://github.com/user-attachments/assets/afb2bf1c-12cb-4063-b98b-2e87ba0147ec" />

After:

<img width="606" height="247" alt="Screenshot 2026-08-07 at 14 04 22" src="https://github.com/user-attachments/assets/e31e728c-ac0c-4543-8b84-89571e73c7c0" />

<img width="873" height="155" alt="Screenshot 2026-08-07 at 14 04 56" src="https://github.com/user-attachments/assets/56599ef3-c336-45f6-99e4-509c91a6fe4a" />


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
