### PR TITLE
daemon/libnetwork: avoid panics on malformed persisted JSON fields

### DIFF
--- a/daemon/libnetwork/driverapi/driverapi_test.go
+++ b/daemon/libnetwork/driverapi/driverapi_test.go
@@ -116,3 +116,37 @@ func TestValidateAndIsV6(t *testing.T) {
 		t.Fatal("expected error but succeeded")
 	}
 }
+
+func TestIPAMDataUnmarshalJSONTypeMismatch(t *testing.T) {
+	tests := []struct {
+		name string
+		m    map[string]any
+	}{
+		{
+			name: "non-string AddressSpace",
+			m:    map[string]any{"AddressSpace": 123},
+		},
+		{
+			name: "non-string Pool",
+			m:    map[string]any{"AddressSpace": "as1", "Pool": 123},
+		},
+		{
+			name: "non-string Gateway",
+			m:    map[string]any{"AddressSpace": "as1", "Pool": "10.0.0.0/24", "Gateway": 123},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(tc.m)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var i IPAMData
+			if err := i.UnmarshalJSON(data); err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+		})
+	}
+}

--- a/daemon/libnetwork/driverapi/ipamdata.go
+++ b/daemon/libnetwork/driverapi/ipamdata.go
@@ -42,14 +42,26 @@ func (i *IPAMData) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return err
 	}
-	i.AddressSpace = m["AddressSpace"].(string)
+	addressSpace, isString := m["AddressSpace"].(string)
+	if !isString {
+		return fmt.Errorf("AddressSpace: expected string, got %T", m["AddressSpace"])
+	}
+	i.AddressSpace = addressSpace
 	if v, ok := m["Pool"]; ok {
-		if i.Pool, err = types.ParseCIDR(v.(string)); err != nil {
+		s, isString := v.(string)
+		if !isString {
+			return fmt.Errorf("Pool: expected string, got %T", v)
+		}
+		if i.Pool, err = types.ParseCIDR(s); err != nil {
 			return err
 		}
 	}
 	if v, ok := m["Gateway"]; ok {
-		if i.Gateway, err = types.ParseCIDR(v.(string)); err != nil {
+		s, isString := v.(string)
+		if !isString {
+			return fmt.Errorf("Gateway: expected string, got %T", v)
+		}
+		if i.Gateway, err = types.ParseCIDR(s); err != nil {
 			return err
 		}
 	}

--- a/daemon/libnetwork/endpoint.go
+++ b/daemon/libnetwork/endpoint.go
@@ -177,65 +177,10 @@ func (ep *Endpoint) UnmarshalJSON(b []byte) (err error) {
 			ep.generic = generic
 
 			if opt, ok := ep.generic[netlabel.PortMap]; ok {
-				optList, isSlice := opt.([]any)
-				if !isSlice {
-					log.G(context.TODO()).Errorf("generic[%s]: expected []any, got %T", netlabel.PortMap, opt)
-				} else {
-					pblist := []types.PortBinding{}
-
-					for i := 0; i < len(optList); i++ {
-						pb := types.PortBinding{}
-						tmp, isMap := optList[i].(map[string]any)
-						if !isMap {
-							log.G(context.TODO()).Errorf("generic[%s][%d]: expected map[string]any, got %T", netlabel.PortMap, i, optList[i])
-							break
-						}
-
-						bytes, err := json.Marshal(tmp)
-						if err != nil {
-							log.G(context.TODO()).Error(err)
-							break
-						}
-						err = json.Unmarshal(bytes, &pb)
-						if err != nil {
-							log.G(context.TODO()).Error(err)
-							break
-						}
-						pblist = append(pblist, pb)
-					}
-					ep.generic[netlabel.PortMap] = pblist
-				}
+				ep.generic[netlabel.PortMap] = decodeGenericList[types.PortBinding](netlabel.PortMap, opt)
 			}
-
 			if opt, ok := ep.generic[netlabel.ExposedPorts]; ok {
-				optList, isSlice := opt.([]any)
-				if !isSlice {
-					log.G(context.TODO()).Errorf("generic[%s]: expected []any, got %T", netlabel.ExposedPorts, opt)
-				} else {
-					tplist := []types.TransportPort{}
-
-					for i := 0; i < len(optList); i++ {
-						tp := types.TransportPort{}
-						tmp, isMap := optList[i].(map[string]any)
-						if !isMap {
-							log.G(context.TODO()).Errorf("generic[%s][%d]: expected map[string]any, got %T", netlabel.ExposedPorts, i, optList[i])
-							break
-						}
-
-						bytes, err := json.Marshal(tmp)
-						if err != nil {
-							log.G(context.TODO()).Error(err)
-							break
-						}
-						err = json.Unmarshal(bytes, &tp)
-						if err != nil {
-							log.G(context.TODO()).Error(err)
-							break
-						}
-						tplist = append(tplist, tp)
-					}
-					ep.generic[netlabel.ExposedPorts] = tplist
-				}
+				ep.generic[netlabel.ExposedPorts] = decodeGenericList[types.TransportPort](netlabel.ExposedPorts, opt)
 			}
 		}
 	}
@@ -326,6 +271,40 @@ func (ep *Endpoint) UnmarshalJSON(b []byte) (err error) {
 	}
 
 	return nil
+}
+
+// decodeGenericList decodes opt (expected to be a []any of map[string]any,
+// as produced by decoding driver-specific "generic" data) into a []T,
+// logging and stopping at the first element that doesn't decode cleanly
+// rather than failing the whole restore.
+func decodeGenericList[T any](key string, opt any) []T {
+	optList, isSlice := opt.([]any)
+	if !isSlice {
+		log.G(context.TODO()).Errorf("generic[%s]: expected []any, got %T", key, opt)
+		return nil
+	}
+
+	list := []T{}
+	for i, item := range optList {
+		tmp, isMap := item.(map[string]any)
+		if !isMap {
+			log.G(context.TODO()).Errorf("generic[%s][%d]: expected map[string]any, got %T", key, i, item)
+			break
+		}
+
+		b, err := json.Marshal(tmp)
+		if err != nil {
+			log.G(context.TODO()).Error(err)
+			break
+		}
+		var v T
+		if err := json.Unmarshal(b, &v); err != nil {
+			log.G(context.TODO()).Error(err)
+			break
+		}
+		list = append(list, v)
+	}
+	return list
 }
 
 func (ep *Endpoint) New() datastore.KVObject {

--- a/daemon/libnetwork/endpoint.go
+++ b/daemon/libnetwork/endpoint.go
@@ -137,8 +137,17 @@ func (ep *Endpoint) UnmarshalJSON(b []byte) (err error) {
 	if err := json.Unmarshal(b, &epMap); err != nil {
 		return err
 	}
-	ep.name = epMap["name"].(string)
-	ep.id = epMap["id"].(string)
+	name, isString := epMap["name"].(string)
+	if !isString {
+		return fmt.Errorf("name: expected string, got %T", epMap["name"])
+	}
+	ep.name = name
+
+	id, isString := epMap["id"].(string)
+	if !isString {
+		return fmt.Errorf("id: expected string, got %T", epMap["id"])
+	}
+	ep.id = id
 
 	// TODO(cpuguy83): So yeah, this isn't checking any errors anywhere.
 	// Seems like we should be checking errors even because of memory related issues that can arise.
@@ -161,78 +170,129 @@ func (ep *Endpoint) UnmarshalJSON(b []byte) (err error) {
 	_ = json.Unmarshal(cb, &ep.sandboxID)   //nolint:errcheck
 
 	if v, ok := epMap["generic"]; ok {
-		ep.generic = v.(map[string]any)
+		generic, isMap := v.(map[string]any)
+		if !isMap {
+			log.G(context.TODO()).Errorf("generic: expected map[string]any, got %T", v)
+		} else {
+			ep.generic = generic
 
-		if opt, ok := ep.generic[netlabel.PortMap]; ok {
-			pblist := []types.PortBinding{}
+			if opt, ok := ep.generic[netlabel.PortMap]; ok {
+				optList, isSlice := opt.([]any)
+				if !isSlice {
+					log.G(context.TODO()).Errorf("generic[%s]: expected []any, got %T", netlabel.PortMap, opt)
+				} else {
+					pblist := []types.PortBinding{}
 
-			for i := 0; i < len(opt.([]any)); i++ {
-				pb := types.PortBinding{}
-				tmp := opt.([]any)[i].(map[string]any)
+					for i := 0; i < len(optList); i++ {
+						pb := types.PortBinding{}
+						tmp, isMap := optList[i].(map[string]any)
+						if !isMap {
+							log.G(context.TODO()).Errorf("generic[%s][%d]: expected map[string]any, got %T", netlabel.PortMap, i, optList[i])
+							break
+						}
 
-				bytes, err := json.Marshal(tmp)
-				if err != nil {
-					log.G(context.TODO()).Error(err)
-					break
+						bytes, err := json.Marshal(tmp)
+						if err != nil {
+							log.G(context.TODO()).Error(err)
+							break
+						}
+						err = json.Unmarshal(bytes, &pb)
+						if err != nil {
+							log.G(context.TODO()).Error(err)
+							break
+						}
+						pblist = append(pblist, pb)
+					}
+					ep.generic[netlabel.PortMap] = pblist
 				}
-				err = json.Unmarshal(bytes, &pb)
-				if err != nil {
-					log.G(context.TODO()).Error(err)
-					break
-				}
-				pblist = append(pblist, pb)
 			}
-			ep.generic[netlabel.PortMap] = pblist
-		}
 
-		if opt, ok := ep.generic[netlabel.ExposedPorts]; ok {
-			tplist := []types.TransportPort{}
+			if opt, ok := ep.generic[netlabel.ExposedPorts]; ok {
+				optList, isSlice := opt.([]any)
+				if !isSlice {
+					log.G(context.TODO()).Errorf("generic[%s]: expected []any, got %T", netlabel.ExposedPorts, opt)
+				} else {
+					tplist := []types.TransportPort{}
 
-			for i := 0; i < len(opt.([]any)); i++ {
-				tp := types.TransportPort{}
-				tmp := opt.([]any)[i].(map[string]any)
+					for i := 0; i < len(optList); i++ {
+						tp := types.TransportPort{}
+						tmp, isMap := optList[i].(map[string]any)
+						if !isMap {
+							log.G(context.TODO()).Errorf("generic[%s][%d]: expected map[string]any, got %T", netlabel.ExposedPorts, i, optList[i])
+							break
+						}
 
-				bytes, err := json.Marshal(tmp)
-				if err != nil {
-					log.G(context.TODO()).Error(err)
-					break
+						bytes, err := json.Marshal(tmp)
+						if err != nil {
+							log.G(context.TODO()).Error(err)
+							break
+						}
+						err = json.Unmarshal(bytes, &tp)
+						if err != nil {
+							log.G(context.TODO()).Error(err)
+							break
+						}
+						tplist = append(tplist, tp)
+					}
+					ep.generic[netlabel.ExposedPorts] = tplist
 				}
-				err = json.Unmarshal(bytes, &tp)
-				if err != nil {
-					log.G(context.TODO()).Error(err)
-					break
-				}
-				tplist = append(tplist, tp)
 			}
-			ep.generic[netlabel.ExposedPorts] = tplist
 		}
 	}
 
 	var anonymous bool
 	if v, ok := epMap["anonymous"]; ok {
-		anonymous = v.(bool)
+		if b, isBool := v.(bool); isBool {
+			anonymous = b
+		} else {
+			log.G(context.TODO()).Errorf("anonymous: expected bool, got %T", v)
+		}
 	}
 	if v, ok := epMap["disableResolution"]; ok {
-		ep.disableResolution = v.(bool)
+		if b, isBool := v.(bool); isBool {
+			ep.disableResolution = b
+		} else {
+			log.G(context.TODO()).Errorf("disableResolution: expected bool, got %T", v)
+		}
 	}
 	if v, ok := epMap["disableIPv6"]; ok {
-		ep.disableIPv6 = v.(bool)
+		if b, isBool := v.(bool); isBool {
+			ep.disableIPv6 = b
+		} else {
+			log.G(context.TODO()).Errorf("disableIPv6: expected bool, got %T", v)
+		}
 	}
 
 	if sn, ok := epMap["svcName"]; ok {
-		ep.svcName = sn.(string)
+		if s, isString := sn.(string); isString {
+			ep.svcName = s
+		} else {
+			log.G(context.TODO()).Errorf("svcName: expected string, got %T", sn)
+		}
 	}
 
 	if si, ok := epMap["svcID"]; ok {
-		ep.svcID = si.(string)
+		if s, isString := si.(string); isString {
+			ep.svcID = s
+		} else {
+			log.G(context.TODO()).Errorf("svcID: expected string, got %T", si)
+		}
 	}
 
 	if vip, ok := epMap["virtualIP"]; ok {
-		ep.virtualIP = net.ParseIP(vip.(string))
+		if s, isString := vip.(string); isString {
+			ep.virtualIP = net.ParseIP(s)
+		} else {
+			log.G(context.TODO()).Errorf("virtualIP: expected string, got %T", vip)
+		}
 	}
 
 	if v, ok := epMap["loadBalancer"]; ok {
-		ep.loadBalancer = v.(bool)
+		if b, isBool := v.(bool); isBool {
+			ep.loadBalancer = b
+		} else {
+			log.G(context.TODO()).Errorf("loadBalancer: expected bool, got %T", v)
+		}
 	}
 
 	sal, _ := json.Marshal(epMap["svcAliases"]) //nolint:errchkjson // FIXME: handle json (Un)Marshal errors (see above)

--- a/daemon/libnetwork/endpoint_info.go
+++ b/daemon/libnetwork/endpoint_info.go
@@ -1,12 +1,14 @@
 package libnetwork
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
 	"net/netip"
 	"slices"
 
+	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/internal/netiputil"
 	"github.com/moby/moby/v2/daemon/libnetwork/driverapi"
 	"github.com/moby/moby/v2/daemon/libnetwork/types"
@@ -490,12 +492,24 @@ func (epj *endpointJoinInfo) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := epMap["gw"]; ok {
-		epj.gw = net.ParseIP(v.(string))
+		if s, isString := v.(string); isString {
+			epj.gw = net.ParseIP(s)
+		} else {
+			log.G(context.TODO()).Errorf("gw: expected string, got %T", v)
+		}
 	}
 	if v, ok := epMap["gw6"]; ok {
-		epj.gw6 = net.ParseIP(v.(string))
+		if s, isString := v.(string); isString {
+			epj.gw6 = net.ParseIP(s)
+		} else {
+			log.G(context.TODO()).Errorf("gw6: expected string, got %T", v)
+		}
 	}
-	epj.disableGatewayService = epMap["disableGatewayService"].(bool)
+	disableGatewayService, isBool := epMap["disableGatewayService"].(bool)
+	if !isBool {
+		return fmt.Errorf("disableGatewayService: expected bool, got %T", epMap["disableGatewayService"])
+	}
+	epj.disableGatewayService = disableGatewayService
 
 	var tStaticRoute []types.StaticRoute
 	if v, ok := epMap["StaticRoutes"]; ok {

--- a/daemon/libnetwork/endpoint_info_test.go
+++ b/daemon/libnetwork/endpoint_info_test.go
@@ -1,0 +1,33 @@
+package libnetwork
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestEndpointJoinInfoUnmarshalJSON(t *testing.T) {
+	t.Run("non-bool disableGatewayService returns an error", func(t *testing.T) {
+		data, err := json.Marshal(map[string]any{
+			"disableGatewayService": "not-a-bool",
+		})
+		assert.NilError(t, err)
+
+		var epj endpointJoinInfo
+		assert.Check(t, epj.UnmarshalJSON(data) != nil)
+	})
+
+	t.Run("non-string gw is logged and ignored, not an error", func(t *testing.T) {
+		data, err := json.Marshal(map[string]any{
+			"gw":                    123,
+			"disableGatewayService": false,
+		})
+		assert.NilError(t, err)
+
+		var epj endpointJoinInfo
+		assert.NilError(t, epj.UnmarshalJSON(data))
+		assert.Check(t, is.Nil(epj.gw))
+	})
+}

--- a/daemon/libnetwork/endpoint_test.go
+++ b/daemon/libnetwork/endpoint_test.go
@@ -1,6 +1,7 @@
 package libnetwork
 
 import (
+	"encoding/json"
 	"sort"
 	"testing"
 
@@ -40,4 +41,54 @@ func TestSortByNetworkType(t *testing.T) {
 		"ep-local1",
 	}
 	assert.Check(t, is.DeepEqual(actual, expected))
+}
+
+func TestEndpointUnmarshalJSONTypeMismatch(t *testing.T) {
+	t.Run("non-string name returns an error", func(t *testing.T) {
+		data, err := json.Marshal(map[string]any{
+			"name": 123,
+			"id":   "id1",
+		})
+		assert.NilError(t, err)
+
+		var ep Endpoint
+		assert.Check(t, ep.UnmarshalJSON(data) != nil)
+	})
+
+	t.Run("non-string id returns an error", func(t *testing.T) {
+		data, err := json.Marshal(map[string]any{
+			"name": "ep1",
+			"id":   123,
+		})
+		assert.NilError(t, err)
+
+		var ep Endpoint
+		assert.Check(t, ep.UnmarshalJSON(data) != nil)
+	})
+
+	t.Run("non-bool disableIPv6 is logged and ignored, not an error", func(t *testing.T) {
+		data, err := json.Marshal(map[string]any{
+			"name":        "ep1",
+			"id":          "id1",
+			"disableIPv6": "not-a-bool",
+		})
+		assert.NilError(t, err)
+
+		var ep Endpoint
+		assert.NilError(t, ep.UnmarshalJSON(data))
+		assert.Check(t, is.Equal(ep.disableIPv6, false))
+	})
+
+	t.Run("non-map generic is logged and ignored, not an error", func(t *testing.T) {
+		data, err := json.Marshal(map[string]any{
+			"name":    "ep1",
+			"id":      "id1",
+			"generic": "not-a-map",
+		})
+		assert.NilError(t, err)
+
+		var ep Endpoint
+		assert.NilError(t, ep.UnmarshalJSON(data))
+		assert.Check(t, is.Nil(ep.generic))
+	})
 }

--- a/daemon/libnetwork/endpoint_test.go
+++ b/daemon/libnetwork/endpoint_test.go
@@ -92,3 +92,33 @@ func TestEndpointUnmarshalJSONTypeMismatch(t *testing.T) {
 		assert.Check(t, is.Nil(ep.generic))
 	})
 }
+
+func TestDecodeGenericList(t *testing.T) {
+	type sample struct {
+		Name string `json:"name"`
+	}
+
+	t.Run("happy path", func(t *testing.T) {
+		opt := []any{
+			map[string]any{"name": "a"},
+			map[string]any{"name": "b"},
+		}
+		list := decodeGenericList[sample]("key", opt)
+		assert.Check(t, is.DeepEqual(list, []sample{{Name: "a"}, {Name: "b"}}))
+	})
+
+	t.Run("non-slice returns nil", func(t *testing.T) {
+		list := decodeGenericList[sample]("key", "not-a-slice")
+		assert.Check(t, is.Nil(list))
+	})
+
+	t.Run("element not a map stops and returns what was collected so far", func(t *testing.T) {
+		opt := []any{
+			map[string]any{"name": "a"},
+			"not-a-map",
+			map[string]any{"name": "c"},
+		}
+		list := decodeGenericList[sample]("key", opt)
+		assert.Check(t, is.DeepEqual(list, []sample{{Name: "a"}}))
+	})
+}


### PR DESCRIPTION
## Summary

`Endpoint.UnmarshalJSON`, `endpointJoinInfo.UnmarshalJSON`, and `IPAMData.UnmarshalJSON` used unchecked type assertions (`x.(T)`) on values decoded from persisted JSON. A daemon restart that tries to load corrupted or version-mismatched on-disk state would panic instead of failing gracefully.

Replaced ~18 of these with checked assertions, preserving the existing distinction each function already encoded:
- Fields read unconditionally (`name`, `id`, `AddressSpace`, `disableGatewayService`) are treated as required — a type mismatch now returns a descriptive error instead of panicking.
- Fields read through an `if v, ok := ...; ok` presence check are treated as optional — a type mismatch is now logged and the assignment skipped instead of panicking.

While in there, also extracted the duplicated `generic` PortMap/ExposedPorts decoding loop (previously ~4 levels of nested if/else) into a small generic `decodeGenericList` helper, to keep the added type checks from making `Endpoint.UnmarshalJSON` harder to follow.

Added tests covering both the error path and the log-and-skip path for each function, plus the extracted helper.

## Release notes (optional)

```markdown changelog
- Fix a daemon panic when restoring corrupted or version-mismatched endpoint/network state from disk.
```

## A picture of a cute animal (not mandatory but encouraged)

🐕
