### PR TITLE
ci: validate DCO through GitHub API

### DIFF
--- a/.github/workflows/.dco.yml
+++ b/.github/workflows/.dco.yml
@@ -3,54 +3,77 @@ name: .dco
 
 # TODO: hide reusable workflow from the UI. Tracked in https://github.com/community/community/discussions/12025
 
-permissions:
-  contents: read
+# Permissions must be granted by the calling workflow.
+permissions: {}
 
 on:
   workflow_call:
 
-env:
-  ALPINE_VERSION: "3.22"
-
 jobs:
   run:
+    permissions:
+      pull-requests: read
     runs-on: ubuntu-24.04
-    timeout-minutes: 10 # guardrails timeout for the whole job
+    timeout-minutes: 5
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-      -
-        name: Dump context
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            console.log(JSON.stringify(context, null, 2));
-      -
-        name: Get base ref
-        id: base-ref
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          result-encoding: string
-          script: |
-            if (/^refs\/pull\//.test(context.ref) && context.payload?.pull_request?.base?.ref != undefined) {
-              return context.payload.pull_request.base.ref;
-            }
-            return context.ref.replace(/^refs\/heads\//g, '');
-      -
-        name: Validate
-        run: |
-          docker run --rm \
-            --quiet \
-            -v ./:/workspace \
-            -w /workspace \
-            -e VALIDATE_REPO \
-            -e VALIDATE_BRANCH \
-            -e VALIDATE_ORIGIN_BRANCH \
-            alpine:${{ env.ALPINE_VERSION }} sh -c 'apk add --no-cache -q bash git openssh-client && git config --system --add safe.directory /workspace && hack/validate/dco'
+      - name: Validate DCO
         env:
-          VALIDATE_REPO: ${{ github.server_url }}/${{ github.repository }}.git
-          VALIDATE_BRANCH: ${{ steps.base-ref.outputs.result }}
-          VALIDATE_ORIGIN_BRANCH: ${{ github.event.pull_request.base.sha || '' }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Skip the check on non-PR events, but don't skip the check itself,
+          # because other jobs may depend on it ("needs: validate-dco").
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Skipping DCO validation; not a pull request."
+            exit 0
+          fi
+          gh api --paginate --slurp "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits" > "$RUNNER_TEMP/pr-commits.json"
+
+          # Number of commits, excluding merge commits.
+          commitCount="$(jq '[.[][] | select(.parents | length <= 1)] | length' "$RUNNER_TEMP/pr-commits.json")"
+
+          badCommits="$(
+            jq -r '
+              def githubUsername:
+                # "Username may only contain alphanumeric characters or dashes and cannot begin with a dash"
+                "[a-zA-Z0-9][a-zA-Z0-9-]+";
+
+              def dco:
+                # https://github.com/moby/moby/blob/master/CONTRIBUTING.md#sign-your-work
+                "^(Docker-DCO-1\\.1-)?Signed-off-by: ([^<]+) <([^<>@]+@[^<>]+)>( \\(github: ("
+                + githubUsername
+                + ")\\))?$";
+
+              .[][]
+              # Skip merge commits.
+              | select(.parents | length <= 1)
+              | select(
+                  .commit.message
+                  | split("\n")
+                  | any(test(dco))
+                  | not
+              )
+              | .sha
+            ' "$RUNNER_TEMP/pr-commits.json"
+          )"
+
+          if [ -z "$badCommits" ]; then
+            echo "Checked ${commitCount} commit(s); all commits are properly signed with the DCO."
+            exit 0
+          fi
+
+          echo "::error::One or more commits are missing a valid DCO 'Signed-off-by:' trailer."
+          while read -r commit; do
+            echo " - ${commit}"
+          done <<< "$badCommits"
+
+          echo
+          echo "The sign-off certifies that you wrote the contribution or have the right to submit it."
+          echo "Use your real name, not a GitHub username, handle, or pseudonym:"
+          echo
+          echo "    Signed-off-by: YourFirstName YourLastName <yourname@example.org>"
+          echo
+          echo "Git can add this automatically with 'git commit -s'."
+          echo "See https://github.com/moby/moby/blob/master/CONTRIBUTING.md#sign-your-work"
+          echo "DCO 1.1: https://developercertificate.org/"
+          exit 1

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -24,6 +24,8 @@ on:
 jobs:
   validate-dco:
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    permissions:
+      pull-requests: read
     uses: ./.github/workflows/.dco.yml
 
   build:

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -26,6 +26,8 @@ env:
 
 jobs:
   validate-dco:
+    permissions:
+      pull-requests: read
     uses: ./.github/workflows/.dco.yml
 
   build-linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ env:
 
 jobs:
   validate-dco:
+    permissions:
+      pull-requests: read
     uses: ./.github/workflows/.dco.yml
 
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ env:
 
 jobs:
   validate-dco:
+    permissions:
+      pull-requests: read
     uses: ./.github/workflows/.dco.yml
 
   build-dev:

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -20,6 +20,8 @@ on:
 
 jobs:
   validate-dco:
+    permissions:
+      pull-requests: read
     uses: ./.github/workflows/.dco.yml
 
   vm:

--- a/.github/workflows/windows-2022.yml
+++ b/.github/workflows/windows-2022.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   validate-dco:
+    permissions:
+      pull-requests: read
     uses: ./.github/workflows/.dco.yml
   run:
     needs: validate-dco

--- a/.github/workflows/windows-2025.yml
+++ b/.github/workflows/windows-2025.yml
@@ -20,6 +20,8 @@ on:
 
 jobs:
   validate-dco:
+    permissions:
+      pull-requests: read
     uses: ./.github/workflows/.dco.yml
 
   run:


### PR DESCRIPTION
- similar to https://github.com/moby/moby/pull/53327

Use the pull request commits API to validate DCO sign-offs instead of checking out the repository and running the validation in a container.

This avoids fetching the repository, starting Docker, and installing dependencies solely to inspect commit messages, making the check faster and more predictable. It also avoids executing validation code from the PR checkout.

Validate all commits returned for the pull request and provide clearer guidance when a sign-off is missing or malformed.


Before this PR;

<img width="1119" height="421" alt="Screenshot 2026-08-07 at 15 22 34" src="https://github.com/user-attachments/assets/fd10d82c-9c41-413a-8e32-5f11001f2812" />


With this PR;

<img width="1109" height="254" alt="Screenshot 2026-08-07 at 15 21 35" src="https://github.com/user-attachments/assets/a4a4eefe-d4ca-4c63-80e5-b00ccaee3cf8" />

<img width="1130" height="606" alt="Screenshot 2026-08-07 at 15 20 12" src="https://github.com/user-attachments/assets/96e82250-ab15-46c4-8b10-39d36542e027" />


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
