### PR TITLE
daemon/containerd: skip valid pull leases during image prune

### DIFF
--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sort"
 	"strings"
+	"time"
 
 	c8dimages "github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/leases"
@@ -65,14 +66,30 @@ func (i *ImageService) ImagePrune(ctx context.Context, fltrs filters.Args) (*ima
 	}
 
 	// Prune leases
+	// Filter out leases that are still valid (held by in-flight pulls).
+	// withLease creates leases with an expireLabel set to 8h in the future.
+	// Only prune expired leases to avoid deleting in-flight pull leases
+	// and corrupting concurrent pulls.
 	leaseManager := i.client.LeasesService()
 	pullLeases, err := leaseManager.List(ctx, pruneLeaseFilter)
 	if err != nil {
 		return nil, err
 	}
-	for i, lease := range pullLeases {
+	now := time.Now()
+	var expiredLeases []leases.Lease
+	for _, lease := range pullLeases {
+		if expireStr, ok := lease.Labels[expireLabel]; ok {
+			expireAt, err := time.Parse(time.RFC3339, expireStr)
+			if err == nil && now.Before(expireAt) {
+				// Lease is still valid — an in-flight pull is using it.
+				continue
+			}
+		}
+		expiredLeases = append(expiredLeases, lease)
+	}
+	for i, lease := range expiredLeases {
 		var opts []leases.DeleteOpt
-		if i == len(pullLeases)-1 {
+		if i == len(expiredLeases)-1 {
 			opts = append(opts, leases.SynchronousDelete)
 		}
 		if err := leaseManager.Delete(ctx, lease, opts...); err != nil {


### PR DESCRIPTION
## Description

When the containerd image store is enabled, `docker image prune` deletes **all** leases matching the `moby/prune.images` label, including leases actively held by in-flight `docker pull` operations. This causes concurrent pulls to fail with content-store errors such as:

```
failed commit on ref "manifest-sha256:…": commit failed: rename .../ingest/<id>/data .../blobs/sha256/<digest>: no such file or directory
unable to lease content: lease does not exist: not found
NotFound: content digest sha256:<digest>: not found
```

### Root cause

`ImagePrune` (`daemon/containerd/image_prune.go`) lists all leases by the `pruneLeaseFilter` and deletes **every one** with `leases.SynchronousDelete` on the last — there is no check for whether a pull currently holds the lease.

With the lease gone, the victim pull's ingest records are no longer GC roots; the sweep aborts the ingest and deletes unreferenced blobs. The victim's writer then fails on `Commit()` with `ENOENT`.

### Fix

Skip leases whose `containerd.io/gc.expire` label indicates they are still valid (expireAt in the future). Only prune expired leases that are no longer protecting any active pull.

- `withLease` creates leases with a `containerd.io/gc.expire` label set to 8h in the future
- Normal pulls release their lease immediately on completion
- Only orphaned leases (from cancelled pulls, process crashes, etc.) should be cleaned up by prune
- `SynchronousDelete` is only applied to the last `expired` lease, not the last lease in the unfiltered list

### Verification

On a shared deploy host with 15+ systemd timers running concurrent pulls, removing the per-deploy `docker image prune -f` (keeping a single nightly prune) reduced failure count from hundreds per day to zero. This fix implements the same protection at the lease level.

Fixes #53321