### PR TITLE
Don't drop host aliases from swarm extra hosts

### DIFF
--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -439,12 +439,11 @@ func (c *containerConfig) hostConfig(deps exec.VolumeGetter) *container.HostConf
 	//    IP_address canonical_hostname [aliases...]
 	// However, the format of ExtraHosts in HostConfig is
 	//    <host>:<ip>
-	// We need to do the conversion here
-	// (Alias is ignored for now)
+	// We need to do the conversion here.
 	for _, entry := range c.spec().Hosts {
 		parts := strings.Fields(entry)
 		if len(parts) > 1 {
-			hc.ExtraHosts = append(hc.ExtraHosts, fmt.Sprintf("%s:%s", parts[1], parts[0]))
+			hc.ExtraHosts = append(hc.ExtraHosts, fmt.Sprintf("%s:%s", strings.Join(parts[1:], " "), parts[0]))
 		}
 	}
 

--- a/daemon/cluster/executor/container/container_test.go
+++ b/daemon/cluster/executor/container/container_test.go
@@ -86,6 +86,37 @@ func TestContainerLabels(t *testing.T) {
 	assert.DeepEqual(t, expected, labels)
 }
 
+func TestExtraHostsConversion(t *testing.T) {
+	tests := []struct {
+		name string
+		from []string
+		to   []string
+	}{
+		{name: "single name", from: []string{"1.2.3.4 foo.example.com"}, to: []string{"foo.example.com:1.2.3.4"}},
+		{name: "aliases", from: []string{"1.1.1.1 host1 host2"}, to: []string{"host1 host2:1.1.1.1"}},
+		{name: "ipv6 with aliases", from: []string{"2001:db8::1 host1 host2"}, to: []string{"host1 host2:2001:db8::1"}},
+		{name: "extra whitespace", from: []string{"  1.1.1.1\thost1   host2  "}, to: []string{"host1 host2:1.1.1.1"}},
+		{name: "ip without hostname is skipped", from: []string{"10.0.0.1"}, to: nil},
+		{name: "multiple entries", from: []string{"1.1.1.1 host1 host2", "2.2.2.2 host3"}, to: []string{"host1 host2:1.1.1.1", "host3:2.2.2.2"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			task := swarmapi.Task{
+				Spec: swarmapi.TaskSpec{
+					Runtime: &swarmapi.TaskSpec_Container{
+						Container: &swarmapi.ContainerSpec{
+							Image: "alpine:latest",
+							Hosts: tc.from,
+						},
+					},
+				},
+			}
+			config := containerConfig{task: &task}
+			assert.DeepEqual(t, tc.to, config.hostConfig(nil).ExtraHosts)
+		})
+	}
+}
+
 func TestCredentialSpecConversion(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
- Related to: https://github.com/moby/moby/pull/28031

## Summary

Swarm stores extra hosts in the hosts(5) format, `IP_address canonical_hostname [aliases...]`.
That format was picked in #28031 on purpose, so that aliases would not get lost.
The executor never implemented that part though. When it converts spec entries
to `HostConfig.ExtraHosts` it keeps the first hostname and drops the rest
("Alias is ignored for now").

With this change all names are kept, so `"1.1.1.1 host1 host2"` becomes
`"host1 host2:1.1.1.1"` and shows up as one line in the container's `/etc/hosts`:

    1.1.1.1	host1 host2

Plain containers already work like this, `docker run --add-host "host1 host2:1.1.1.1"`
gives the same line. No CLI changes are needed, `service update --host-rm`
already knows how to deal with multi-name entries.

To verify:

    docker service create --name demo --host 'host1 host2:1.1.1.1' busybox sleep 300
    docker exec $(docker ps -q -f label=com.docker.swarm.service.name=demo) cat /etc/hosts

Before this change the line only contains host1, now it has both names.

## Release notes (optional)

```markdown changelog
Don't drop hostname aliases from `ContainerSpec.Hosts` when writing a swarm task's `/etc/hosts` file.
```

## A picture of a cute animal (not mandatory but encouraged)
<img width="765" height="496" alt="cute-cat" src="https://github.com/user-attachments/assets/e0f7ed05-7d4c-4784-a23f-ffe44a31c51b" />
