### PR TITLE
Fix flaky PublishAllPorts regression test

### DIFF
--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -2255,7 +2255,7 @@ func TestGatewayErrorOnNetDisconnect(t *testing.T) {
 		}}),
 		container.WithCapability("NET_ADMIN"),
 	)
-	container.Remove(ctx, t, c, ctrID, client.ContainerRemoveOptions{Force: true})
+	defer container.Remove(ctx, t, c, ctrID, client.ContainerRemoveOptions{Force: true})
 
 	// Break n2 so it can't be used as a gateway (there will be no route).
 	execRes := container.ExecT(ctx, t, c, ctrID, []string{"ip", "link", "set", "eth2", "down"})
@@ -2292,5 +2292,5 @@ func TestPublishAllWithNilPortBindings(t *testing.T) {
 		container.WithExposedPorts("80/tcp"),
 		container.WithPublishAllPorts(true),
 	)
-	defer c.ContainerRemove(ctx, ctrID, client.ContainerRemoveOptions{})
+	container.Remove(ctx, t, c, ctrID, client.ContainerRemoveOptions{Force: true})
 }

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -2255,7 +2255,7 @@ func TestGatewayErrorOnNetDisconnect(t *testing.T) {
 		}}),
 		container.WithCapability("NET_ADMIN"),
 	)
-	defer container.Remove(ctx, t, c, ctrID, client.ContainerRemoveOptions{Force: true})
+	container.Remove(ctx, t, c, ctrID, client.ContainerRemoveOptions{Force: true})
 
 	// Break n2 so it can't be used as a gateway (there will be no route).
 	execRes := container.ExecT(ctx, t, c, ctrID, []string{"ip", "link", "set", "eth2", "down"})

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -22,14 +22,12 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge"
 	"github.com/moby/moby/v2/daemon/libnetwork/iptables"
 	"github.com/moby/moby/v2/daemon/libnetwork/netlabel"
-	"github.com/moby/moby/v2/integration/internal/build"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/integration/internal/network"
 	"github.com/moby/moby/v2/integration/internal/testutils/networking"
 	n "github.com/moby/moby/v2/integration/network"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/daemon"
-	"github.com/moby/moby/v2/internal/testutil/fakecontext"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
@@ -2289,12 +2287,10 @@ func TestPublishAllWithNilPortBindings(t *testing.T) {
 	ctx := setupTest(t)
 	c := testEnv.APIClient()
 
-	imgWithExpose := container.WithImage(build.Do(ctx, t, c,
-		fakecontext.New(t, "", fakecontext.WithDockerfile("FROM busybox\nEXPOSE 80/tcp\n")), client.ImageBuildOptions{}))
-
-	_ = container.Run(ctx, t, c,
-		container.WithAutoRemove,
+	ctrID := container.Create(ctx, t, c,
+		container.WithImage("busybox:latest"),
+		container.WithExposedPorts("80/tcp"),
 		container.WithPublishAllPorts(true),
-		imgWithExpose,
 	)
+	defer c.ContainerRemove(ctx, ctrID, client.ContainerRemoveOptions{})
 }


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/53255

## Summary

Create the regression-test container directly from the regular `busybox:latest` image with port 80 exposed and `PublishAllPorts` enabled. The test does not start the container, avoiding host-port allocation while still exercising the container-create path that previously triggered the rootless panic.

## Release notes (optional)

```markdown changelog

```

Created with: Codex
