### PR TITLE
fix: set CNI.Root to absolute path to prevent autofs blocking dockerd startup

### DIFF
--- a/daemon/internal/builder-next/controller.go
+++ b/daemon/internal/builder-next/controller.go
@@ -134,6 +134,7 @@ func newSnapshotterController(ctx context.Context, rt http.RoundTripper, opt Opt
 		Selinux:         false,
 		CDIManager:      cdiManager,
 	}
+	workerOpts.NetworkOpt.CNI.Root = opt.Root
 
 	ctdOpts := []ctd.Opt{ctd.WithTimeout(60 * time.Second)}
 	if opt.ContainerdDialer != nil {


### PR DESCRIPTION
Closes #53344

## Problem
On a host with a standard autofs hosts map mounted at `/net`, dockerd blocks for several minutes during BuildKit initialization. BuildKit reads a relative `net/proxy` directory with an empty proxy-provider root. Because dockerd's working directory is `/`, this reaches `/net/proxy`; autofs interprets `proxy` as a hostname and performs two long failed lookups.

## Root cause
In `daemon/internal/builder-next/controller.go`, the containerd worker is initialized with `NetworkOpt: netproviders.Opt{Mode: networkMode}`, leaving `CNI.Root` empty. BuildKit's proxy provider then uses a relative `net/proxy` path for namespace cleanup, which resolves against dockerd's working directory (`/`) and triggers the autofs mount.

## Fix
Set `workerOpts.NetworkOpt.CNI.Root = opt.Root` so the proxy provider uses an absolute state directory and never traverses the host's `/net` automount:
\`\`\`go
workerOpts.NetworkOpt.CNI.Root = opt.Root
\`\`\`

This matches the absolute root the executor later uses for its own proxy provider and prevents the autofs blocking during startup.