### PR TITLE
fix: widen okIntervalDelta tolerance for AdvertiseAddresses flaky test

### DIFF
--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -1891,7 +1891,7 @@ func TestAdvertiseAddresses(t *testing.T) {
 						// the interval to the next may be shorted than the configured interval.
 						// Send variance should be a lot less than this but, this is enough to check that
 						// the interval is configurable, while (hopefully) avoiding flakiness on a busy host ...
-						const okIntervalDelta = 100 * time.Millisecond
+						const okIntervalDelta = 300 * time.Millisecond
 						assert.Check(t, time.Duration(math.Abs(float64(interval-tc.expInterval))) < okIntervalDelta,
 							"interval %s is expected to be within %s of configured interval %s",
 							interval, okIntervalDelta, tc.expInterval)
@@ -2298,3 +2298,4 @@ func TestPublishAllWithNilPortBindings(t *testing.T) {
 		imgWithExpose,
 	)
 }
+


### PR DESCRIPTION
## Description

Fixes flaky test `TestAdvertiseAddresses/min_interval` which fails intermittently on loaded CI runners.

The test measures ARP/NA message intervals and asserts that the observed interval is within 100ms of the configured 100ms interval. On a loaded CI runner, scheduling jitter can push the measured interval above 200ms (e.g., 227ms), exceeding the ±100ms tolerance.

## Changes

- Widen `okIntervalDelta` from 100ms to 300ms to accommodate timing variance on loaded CI runners.
- The existing comment already notes: "Send variance should be a lot less than this but, this is enough to check that the interval is configurable, while (hopefully) avoiding flakiness on a busy host"

## Related issue

Closes #53355