### PR TITLE
docker-proxy: retry TCP backend dial on ECONNREFUSED

### DIFF
--- a/cmd/docker-proxy/tcp_proxy_linux.go
+++ b/cmd/docker-proxy/tcp_proxy_linux.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"errors"
 	"io"
 	"log"
 	"net"
 	"sync"
+	"syscall"
+	"time"
 )
 
 // TCPProxy is a proxy for TCP connections. It implements the Proxy interface to
@@ -25,11 +28,25 @@ func NewTCPProxy(listener *net.TCPListener, backendAddr *net.TCPAddr) (*TCPProxy
 }
 
 func (proxy *TCPProxy) clientLoop(client *net.TCPConn, quit chan bool) {
-	backend, err := net.DialTCP("tcp", nil, proxy.backendAddr)
-	if err != nil {
-		log.Printf("Can't forward traffic to backend tcp/%v: %s\n", proxy.backendAddr, err)
-		client.Close()
-		return
+	var backend *net.TCPConn
+	for {
+		var err error
+		backend, err = net.DialTCP("tcp", nil, proxy.backendAddr)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, syscall.ECONNREFUSED) {
+			log.Printf("Can't forward traffic to backend tcp/%v: %s\n", proxy.backendAddr, err)
+			client.Close()
+			return
+		}
+		// Backend not ready yet (container application not listening); retry.
+		select {
+		case <-quit:
+			client.Close()
+			return
+		case <-time.After(10 * time.Millisecond):
+		}
 	}
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Problem

When a container port is published, `docker-proxy` starts listening on the host port *before* the containerised application has finished binding its own listening socket. This creates a race:

1. `docker-proxy` binds the host port and starts accepting connections.
2. The test's `poll.WaitOn` dial to the proxy succeeds immediately (the proxy is up).
3. The proxy's `clientLoop()` calls `net.DialTCP` to the container backend — but the container's `nc` (or equivalent) process is not yet listening, so the kernel returns `ECONNREFUSED`.
4. The proxy logs "Can't forward traffic" and closes the client connection with no data written.
5. The test's `io.ReadAll(conn)` returns an empty string, causing the assertion to fail.

This is the root cause of intermittent failures in `TestNetworkNat` and `TestNetworkLocalhostTCPNat` (`integration/container/nat_test.go`) and the related `TestProxy4To6` (`integration/networking/port_mapping_linux_test.go`), tracked in issue #48970.

## Fix

Add a retry loop inside `clientLoop()` that spins on `ECONNREFUSED` with a 10 ms back-off, honouring the `quit` channel so the proxy still shuts down cleanly. Any other error is still treated as fatal (logged and connection closed), preserving existing behaviour.

The retry is bounded by the `quit` signal: when the proxy's `Run()` loop returns and closes `quit`, any in-flight `clientLoop` goroutine will exit on the next back-off iteration.

## Testing

Existing integration tests cover this path. The fix removes the timing-sensitive window that caused the flakiness, so no new sleep/poll logic is needed in the tests.

Fixes #48970
