### PR TITLE
fix: Update RootlessKit (v3.1.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -324,7 +324,7 @@ FROM tini-${TARGETOS} AS tini
 # rootlesskit
 FROM base AS rootlesskit-src
 WORKDIR /usr/src/rootlesskit
-ARG ROOTLESSKIT_VERSION=v3.0.2
+ARG ROOTLESSKIT_VERSION=v3.1.0
 ADD https://github.com/rootless-containers/rootlesskit.git?ref=${ROOTLESSKIT_VERSION}&keep-git-dir=1 .
 
 FROM base AS rootlesskit-build

--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -14,7 +14,7 @@
 #   * Defaults to "slirp4netns" if slirp4netns (>= v0.4.0) is installed, else "pasta", else "vpnkit", else "gvisor-tap-vsock".
 # * DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=NUM: the MTU value for the rootlesskit network driver.
 #   * Defaults to 65520 for slirp4netns, pasta, and gvisor-tap-vsock. Defaults to 1500 for other rootlesskit network drivers.
-# * DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=(builtin|slirp4netns|implicit|gvisor-tap-vsock): the rootlesskit port driver.
+# * DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=(builtin|slirp4netns|pesto|implicit|gvisor-tap-vsock): the rootlesskit port driver.
 #   * Defaults to "implicit" for "pasta", "builtin" for other rootlesskit network drivers.
 # * DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SANDBOX=(auto|true|false): whether to protect slirp4netns with a dedicated mount namespace.
 #   * Defaults to "auto".
@@ -44,6 +44,7 @@
 #  gvisor-tap-vsock | gvisor-tap-vsock | Slow           | Slow            | ❌     | ✅      | Not recommended. Use `builtin` port driver instead.
 #  slirp4netns      | slirp4netns      | Slow           | Slow            | ✅     | ✅      |
 #  pasta            | implicit         | Slow           | Fast ✅         | ✅     | ✅      | Experimental; Needs recent version of pasta (2023_12_04)
+#  pasta            | pesto            | Slow           | Fast ✅         | ✅     | ✅      | Experimental; IPv4 only; Needs recent version of pasta (2026_05_07)
 #  lxc-user-nic     | builtin          | Fast ✅        | Fast ✅         | ✅ (*) | ❌      | Experimental
 #  (bypass4netns)   | (bypass4netns)   | Fast ✅        | Fast ✅         | ✅     | ✅      | (Not integrated to RootlessKit)
 #

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # When updating, also update go.mod and Dockerfile accordingly.
-: "${ROOTLESSKIT_VERSION:=v3.0.2}"
+: "${ROOTLESSKIT_VERSION:=v3.1.0}"
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

- Follow up to: https://github.com/moby/moby/pull/53326

#53326 updated the Go module only, so the RootlessKit binary built by the Dockerfile and hack/dockerfile/install/rootlesskit.installer is still pinned to v3.0.2.

Updated RootlessKit from `v3.0.2` to `v3.1.0`: https://github.com/rootless-containers/rootlesskit/compare/v3.0.2...v3.1.0

Therefore, following the release of a new version of RootlessKit, we should update the related versions (`Dockerfile` and `rootlesskit.installer`) and documentation in `contrib/dockerd-rootless.sh`.

---

This version adds a new port driver, `pesto`, and I confirmed the new port-driver works on moby.

<details><summary>Details</summary>
<p>

I've set `Environment=DOCKERD_ROOTLESS_ROOTLESSKIT_NET=pasta` and `Environment=DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=pesto` into the systemd service unit file for dockerd.

```bash
$ docker version
Client: Docker Engine - Community
 Version:           29.1.2
 API version:       1.52
 Go version:        go1.25.5
 Git commit:        890dcca
 Built:             Tue Dec  2 21:56:10 2025
 OS/Arch:           linux/arm64
 Context:           rootless

Server:
 Engine:
  Version:          dev
  API version:      1.55 (minimum version 1.40)
  Go version:       go1.26.5
  Git commit:       e456107947c1d554ae1ad0645ed6e13978aa1c2d
  Built:            Tue Aug 11 11:33:56 2026
  OS/Arch:          linux/arm64
  Experimental:     false
 containerd:
  Version:          v2.2.0
  GitCommit:        1c4457e00facac03ce1d75f7b6777a7a851e5c41
 runc:
  Version:          1.3.4
  GitCommit:        v1.3.4-0-gd6d73eb8
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
 rootlesskit:
  Version:          3.1.0
  ApiVersion:       1.1.2
  NetworkDriver:    pasta
  PortDriver:       pesto
  StateDir:         /run/user/501/dockerd-rootless
```

```bash
(host) $ docker run -d -p 8080:80 nginx:alpine
6b63ca313380bc354ae9031b9534b1686ca67c2eae0d5f9890d990cb198c6654

(host) $ docker ps
CONTAINER ID   IMAGE          COMMAND                  CREATED              STATUS              PORTS                  NAMES
6b63ca313380   nginx:alpine   "/docker-entrypoint.…"   About a minute ago   Up About a minute   0.0.0.0:8080->80/tcp   dazzling_payne

(host) $ curl localhost:8080
<!DOCTYPE html>
<html>
...
```

</p>
</details> 

reference: https://github.com/rootless-containers/rootlesskit/issues/611

Note that `pesto` is opt-in and it is never selected automatically. It's used only when `pesto` is set to `DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER` together with the `pasta` network driver.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
- Update RootlessKit to v3.1.0, adding support for the `pesto` port driver in rootless mode. Set `DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=pesto` to use it; it requires the `pasta` network driver and supports IPv4 only.
- Fix `--disable-host-loopback` not being enforced for the `pasta` network driver in rootless mode.
```

## A picture of a cute animal (not mandatory but encouraged)
