### PR TITLE
integration: Fix Windows test daemon startup defaults

### DIFF
--- a/internal/testutil/daemon/daemon.go
+++ b/internal/testutil/daemon/daemon.go
@@ -48,7 +48,6 @@ func (nopLog) Logf(string, ...any) {}
 
 const (
 	defaultDockerdBinary         = "dockerd"
-	defaultContainerdSocket      = "/var/run/docker/containerd/containerd.sock"
 	defaultDockerdRootlessBinary = "dockerd-rootless.sh"
 	defaultUnixSocket            = "/var/run/docker.sock"
 	defaultTLSHost               = "localhost:2376"
@@ -538,7 +537,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 
 	d.args = append(d.args,
 		// Make sure we don't use the environment-provided global config file.
-		"--config-file", "/dev/null",
+		"--config-file", os.DevNull,
 		"--data-root", d.Root,
 		"--exec-root", d.execRoot,
 		"--pidfile", d.pidFile,

--- a/internal/testutil/daemon/daemon.go
+++ b/internal/testutil/daemon/daemon.go
@@ -542,10 +542,11 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 		"--data-root", d.Root,
 		"--exec-root", d.execRoot,
 		"--pidfile", d.pidFile,
-		"--userland-proxy="+strconv.FormatBool(d.userlandProxy),
 		"--containerd-namespace", d.id,
 		"--containerd-plugins-namespace", d.id+"p",
 	)
+	d.args = append(d.args, d.platformArgs()...)
+
 	if d.containerdEmbedded {
 		d.args = append(d.args, "--feature", "embedded-containerd")
 	} else if d.containerdSocket != "" {

--- a/internal/testutil/daemon/daemon.go
+++ b/internal/testutil/daemon/daemon.go
@@ -47,10 +47,8 @@ type nopLog struct{}
 func (nopLog) Logf(string, ...any) {}
 
 const (
-	defaultDockerdBinary         = "dockerd"
-	defaultDockerdRootlessBinary = "dockerd-rootless.sh"
-	defaultUnixSocket            = "/var/run/docker.sock"
-	defaultTLSHost               = "localhost:2376"
+	defaultDockerdBinary = "dockerd"
+	defaultTLSHost       = "localhost:2376"
 )
 
 var errDaemonNotStarted = errors.New("daemon not started")
@@ -518,22 +516,11 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 		d.pidFile = filepath.Join(d.Folder, "docker.pid")
 	}
 
-	d.args = []string{}
-	if d.rootlessUser != nil {
-		if d.dockerdBinary != defaultDockerdBinary {
-			return errors.Errorf("[%s] DOCKER_ROOTLESS doesn't support non-default dockerd binary path %q", d.id, d.dockerdBinary)
-		}
-		dockerdBinary = "sudo"
-		d.args = append(d.args,
-			"-u", d.rootlessUser.Username,
-			"--preserve-env",
-			"--preserve-env=PATH", // Pass through PATH, overriding secure_path.
-			"XDG_RUNTIME_DIR="+d.rootlessXDGRuntimeDir,
-			"HOME="+d.rootlessUser.HomeDir,
-			"--",
-			defaultDockerdRootlessBinary,
-		)
+	dockerdBinary, args, err := d.rootlessCommand(dockerdBinary)
+	if err != nil {
+		return err
 	}
+	d.args = args
 
 	d.args = append(d.args,
 		// Make sure we don't use the environment-provided global config file.
@@ -974,10 +961,7 @@ func (d *Daemon) getClientConfig() (*clientConfig, error) {
 		scheme = "https"
 		proto = "tcp"
 	} else if d.UseDefaultHost {
-		addr = defaultUnixSocket
-		proto = "unix"
-		scheme = "http"
-		transport = &http.Transport{}
+		transport, scheme, proto, addr = defaultHostConfig()
 	} else {
 		addr = d.sockPath()
 		proto = "unix"

--- a/internal/testutil/daemon/daemon_unix.go
+++ b/internal/testutil/daemon/daemon_unix.go
@@ -3,19 +3,47 @@
 package daemon
 
 import (
+	"net/http"
 	"os/exec"
 	"strconv"
 	"syscall"
 	"testing"
 
 	"github.com/moby/sys/mount"
+	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
-const defaultContainerdSocket = "/var/run/docker/containerd/containerd.sock"
+const (
+	defaultContainerdSocket      = "/var/run/docker/containerd/containerd.sock"
+	defaultDockerdRootlessBinary = "dockerd-rootless.sh"
+	defaultUnixSocket            = "/var/run/docker.sock"
+)
+
+func (d *Daemon) rootlessCommand(dockerdBinary string) (string, []string, error) {
+	if d.rootlessUser == nil {
+		return dockerdBinary, nil, nil
+	}
+	if d.dockerdBinary != defaultDockerdBinary {
+		return "", nil, errors.Errorf("[%s] DOCKER_ROOTLESS doesn't support non-default dockerd binary path %q", d.id, d.dockerdBinary)
+	}
+	return "sudo", []string{
+		"-u", d.rootlessUser.Username,
+		"--preserve-env",
+		"--preserve-env=PATH", // Pass through PATH, overriding secure_path.
+		"XDG_RUNTIME_DIR=" + d.rootlessXDGRuntimeDir,
+		"HOME=" + d.rootlessUser.HomeDir,
+		"--",
+		defaultDockerdRootlessBinary,
+	}, nil
+}
 
 func (d *Daemon) platformArgs() []string {
 	return []string{"--userland-proxy=" + strconv.FormatBool(d.userlandProxy)}
+}
+
+func defaultHostConfig() (*http.Transport, string, string, string) {
+	return &http.Transport{}, "http", "unix", defaultUnixSocket
 }
 
 // cleanupMount unmounts the daemon root directory, or logs a message if

--- a/internal/testutil/daemon/daemon_unix.go
+++ b/internal/testutil/daemon/daemon_unix.go
@@ -4,12 +4,17 @@ package daemon
 
 import (
 	"os/exec"
+	"strconv"
 	"syscall"
 	"testing"
 
 	"github.com/moby/sys/mount"
 	"golang.org/x/sys/unix"
 )
+
+func (d *Daemon) platformArgs() []string {
+	return []string{"--userland-proxy=" + strconv.FormatBool(d.userlandProxy)}
+}
 
 // cleanupMount unmounts the daemon root directory, or logs a message if
 // unmounting failed.

--- a/internal/testutil/daemon/daemon_unix.go
+++ b/internal/testutil/daemon/daemon_unix.go
@@ -12,6 +12,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const defaultContainerdSocket = "/var/run/docker/containerd/containerd.sock"
+
 func (d *Daemon) platformArgs() []string {
 	return []string{"--userland-proxy=" + strconv.FormatBool(d.userlandProxy)}
 }

--- a/internal/testutil/daemon/daemon_windows.go
+++ b/internal/testutil/daemon/daemon_windows.go
@@ -10,6 +10,8 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+const defaultContainerdSocket = ""
+
 func (*Daemon) platformArgs() []string {
 	return nil
 }

--- a/internal/testutil/daemon/daemon_windows.go
+++ b/internal/testutil/daemon/daemon_windows.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"fmt"
+	"net/http"
 	"os/exec"
 	"strconv"
 	"testing"
@@ -12,8 +13,16 @@ import (
 
 const defaultContainerdSocket = ""
 
+func (*Daemon) rootlessCommand(dockerdBinary string) (string, []string, error) {
+	return dockerdBinary, nil, nil
+}
+
 func (*Daemon) platformArgs() []string {
 	return nil
+}
+
+func defaultHostConfig() (*http.Transport, string, string, string) {
+	return &http.Transport{}, "http", "npipe", `//./pipe/docker_engine`
 }
 
 // SignalDaemonDump sends a signal to the daemon to write a dump file

--- a/internal/testutil/daemon/daemon_windows.go
+++ b/internal/testutil/daemon/daemon_windows.go
@@ -10,6 +10,10 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+func (*Daemon) platformArgs() []string {
+	return nil
+}
+
 // SignalDaemonDump sends a signal to the daemon to write a dump file
 func SignalDaemonDump(pid int) {
 	ev, _ := windows.UTF16PtrFromString("Global\\docker-daemon-" + strconv.Itoa(pid))

--- a/internal/testutil/daemon/ops.go
+++ b/internal/testutil/daemon/ops.go
@@ -14,7 +14,8 @@ type Option func(*Daemon)
 // WithContainerdSocket sets the --containerd option on the daemon.
 // Use an empty string to remove the option.
 //
-// If unset the --containerd option will be used with a default value.
+// On Unix, the default is /var/run/docker/containerd/containerd.sock.
+// On Windows, the option is omitted by default.
 func WithContainerdSocket(socket string) Option {
 	return func(d *Daemon) {
 		d.containerdSocket = socket


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

- extracted from: https://github.com/moby/moby/pull/53021

### integration: Avoid Unix containerd socket on Windows

  The test daemon helper passed /var/run/docker/containerd/containerd.sock on every platform. Windows cannot use that Unix socket, so test daemons failed to start.

  Keep the socket default on Unix and omit the implicit --containerd option on Windows, allowing dockerd to select its native default. Explicit containerd addresses remain supported. Use os.DevNull for the empty configuration path so it also follows the platform default.


### integration: Avoid unsupported userland proxy flag on Windows

  The integration daemon helper always passed --userland-proxy, but Windows dockerd does not register that flag and exited before tests could start. Build this default argument per platform so Unix behavior remains unchanged and Windows daemon startup omits the unsupported option.


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
