### PR TITLE
integration-cli: TestDaemonDebugLog don't color-match output

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1505,21 +1505,18 @@ func (s *DockerDaemonSuite) TestDaemonStartWithoutColors(c *testing.T) {
 func (s *DockerDaemonSuite) TestDaemonDebugLog(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
-	debugLog := "\x1b[37mDEBU\x1b"
-
-	p, tty, err := pty.Open()
+	logFile, err := os.CreateTemp(c.TempDir(), "dockerd-debug-*.log")
 	assert.NilError(c, err)
-	defer func() {
-		tty.Close()
-		p.Close()
-	}()
+	defer logFile.Close()
 
-	b := bytes.NewBuffer(nil)
-	go io.Copy(b, p)
-
-	s.d.StartWithLogFile(tty, "--debug")
+	err = s.d.StartWithLogFile(logFile, "--debug", "--log-format=json")
+	assert.NilError(c, err)
 	s.d.Stop(c)
-	assert.Assert(c, is.Contains(b.String(), debugLog))
+
+	data, err := os.ReadFile(logFile.Name())
+	assert.NilError(c, err)
+
+	assert.Assert(c, is.Contains(string(data), `"level":"debug"`))
 }
 
 // Test for #21956


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/52462

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
