### PR TITLE
fix(awslogs): recreate log stream when it is deleted

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -689,6 +689,20 @@ func (l *logStream) publishBatch(batch *eventBatch) {
 			err = nil
 		} else if apiErr := (*types.InvalidSequenceTokenException)(nil); errors.As(err, &apiErr) {
 			nextSequenceToken, err = l.putLogEvents(cwEvents, apiErr.ExpectedSequenceToken)
+		} else if apiErr := (*types.ResourceNotFoundException)(nil); errors.As(err, &apiErr) && l.logCreateStream {
+			// The log stream (or the log group holding it) was deleted after
+			// the logger was initialized. Recreate it and resubmit the batch,
+			// otherwise the container would stop logging until it is restarted.
+			log.G(context.TODO()).WithFields(log.Fields{
+				"errorCode":     apiErr.ErrorCode(),
+				"message":       apiErr.ErrorMessage(),
+				"logGroupName":  l.logGroupName,
+				"logStreamName": l.logStreamName,
+			}).Info("Log stream not found, recreating it")
+			if err = l.create(); err == nil {
+				// A freshly created log stream has no sequence token yet.
+				nextSequenceToken, err = l.putLogEvents(cwEvents, nil)
+			}
 		}
 	}
 	if err != nil {

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -547,6 +547,113 @@ func TestPublishBatchAlreadyAccepted(t *testing.T) {
 	assert.Equal(t, events[0].inputLogEvent, argument.LogEvents[0])
 }
 
+func TestPublishBatchStreamNotFound(t *testing.T) {
+	mockClient := &mockClient{}
+	stream := &logStream{
+		client:          mockClient,
+		logGroupName:    groupName,
+		logStreamName:   streamName,
+		logCreateStream: true,
+		sequenceToken:   aws.String(sequenceToken),
+	}
+	createLogStreamCalls := 0
+	mockClient.createLogStreamFunc = func(ctx context.Context, input *cloudwatchlogs.CreateLogStreamInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.CreateLogStreamOutput, error) {
+		createLogStreamCalls++
+		return &cloudwatchlogs.CreateLogStreamOutput{}, nil
+	}
+	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
+	mockClient.putLogEventsFunc = func(ctx context.Context, input *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
+		calls = append(calls, input)
+		if createLogStreamCalls == 0 {
+			return nil, &types.ResourceNotFoundException{}
+		}
+		return &cloudwatchlogs.PutLogEventsOutput{
+			NextSequenceToken: aws.String(nextSequenceToken),
+		}, nil
+	}
+
+	events := []wrappedEvent{
+		{
+			inputLogEvent: types.InputLogEvent{
+				Message: aws.String(logline),
+			},
+		},
+	}
+
+	stream.publishBatch(testEventBatch(events))
+	assert.Equal(t, 1, createLogStreamCalls)
+	assert.Assert(t, is.Len(calls, 2))
+	assert.Equal(t, sequenceToken, aws.ToString(calls[0].SequenceToken))
+	// A newly created log stream does not have a sequence token yet.
+	assert.Assert(t, calls[1].SequenceToken == nil)
+	assert.Assert(t, is.Len(calls[1].LogEvents, 1))
+	assert.Equal(t, events[0].inputLogEvent, calls[1].LogEvents[0])
+	assert.Equal(t, nextSequenceToken, aws.ToString(stream.sequenceToken))
+}
+
+func TestPublishBatchStreamNotFoundCreateStreamDisabled(t *testing.T) {
+	mockClient := &mockClient{}
+	stream := &logStream{
+		client:          mockClient,
+		logGroupName:    groupName,
+		logStreamName:   streamName,
+		logCreateStream: false,
+		sequenceToken:   aws.String(sequenceToken),
+	}
+	mockClient.createLogStreamFunc = func(ctx context.Context, input *cloudwatchlogs.CreateLogStreamInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.CreateLogStreamOutput, error) {
+		t.Error("CreateLogStream should not be called")
+		return nil, errors.New("should not be called")
+	}
+	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
+	mockClient.putLogEventsFunc = func(ctx context.Context, input *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
+		calls = append(calls, input)
+		return nil, &types.ResourceNotFoundException{}
+	}
+
+	events := []wrappedEvent{
+		{
+			inputLogEvent: types.InputLogEvent{
+				Message: aws.String(logline),
+			},
+		},
+	}
+
+	stream.publishBatch(testEventBatch(events))
+	assert.Assert(t, is.Len(calls, 1))
+	assert.Equal(t, sequenceToken, aws.ToString(stream.sequenceToken))
+}
+
+func TestPublishBatchStreamNotFoundCreateError(t *testing.T) {
+	mockClient := &mockClient{}
+	stream := &logStream{
+		client:          mockClient,
+		logGroupName:    groupName,
+		logStreamName:   streamName,
+		logCreateStream: true,
+		sequenceToken:   aws.String(sequenceToken),
+	}
+	mockClient.createLogStreamFunc = func(ctx context.Context, input *cloudwatchlogs.CreateLogStreamInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.CreateLogStreamOutput, error) {
+		return nil, errors.New("error")
+	}
+	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
+	mockClient.putLogEventsFunc = func(ctx context.Context, input *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
+		calls = append(calls, input)
+		return nil, &types.ResourceNotFoundException{}
+	}
+
+	events := []wrappedEvent{
+		{
+			inputLogEvent: types.InputLogEvent{
+				Message: aws.String(logline),
+			},
+		},
+	}
+
+	stream.publishBatch(testEventBatch(events))
+	assert.Assert(t, is.Len(calls, 1))
+	assert.Equal(t, sequenceToken, aws.ToString(stream.sequenceToken))
+}
+
 func TestCollectBatchSimple(t *testing.T) {
 	mockClient := &mockClient{}
 	stream := &logStream{


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/52976

## Summary

`PutLogEvents` returns a `ResourceNotFoundException` when the log stream, or the log group holding it, is deleted while the container is still running. `publishBatch` did not handle it, so the batch was dropped, and since the stream is only created once in `New`, the container stopped logging until it was restarted.

`publishBatch` now recreates the stream via the existing `create()` and resubmits the batch once, with a `nil` sequence token, as a fresh stream does not have one yet. The retry is skipped when `awslogs-create-stream` is disabled, since the driver may not create the stream in that case.

## Release notes (optional)

```markdown changelog
Recreate the CloudWatch log stream for the `awslogs` logging driver if it is deleted while the container is running, instead of silently dropping log messages.
```
