### PR TITLE
update to go1.26.6

### DIFF
--- a/.github/workflows/.test-unit.yml
+++ b/.github/workflows/.test-unit.yml
@@ -22,7 +22,7 @@ on:
         required: false
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   SETUP_BUILDX_VERSION: edge

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -30,7 +30,7 @@ on:
         required: false
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   ITG_CLI_MATRIX_SIZE: 6

--- a/.github/workflows/.vm.yml
+++ b/.github/workflows/.vm.yml
@@ -19,7 +19,7 @@ on:
         default: ""
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
   TESTSTAT_VERSION: v0.1.25
   TEMPLATE_NAME: ${{ inputs.template }}
 

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -29,7 +29,7 @@ on:
         required: false
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   WINDOWS_BASE_IMAGE: mcr.microsoft.com/windows/servercore

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -19,7 +19,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
   DESTDIR: ./build
   SETUP_BUILDX_VERSION: edge
   SETUP_BUILDKIT_IMAGE: moby/buildkit:latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ on:
     - cron: '0 9 * * 4'
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
 
 jobs:
   codeql:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
   GIT_PAGER: "cat"
   PAGER: "cat"
   SETUP_BUILDX_VERSION: edge

--- a/.github/workflows/windows-integration-flaky.yml
+++ b/.github/workflows/windows-integration-flaky.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
   TEST_REPEAT: "10"
   WINDOWS_BASE_IMAGE: mcr.microsoft.com/windows/servercore
   WINDOWS_BASE_TAG_2025: ltsc2025

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ version: "2"
 
 run:
   # prevent golangci-lint from deducting the go version to lint for through go.mod,
-  go: "1.26.5"
+  go: "1.26.6"
   # Only supported with go modules enabled (build flag -mod=vendor only valid when using modules)
   # modules-download-mode: vendor
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"
 

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -161,7 +161,7 @@ FROM ${WINDOWS_BASE_IMAGE}:${WINDOWS_BASE_IMAGE_TAG}
 # Use PowerShell as the default shell
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 
 # GOTESTSUM_VERSION is the version of gotest.tools/gotestsum to install.
 ARG GOTESTSUM_VERSION=v1.13.0

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 
 FROM golang:${GO_VERSION}-alpine AS base
 RUN apk add --no-cache bash make yamllint

--- a/hack/dockerfiles/generate-files.Dockerfile
+++ b/hack/dockerfiles/generate-files.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG PROTOC_VERSION=3.11.4
 

--- a/hack/dockerfiles/govulncheck.Dockerfile
+++ b/hack/dockerfiles/govulncheck.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 ARG GOVULNCHECK_VERSION=v1.1.4
 ARG FORMAT=text
 


### PR DESCRIPTION
- https://github.com/golang/go/issues?q=milestone%3AGo1.26.6+label%3ACherryPickApproved
- full diff: https://github.com/golang/go/compare/go1.26.5...go1.26.6

**- Description for the changelog**

```markdown changelog
Update Go runtime to [1.26.6](https://go.dev/doc/devel/release#go1.26.6)
```

This release includes 10 security fixes following the security policy:

- x/mod/sumdb/tlog: fix transparency log tile verification bypass

    A malicious GOPROXY was previously capable of forging
   up to two sumdb tiles that allow for a requested module
   to bypass the GOSUMDB check and persist attacker-controlled
   module content to a local Go module cache.

    This attack allows for a malicious GOPROXY to serve
   malicious module content that cannot be detected
   by evaluating the transparency log.

    All tiles are now correctly verified against their parents.

    In order to determine if you have been affected:

    rm -r go.sum go.work.sum vendor/ && go mod tidy

    Thanks to Filippo Valsorda (Geomys) for reporting this issue.

    This is CVE-2026-56865 and Go issue https://go.dev/issue/80744.

- x/mod/sumdb: ignore unrelated, unauthenticated hashes in Lookup

    A malicious GOSUMDB was capable of serving arbitrary
   module content not contained within the transparency
   log.

    This attack allows for a coordinating GOPROXY and
   GOSUMDB to serve a client malicious module content
   that cannot be detected by evaluating the transparency
   log.

    In order to determine if you have been affected:

    rm -r go.sum go.work.sum vendor/ && go mod tidy

    Thanks to mundur for reporting this issue.

    This is CVE-2026-56864 and Go issue https://go.dev/issue/80745.

- encoding/xml: add recursion depth guard during decode

    Previously, DecodeElement would reset the depth counter
   causing it to never fire; this could lead to stack
   exhaustion.

    This is CVE-2026-56859 and Go issue https://go.dev/issue/80481.

- net/http: apply ReadHeaderTimeout when doing unencrypted HTTP/2 check

    When a server is configured to support unencrypted HTTP/2, it reads a
   few bytes from each new connection to see if they contain the HTTP/2
   client preface. Previously, this was being done with no timeout applied.
   ReadHeaderTimeout is now applied for this.

    This is CVE-2026-56853 and Go issue https://go.dev/issue/80205.

- net/url: avoid quadratic complexity in resolvePath

    Previously, resolving relative paths containing parent directory (..) segments performed string conversions and buffer rewrites on each step, resulting in quadratic time complexity and high memory allocation overhead.

    Now, path resolution operates on a byte buffer using index-based backtracking for .. segments, eliminating the quadratic time complexity and significantly reducing memory allocations.

    This is CVE-2026-56860 and Go issue https://go.dev/issue/80494.

- golang.org/x/net/dns/dnsmessage: panic when parsing invalid SVCB record

    Parsing an invalid SVCB or HTTPS RR can panic when
   the size of a parameter value overflows the message buffer.

    Thanks to Mundur (https://github.com/M0nd0R) for reporting this issue.

    This is CVE-2026-46600 and Go issue https://go.dev/issue/79795.

- crypto/tls: limit handshake messages we are willing to accept post-handshake

    Previously, we always counted handshake messages, such as KeyUpdate, as
   state-advancing, regardless of whether a handshake has been completed or
   not. As a result, a malicious client can keep sending KeyUpdate messages
   to force the server to keep performing key derivation operations
   indefinitely.

    Thanks to Qi Deng of Aurascape.ai for reporting this issue.

    This is CVE-2026-56862 and Go issue https://go.dev/issue/80528.

- html/template: fix Javascript regexp context tracking

    Previously, pathological inputs could close an
   unescaped / early, allowing for attack-controlled
   data to inject arbitrary content, potentially
   leading to XSS.

    Thanks to Ali Sherif for reporting this issue.

    This is CVE-2026-56858 and Go issue https://go.dev/issue/80435.

- x/net/idna: failure to reject ASCII-only Punycode-encoded labels

    The ToASCII and ToUnicode functions incorrectly accepted Punycode-encoded labels
   that decode to an ASCII-only label. For example, ToUnicode("xn--example-.com")
   incorrectly returned the name "example.com" rather than an error.

    The idna package implements the processing algorithm from UTS 46.
   Older versions of UTS 46 included a specification bug which permitted
   multiple ASCII labels to decode to the same Unicode label.
   UTS 46 revision 33 fixed the specification bug.
   The idna package now implements the updated specification.

    This behavior can lead to privilege escalation in programs using the idna package.
   For example, a program which performs privilege checks on the ASCII hostname
   may reject "example.com" but permit "xn--example-.com". If that program subsequently
   converts the ASCII hostname to Unicode, it will inadvertently permits access
   to the Unicode name "example.com".

    Thanks to KC1zs4 (https://github.com/KC1zs4) for reporting this issue.

    This is CVE-2026-39821 and Go issue https://go.dev/issue/78760.

- encoding/asn1: enforce maximum recursion depth

    Enforce a recursion limit in Unmarshal to prevent stack exhaustion
   when parsing deeply-nested, recursive structures.

    Thanks to Marwan Atia (marwans...@gmail.com) for reporting this issue.

    This is CVE-2026-33818 and Go issue https://go.dev/issue/80405.