### PR TITLE
ci: update to Ubuntu 26.04 runners

### DIFF
--- a/.github/workflows/.dco.yml
+++ b/.github/workflows/.dco.yml
@@ -13,7 +13,7 @@ jobs:
   run:
     permissions:
       pull-requests: read
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 5
     steps:
       - name: Validate DCO

--- a/.github/workflows/.test-unit.yml
+++ b/.github/workflows/.test-unit.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   unit:
-    runs-on: ubuntu-24.04${{ inputs.runnerSuffix }}
+    runs-on: ubuntu-26.04${{ inputs.runnerSuffix }}
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     strategy:
@@ -103,7 +103,7 @@ jobs:
           retention-days: 1
 
   unit-report:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 10
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     if: always()

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -42,7 +42,7 @@ env:
 
 jobs:
   docker-py:
-    runs-on: ubuntu-24.04${{ inputs.runnerSuffix }}
+    runs-on: ubuntu-26.04${{ inputs.runnerSuffix }}
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -98,7 +98,7 @@ jobs:
           retention-days: 1
 
   integration-flaky:
-    runs-on: ubuntu-24.04${{ inputs.runnerSuffix }}
+    runs-on: ubuntu-26.04${{ inputs.runnerSuffix }}
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -137,7 +137,7 @@ jobs:
           TEST_SKIP_INTEGRATION_CLI: 1
 
   integration-prepare:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 10 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     outputs:
@@ -157,9 +157,9 @@ jobs:
             const extraModes = JSON.parse(`${{ env.MATRIX_EXTRA_MODES }}`);
             const runnerSuffix = `${{ env.MATRIX_RUNNER_SUFFIX }}`;
             let includes = [
-              { arch: arch, runner: `ubuntu-24.04${runnerSuffix}`, mode: '' },
+              { arch: arch, runner: `ubuntu-26.04${runnerSuffix}`, mode: '' },
             ];
-            includes.push(...extraModes.map(mode => ({ arch: arch, runner: `ubuntu-24.04${runnerSuffix}`, mode: mode })));
+            includes.push(...extraModes.map(mode => ({ arch: arch, runner: `ubuntu-26.04${runnerSuffix}`, mode: mode })));
 
             if (arch == "amd64") {
               includes.push({ arch: arch, runner: 'ubuntu-22.04', mode: '' });
@@ -297,7 +297,7 @@ jobs:
           retention-days: 1
 
   integration-report:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 10
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     if: always()
@@ -329,7 +329,7 @@ jobs:
           fi
 
   integration-cli-prepare:
-    runs-on: ubuntu-24.04${{ inputs.runnerSuffix }}
+    runs-on: ubuntu-26.04${{ inputs.runnerSuffix }}
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     outputs:
@@ -424,7 +424,7 @@ jobs:
             });
 
   integration-cli:
-    runs-on: ubuntu-24.04${{ inputs.runnerSuffix }}
+    runs-on: ubuntu-26.04${{ inputs.runnerSuffix }}
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     needs:
@@ -520,7 +520,7 @@ jobs:
           retention-days: 1
 
   integration-cli-report:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 10
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     if: always()

--- a/.github/workflows/.vm.yml
+++ b/.github/workflows/.vm.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   integration:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
@@ -191,7 +191,7 @@ jobs:
           retention-days: 1
 
   integration-report:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 10
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     if: always() && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only'))

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -167,7 +167,7 @@ jobs:
           retention-days: 1
 
   unit-test-report:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     if: always()
     needs:
@@ -197,7 +197,7 @@ jobs:
           fi
 
   integration-test-prepare:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     outputs:
       matrix: ${{ steps.tests.outputs.matrix }}
@@ -419,7 +419,7 @@ jobs:
           retention-days: 1
 
   integration-test-report:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ inputs.storage == 'snapshotter' && github.event_name != 'pull_request' }}
     if: always()

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -31,7 +31,7 @@ jobs:
     uses: ./.github/workflows/.dco.yml
 
   build-linux:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 60 # guardrails timeout for the whole job
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
@@ -59,7 +59,7 @@ jobs:
           retention-days: 1
 
   test-linux:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 60 # guardrails timeout for the whole job
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-24.04
+          - runner: ubuntu-26.04
             target: binary
-          - runner: ubuntu-24.04
+          - runner: ubuntu-26.04
             target: dynbinary
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-26.04-arm
             target: binary
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-26.04-arm
             target: dynbinary
     steps:
       -
@@ -69,7 +69,7 @@ jobs:
           find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
 
   prepare-cross:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 20 # guardrails timeout for the whole job
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
@@ -89,7 +89,7 @@ jobs:
           fields: platforms
 
   cross:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 20 # guardrails timeout for the whole job
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
@@ -130,7 +130,7 @@ jobs:
           find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
 
   govulncheck:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     # Always run security checks, even with 'ci/validate-only' label
     permissions:
@@ -159,7 +159,7 @@ jobs:
           sarif_file: ${{ env.DESTDIR }}/govulncheck.out
 
   build-dind:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
@@ -182,7 +182,7 @@ jobs:
 
   success:
     name: CI Build Success
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     if: ${{ always() }}
     needs:
       - validate-dco
@@ -204,7 +204,7 @@ jobs:
   # TODO(vvoland): Remove once most PRs have rebased
   build-binary:
     name: build (binary)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     if: ${{ always() }}
     needs:
       - success

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   codeql:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/sync-release-branch.yml
+++ b/.github/workflows/sync-release-branch.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   sync-release-branch:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
     outputs:
@@ -97,7 +97,7 @@ jobs:
   push-release-branch:
     needs: sync-release-branch
     if: ${{ !inputs.dry_run && needs.sync-release-branch.outputs.has_changes == 'true' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     environment: docker-releases
     permissions:
       contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     uses: ./.github/workflows/.dco.yml
 
   build-dev:
-    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-26.04-arm' || 'ubuntu-26.04' }}
     timeout-minutes: 120 # guardrails timeout for the whole job
     needs:
       - validate-dco
@@ -132,7 +132,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   validate-prepare:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 10 # guardrails timeout for the whole job
     needs:
       - validate-dco
@@ -153,7 +153,7 @@ jobs:
           echo "$scripts"
 
   validate:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 30 # guardrails timeout for the whole job
     needs:
       - validate-prepare
@@ -207,7 +207,7 @@ jobs:
           make -o build "validate-${SCRIPT}"
 
   validate-api-swagger:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 10 # guardrails timeout for the whole job
     defaults:
       run:
@@ -226,7 +226,7 @@ jobs:
           make validate-swagger-gen
 
   smoke-prepare:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 10 # guardrails timeout for the whole job
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
@@ -246,7 +246,7 @@ jobs:
           fields: platforms
 
   smoke:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 20 # guardrails timeout for the whole job
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:

--- a/.github/workflows/validate-milestone.yml
+++ b/.github/workflows/validate-milestone.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   validate-milestone:
     if: ${{ github.event.pull_request.state == 'open' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 5
     steps:
       - name: Validate milestone matches docker next version

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -22,7 +22,7 @@ jobs:
           github.event.action == 'unlabeled'
         )
       }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 5
     steps:
       - name: Missing `area/` label
@@ -56,7 +56,7 @@ jobs:
           )
         )
       }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 5
     env:
       HAS_IMPACT_LABEL: ${{ contains(join(github.event.pull_request.labels.*.name, ','), 'impact/') }}
@@ -106,7 +106,7 @@ jobs:
           github.event.action == 'synchronize'
         )
       }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 5
     steps:
       - name: Check GitHub references
@@ -168,7 +168,7 @@ jobs:
           )
         )
       }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 5
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/windows-integration-flaky.yml
+++ b/.github/workflows/windows-integration-flaky.yml
@@ -26,7 +26,7 @@ jobs:
     # Test detection only needs git, so run it on Linux; it is cheaper and
     # avoids CRLF line endings that break sourcing the bash helpers, as the
     # Windows runners check out with core.autocrlf=true.
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 10
     outputs:
       has_tests: ${{ steps.detect-tests.outputs.has_tests }}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
