### PR TITLE
awslogs: use the datetime format for the event time

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 	"unicode/utf8"
@@ -40,6 +41,10 @@ const (
 	logCreateGroupKey      = "awslogs-create-group"
 	logCreateStreamKey     = "awslogs-create-stream"
 	datetimeFormatKey      = "awslogs-datetime-format"
+	datetimeAsEventTimeKey = "awslogs-datetime-as-event-time"
+	datetimeTimezoneKey    = "awslogs-datetime-timezone"
+	datetimeTimezoneUTC    = "utc"
+	datetimeTimezoneLocal  = "local"
 	multilinePatternKey    = "awslogs-multiline-pattern"
 	credentialsEndpointKey = "awslogs-credentials-endpoint" // #nosec G101 -- Potential hardcoded credentials
 	forceFlushIntervalKey  = "awslogs-force-flush-interval-seconds"
@@ -53,6 +58,10 @@ const (
 	perEventBytes          = 26
 	maximumBytesPerPut     = 1048576
 	maximumLogEventsPerPut = 10000
+	// A batch spanning more than this fails as a whole, so it matters once
+	// event timestamps are read off the log lines and no longer bounded by the
+	// flush interval.
+	maximumTimeSpanPerPut = int64(24 * time.Hour / time.Millisecond)
 
 	// See: http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_limits.html
 	// Because the events are interpreted as UTF-8 encoded Unicode, invalid UTF-8 byte sequences are replaced with the
@@ -75,6 +84,7 @@ type logStream struct {
 	logCreateStream    bool
 	forceFlushInterval time.Duration
 	multilinePattern   *regexp.Regexp
+	eventTime          *eventTimeParser
 	client             api
 
 	messages *loggerutils.MessageQueue
@@ -91,6 +101,7 @@ type logStreamConfig struct {
 	forceFlushInterval time.Duration
 	maxBufferedEvents  int
 	multilinePattern   *regexp.Regexp
+	eventTime          *eventTimeParser
 }
 
 var _ logger.SizedLogger = &logStream{}
@@ -118,14 +129,17 @@ type byTimestamp []wrappedEvent
 // concurrently. This type is expected to be consumed in a single go
 // routine and never concurrently.
 type eventBatch struct {
-	batch []wrappedEvent
-	bytes int
+	batch        []wrappedEvent
+	bytes        int
+	minTimestamp int64
+	maxTimestamp int64
 }
 
 // New creates an awslogs logger using the configuration passed in on the
 // context.  Supported context configuration variables are awslogs-region,
 // awslogs-endpoint, awslogs-group, awslogs-stream, awslogs-create-group,
-// awslogs-multiline-pattern and awslogs-datetime-format.
+// awslogs-multiline-pattern, awslogs-datetime-format,
+// awslogs-datetime-as-event-time and awslogs-datetime-timezone.
 // When available, configuration is also taken from environment variables
 // AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, the shared credentials
 // file (~/.aws/credentials), and the EC2 Instance Metadata Service.
@@ -148,6 +162,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		logCreateStream:    containerStreamConfig.logCreateStream,
 		forceFlushInterval: containerStreamConfig.forceFlushInterval,
 		multilinePattern:   containerStreamConfig.multilinePattern,
+		eventTime:          containerStreamConfig.eventTime,
 		client:             client,
 		messages:           loggerutils.NewMessageQueue(containerStreamConfig.maxBufferedEvents),
 	}
@@ -235,6 +250,11 @@ func newStreamConfig(info logger.Info) (*logStreamConfig, error) {
 		return nil, err
 	}
 
+	eventTime, err := parseEventTimeOptions(info, multilinePattern)
+	if err != nil {
+		return nil, err
+	}
+
 	containerStreamConfig := &logStreamConfig{
 		logStreamName:      logStreamName,
 		logGroupName:       logGroupName,
@@ -243,6 +263,7 @@ func newStreamConfig(info logger.Info) (*logStreamConfig, error) {
 		forceFlushInterval: forceFlushInterval,
 		maxBufferedEvents:  maxBufferedEvents,
 		multilinePattern:   multilinePattern,
+		eventTime:          eventTime,
 	}
 
 	return containerStreamConfig, nil
@@ -298,6 +319,250 @@ var strftimeToRegex = map[string]string{
 	/*tzName                */ `%Z`: `[A-Z]{1,4}T`,
 	/*dayOfYearZeroPadded   */ `%j`: `(?:0[0-9][1-9]|[1,2][0-9][0-9]|3[0-5][0-9]|36[0-6])`,
 	/*milliseconds          */ `%L`: `\.\d{3}`,
+}
+
+// Maps strftime format strings to the reference time layout used by time.Parse.
+// Every sequence in strftimeToRegex is present except %w (weekday as a digit),
+// which has no equivalent in a Go layout, and %Z (timezone abbreviation), which
+// cannot be resolved reliably.
+var strftimeToGoLayout = map[string]string{
+	/*weekdayShort          */ `%a`: `Mon`,
+	/*weekdayFull           */ `%A`: `Monday`,
+	/*dayZeroPadded         */ `%d`: `02`,
+	/*monthShort            */ `%b`: `Jan`,
+	/*monthFull             */ `%B`: `January`,
+	/*monthZeroPadded       */ `%m`: `01`,
+	/*yearCentury           */ `%Y`: `2006`,
+	/*yearZeroPadded        */ `%y`: `06`,
+	/*hour24ZeroPadded      */ `%H`: `15`,
+	/*hour12ZeroPadded      */ `%I`: `03`,
+	/*AM or PM              */ `%p`: `PM`,
+	/*minuteZeroPadded      */ `%M`: `04`,
+	/*secondZeroPadded      */ `%S`: `05`,
+	/*microsecondZeroPadded */ `%f`: `000000`,
+	/*utcOffset             */ `%z`: `-0700`,
+	/*dayOfYearZeroPadded   */ `%j`: `002`,
+	/*milliseconds          */ `%L`: `.000`,
+}
+
+// eventTimeParser derives the CloudWatch Logs event timestamp from the datetime
+// embedded in a log line, as described by awslogs-datetime-format.  It matches
+// with the very same expression that detects the start of a multiline event, so
+// the matched text is guaranteed to line up with the layout derived from the
+// same format.
+type eventTimeParser struct {
+	pattern  *regexp.Regexp
+	layout   string
+	location *time.Location
+	hasYear  bool
+	hasMonth bool
+	hasDay   bool
+	hasHour  bool
+}
+
+// Parses the awslogs-datetime-as-event-time option.  The option is only
+// meaningful together with awslogs-datetime-format, whose compiled expression is
+// passed in as pattern.  Returns nil when the option is disabled, leaving the
+// event timestamp to be taken from the time the message was read.
+func parseEventTimeOptions(info logger.Info, pattern *regexp.Regexp) (*eventTimeParser, error) {
+	if info.Config[datetimeAsEventTimeKey] == "" {
+		return nil, nil
+	}
+	datetimeAsEventTime, err := strconv.ParseBool(info.Config[datetimeAsEventTimeKey])
+	if err != nil {
+		return nil, err
+	}
+	if !datetimeAsEventTime {
+		return nil, nil
+	}
+	dateTimeFormat := info.Config[datetimeFormatKey]
+	if dateTimeFormat == "" {
+		return nil, fmt.Errorf("log opt '%s' requires log opt '%s' to be set", datetimeAsEventTimeKey, datetimeFormatKey)
+	}
+	layout, err := strftimeToLayout(dateTimeFormat)
+	if err != nil {
+		return nil, err
+	}
+	location, err := parseDatetimeTimezone(info.Config[datetimeTimezoneKey])
+	if err != nil {
+		return nil, err
+	}
+	// %j (day of the year) carries both the month and the day
+	dayOfYear := strings.Contains(dateTimeFormat, `%j`)
+	return &eventTimeParser{
+		pattern:  pattern,
+		layout:   layout,
+		location: location,
+		hasYear:  strings.Contains(dateTimeFormat, `%Y`) || strings.Contains(dateTimeFormat, `%y`),
+		hasMonth: dayOfYear || strings.Contains(dateTimeFormat, `%m`) || strings.Contains(dateTimeFormat, `%b`) || strings.Contains(dateTimeFormat, `%B`),
+		hasDay:   dayOfYear || strings.Contains(dateTimeFormat, `%d`),
+		hasHour:  strings.Contains(dateTimeFormat, `%H`) || strings.Contains(dateTimeFormat, `%I`),
+	}, nil
+}
+
+// Parses the awslogs-datetime-timezone option, which tells in what timezone a
+// datetime that carries none of its own is to be read.  Defaults to UTC.
+func parseDatetimeTimezone(datetimeTimezone string) (*time.Location, error) {
+	switch strings.ToLower(datetimeTimezone) {
+	case "", datetimeTimezoneUTC:
+		return time.UTC, nil
+	case datetimeTimezoneLocal:
+		return time.Local, nil
+	default:
+		return nil, fmt.Errorf("must specify '%s' or '%s' for log opt '%s': %s", datetimeTimezoneUTC, datetimeTimezoneLocal, datetimeTimezoneKey, datetimeTimezone)
+	}
+}
+
+// strftimeToLayout converts a strftime format to the reference time layout used
+// by time.Parse, keeping any literal text in between as-is.  It errors out on
+// format sequences that cannot be expressed as a Go layout.
+func strftimeToLayout(dateTimeFormat string) (string, error) {
+	var unsupported string
+	layout := formatSequences.ReplaceAllStringFunc(dateTimeFormat, func(s string) string {
+		goLayout, ok := strftimeToGoLayout[s]
+		if !ok {
+			unsupported = s
+		}
+		return goLayout
+	})
+	if unsupported != "" {
+		err := fmt.Errorf("awslogs cannot use log opt '%s' as event time: format sequence %q is not supported", datetimeFormatKey, unsupported)
+		if unsupported == `%Z` {
+			// A timezone abbreviation is ambiguous (CST is both -06:00 and
+			// +08:00), and time.Parse resolves one it does not know to a zero
+			// offset without failing, silently dating the event wrong
+			err = fmt.Errorf("%w, use %%z or log opt '%s' instead", err, datetimeTimezoneKey)
+		}
+		return "", err
+	}
+	return layout, nil
+}
+
+// parse returns the timestamp carried by line, falling back to readTime when the
+// line holds no datetime (a continuation line of a multiline event) or when the
+// datetime does not parse.
+func (p *eventTimeParser) parse(line []byte, readTime time.Time) time.Time {
+	loc := p.pattern.FindIndex(line)
+	if loc == nil {
+		return readTime
+	}
+	timestamp, err := time.ParseInLocation(p.layout, string(line[loc[0]:loc[1]]), p.location)
+	if err != nil {
+		log.G(context.TODO()).WithError(err).Debugf("awslogs could not parse event time from %q", line[loc[0]:loc[1]])
+		return readTime
+	}
+	completed, ok := p.completeDate(timestamp, readTime)
+	if !ok {
+		log.G(context.TODO()).Debugf("awslogs could not complete the date of event time %q", line[loc[0]:loc[1]])
+		return readTime
+	}
+	return completed
+}
+
+// completeDate fills in the date components that the datetime format does not
+// carry (a bare time, or the year-less format used by syslog) from the time the
+// message was read.
+func (p *eventTimeParser) completeDate(timestamp, readTime time.Time) (time.Time, bool) {
+	if p.hasYear && p.hasMonth && p.hasDay {
+		return timestamp, true
+	}
+	// Compare dates in the zone of the parsed timestamp, so that a date taken
+	// from the read time is the date the log line was written in its own zone.
+	readTime = readTime.In(timestamp.Location())
+
+	// Missing components are taken from the day the line would have been
+	// written on: the read time less the time of day the line carries, rounded
+	// to the nearest day.  Borrowing from that rather than from the read time
+	// itself keeps the event next to it even when the two fall either side of a
+	// midnight, and with it either side of a month or a year.
+	//
+	// A format carrying no hour has no time of day to go by: time.Parse fills a
+	// midnight the line never carried, and rounding on it would make the same
+	// line land differently for having been read before or after noon.
+	written := readTime
+	if p.hasHour {
+		timeOfDay := time.Duration(timestamp.Hour())*time.Hour +
+			time.Duration(timestamp.Minute())*time.Minute +
+			time.Duration(timestamp.Second())*time.Second +
+			time.Duration(timestamp.Nanosecond())
+		written = readTime.Add(12*time.Hour - timeOfDay)
+	}
+
+	// What the borrowed day cannot settle, the format repeats: one carrying no
+	// year reads the same every year, one carrying no month the same every
+	// month.  Of the candidate on the borrowed date and the one a period back,
+	// the one closer to the time the message was read wins.
+	var years, months int
+	switch {
+	case !p.hasYear && p.hasMonth:
+		years = -1
+	case !p.hasMonth && p.hasDay:
+		months = -1
+	}
+
+	// A borrowed component may still not go together with one the line carries,
+	// a borrowed 31st in a parsed February being the case time cannot normalize
+	// away without changing that February.  Such a candidate is dropped, and if
+	// neither survives the event keeps the time it was read.
+	var best time.Time
+	var found bool
+	for _, candidate := range [...]time.Time{
+		p.fillDate(timestamp, written, 0, 0),
+		p.fillDate(timestamp, written, years, months),
+	} {
+		if !p.preservesDate(candidate, timestamp) {
+			continue
+		}
+		if !found || candidate.Sub(readTime).Abs() < best.Sub(readTime).Abs() {
+			best, found = candidate, true
+		}
+	}
+	return best, found
+}
+
+// preservesDate reports whether candidate still holds every date component the
+// line itself carries, which time.Date normalizes away when a component taken
+// from readTime does not go together with them.
+func (p *eventTimeParser) preservesDate(candidate, timestamp time.Time) bool {
+	switch {
+	case p.hasYear && candidate.Year() != timestamp.Year():
+		return false
+	case p.hasMonth && candidate.Month() != timestamp.Month():
+		return false
+	case p.hasDay && candidate.Day() != timestamp.Day():
+		return false
+	}
+	return true
+}
+
+// fillDate rebuilds timestamp, taking the date components that the datetime
+// format does not carry from written, shifted a period back by the given number
+// of years and months.  Shifting the components rather than the date they came
+// from keeps a month off the end of a longer one, February off the 31st of
+// March being the case that would otherwise not shift at all.
+func (p *eventTimeParser) fillDate(timestamp, written time.Time, years, months int) time.Time {
+	year, month, day := timestamp.Date()
+	writtenYear, writtenMonth, writtenDay := written.Date()
+	if !p.hasYear {
+		year = writtenYear + years
+	}
+	if !p.hasMonth {
+		month = writtenMonth + time.Month(months)
+	}
+	if !p.hasDay {
+		day = writtenDay
+		if p.hasMonth {
+			// The day is not the line's own, so rather than let it push the
+			// month the line does carry along, take the closest one that month
+			// can hold.  Only a format carrying a month gets here with a day to
+			// clamp: without one the day is borrowed alongside the month it is
+			// known to fit.
+			if last := time.Date(year, month+1, 0, 0, 0, 0, 0, timestamp.Location()).Day(); day > last {
+				day = last
+			}
+		}
+	}
+	return time.Date(year, month, day, timestamp.Hour(), timestamp.Minute(), timestamp.Second(), timestamp.Nanosecond(), timestamp.Location())
 }
 
 // newRegionFinder is a variable such that the implementation
@@ -537,6 +802,9 @@ var newTicker = func(freq time.Duration) *time.Ticker {
 // messages. When events are ready to be processed for submission to CloudWatch
 // Logs, the processEvents method is called.  If a multiline pattern is not
 // configured, log events are submitted to the processEvents method immediately.
+// If the awslogs-datetime-as-event-time option has been enabled, the timestamp
+// of a log event is taken from the datetime matched in the log line itself
+// rather than from the time the message was read.
 func (l *logStream) collectBatch(created chan bool) {
 	// Wait for the logstream/group to be created
 	<-created
@@ -547,6 +815,11 @@ func (l *logStream) collectBatch(created chan bool) {
 	ticker := newTicker(flushInterval)
 	var eventBuffer []byte
 	var eventBufferTimestamp int64
+	// Time at which the buffered event was read.  It only differs from
+	// eventBufferTimestamp when the event timestamp is taken from the log line
+	// itself, and is kept apart from it so that how long an event may be
+	// buffered stays a matter of wall-clock time.
+	var eventBufferReadTime int64
 	batch := newEventBatch()
 
 	chLogs := l.messages.Receiver()
@@ -554,8 +827,8 @@ func (l *logStream) collectBatch(created chan bool) {
 		select {
 		case t := <-ticker.C:
 			// If event buffer is older than batch publish frequency flush the event buffer
-			if eventBufferTimestamp > 0 && len(eventBuffer) > 0 {
-				eventBufferAge := t.UnixNano()/int64(time.Millisecond) - eventBufferTimestamp
+			if eventBufferReadTime > 0 && len(eventBuffer) > 0 {
+				eventBufferAge := t.UnixNano()/int64(time.Millisecond) - eventBufferReadTime
 				eventBufferExpired := eventBufferAge >= int64(flushInterval)/int64(time.Millisecond)
 				eventBufferNegative := eventBufferAge < 0
 				if eventBufferExpired || eventBufferNegative {
@@ -573,17 +846,31 @@ func (l *logStream) collectBatch(created chan bool) {
 				batch.reset()
 				return
 			}
+			eventTimestamp := msg.Timestamp
+			if l.eventTime != nil {
+				eventTimestamp = l.eventTime.parse(msg.Line, msg.Timestamp)
+			}
+			timestamp := eventTimestamp.UnixNano() / int64(time.Millisecond)
+			readTime := msg.Timestamp.UnixNano() / int64(time.Millisecond)
 			if eventBufferTimestamp == 0 {
-				eventBufferTimestamp = msg.Timestamp.UnixNano() / int64(time.Millisecond)
+				eventBufferTimestamp = timestamp
+				eventBufferReadTime = readTime
 			}
 			line := msg.Line
 			if l.multilinePattern != nil {
 				lineEffectiveLen := effectiveLen(string(line))
-				if l.multilinePattern.Match(line) || effectiveLen(string(eventBuffer))+lineEffectiveLen > maximumBytesPerEvent {
+				newEvent := l.multilinePattern.Match(line)
+				if newEvent || effectiveLen(string(eventBuffer))+lineEffectiveLen > maximumBytesPerEvent {
 					// This is a new log event or we will exceed max bytes per event
 					// so flush the current eventBuffer to events and reset timestamp
 					l.processEvent(batch, eventBuffer, eventBufferTimestamp)
-					eventBufferTimestamp = msg.Timestamp.UnixNano() / int64(time.Millisecond)
+					if newEvent {
+						// Exceeding max bytes per event splits a single event,
+						// whose parts all keep the timestamp of the line that
+						// started it.
+						eventBufferTimestamp = timestamp
+					}
+					eventBufferReadTime = readTime
 					eventBuffer = eventBuffer[:0]
 				}
 				// Append newline if event is less than max event size
@@ -593,7 +880,7 @@ func (l *logStream) collectBatch(created chan bool) {
 				eventBuffer = append(eventBuffer, line...)
 				logger.PutMessage(msg)
 			} else {
-				l.processEvent(batch, line, msg.Timestamp.UnixNano()/int64(time.Millisecond))
+				l.processEvent(batch, line, timestamp)
 				logger.PutMessage(msg)
 			}
 		}
@@ -724,7 +1011,7 @@ func (l *logStream) putLogEvents(events []types.InputLogEvent, sequenceToken *st
 
 // ValidateLogOpt looks for awslogs-specific log options awslogs-region, awslogs-endpoint
 // awslogs-group, awslogs-stream, awslogs-create-group, awslogs-create-stream, awslogs-datetime-format,
-// awslogs-multiline-pattern
+// awslogs-datetime-as-event-time, awslogs-datetime-timezone, awslogs-multiline-pattern
 func ValidateLogOpt(cfg map[string]string) error {
 	for key := range cfg {
 		switch key {
@@ -737,6 +1024,8 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case regionKey:
 		case endpointKey:
 		case datetimeFormatKey:
+		case datetimeAsEventTimeKey:
+		case datetimeTimezoneKey:
 		case multilinePatternKey:
 		case credentialsEndpointKey:
 		case forceFlushIntervalKey:
@@ -773,6 +1062,30 @@ func ValidateLogOpt(cfg map[string]string) error {
 	_, multilinePatternKeyExists := cfg[multilinePatternKey]
 	if datetimeFormatKeyExists && multilinePatternKeyExists {
 		return fmt.Errorf("you cannot configure log opt '%s' and '%s' at the same time", datetimeFormatKey, multilinePatternKey)
+	}
+	datetimeAsEventTime := false
+	if cfg[datetimeAsEventTimeKey] != "" {
+		var err error
+		datetimeAsEventTime, err = strconv.ParseBool(cfg[datetimeAsEventTimeKey])
+		if err != nil {
+			return fmt.Errorf("must specify valid value for log opt '%s': %v", datetimeAsEventTimeKey, err)
+		}
+		if datetimeAsEventTime {
+			if cfg[datetimeFormatKey] == "" {
+				return fmt.Errorf("log opt '%s' requires log opt '%s' to be set", datetimeAsEventTimeKey, datetimeFormatKey)
+			}
+			if _, err := strftimeToLayout(cfg[datetimeFormatKey]); err != nil {
+				return err
+			}
+		}
+	}
+	if cfg[datetimeTimezoneKey] != "" {
+		if !datetimeAsEventTime {
+			return fmt.Errorf("log opt '%s' requires log opt '%s' to be enabled", datetimeTimezoneKey, datetimeAsEventTimeKey)
+		}
+		if _, err := parseDatetimeTimezone(cfg[datetimeTimezoneKey]); err != nil {
+			return err
+		}
 	}
 
 	if cfg[logFormatKey] != "" {
@@ -851,15 +1164,26 @@ func (b *eventBatch) events() []wrappedEvent {
 func (b *eventBatch) add(event wrappedEvent, size int) bool {
 	addBytes := size + perEventBytes
 
+	timestamp := aws.ToInt64(event.inputLogEvent.Timestamp)
+	minTimestamp, maxTimestamp := timestamp, timestamp
+	if len(b.batch) > 0 {
+		minTimestamp = min(b.minTimestamp, timestamp)
+		maxTimestamp = max(b.maxTimestamp, timestamp)
+	}
+
 	// verify we are still within service limits
 	switch {
 	case len(b.batch) >= maximumLogEventsPerPut:
 		return false
 	case b.bytes+addBytes > maximumBytesPerPut:
 		return false
+	case maxTimestamp-minTimestamp > maximumTimeSpanPerPut:
+		// An empty batch always accepts, so a single event never gets stuck here
+		return false
 	}
 
 	b.bytes += addBytes
+	b.minTimestamp, b.maxTimestamp = minTimestamp, maxTimestamp
 	b.batch = append(b.batch, event)
 
 	return true
@@ -888,5 +1212,7 @@ func (b *eventBatch) isEmpty() bool {
 // reset prepares the batch for reuse.
 func (b *eventBatch) reset() {
 	b.bytes = 0
+	b.minTimestamp = 0
+	b.maxTimestamp = 0
 	b.batch = b.batch[:0]
 }

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -790,6 +790,207 @@ func BenchmarkCollectBatchMultilinePattern(b *testing.B) {
 	}
 }
 
+// Parses the log options enabling awslogs-datetime-as-event-time for the given
+// datetime format.
+func testDatetimeAsEventTime(t *testing.T, datetimeFormat string) (*regexp.Regexp, *eventTimeParser) {
+	t.Helper()
+	info := logger.Info{
+		Config: map[string]string{
+			datetimeFormatKey:      datetimeFormat,
+			datetimeAsEventTimeKey: "true",
+		},
+	}
+	multilinePattern, err := parseMultilineOptions(info)
+	assert.NilError(t, err)
+	eventTime, err := parseEventTimeOptions(info, multilinePattern)
+	assert.NilError(t, err)
+	assert.Assert(t, eventTime != nil)
+	return multilinePattern, eventTime
+}
+
+func TestCollectBatchMultilineDatetimeAsEventTime(t *testing.T) {
+	mockClient := &mockClient{}
+	multilinePattern, eventTime := testDatetimeAsEventTime(t, "%Y-%m-%d %H:%M:%S")
+	stream := &logStream{
+		client:           mockClient,
+		logGroupName:     groupName,
+		logStreamName:    streamName,
+		multilinePattern: multilinePattern,
+		eventTime:        eventTime,
+		sequenceToken:    aws.String(sequenceToken),
+		messages:         loggerutils.NewMessageQueue(0),
+	}
+	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
+	called := make(chan struct{}, 50)
+	mockClient.putLogEventsFunc = func(ctx context.Context, input *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
+		calls = append(calls, input)
+		called <- struct{}{}
+		return &cloudwatchlogs.PutLogEventsOutput{
+			NextSequenceToken: aws.String(nextSequenceToken),
+		}, nil
+	}
+	ticks := make(chan time.Time)
+	newTicker = func(_ time.Duration) *time.Ticker {
+		return &time.Ticker{
+			C: ticks,
+		}
+	}
+
+	d := make(chan bool)
+	close(d)
+	go stream.collectBatch(d)
+
+	// The read time is deliberately unrelated to the datetime in the log lines
+	readTime := time.Now()
+	stream.Log(&logger.Message{
+		Line:      []byte("2017-01-01 01:01:44 first event"),
+		Timestamp: readTime,
+	})
+	stream.Log(&logger.Message{
+		Line:      []byte("a continuation line"),
+		Timestamp: readTime,
+	})
+	stream.Log(&logger.Message{
+		Line:      []byte("2017-01-01 01:01:45 second event"),
+		Timestamp: readTime,
+	})
+
+	stream.Close()
+
+	<-called
+	assert.Assert(t, len(calls) == 1)
+	argument := calls[0]
+	close(called)
+	assert.Assert(t, argument != nil)
+	assert.Assert(t, is.Len(argument.LogEvents, 2))
+	assert.Check(t, is.Equal("2017-01-01 01:01:44 first event\na continuation line\n", aws.ToString(argument.LogEvents[0].Message)))
+	assert.Check(t, is.Equal(time.Date(2017, time.January, 1, 1, 1, 44, 0, time.UTC).UnixMilli(), aws.ToInt64(argument.LogEvents[0].Timestamp)), "Expected the event time to be taken from the log line")
+	assert.Check(t, is.Equal("2017-01-01 01:01:45 second event\n", aws.ToString(argument.LogEvents[1].Message)))
+	assert.Check(t, is.Equal(time.Date(2017, time.January, 1, 1, 1, 45, 0, time.UTC).UnixMilli(), aws.ToInt64(argument.LogEvents[1].Timestamp)), "Expected the event time to be taken from the log line")
+}
+
+// A batch spanning more than 24 hours is rejected as a whole by CloudWatch, so
+// it has to be split once event timestamps are read off the log lines.
+func TestCollectBatchDatetimeAsEventTimeMaxTimeSpan(t *testing.T) {
+	mockClient := &mockClient{}
+	multilinePattern, eventTime := testDatetimeAsEventTime(t, "%Y-%m-%d %H:%M:%S")
+	stream := &logStream{
+		client:           mockClient,
+		logGroupName:     groupName,
+		logStreamName:    streamName,
+		multilinePattern: multilinePattern,
+		eventTime:        eventTime,
+		sequenceToken:    aws.String(sequenceToken),
+		messages:         loggerutils.NewMessageQueue(0),
+	}
+	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
+	called := make(chan struct{}, 50)
+	mockClient.putLogEventsFunc = func(ctx context.Context, input *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
+		calls = append(calls, input)
+		called <- struct{}{}
+		return &cloudwatchlogs.PutLogEventsOutput{
+			NextSequenceToken: aws.String(nextSequenceToken),
+		}, nil
+	}
+	ticks := make(chan time.Time)
+	newTicker = func(_ time.Duration) *time.Ticker {
+		return &time.Ticker{
+			C: ticks,
+		}
+	}
+
+	d := make(chan bool)
+	close(d)
+	go stream.collectBatch(d)
+
+	// Two events 48 hours apart
+	readTime := time.Now()
+	stream.Log(&logger.Message{
+		Line:      []byte("2017-01-01 01:01:44 first event"),
+		Timestamp: readTime,
+	})
+	stream.Log(&logger.Message{
+		Line:      []byte("2017-01-03 01:01:44 second event"),
+		Timestamp: readTime,
+	})
+
+	stream.Close()
+
+	for range 2 {
+		select {
+		case <-called:
+		case <-time.After(10 * time.Second):
+			t.Fatal("Timed out waiting for the batch to be split")
+		}
+	}
+	assert.Assert(t, is.Len(calls, 2), "Expected the batch to be split")
+	close(called)
+	assert.Assert(t, is.Len(calls[0].LogEvents, 1))
+	assert.Check(t, is.Equal(time.Date(2017, time.January, 1, 1, 1, 44, 0, time.UTC).UnixMilli(), aws.ToInt64(calls[0].LogEvents[0].Timestamp)))
+	assert.Assert(t, is.Len(calls[1].LogEvents, 1))
+	assert.Check(t, is.Equal(time.Date(2017, time.January, 3, 1, 1, 44, 0, time.UTC).UnixMilli(), aws.ToInt64(calls[1].LogEvents[0].Timestamp)))
+}
+
+// Exceeding the maximum event size splits a single logical event, so all of its
+// parts have to keep the timestamp of the line that started it, even though the
+// line causing the overflow carries no datetime of its own.
+func TestCollectBatchDatetimeAsEventTimeMaxEventSize(t *testing.T) {
+	mockClient := &mockClient{}
+	multilinePattern, eventTime := testDatetimeAsEventTime(t, "%Y-%m-%d %H:%M:%S")
+	stream := &logStream{
+		client:           mockClient,
+		logGroupName:     groupName,
+		logStreamName:    streamName,
+		multilinePattern: multilinePattern,
+		eventTime:        eventTime,
+		sequenceToken:    aws.String(sequenceToken),
+		messages:         loggerutils.NewMessageQueue(0),
+	}
+	calls := make([]*cloudwatchlogs.PutLogEventsInput, 0)
+	called := make(chan struct{}, 50)
+	mockClient.putLogEventsFunc = func(ctx context.Context, input *cloudwatchlogs.PutLogEventsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutLogEventsOutput, error) {
+		calls = append(calls, input)
+		called <- struct{}{}
+		return &cloudwatchlogs.PutLogEventsOutput{
+			NextSequenceToken: aws.String(nextSequenceToken),
+		}, nil
+	}
+	ticks := make(chan time.Time)
+	newTicker = func(_ time.Duration) *time.Ticker {
+		return &time.Ticker{
+			C: ticks,
+		}
+	}
+
+	d := make(chan bool)
+	close(d)
+	go stream.collectBatch(d)
+
+	readTime := time.Now()
+	// A line filling up a whole event, so that the next one overflows it
+	datetimePrefix := "2017-01-01 01:01:44 "
+	stream.Log(&logger.Message{
+		Line:      []byte(datetimePrefix + strings.Repeat("A", maximumBytesPerEvent-len(datetimePrefix))),
+		Timestamp: readTime,
+	})
+	// A continuation line, carrying no datetime, overflows the buffered event
+	stream.Log(&logger.Message{
+		Line:      []byte(strings.Repeat("B", 100)),
+		Timestamp: readTime,
+	})
+
+	stream.Close()
+
+	<-called
+	assert.Assert(t, is.Len(calls, 1))
+	argument := calls[0]
+	close(called)
+	assert.Assert(t, is.Len(argument.LogEvents, 2), "Expected the event to be split")
+	eventTimestamp := time.Date(2017, time.January, 1, 1, 1, 44, 0, time.UTC).UnixMilli()
+	assert.Check(t, is.Equal(eventTimestamp, aws.ToInt64(argument.LogEvents[0].Timestamp)))
+	assert.Check(t, is.Equal(eventTimestamp, aws.ToInt64(argument.LogEvents[1].Timestamp)), "Expected both parts to keep the timestamp of the line that started the event")
+}
+
 func TestCollectBatchMultilinePatternMaxEventAge(t *testing.T) {
 	mockClient := &mockClient{}
 	multilinePattern := regexp.MustCompile("xxxx")
@@ -1488,6 +1689,421 @@ func TestParseLogOptionsDatetimeFormat(t *testing.T) {
 			multilinePattern, err := parseMultilineOptions(info)
 			assert.Check(t, err, "Received unexpected error")
 			assert.Check(t, multilinePattern.MatchString(dt.match), "No multiline pattern match found")
+		})
+	}
+}
+
+func TestStrftimeToLayout(t *testing.T) {
+	tests := []struct {
+		format    string
+		layout    string
+		shouldErr bool
+	}{
+		{format: "%Y-%m-%d %H:%M:%S", layout: "2006-01-02 15:04:05"},
+		{format: "[%d/%b/%Y:%H:%M:%S %z]", layout: "[02/Jan/2006:15:04:05 -0700]"},
+		{format: "%a %B %d %I:%M:%S%L %p", layout: "Mon January 02 03:04:05.000 PM"},
+		{format: "%y-%j %H:%M:%S.%f", layout: "06-002 15:04:05.000000"},
+		// %w (weekday as a digit) has no equivalent in a Go layout
+		{format: "%Y-%m-%d %w", shouldErr: true},
+		// %Z (timezone abbreviation) cannot be resolved reliably
+		{format: "%Y-%m-%d %H:%M:%S %Z", shouldErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.format, func(t *testing.T) {
+			layout, err := strftimeToLayout(tc.format)
+			if tc.shouldErr {
+				assert.Check(t, err != nil, "Expected an error")
+				return
+			}
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(tc.layout, layout), "Unexpected layout")
+		})
+	}
+}
+
+func TestEventTimeParserParse(t *testing.T) {
+	readTime := time.Date(2026, time.June, 17, 9, 0, 0, 0, time.UTC)
+	tests := []struct {
+		testName string
+		format   string
+		line     string
+		// Defaults to readTime when left out
+		readTime time.Time
+		expected time.Time
+	}{
+		{
+			testName: "full datetime",
+			format:   "%Y-%m-%d %H:%M:%S",
+			line:     "2017-01-01 01:01:44 This is a log entry",
+			expected: time.Date(2017, time.January, 1, 1, 1, 44, 0, time.UTC),
+		},
+		{
+			testName: "datetime preceded by other text",
+			format:   "%Y-%m-%d %H:%M:%S",
+			line:     "INFO 2017-01-01 01:01:44 This is a log entry",
+			expected: time.Date(2017, time.January, 1, 1, 1, 44, 0, time.UTC),
+		},
+		{
+			testName: "milliseconds",
+			format:   "%Y-%m-%d %H:%M:%S%L",
+			line:     "2017-01-01 01:01:44.123 This is a log entry",
+			expected: time.Date(2017, time.January, 1, 1, 1, 44, int(123*time.Millisecond), time.UTC),
+		},
+		{
+			testName: "utc offset",
+			format:   "%Y-%m-%d %H:%M:%S%z",
+			line:     "2017-01-01 01:01:44+0200 This is a log entry",
+			expected: time.Date(2016, time.December, 31, 23, 1, 44, 0, time.UTC),
+		},
+		{
+			testName: "day of the year",
+			format:   "%Y-%j %H:%M:%S",
+			line:     "2017-032 01:01:44 This is a log entry",
+			expected: time.Date(2017, time.February, 1, 1, 1, 44, 0, time.UTC),
+		},
+		{
+			testName: "year taken from the read time",
+			format:   "%b %d %H:%M:%S",
+			line:     "Jan 15 01:01:44 This is a log entry",
+			expected: time.Date(2026, time.January, 15, 1, 1, 44, 0, time.UTC),
+		},
+		{
+			testName: "date taken from the read time",
+			format:   "%H:%M:%S",
+			line:     "01:01:44 This is a log entry",
+			expected: time.Date(2026, time.June, 17, 1, 1, 44, 0, time.UTC),
+		},
+		{
+			testName: "year and month taken from the read time",
+			format:   "%d %H:%M:%S",
+			line:     "13 01:01:44 This is a log entry",
+			expected: time.Date(2026, time.June, 13, 1, 1, 44, 0, time.UTC),
+		},
+		{
+			testName: "day taken from the read time",
+			format:   "%Y-%m",
+			line:     "2017-01 This is a log entry",
+			expected: time.Date(2017, time.January, 17, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// The 31st of the read time does not go into a parsed February
+			testName: "borrowed day clamped to the parsed month",
+			format:   "%Y-%m",
+			line:     "2026-02 This is a log entry",
+			readTime: time.Date(2026, time.March, 31, 9, 0, 0, 0, time.UTC),
+			expected: time.Date(2026, time.February, 28, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// Same as above, read in the afternoon: a format carrying no hour
+			// must not be rounded on the midnight time.Parse fills in
+			testName: "borrowed day for a format carrying no hour",
+			format:   "%Y-%m",
+			line:     "2026-02 This is a log entry",
+			readTime: time.Date(2026, time.March, 31, 20, 0, 0, 0, time.UTC),
+			expected: time.Date(2026, time.February, 28, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// The parsed day rules out the month of the read time, leaving the
+			// one before it
+			testName: "borrowed month rejected by the parsed day",
+			format:   "%d %H:%M:%S",
+			line:     "31 01:01:44 This is a log entry",
+			readTime: time.Date(2026, time.February, 20, 9, 0, 0, 0, time.UTC),
+			expected: time.Date(2026, time.January, 31, 1, 1, 44, 0, time.UTC),
+		},
+		{
+			// Neither the read year nor the one before it has a 29th of
+			// February, so the date cannot be completed at all
+			testName: "no usable date falls back to the read time",
+			format:   "%b %d %H:%M:%S",
+			line:     "Feb 29 01:01:44 This is a log entry",
+			expected: readTime,
+		},
+		{
+			testName: "no match falls back to the read time",
+			format:   "%Y-%m-%d %H:%M:%S",
+			line:     "a continuation line of a multiline event",
+			expected: readTime,
+		},
+		{
+			testName: "unparsable datetime falls back to the read time",
+			format:   "%Y-%m-%d",
+			line:     "2017-02-31 This is a log entry",
+			expected: readTime,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			at := tc.readTime
+			if at.IsZero() {
+				at = readTime
+			}
+			_, eventTime := testDatetimeAsEventTime(t, tc.format)
+			parsed := eventTime.parse([]byte(tc.line), at)
+			assert.Check(t, is.Equal(tc.expected.UTC(), parsed.UTC()), "Unexpected event time")
+		})
+	}
+}
+
+// A log line written just before the turn of a year or a month is read after
+// it, so the component taken from the read time cannot be used as-is.
+func TestEventTimeParserParseRollover(t *testing.T) {
+	tests := []struct {
+		testName string
+		format   string
+		line     string
+		readTime time.Time
+		expected time.Time
+	}{
+		{
+			testName: "year",
+			format:   "%b %d %H:%M:%S",
+			line:     "Dec 31 23:59:59 last entry",
+			readTime: time.Date(2026, time.January, 1, 0, 0, 5, 0, time.UTC),
+			expected: time.Date(2025, time.December, 31, 23, 59, 59, 0, time.UTC),
+		},
+		{
+			testName: "month",
+			format:   "%d %H:%M:%S",
+			line:     "31 23:59:59 last entry",
+			readTime: time.Date(2026, time.September, 1, 0, 0, 5, 0, time.UTC),
+			expected: time.Date(2026, time.August, 31, 23, 59, 59, 0, time.UTC),
+		},
+		{
+			testName: "day",
+			format:   "%H:%M:%S",
+			line:     "23:59:59 last entry",
+			readTime: time.Date(2026, time.June, 18, 0, 0, 5, 0, time.UTC),
+			expected: time.Date(2026, time.June, 17, 23, 59, 59, 0, time.UTC),
+		},
+		{
+			// Stepping a day back off the first of a year crosses both the
+			// month and the year
+			testName: "day across the turn of the year",
+			format:   "%H:%M:%S",
+			line:     "23:59:59 last entry",
+			readTime: time.Date(2026, time.January, 1, 0, 0, 5, 0, time.UTC),
+			expected: time.Date(2025, time.December, 31, 23, 59, 59, 0, time.UTC),
+		},
+		{
+			// The month is carried, so the format repeats yearly even though
+			// the day is missing too
+			testName: "year for a format carrying no day",
+			format:   "%m %H:%M:%S",
+			line:     "12 23:59:59 last entry",
+			readTime: time.Date(2026, time.January, 1, 0, 0, 5, 0, time.UTC),
+			expected: time.Date(2025, time.December, 31, 23, 59, 59, 0, time.UTC),
+		},
+		{
+			// The year and the month are carried and only the day is borrowed,
+			// so it is the borrowed day that has to give
+			testName: "day for a format carrying a year and a month",
+			format:   "%Y-%m %H:%M:%S",
+			line:     "2026-06 23:59:59 last entry",
+			readTime: time.Date(2026, time.July, 1, 0, 0, 5, 0, time.UTC),
+			expected: time.Date(2026, time.June, 30, 23, 59, 59, 0, time.UTC),
+		},
+		{
+			// Stepping a month back off January crosses the year, which is
+			// taken from the read time anyway
+			testName: "month across the turn of the year",
+			format:   "%d %H:%M:%S",
+			line:     "31 23:59:59 last entry",
+			readTime: time.Date(2026, time.January, 1, 0, 0, 5, 0, time.UTC),
+			expected: time.Date(2025, time.December, 31, 23, 59, 59, 0, time.UTC),
+		},
+		{
+			// The year pins the date, so the month the line carries must not be
+			// stepped away from even though the resulting date is far ahead
+			testName: "no rollover when the format carries a year",
+			format:   "%Y-%m",
+			line:     "2027-01 an entry",
+			readTime: time.Date(2026, time.March, 1, 0, 0, 5, 0, time.UTC),
+			expected: time.Date(2027, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// A clock slightly ahead must not cost a whole day
+			testName: "no rollover for a small offset into the future",
+			format:   "%H:%M:%S",
+			line:     "09:30:00 an entry",
+			readTime: time.Date(2026, time.June, 17, 9, 0, 0, 0, time.UTC),
+			expected: time.Date(2026, time.June, 17, 9, 30, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			_, eventTime := testDatetimeAsEventTime(t, tc.format)
+			assert.Check(t, is.Equal(tc.expected, eventTime.parse([]byte(tc.line), tc.readTime).UTC()))
+		})
+	}
+}
+
+// A format carrying no hour has no time of day to place the event by, so the
+// hour the message happened to be read at must not move it.
+func TestEventTimeParserParseIndependentOfTheReadHour(t *testing.T) {
+	formats := []string{"%Y-%m", "%m", "%d", "%Y-%m-%d"}
+	for _, format := range formats {
+		t.Run(format, func(t *testing.T) {
+			_, eventTime := testDatetimeAsEventTime(t, format)
+			line := []byte(time.Date(2026, time.February, 28, 0, 0, 0, 0, time.UTC).Format(eventTime.layout))
+
+			var first time.Time
+			for hour := range 24 {
+				readTime := time.Date(2026, time.March, 31, hour, 30, 0, 0, time.UTC)
+				parsed := eventTime.parse(line, readTime)
+				if hour == 0 {
+					first = parsed
+					continue
+				}
+				assert.Check(t, is.Equal(first, parsed), "Read at %02d:30 differs from read at 00:30", hour)
+			}
+		})
+	}
+}
+
+func TestEventTimeParserParseTimezone(t *testing.T) {
+	readTime := time.Date(2026, time.June, 17, 9, 0, 0, 0, time.UTC)
+	tests := []struct {
+		datetimeTimezone string
+		location         *time.Location
+	}{
+		{datetimeTimezone: "", location: time.UTC},
+		{datetimeTimezone: "utc", location: time.UTC},
+		{datetimeTimezone: "local", location: time.Local},
+		{datetimeTimezone: "LOCAL", location: time.Local},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.datetimeTimezone, func(t *testing.T) {
+			info := logger.Info{
+				Config: map[string]string{
+					datetimeFormatKey:      "%Y-%m-%d %H:%M:%S",
+					datetimeAsEventTimeKey: "true",
+					datetimeTimezoneKey:    tc.datetimeTimezone,
+				},
+			}
+			multilinePattern, err := parseMultilineOptions(info)
+			assert.NilError(t, err)
+			eventTime, err := parseEventTimeOptions(info, multilinePattern)
+			assert.NilError(t, err)
+
+			parsed := eventTime.parse([]byte("2017-01-01 01:01:44 This is a log entry"), readTime)
+			// Asserted on its own, so that the test still says something on a
+			// host whose local timezone happens to be UTC
+			assert.Check(t, parsed.Location() == tc.location, "Unexpected location %s", parsed.Location())
+			expected := time.Date(2017, time.January, 1, 1, 1, 44, 0, tc.location)
+			assert.Check(t, is.Equal(expected.UTC(), parsed.UTC()), "Unexpected event time")
+		})
+	}
+}
+
+func TestParseDatetimeTimezone(t *testing.T) {
+	_, err := parseDatetimeTimezone("cet")
+	assert.Check(t, err != nil, "Expected an error")
+	assert.Check(t, is.Contains(err.Error(), "must specify 'utc' or 'local' for log opt 'awslogs-datetime-timezone': cet"))
+}
+
+func TestParseEventTimeOptions(t *testing.T) {
+	tests := []struct {
+		testName            string
+		datetimeFormat      string
+		datetimeAsEventTime string
+		shouldErr           bool
+		expectParser        bool
+	}{
+		{testName: "unset", datetimeFormat: "%Y-%m-%d"},
+		{testName: "disabled", datetimeFormat: "%Y-%m-%d", datetimeAsEventTime: "false"},
+		{testName: "enabled", datetimeFormat: "%Y-%m-%d", datetimeAsEventTime: "true", expectParser: true},
+		{testName: "invalid value", datetimeFormat: "%Y-%m-%d", datetimeAsEventTime: "yes please", shouldErr: true},
+		{testName: "without datetime format", datetimeAsEventTime: "true", shouldErr: true},
+		{testName: "unsupported datetime format", datetimeFormat: "%w", datetimeAsEventTime: "true", shouldErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			info := logger.Info{
+				Config: map[string]string{
+					datetimeFormatKey:      tc.datetimeFormat,
+					datetimeAsEventTimeKey: tc.datetimeAsEventTime,
+				},
+			}
+			multilinePattern, err := parseMultilineOptions(info)
+			assert.NilError(t, err)
+
+			eventTime, err := parseEventTimeOptions(info, multilinePattern)
+			if tc.shouldErr {
+				assert.Check(t, err != nil, "Expected an error")
+				return
+			}
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(tc.expectParser, eventTime != nil), "Unexpected parser")
+		})
+	}
+}
+
+func TestValidateLogOptionsDatetimeAsEventTime(t *testing.T) {
+	tests := []struct {
+		testName    string
+		cfg         map[string]string
+		expectedErr string
+	}{
+		{
+			testName: "enabled",
+			cfg:      map[string]string{datetimeFormatKey: "%Y-%m-%d", datetimeAsEventTimeKey: "true"},
+		},
+		{
+			testName: "disabled without datetime format",
+			cfg:      map[string]string{datetimeAsEventTimeKey: "false"},
+		},
+		{
+			testName:    "invalid value",
+			cfg:         map[string]string{datetimeFormatKey: "%Y-%m-%d", datetimeAsEventTimeKey: "1.5"},
+			expectedErr: "must specify valid value for log opt 'awslogs-datetime-as-event-time'",
+		},
+		{
+			testName:    "without datetime format",
+			cfg:         map[string]string{datetimeAsEventTimeKey: "true"},
+			expectedErr: "log opt 'awslogs-datetime-as-event-time' requires log opt 'awslogs-datetime-format' to be set",
+		},
+		{
+			testName:    "unsupported datetime format",
+			cfg:         map[string]string{datetimeFormatKey: "%Y-%m-%d %w", datetimeAsEventTimeKey: "true"},
+			expectedErr: "awslogs cannot use log opt 'awslogs-datetime-format' as event time: format sequence \"%w\" is not supported",
+		},
+		{
+			testName:    "timezone abbreviation in the datetime format",
+			cfg:         map[string]string{datetimeFormatKey: "%Y-%m-%d %H:%M:%S %Z", datetimeAsEventTimeKey: "true"},
+			expectedErr: "format sequence \"%Z\" is not supported, use %z or log opt 'awslogs-datetime-timezone' instead",
+		},
+		{
+			testName: "local timezone",
+			cfg:      map[string]string{datetimeFormatKey: "%Y-%m-%d", datetimeAsEventTimeKey: "true", datetimeTimezoneKey: "local"},
+		},
+		{
+			testName:    "invalid timezone",
+			cfg:         map[string]string{datetimeFormatKey: "%Y-%m-%d", datetimeAsEventTimeKey: "true", datetimeTimezoneKey: "cet"},
+			expectedErr: "must specify 'utc' or 'local' for log opt 'awslogs-datetime-timezone': cet",
+		},
+		{
+			testName:    "timezone without datetime as event time",
+			cfg:         map[string]string{datetimeFormatKey: "%Y-%m-%d", datetimeTimezoneKey: "local"},
+			expectedErr: "log opt 'awslogs-datetime-timezone' requires log opt 'awslogs-datetime-as-event-time' to be enabled",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			tc.cfg[logGroupKey] = groupName
+			err := ValidateLogOpt(tc.cfg)
+			if tc.expectedErr == "" {
+				assert.NilError(t, err)
+				return
+			}
+			assert.Check(t, err != nil, "Expected an error")
+			assert.Check(t, is.Contains(err.Error(), tc.expectedErr), "Received invalid error")
 		})
 	}
 }


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/52900
- Related to: https://github.com/moby/moby/pull/30891

## Summary

`awslogs-datetime-format` only serves to detect where a new multiline event starts. The datetime it matches is thrown away, and the event carries the time the daemon read the message rather than the time the log line reports. Two log options let it be used for the event timestamp too, as the CloudWatch agent does with its own datetime format:

- **`awslogs-datetime-as-event-time`** (bool, off by default) - takes the event timestamp from the log line. The expression that detects a multiline start locates the datetime, and the same strftime format is translated into a Go layout to read it, so no second pattern is involved. Existing setups are unaffected.
- **`awslogs-datetime-timezone`** (`utc` by default, or `local`) - in what timezone a datetime carrying no zone of its own is read. `local` matches the agent's `time_zone = LOCAL` default.

`%Z` is refused for an event time: an abbreviation is ambiguous (`CST` is both -06:00 and +08:00), and `time.Parse` resolves one it does not know to a zero offset *without failing*, silently dating events wrong instead of falling back. `%z` and `awslogs-datetime-timezone` cover the ground unambiguously. `%w` is refused too, having no Go layout equivalent. Both fail at container start; multiline splitting on either is untouched.

**Partial dates.** Year-less syslog (`%b %d %H:%M:%S`) and bare-time formats otherwise parse to year 0, which CloudWatch rejects along with the rest of the batch. Missing components are borrowed from the day the line would have been written on - the read time less the time of day it carries, rounded to the nearest day - so a line written at 23:59:59 on 31 December and read six seconds later is dated December, not eleven months ahead. A format carrying no hour borrows from the read time directly, having no time of day to round on. What the day cannot settle the format repeats yearly or monthly, and the nearer candidate wins. A borrowed component that cannot go together with a parsed one (a 31st in a parsed February) is clamped where the day is ours to choose and dropped where it is the line's own. Anything that cannot be resolved keeps the time it was read.

**Batching.** Timestamps read off log lines are no longer bounded by the flush interval, so a batch can exceed the 24 hours CloudWatch [rejects as a whole](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html). `eventBatch` now tracks its span and refuses an event that would exceed it, reusing the publish-and-retry path already there for the size and count limits. Parts of an oversized multiline event keep the timestamp of the line that started it, and the buffered event's read time is tracked apart from its timestamp so buffering stays a matter of wall-clock time.

## Testing

`daemon/logger/awslogs` unit tests, extended with the format translation, every partial-date and rollover case, both options and their validation, the batch span split and the oversized multiline event. Verified under `TZ=UTC`, `TZ=Pacific/Auckland`, `TZ=America/Los_Angeles` and the host default, with `-race -count=5`.

## Release notes (optional)

```markdown changelog
Add `awslogs-datetime-as-event-time` and `awslogs-datetime-timezone` log options to the awslogs logging driver, taking the CloudWatch Logs event timestamp from the datetime matched by `awslogs-datetime-format`.
```
