### PR TITLE
fix: flush conntrack entries on host port, not container port

### DIFF
--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -1691,6 +1691,13 @@ func clearConntrackEntries(nlh nlwrap.Handle, ep *bridgeEndpoint) {
 	var udpPorts []types.PortBinding
 	for _, pb := range ep.portMapping {
 		if pb.Proto == types.UDP {
+			// NAT'd bindings: the conntrack entry's orig-dst-port is the
+			// published host port. Routed bindings (no NAT) are covered by
+			// the IP-keyed flush above — their flows are never DNAT'd, so
+			// a port-keyed flush is not needed for them.
+			if !pb.NAT.IsValid() {
+				continue
+			}
 			udpPorts = append(udpPorts, pb.PortBinding)
 		}
 	}

--- a/daemon/libnetwork/iptables/conntrack.go
+++ b/daemon/libnetwork/iptables/conntrack.go
@@ -85,16 +85,16 @@ func DeleteConntrackEntriesByPort(nlh nlwrap.Handle, proto types.Protocol, ports
 				"error":  err,
 				"hostIP": port.HostIP.String(),
 				"proto":  port.Proto.String(),
-				"port":   port.Port,
+				"port":   port.HostPort,
 			}).Warn("Failed to delete conntrack state for port")
 			continue
 		}
-		if err := filter.AddPort(netlink.ConntrackOrigDstPort, port.Port); err != nil {
+		if err := filter.AddPort(netlink.ConntrackOrigDstPort, port.HostPort); err != nil {
 			log.G(context.TODO()).WithFields(log.Fields{
 				"error":  err,
 				"hostIP": port.HostIP.String(),
 				"proto":  port.Proto.String(),
-				"port":   port.Port,
+				"port":   port.HostPort,
 			}).Warn("Failed to delete conntrack state for port")
 			continue
 		}
@@ -108,7 +108,7 @@ func DeleteConntrackEntriesByPort(nlh nlwrap.Handle, proto types.Protocol, ports
 					"error":  err,
 					"hostIP": port.HostIP.String(),
 					"proto":  port.Proto.String(),
-					"port":   port.Port,
+					"port":   port.HostPort,
 				}).Warn("Failed to delete conntrack state for port")
 				continue
 			}
@@ -120,7 +120,7 @@ func DeleteConntrackEntriesByPort(nlh nlwrap.Handle, proto types.Protocol, ports
 				"error":  err,
 				"hostIP": port.HostIP.String(),
 				"proto":  port.Proto.String(),
-				"port":   port.Port,
+				"port":   port.HostPort,
 			}).Warn("Failed to delete conntrack state for IPv4 port")
 		}
 		totalIPv4FlowPurged += v4FlowPurged
@@ -131,7 +131,7 @@ func DeleteConntrackEntriesByPort(nlh nlwrap.Handle, proto types.Protocol, ports
 				"error":  err,
 				"hostIP": port.HostIP.String(),
 				"proto":  port.Proto.String(),
-				"port":   port.Port,
+				"port":   port.HostPort,
 			}).Warn("Failed to delete conntrack state for IPv6 port")
 		}
 		totalIPv6FlowPurged += v6FlowPurged


### PR DESCRIPTION
### Description

`DeleteConntrackEntriesByPort` in `daemon/libnetwork/iptables/conntrack.go` filters conntrack entries on the **container** port (`port.Port`) instead of the **published host** port (`port.HostPort`). When `hostPort != containerPort`, the filter is built on the wrong port, which:

1. **Misses stale entries** — the entry Docker means to clear is never matched, so it survives.
2. **Collateral deletion** — the filter can delete unrelated flows on any host port that equals this container's container-port number.

The NAT portmapper (`daemon/libnetwork/portmappers/nat/mapper_linux.go`) sets `HostPort` to the concrete allocated host port while `Port` stays the container port, so the fix is to filter on `HostPort` (restoring the pre-#52423 `pb.HostPort` behavior that #52640 kept only for the IP half).

For **routed bindings** (no NAT, `Forwarding: true`), the routed portmapper zeroes `HostPort`; their flows are not DNAT'd and are already covered by the IP-keyed flush in `DeleteConntrackEntries`. This PR skips the port-keyed flush for those bindings in `clearConntrackEntries` (bridge driver), matching the issue's suggested design.

### Related

Fixes #53384

Related, not duplicate: #46276 (missing IP filter, addressed by #52423/#52640).

Signed-off-by: waterWang <waterWang@users.noreply.github.com>
