### PR TITLE
embedded containerd: clean up server lifecycle and metrics

### DIFF
--- a/daemon/internal/containerd/server/embedded/containerd.go
+++ b/daemon/internal/containerd/server/embedded/containerd.go
@@ -129,14 +129,14 @@ func newServerWithRegistrations(ctx context.Context, cfg *serverConfig, registra
 
 		instance, err := result.Instance()
 		if err != nil {
+			if mustSucceed.Load() {
+				return nil, fmt.Errorf("plugin %q failed after registering readiness: %w", id, err)
+			}
 			fields := log.Fields{"error": err, "id": id, "type": registration.Type}
 			if plugin.IsSkipPlugin(err) {
 				log.G(ctx).WithFields(fields).Info("skip loading plugin")
 			} else {
 				log.G(ctx).WithFields(fields).Warn("failed to load plugin")
-			}
-			if mustSucceed.Load() {
-				return nil, fmt.Errorf("plugin %q failed after registering readiness: %w", id, err)
 			}
 			continue
 		}

--- a/daemon/internal/containerd/server/embedded/containerd.go
+++ b/daemon/internal/containerd/server/embedded/containerd.go
@@ -107,22 +107,20 @@ func newServerWithRegistrations(ctx context.Context, cfg *serverConfig, registra
 		id := registration.URI()
 		log.G(ctx).WithFields(log.Fields{"id": id, "type": registration.Type}).Info("loading plugin")
 
+		initContext := plugin.NewContext(ctx, initialized, map[string]string{
+			plugins.PropertyRootDir:      filepath.Join(cfg.root, id),
+			plugins.PropertyStateDir:     filepath.Join(cfg.state, id),
+			plugins.PropertyGRPCAddress:  cfg.grpcAddress,
+			plugins.PropertyTTRPCAddress: cfg.ttrpcAddress,
+		})
+
+		initContext.Config = registration.Config
+
 		var mustSucceed atomic.Bool
-		initContext := plugin.NewContext(
-			ctx,
-			initialized,
-			map[string]string{
-				plugins.PropertyRootDir:      filepath.Join(cfg.root, id),
-				plugins.PropertyStateDir:     filepath.Join(cfg.state, id),
-				plugins.PropertyGRPCAddress:  cfg.grpcAddress,
-				plugins.PropertyTTRPCAddress: cfg.ttrpcAddress,
-			},
-		)
 		initContext.RegisterReadiness = func() func() {
 			mustSucceed.Store(true)
 			return srv.registerReadiness()
 		}
-		initContext.Config = registration.Config
 
 		result := registration.Init(initContext)
 		if err := initialized.Add(result); err != nil {

--- a/daemon/internal/containerd/server/embedded/containerd.go
+++ b/daemon/internal/containerd/server/embedded/containerd.go
@@ -114,7 +114,12 @@ func newServerWithRegistrations(ctx context.Context, cfg *serverConfig, registra
 			plugins.PropertyTTRPCAddress: cfg.ttrpcAddress,
 		})
 
-		initContext.Config = registration.Config
+		// Disable cgroups Prometheus metrics for the embedded server to
+		// avoid exposing them through dockerd's process-global Prometheus
+		// registry.
+		//
+		// TODO(thaJeztah): Consider making containerd's cgroups Prometheus metrics configurable.
+		initContext.Config = disableCgroupsPrometheus(registration)
 
 		var mustSucceed atomic.Bool
 		initContext.RegisterReadiness = func() func() {

--- a/daemon/internal/containerd/server/embedded/embedded.go
+++ b/daemon/internal/containerd/server/embedded/embedded.go
@@ -11,24 +11,3 @@
 // containerd still runs each container's shim as a separate process, so
 // containers keep running across a daemon restart, as they do today.
 package embedded
-
-import (
-	"context"
-	"net"
-	"time"
-)
-
-// Daemon is an in-process containerd server.
-type Daemon interface {
-	// Address returns the containerd gRPC address (unix socket path, or named
-	// pipe on Windows) external clients and tooling should dial.
-	Address() string
-	// Dial returns an in-memory connection to the server, which dockerd's own
-	// client uses to avoid socket syscalls. The signature matches
-	// grpc.WithContextDialer, and the addr argument is ignored.
-	Dial(ctx context.Context, addr string) (net.Conn, error)
-	// WaitTimeout waits up to d for the server to stop after Shutdown.
-	WaitTimeout(d time.Duration) error
-	// Shutdown gracefully stops the in-process server and waits for it to exit.
-	Shutdown(ctx context.Context) error
-}

--- a/daemon/internal/containerd/server/embedded/embedded_linux.go
+++ b/daemon/internal/containerd/server/embedded/embedded_linux.go
@@ -6,15 +6,18 @@ import (
 	"net"
 	"path/filepath"
 
+	"github.com/containerd/containerd/v2/core/metrics/cgroups"
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/plugin"
 	"github.com/containerd/ttrpc"
 	"github.com/docker/go-connections/sockets"
 
-	// Linux-specific containerd plugin registrations: the overlayfs
-	// snapshotter, the walking differ, the cgroups task monitor (for container
-	// metrics), and the runc runtime options type. Cross-platform plugins are
-	// registered in server.go.
+	// Linux-specific containerd plugin registrations: the overlayfs and native
+	// snapshotters, the walking differ, and the runc runtime options type.
+	// The cgroups task monitor is registered by the cgroups import above.
+	//
+	// Cross-platform plugins are registered in server.go.
 	_ "github.com/containerd/containerd/api/types/runc/options"
-	_ "github.com/containerd/containerd/v2/core/metrics/cgroups"
 	_ "github.com/containerd/containerd/v2/plugins/diff/walking/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/snapshots/native/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/snapshots/overlay/plugin"
@@ -32,4 +35,17 @@ func newTTRPCServer() (*ttrpc.Server, error) {
 	return ttrpc.NewServer(
 		ttrpc.WithServerHandshaker(ttrpc.UnixSocketRequireSameUser()),
 	)
+}
+
+// disableCgroupsPrometheus disables Prometheus metrics for the cgroups task monitor,
+// avoiding process-global collector registration in the embedded server.
+func disableCgroupsPrometheus(registration plugin.Registration) any {
+	if registration.Type == plugins.TaskMonitorPlugin && registration.ID == "cgroups" {
+		if c, ok := registration.Config.(*cgroups.Config); ok {
+			cfg := *c
+			cfg.NoPrometheus = true
+			return &cfg
+		}
+	}
+	return registration.Config
 }

--- a/daemon/internal/containerd/server/embedded/embedded_test.go
+++ b/daemon/internal/containerd/server/embedded/embedded_test.go
@@ -3,12 +3,8 @@
 package embedded
 
 import (
-	"path/filepath"
 	"strings"
 	"testing"
-
-	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
 // TestPluginGraphResolves guards the blank-import plugin set: it starts the
@@ -26,17 +22,4 @@ func TestPluginGraphResolves(t *testing.T) {
 		t.Skipf("embedded containerd did not start in this environment: %v", err)
 	}
 	t.Cleanup(func() { _ = d.Shutdown(ctx) })
-}
-
-func TestBuildServerConfigUsesSupervisedLayout(t *testing.T) {
-	rootDir := filepath.Join(t.TempDir(), "root")
-	stateDir := filepath.Join(t.TempDir(), "state")
-	address := defaultAddress(stateDir)
-
-	cfg := buildServerConfig(rootDir, stateDir, address)
-
-	assert.Check(t, is.Equal(cfg.root, rootDir))
-	assert.Check(t, is.Equal(cfg.state, filepath.Join(stateDir, "daemon")))
-	assert.Check(t, is.Equal(cfg.grpcAddress, address))
-	assert.Check(t, is.Equal(cfg.ttrpcAddress, address+".ttrpc"))
 }

--- a/daemon/internal/containerd/server/embedded/embedded_test.go
+++ b/daemon/internal/containerd/server/embedded/embedded_test.go
@@ -3,8 +3,10 @@
 package embedded
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestPluginGraphResolves guards the blank-import plugin set: it starts the
@@ -12,8 +14,13 @@ import (
 // the registry or its dependency graph cannot be satisfied. Runtime init
 // failures unrelated to registration (e.g. requiring root) are tolerated, so
 // the test is safe to run unprivileged.
+//
+// On successful startup, it also verifies that context cancellation shuts
+// down the server.
 func TestPluginGraphResolves(t *testing.T) {
-	ctx := t.Context()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
 	d, err := Start(ctx, t.TempDir(), t.TempDir())
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "no plugins registered") {
@@ -21,5 +28,10 @@ func TestPluginGraphResolves(t *testing.T) {
 		}
 		t.Skipf("embedded containerd did not start in this environment: %v", err)
 	}
-	t.Cleanup(func() { _ = d.Shutdown(ctx) })
+
+	// Shutdown the embedded containerd server, and wait for it to be stopped.
+	cancel()
+	if err := d.WaitTimeout(10 * time.Second); err != nil {
+		t.Fatalf("embedded containerd did not stop: %v", err)
+	}
 }

--- a/daemon/internal/containerd/server/embedded/embedded_windows.go
+++ b/daemon/internal/containerd/server/embedded/embedded_windows.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/Microsoft/go-winio"
+	"github.com/containerd/plugin"
 	"github.com/containerd/ttrpc"
 
 	// Windows-specific containerd plugin registrations. Cross-platform plugins
@@ -40,4 +41,8 @@ func listen(address string) (net.Listener, error) {
 
 func newTTRPCServer() (*ttrpc.Server, error) {
 	return ttrpc.NewServer()
+}
+
+func disableCgroupsPrometheus(registration plugin.Registration) any {
+	return registration.Config
 }

--- a/daemon/internal/containerd/server/embedded/server.go
+++ b/daemon/internal/containerd/server/embedded/server.go
@@ -53,7 +53,7 @@ import (
 // See the package doc for the transport layout.
 // Plugins self-register via the blank imports above and in the platform-specific
 // files.
-func Start(ctx context.Context, rootDir, stateDir string) (Daemon, error) {
+func Start(ctx context.Context, rootDir, stateDir string) (*Daemon, error) {
 	setContainerdVersion()
 
 	address := defaultAddress(stateDir)
@@ -91,7 +91,7 @@ func Start(ctx context.Context, rootDir, stateDir string) (Daemon, error) {
 	// dials during startup or reconnects.
 	inMemory := sockets.NewInmemSocket("embedded-containerd", 16)
 
-	e := &embeddedDaemon{
+	e := &Daemon{
 		srv:      srv,
 		address:  address,
 		inMemory: inMemory,
@@ -162,7 +162,8 @@ func buildServerConfig(rootDir, stateDir, address string) *serverConfig {
 	}
 }
 
-type embeddedDaemon struct {
+// Daemon is an in-process containerd server.
+type Daemon struct {
 	srv      *containerdServer
 	address  string
 	inMemory *sockets.InmemSocket
@@ -171,17 +172,20 @@ type embeddedDaemon struct {
 	stopping atomic.Bool
 }
 
-func (e *embeddedDaemon) Address() string {
+// Address returns the containerd gRPC address (unix socket path, or named
+// pipe on Windows) external clients and tooling should dial.
+func (e *Daemon) Address() string {
 	return e.address
 }
 
 // Dial returns one end of an in-memory pipe connected to the gRPC server. The
 // addr argument is ignored, and only present to satisfy grpc.WithContextDialer.
-func (e *embeddedDaemon) Dial(ctx context.Context, addr string) (net.Conn, error) {
+func (e *Daemon) Dial(ctx context.Context, addr string) (net.Conn, error) {
 	return e.inMemory.DialContext(ctx, "inmem", addr)
 }
 
-func (e *embeddedDaemon) WaitTimeout(d time.Duration) error {
+// WaitTimeout waits up to d for the server to stop after Shutdown.
+func (e *Daemon) WaitTimeout(d time.Duration) error {
 	timer := time.NewTimer(d)
 	defer timer.Stop()
 	select {
@@ -192,7 +196,8 @@ func (e *embeddedDaemon) WaitTimeout(d time.Duration) error {
 	}
 }
 
-func (e *embeddedDaemon) Shutdown(ctx context.Context) error {
+// Shutdown gracefully stops the in-process server and waits for it to exit.
+func (e *Daemon) Shutdown(ctx context.Context) error {
 	e.stopping.Store(true)
 	// Stop closes both RPC servers and their listeners.
 	e.srv.Stop()

--- a/daemon/internal/containerd/server/embedded/server.go
+++ b/daemon/internal/containerd/server/embedded/server.go
@@ -129,7 +129,7 @@ func Start(ctx context.Context, rootDir, stateDir string) (*Daemon, error) {
 	// for the server to stop after ctx is already done.
 	go func() {
 		<-ctx.Done()
-		if err := e.Shutdown(context.WithoutCancel(ctx)); err != nil {
+		if err := e.shutdown(context.WithoutCancel(ctx)); err != nil {
 			log.G(ctx).WithError(err).Error("failed to shut down embedded containerd")
 		}
 	}()
@@ -180,7 +180,7 @@ func (e *Daemon) Dial(ctx context.Context, addr string) (net.Conn, error) {
 	return e.inMemory.DialContext(ctx, "inmem", addr)
 }
 
-// WaitTimeout waits up to d for the server to stop after Shutdown.
+// WaitTimeout waits up to d for the server to stop after shutdown.
 func (e *Daemon) WaitTimeout(d time.Duration) error {
 	timer := time.NewTimer(d)
 	defer timer.Stop()
@@ -192,8 +192,8 @@ func (e *Daemon) WaitTimeout(d time.Duration) error {
 	}
 }
 
-// Shutdown gracefully stops the in-process server and waits for it to exit.
-func (e *Daemon) Shutdown(ctx context.Context) error {
+// shutdown gracefully stops the in-process server and waits for it to exit.
+func (e *Daemon) shutdown(ctx context.Context) error {
 	e.stopping.Store(true)
 	// Stop closes both RPC servers and their listeners.
 	e.srv.Stop()

--- a/daemon/internal/containerd/server/embedded/server.go
+++ b/daemon/internal/containerd/server/embedded/server.go
@@ -57,7 +57,14 @@ func Start(ctx context.Context, rootDir, stateDir string) (*Daemon, error) {
 	setContainerdVersion()
 
 	address := defaultAddress(stateDir)
-	cfg := buildServerConfig(rootDir, stateDir, address)
+	cfg := &serverConfig{
+		root:               rootDir,
+		state:              filepath.Join(stateDir, "daemon"),
+		grpcAddress:        address,
+		ttrpcAddress:       address + ".ttrpc",
+		maxRecvMessageSize: defaults.DefaultMaxRecvMsgSize,
+		maxSendMessageSize: defaults.DefaultMaxSendMsgSize,
+	}
 
 	// Create the root and state directories with the permissions containerd
 	// expects (e.g. the state dir at 0o711 for userns-remapped containers),
@@ -148,17 +155,6 @@ func setContainerdVersion() {
 			version.Version = dep.Version
 			break
 		}
-	}
-}
-
-func buildServerConfig(rootDir, stateDir, address string) *serverConfig {
-	return &serverConfig{
-		root:               rootDir,
-		state:              filepath.Join(stateDir, "daemon"),
-		grpcAddress:        address,
-		ttrpcAddress:       address + ".ttrpc",
-		maxRecvMessageSize: defaults.DefaultMaxRecvMsgSize,
-		maxSendMessageSize: defaults.DefaultMaxSendMsgSize,
 	}
 }
 


### PR DESCRIPTION
### embedded: use concrete type for daemon

The embedded containerd server only has a single implementation, so an
interface does not provide any useful abstraction.

Export the concrete Daemon type directly and have Start return *Daemon.
This also keeps its API and documentation together with the implementation.


### embedded: inline server configuration

Remove the buildServerConfig helper and construct the server configuration
directly in Start. The helper had a single caller, and its test only verified
that the function returned the values assigned within it.

### embedded: un-export Shutdown method

Make embedded containerd shutdown an internal implementation detail and rely on
cancelling the context passed to Start to initiate shutdown.

Update TestPluginGraphResolves to wait for the server to stop through WaitTimeout,
which matches how it's used in our code.

### embedded: move vars closer to where used


### embedded: avoid logging fatal plugin init errors

Return plugin initialization errors directly once readiness has been
registered, and only log failures that are intentionally ignored.

This avoids reporting the same fatal startup error both from plugin loading and
again when it reaches the top-level process.

### embedded: disable containerd cgroups Prometheus metrics

Disable Prometheus export from containerd's cgroups task monitor when running
embedded.

Standalone containerd exposes these metrics through its own metrics endpoint,
while dockerd using an external containerd does not expose them through
dockerd's --metrics-addr endpoint. With embedded containerd, the shared
process-global Prometheus registry causes these collectors to be exposed
through dockerd unintentionally.

Disable the collectors to preserve dockerd's existing metrics surface while
keeping the cgroups task monitor itself enabled.

Before this change, the prometheus metrics were exposed in dockerd's metrics,
which was not the case when running containerd out of process;

With external containerd:

    dockerd --metrics-addr 127.0.0.1:9323
    docker run -d --name foo nginx:alpine
    curl -s http://127.0.0.1:9323/metrics | grep '^container_'
    # no output

With embedded containerd:

    dockerd --metrics-addr 127.0.0.1:9323
    docker run -d --name foo nginx:alpine

    curl -s http://127.0.0.1:9323/metrics | grep '^container_'
    container_cpu_nr_periods_total{container_id="c8877938fad6c0175d047e4674f1dab044768b4e8ec177b4931d7cd72fc9940d",namespace="moby",runtime="io.containerd.runc.v2"} 0
    container_cpu_nr_throttled_total{container_id="c8877938fad6c0175d047e4674f1dab044768b4e8ec177b4931d7cd72fc9940d",namespace="moby",runtime="io.containerd.runc.v2"} 0
    container_cpu_system_usec_microseconds{container_id="c8877938fad6c0175d047e4674f1dab044768b4e8ec177b4931d7cd72fc9940d",namespace="moby",runtime="io.containerd.runc.v2"} 21389
    ...




## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
