### PR TITLE
containerd: simplify supervisor lifecycle and shutdown handling

### DIFF
--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -1173,8 +1173,11 @@ func (cli *daemonCLI) initializeContainerd(ctx context.Context) (func(time.Durat
 		return nil, err
 	}
 	opts := supervisorOpts(cli.Config)
-	r, err := supervisor.Start(ctx, rootDir, filepath.Join(cli.Config.ExecRoot, "containerd"), opts...)
+	r, err := supervisor.New(rootDir, filepath.Join(cli.Config.ExecRoot, "containerd"), opts...)
 	if err != nil {
+		return nil, err
+	}
+	if err := r.Start(ctx); err != nil {
 		return nil, errors.Wrap(err, "failed to start containerd")
 	}
 	cli.Config.ContainerdAddr = r.Address()

--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -202,15 +202,22 @@ func (cli *daemonCLI) start(ctx context.Context) (retErr error) {
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
-	waitForContainerDShutdown, err := cli.initContainerd(ctx)
-	if waitForContainerDShutdown != nil {
-		defer waitForContainerDShutdown(10 * time.Second)
-	}
+	waitShutdown, err := cli.initContainerd(ctx)
 	if err != nil {
 		cancel()
 		return err
 	}
-	defer cancel()
+
+	// The normal shutdown path calls this before tracing is torn down. Defer it
+	// as a fallback for startup failures after containerd has started; OnceFunc
+	// prevents the deferred call from repeating the wait.
+	shutdownContainerd := sync.OnceFunc(func() {
+		cancel()
+		if err := waitShutdown(10 * time.Second); err != nil {
+			log.G(ctx).WithError(err).Warn("failed to wait for containerd to stop")
+		}
+	})
+	defer shutdownContainerd()
 
 	httpServer := &http.Server{
 		ReadHeaderTimeout: 5 * time.Minute, // "G112: Potential Slowloris Attack (gosec)"; not a real concern for our use, so setting a long timeout.
@@ -405,17 +412,20 @@ func (cli *daemonCLI) start(ctx context.Context) (retErr error) {
 	// shutdown / close BuildKit backend
 	shutdownBuildKit()
 
-	// Stop notification processing and any background processes
-	cancel()
+	// Stop notification processing and background processes, then wait for
+	// containerd to stop.
+	shutdownContainerd()
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer shutdownCancel()
+
+	if err := otelShutdown(shutdownCtx); err != nil {
+		log.G(ctx).WithError(err).Error("failed to shutdown OTEL tracing")
+	}
 
 	if err, ok := <-errAPI; ok {
 		return errors.Wrap(err, "shutting down due to ServeAPI error")
 	}
-
-	if err := otelShutdown(context.WithoutCancel(ctx)); err != nil {
-		log.G(ctx).WithError(err).Error("Failed to shutdown OTEL tracing")
-	}
-
 	return nil
 }
 
@@ -1141,15 +1151,20 @@ func overrideProxyEnv(ctx context.Context, name, val string) {
 	_ = os.Setenv(name, val)
 }
 
+// nopWaitFunc is used when containerd is managed externally.
+func nopWaitFunc(time.Duration) error {
+	return nil
+}
+
 func (cli *daemonCLI) initializeContainerd(ctx context.Context) (func(time.Duration) error, error) {
 	systemContainerdAddr, ok, err := systemContainerdRunning(honorXDG)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not determine whether the system containerd is running")
 	}
 	if ok {
-		// detected a system containerd at the given address.
+		// Use the externally managed system containerd detected at this address.
 		cli.Config.ContainerdAddr = systemContainerdAddr
-		return nil, nil
+		return nopWaitFunc, nil
 	}
 
 	log.G(ctx).Info("containerd not running, starting managed containerd")

--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -882,7 +882,7 @@ func initMiddlewares(_ context.Context, s *apiserver.Server, cfg *config.Config,
 	return authzMiddleware, nil
 }
 
-func getContainerdDaemonOpts(cfg *config.Config) ([]supervisor.DaemonOpt, error) {
+func supervisorOpts(cfg *config.Config) []supervisor.DaemonOpt {
 	var opts []supervisor.DaemonOpt
 	if cfg.Debug {
 		opts = append(opts, supervisor.WithLogLevel("debug"))
@@ -914,7 +914,7 @@ func getContainerdDaemonOpts(cfg *config.Config) ([]supervisor.DaemonOpt, error)
 		opts = append(opts, supervisor.WithDetectLocalBinary())
 	}
 
-	return opts, nil
+	return opts
 }
 
 func newAPIServerTLSConfig(cfg *config.Config) (*tls.Config, error) {
@@ -1168,15 +1168,11 @@ func (cli *daemonCLI) initializeContainerd(ctx context.Context) (func(time.Durat
 	}
 
 	log.G(ctx).Info("containerd not running, starting managed containerd")
-	opts, err := getContainerdDaemonOpts(cli.Config)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate containerd options")
-	}
-
 	rootDir, err := containerdRootDir(ctx, cli.Config)
 	if err != nil {
 		return nil, err
 	}
+	opts := supervisorOpts(cli.Config)
 	r, err := supervisor.Start(ctx, rootDir, filepath.Join(cli.Config.ExecRoot, "containerd"), opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start containerd")

--- a/daemon/command/daemon_unix.go
+++ b/daemon/command/daemon_unix.go
@@ -124,7 +124,7 @@ func (cli *daemonCLI) initContainerd(ctx context.Context) (func(time.Duration) e
 	}
 	if cli.Config.ContainerdAddr != "" {
 		// use system containerd at the given address.
-		return nil, nil
+		return nopWaitFunc, nil
 	}
 
 	return cli.initializeContainerd(ctx)

--- a/daemon/command/daemon_windows.go
+++ b/daemon/command/daemon_windows.go
@@ -116,12 +116,13 @@ func (cli *daemonCLI) initContainerd(ctx context.Context) (func(time.Duration) e
 		return cli.initEmbeddedContainerd(ctx)
 	}
 	if cli.Config.ContainerdAddr != "" {
-		return nil, nil
+		// use system containerd at the given address.
+		return nopWaitFunc, nil
 	}
 
 	if cli.Config.DefaultRuntime == "" || cli.Config.DefaultRuntime == config.WindowsV1RuntimeName {
 		// Legacy non-containerd runtime is used
-		return nil, nil
+		return nopWaitFunc, nil
 	}
 
 	return cli.initializeContainerd(ctx)

--- a/daemon/internal/containerd/server/supervisor/remote_daemon.go
+++ b/daemon/internal/containerd/server/supervisor/remote_daemon.go
@@ -39,6 +39,7 @@ type Daemon struct {
 	// configFile is the location where the generated containerd configuration
 	// file is saved.
 	configFile string
+	stateDir   string
 
 	// daemonPath is the binary to execute, and can be either a basename (to use
 	// a binary installed in the system's $PATH), or the full path to the binary
@@ -56,10 +57,11 @@ type Daemon struct {
 // DaemonOpt allows to configure parameters of container daemons
 type DaemonOpt func(c *Daemon) error
 
-// Start starts a containerd daemon and monitors it.
+// New creates a containerd daemon supervisor.
+//
 // It uses rootDir for persistent state and the daemon subdirectory under
 // stateDir for runtime state.
-func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (*Daemon, error) {
+func New(rootDir, stateDir string, opts ...DaemonOpt) (*Daemon, error) {
 	r := &Daemon{
 		config: config.Config{
 			Version: 2, // FIXME(thaJeztah): update to v3 when we drop support for containerd v1.
@@ -74,6 +76,7 @@ func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (*D
 				Address: defaultDebugAddress(stateDir), //nolint:staticcheck // Deprecated in config v4, but required for config v3.
 			},
 		},
+		stateDir:      stateDir,
 		configFile:    filepath.Join(stateDir, configFile),
 		daemonPath:    binaryName,
 		daemonPid:     -1,
@@ -88,13 +91,29 @@ func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (*D
 		}
 	}
 
+	path, err := exec.LookPath(r.daemonPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to find containerd binary: %s", r.daemonPath)
+	}
+	r.daemonPath = path
+
+	return r, nil
+}
+
+// Start starts the containerd daemon and monitors it until ctx is canceled.
+func (r *Daemon) Start(ctx context.Context) error {
+	path, err := exec.LookPath(r.daemonPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to find containerd binary: %s", r.daemonPath)
+	}
+	r.daemonPath = path
 	r.logger = log.G(ctx).WithFields(log.Fields{
 		"binary": r.daemonPath,
 		"module": "supervisor",
 	})
 
-	if err := os.MkdirAll(stateDir, 0o700); err != nil {
-		return nil, err
+	if err := os.MkdirAll(r.stateDir, 0o700); err != nil {
+		return err
 	}
 
 	go r.monitorDaemon(ctx)
@@ -104,13 +123,13 @@ func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (*D
 
 	select {
 	case <-timeout.C:
-		return nil, errors.New("timeout waiting for containerd to start")
+		return errors.New("timeout waiting for containerd to start")
 	case err := <-r.daemonStartCh:
 		if err != nil {
-			return nil, err
+			return err
 		}
 		r.logger.Info("started managed containerd")
-		return r, nil
+		return nil
 	}
 }
 

--- a/daemon/internal/containerd/server/supervisor/remote_daemon.go
+++ b/daemon/internal/containerd/server/supervisor/remote_daemon.go
@@ -83,7 +83,6 @@ func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (Da
 		daemonPath:    binaryName,
 		daemonPid:     -1,
 		pidFile:       filepath.Join(stateDir, pidFile),
-		logger:        log.G(ctx).WithField("module", "libcontainerd"),
 		daemonStartCh: make(chan error, 1),
 		daemonStopCh:  make(chan struct{}),
 	}
@@ -93,6 +92,11 @@ func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (Da
 			return nil, err
 		}
 	}
+
+	r.logger = log.G(ctx).WithFields(log.Fields{
+		"binary": r.daemonPath,
+		"module": "supervisor",
+	})
 
 	if err := os.MkdirAll(stateDir, 0o700); err != nil {
 		return nil, err
@@ -110,9 +114,9 @@ func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (Da
 		if err != nil {
 			return nil, err
 		}
+		r.logger.Info("started managed containerd")
+		return r, nil
 	}
-
-	return r, nil
 }
 
 func (r *remote) WaitTimeout(d time.Duration) error {
@@ -153,7 +157,8 @@ func (r *remote) startContainerd() error {
 
 	if pid > 0 {
 		r.daemonPid = pid
-		r.logger.WithField("pid", pid).Infof("%s is still running", binaryName)
+		r.logger = r.logger.WithField("pid", pid)
+		r.logger.Info("containerd is still running")
 		return nil
 	}
 
@@ -162,7 +167,7 @@ func (r *remote) startContainerd() error {
 		return err
 	}
 
-	r.logger.WithField("binary", r.daemonPath).Debug("starting containerd binary")
+	r.logger.Debug("starting containerd binary")
 	// Docker clears its umask on startup.
 	// Managed containerd inherits that umask, so paths it creates use the
 	// literal modes requested by containerd instead of being masked by the
@@ -219,10 +224,11 @@ func (r *remote) startContainerd() error {
 
 	if err := pidfile.Write(r.pidFile, r.daemonPid); err != nil {
 		_ = process.Kill(r.daemonPid)
-		return errors.Wrap(err, "libcontainerd: failed to save daemon pid to disk")
+		return errors.Wrap(err, "failed to save containerd pid to disk")
 	}
 
-	r.logger.WithField("pid", r.daemonPid).WithField("address", r.Address()).Infof("started new %s process", binaryName)
+	r.logger = r.logger.WithField("pid", r.daemonPid)
+	r.logger.WithField("address", r.Address()).Info("started new containerd process")
 
 	return nil
 }
@@ -261,9 +267,9 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 
 		select {
 		case <-ctx.Done():
-			r.logger.Info("stopping healthcheck following graceful shutdown")
+			r.logger.Info("stopping containerd healthcheck following graceful shutdown")
 			if client != nil {
-				client.Close()
+				_ = client.Close()
 			}
 			return
 		case <-timer.C:
@@ -334,14 +340,18 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 				continue
 			}
 
-			r.logger.WithError(err).WithField("binary", binaryName).Debug("daemon is not responding")
+			r.logger.WithFields(log.Fields{
+				"error":   err,
+				"pid":     r.daemonPid,
+				"retries": transientFailureCount,
+			}).Debug("daemon is not responding")
 
 			transientFailureCount++
 			if transientFailureCount < maxConnectionRetryCount || process.Alive(r.daemonPid) {
 				delay = time.Duration(transientFailureCount) * 200 * time.Millisecond
 				continue
 			}
-			client.Close()
+			_ = client.Close()
 			client = nil
 		}
 

--- a/daemon/internal/containerd/server/supervisor/remote_daemon.go
+++ b/daemon/internal/containerd/server/supervisor/remote_daemon.go
@@ -32,8 +32,9 @@ const (
 	pidFile                 = "containerd.pid"
 )
 
-type remote struct {
-	config.Config
+// Daemon configures, starts, and monitors a containerd daemon.
+type Daemon struct {
+	config config.Config
 
 	// configFile is the location where the generated containerd configuration
 	// file is saved.
@@ -52,21 +53,15 @@ type remote struct {
 	daemonStopCh  chan struct{}
 }
 
-// Daemon represents a running containerd daemon
-type Daemon interface {
-	WaitTimeout(time.Duration) error
-	Address() string
-}
-
 // DaemonOpt allows to configure parameters of container daemons
-type DaemonOpt func(c *remote) error
+type DaemonOpt func(c *Daemon) error
 
 // Start starts a containerd daemon and monitors it.
 // It uses rootDir for persistent state and the daemon subdirectory under
 // stateDir for runtime state.
-func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (Daemon, error) {
-	r := &remote{
-		Config: config.Config{
+func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (*Daemon, error) {
+	r := &Daemon{
+		config: config.Config{
 			Version: 2, // FIXME(thaJeztah): update to v3 when we drop support for containerd v1.
 			Root:    rootDir,
 			State:   filepath.Join(stateDir, "daemon"),
@@ -119,7 +114,7 @@ func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (Da
 	}
 }
 
-func (r *remote) WaitTimeout(d time.Duration) error {
+func (r *Daemon) WaitTimeout(d time.Duration) error {
 	timeout := time.NewTimer(d)
 	defer timeout.Stop()
 
@@ -132,24 +127,24 @@ func (r *remote) WaitTimeout(d time.Duration) error {
 	return nil
 }
 
-func (r *remote) Address() string {
-	return r.GRPC.Address //nolint:staticcheck // Deprecated in config v4, but required for config v3.
+func (r *Daemon) Address() string {
+	return r.config.GRPC.Address //nolint:staticcheck // Deprecated in config v4, but required for config v3.
 }
 
-func (r *remote) getContainerdConfig() (string, error) {
+func (r *Daemon) getContainerdConfig() (string, error) {
 	f, err := os.OpenFile(r.configFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to open containerd config file (%s)", r.configFile)
 	}
 	defer f.Close()
 
-	if err := toml.NewEncoder(f).Encode(r); err != nil {
+	if err := toml.NewEncoder(f).Encode(r.config); err != nil {
 		return "", errors.Wrapf(err, "failed to write containerd config file (%s)", r.configFile)
 	}
 	return r.configFile, nil
 }
 
-func (r *remote) startContainerd() error {
+func (r *Daemon) startContainerd() error {
 	pid, err := pidfile.Read(r.pidFile)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
@@ -233,7 +228,7 @@ func (r *remote) startContainerd() error {
 	return nil
 }
 
-func (r *remote) monitorDaemon(ctx context.Context) {
+func (r *Daemon) monitorDaemon(ctx context.Context) {
 	var (
 		transientFailureCount = 0
 		client                *containerd.Client

--- a/daemon/internal/containerd/server/supervisor/remote_daemon_linux.go
+++ b/daemon/internal/containerd/server/supervisor/remote_daemon_linux.go
@@ -25,7 +25,7 @@ func defaultDebugAddress(stateDir string) string {
 
 func (r *remote) stopDaemon() {
 	// Ask the daemon to quit
-	syscall.Kill(r.daemonPid, syscall.SIGTERM)
+	_ = syscall.Kill(r.daemonPid, syscall.SIGTERM)
 	// Wait up to 15secs for it to stop
 	for i := time.Duration(0); i < shutdownTimeout; i += time.Second {
 		if !process.Alive(r.daemonPid) {
@@ -35,8 +35,8 @@ func (r *remote) stopDaemon() {
 	}
 
 	if process.Alive(r.daemonPid) {
-		r.logger.WithField("pid", r.daemonPid).Warn("daemon didn't stop within 15 secs, killing it")
-		syscall.Kill(r.daemonPid, syscall.SIGKILL)
+		r.logger.WithField("pid", r.daemonPid).Warn("containerd didn't stop within 15 secs, killing it")
+		_ = syscall.Kill(r.daemonPid, syscall.SIGKILL)
 	}
 }
 

--- a/daemon/internal/containerd/server/supervisor/remote_daemon_linux.go
+++ b/daemon/internal/containerd/server/supervisor/remote_daemon_linux.go
@@ -23,7 +23,7 @@ func defaultDebugAddress(stateDir string) string {
 	return filepath.Join(stateDir, debugSockFile)
 }
 
-func (r *remote) stopDaemon() {
+func (r *Daemon) stopDaemon() {
 	// Ask the daemon to quit
 	_ = syscall.Kill(r.daemonPid, syscall.SIGTERM)
 	// Wait up to 15secs for it to stop
@@ -40,13 +40,13 @@ func (r *remote) stopDaemon() {
 	}
 }
 
-func (r *remote) killDaemon() {
+func (r *Daemon) killDaemon() {
 	// Try to get a stack trace
 	_ = syscall.Kill(r.daemonPid, syscall.SIGUSR1)
 	<-time.After(100 * time.Millisecond)
 	_ = process.Kill(r.daemonPid)
 }
 
-func (r *remote) platformCleanup() {
+func (r *Daemon) platformCleanup() {
 	_ = os.Remove(r.Address())
 }

--- a/daemon/internal/containerd/server/supervisor/remote_daemon_options.go
+++ b/daemon/internal/containerd/server/supervisor/remote_daemon_options.go
@@ -60,7 +60,6 @@ func WithDetectLocalBinary() DaemonOpt {
 			return errors.Errorf("local containerd path found (%s), but is a directory", localBinary)
 		}
 		r.daemonPath = localBinary
-		r.logger.WithField("daemon path", r.daemonPath).Debug("Local containerd daemon found.")
 
 		return nil
 	}

--- a/daemon/internal/containerd/server/supervisor/remote_daemon_options.go
+++ b/daemon/internal/containerd/server/supervisor/remote_daemon_options.go
@@ -10,13 +10,13 @@ import (
 
 // WithLogLevel defines which log level to start containerd with.
 func WithLogLevel(lvl string) DaemonOpt {
-	return func(r *remote) error {
+	return func(r *Daemon) error {
 		if lvl == "info" {
 			// both dockerd and containerd default log-level is "info",
 			// so don't pass the default.
 			lvl = ""
 		}
-		r.Config.Debug.Level = lvl
+		r.config.Debug.Level = lvl
 		return nil
 	}
 }
@@ -24,16 +24,16 @@ func WithLogLevel(lvl string) DaemonOpt {
 // WithLogFormat defines the containerd log format.
 // This only makes sense if WithStartDaemon() was set to true.
 func WithLogFormat(format log.OutputFormat) DaemonOpt {
-	return func(r *remote) error {
-		r.Debug.Format = string(format)
+	return func(r *Daemon) error {
+		r.config.Debug.Format = string(format)
 		return nil
 	}
 }
 
 // WithCRIDisabled disables the CRI plugin.
 func WithCRIDisabled() DaemonOpt {
-	return func(r *remote) error {
-		r.DisabledPlugins = append(r.DisabledPlugins, "io.containerd.grpc.v1.cri")
+	return func(r *Daemon) error {
+		r.config.DisabledPlugins = append(r.config.DisabledPlugins, "io.containerd.grpc.v1.cri")
 		return nil
 	}
 }
@@ -42,7 +42,7 @@ func WithCRIDisabled() DaemonOpt {
 // directory as the dockerd binary, and overrides the path of the containerd
 // binary to start if found. If no binary is found, no changes are made.
 func WithDetectLocalBinary() DaemonOpt {
-	return func(r *remote) error {
+	return func(r *Daemon) error {
 		dockerdPath, err := os.Executable()
 		if err != nil {
 			return errors.Wrap(err, "looking up binary path")

--- a/daemon/internal/containerd/server/supervisor/remote_daemon_windows.go
+++ b/daemon/internal/containerd/server/supervisor/remote_daemon_windows.go
@@ -20,7 +20,7 @@ func defaultDebugAddress(_ string) string {
 	return debugPipeName
 }
 
-func (r *remote) stopDaemon() {
+func (r *Daemon) stopDaemon() {
 	p, err := os.FindProcess(r.daemonPid)
 	if err != nil {
 		r.logger.WithField("pid", r.daemonPid).Warn("could not find containerd process")
@@ -39,10 +39,10 @@ func (r *remote) stopDaemon() {
 	}
 }
 
-func (r *remote) killDaemon() {
+func (r *Daemon) killDaemon() {
 	_ = process.Kill(r.daemonPid)
 }
 
-func (r *remote) platformCleanup() {
+func (r *Daemon) platformCleanup() {
 	// Nothing to do
 }

--- a/daemon/internal/containerd/server/supervisor/remote_daemon_windows.go
+++ b/daemon/internal/containerd/server/supervisor/remote_daemon_windows.go
@@ -12,29 +12,29 @@ const (
 	debugPipeName = `\\.\pipe\docker-containerd-debug`
 )
 
-func defaultGRPCAddress(stateDir string) string {
+func defaultGRPCAddress(_ string) string {
 	return grpcPipeName
 }
 
-func defaultDebugAddress(stateDir string) string {
+func defaultDebugAddress(_ string) string {
 	return debugPipeName
 }
 
 func (r *remote) stopDaemon() {
 	p, err := os.FindProcess(r.daemonPid)
 	if err != nil {
-		r.logger.WithField("pid", r.daemonPid).Warn("could not find daemon process")
+		r.logger.WithField("pid", r.daemonPid).Warn("could not find containerd process")
 		return
 	}
 
 	if err = p.Kill(); err != nil {
-		r.logger.WithError(err).WithField("pid", r.daemonPid).Warn("could not kill daemon process")
+		r.logger.WithError(err).WithField("pid", r.daemonPid).Warn("could not kill containerd process")
 		return
 	}
 
 	_, err = p.Wait()
 	if err != nil {
-		r.logger.WithError(err).WithField("pid", r.daemonPid).Warn("wait for daemon process")
+		r.logger.WithError(err).WithField("pid", r.daemonPid).Warn("wait for containerd process")
 		return
 	}
 }


### PR DESCRIPTION
### containerd: make shutdown waiting explicit

Always return a containerd shutdown wait function after successful
initialization, including when using an externally managed system containerd,
where the function is a no-op.

Use the returned function during the normal shutdown sequence, after the API
server has stopped, so managed and embedded containerd instances have finished
shutting down before tracing is torn down. Keep a deferred context cancellation
as a safeguard for early returns.

Bound OpenTelemetry shutdown to avoid blocking daemon shutdown indefinitely,
and defer returning ServeAPI errors until containerd and tracing shutdown have
completed.

Also report failures while waiting for containerd to stop instead of silently
discarding them.

### containerd: replace supervisor interface with concrete type

The containerd supervisor only has a single implementation, so the Daemon
interface does not provide a useful abstraction.

Replace it with the concrete Daemon type and keep its containerd
configuration private.


### containerd: split supervisor construction from start

Separate construction of the containerd supervisor from starting and
monitoring the daemon.

This allows callers to configure and inspect the supervisor before starting
it, and keeps runtime operations tied to the context passed to Start.


### containerd: clean up supervisor logging and errors

Make supervisor logging consistently refer to containerd and attach useful
process context, including the resolved binary path and containerd PID.

Also clean up error messages, explicitly ignore expected cleanup errors, and
mark unused Windows address parameters.


### containerd: simplify supervisor option construction

`getContainerdDaemonOpts` never returned an error; remove the error-return,
rename it to `supervisorOpts`, and inline it.


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
