### PR TITLE
containerd: fall back to embedded when binary is unavailable

### DIFF
--- a/daemon/command/daemon_unix.go
+++ b/daemon/command/daemon_unix.go
@@ -6,11 +6,13 @@ import (
 	"context"
 	"net"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strconv"
 	"time"
 
+	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon"
 	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/daemon/libnetwork/portallocator"
@@ -127,5 +129,10 @@ func (cli *daemonCLI) initContainerd(ctx context.Context) (func(time.Duration) e
 		return nopWaitFunc, nil
 	}
 
-	return cli.initializeContainerd(ctx)
+	waitTimeout, err := cli.initializeContainerd(ctx)
+	if errors.Is(err, exec.ErrNotFound) {
+		log.G(ctx).WithError(err).Info("containerd binary not found, starting embedded containerd")
+		return cli.initEmbeddedContainerd(ctx)
+	}
+	return waitTimeout, err
 }

--- a/daemon/command/daemon_windows.go
+++ b/daemon/command/daemon_windows.go
@@ -2,8 +2,10 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -125,7 +127,12 @@ func (cli *daemonCLI) initContainerd(ctx context.Context) (func(time.Duration) e
 		return nopWaitFunc, nil
 	}
 
-	return cli.initializeContainerd(ctx)
+	waitTimeout, err := cli.initializeContainerd(ctx)
+	if errors.Is(err, exec.ErrNotFound) {
+		log.G(ctx).WithError(err).Info("containerd binary not found, starting embedded containerd")
+		return cli.initEmbeddedContainerd(ctx)
+	}
+	return waitTimeout, err
 }
 
 func validateCPURealtimeOptions(_ *config.Config) error {


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/moby/moby/pull/53387

----

### containerd: fall back to embedded when binary is unavailable

Fall back to the embedded containerd implementation when no system containerd
is configured or running and the managed containerd binary cannot be found.

Keep other managed-containerd startup failures fatal so configuration,
permission, and runtime errors are not silently masked by the fallback.

Apply the same behavior on Unix and Windows.

This moves the default fallback toward the embedded implementation, allowing
the managed-containerd path to be deprecated or removed in the future.

With this patch, the daemon can be started without the containerd binary present;

```bash
command -v containerd || echo 'containerd binary not found'
containerd binary not found

dockerd
INFO[2026-08-16T15:05:35.341440421Z] Starting up
INFO[2026-08-16T15:05:35.344028963Z] containerd not running, starting managed containerd
INFO[2026-08-16T15:05:35.344604171Z] containerd binary not found, starting embedded containerd  error="failed to find containerd binary: containerd: exec: \"containerd\": executable file not found in $PATH"
WARN[2026-08-16T15:05:35.344616963Z] Running with experimental embedded-containerd mode
INFO[2026-08-16T15:05:35.344720338Z] starting embedded containerd server           address=/var/run/docker/containerd/containerd.sock
...
INFO[2026-08-16T15:05:36.191205463Z] Daemon has completed initialization
INFO[2026-08-16T15:05:36.191244088Z] API listen on /var/run/docker.sock
```

One thing worth noting is that it currently does not check for the shim to
be present; the daemon starts successfully;

```bash
command -v containerd-shim-runc-v2 || echo 'containerd shim not found'
containerd shim not found

dockerd
...
INFO[2026-08-16T15:05:36.191205463Z] Daemon has completed initialization
INFO[2026-08-16T15:05:36.191244088Z] API listen on /var/run/docker.sock
```

Pulling images also works, but the container fails to start;

```bash
docker run --rm --quiet alpine
docker: Error response from daemon: failed to create task for container: failed to start shim: failed to resolve runtime path: runtime "io.containerd.runc.v2" binary not installed "containerd-shim-runc-v2": file does not exist
```

Daemon logs;

```console
INFO[2026-08-16T15:08:56.091416375Z] image pulled                                  digest="sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b" remote="docker.io/library/alpine:latest"
ERRO[2026-08-16T15:08:56.134184333Z] copy stream failed                            error="reading from a closed fifo" stream=stdout
ERRO[2026-08-16T15:08:56.134201042Z] copy stream failed                            error="reading from a closed fifo" stream=stderr
ERRO[2026-08-16T15:08:56.139684375Z] Handler for POST /containers/{name:.*}/start returned error  error-response="failed to create task for container: failed to start shim: failed to resolve runtime path: runtime \"io.containerd.runc.v2\" binary not installed \"containerd-shim-runc-v2\": file does not exist" method=POST module=api request-url=/v1.55/containers/5cdb5c75a4c5e2b6f8a46c14258d9aded81d7e8fd824a1158d613f8704356ecd/start status=500 vars="map[name:5cdb5c75a4c5e2b6f8a46c14258d9aded81d7e8fd824a1158d613f8704356ecd version:1.55]"
INFO[2026-08-16T15:09:29.483493418Z] image pulled                                  digest="sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b" remote="docker.io/library/alpine:latest"
ERRO[2026-08-16T15:09:29.518634168Z] copy stream failed                            error="reading from a closed fifo" stream=stdout
ERRO[2026-08-16T15:09:29.518660043Z] copy stream failed                            error="reading from a closed fifo" stream=stderr
ERRO[2026-08-16T15:09:29.524466210Z] Handler for POST /containers/{name:.*}/start returned error  error-response="failed to create task for container: failed to start shim: failed to resolve runtime path: runtime \"io.containerd.runc.v2\" binary not installed \"containerd-shim-runc-v2\": file does not exist" method=POST module=api request-url=/v1.55/containers/6ca6224313a2bdc595d108702f89fe88abd97b6ebe021ddcc8b0dce402057cfa/start status=500 vars="map[name:6ca6224313a2bdc595d108702f89fe88abd97b6ebe021ddcc8b0dce402057cfa version:1.55]"
```



## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
dockerd now uses the embedded containerd if no system containerd service is configured and containerd is not installed.
```

## A picture of a cute animal (not mandatory but encouraged)
