### PR TITLE
integration-cli: retry Windows npipe connect EOF in TestRunTwoConcurrentContainers

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -800,7 +800,7 @@ func (s *DockerCLIRunSuite) TestRunUserNotFound(c *testing.T) {
 }
 
 func (s *DockerCLIRunSuite) TestRunTwoConcurrentContainers(c *testing.T) {
-	sleepTime := "2"
+	const sleepTime = "2"
 	group := sync.WaitGroup{}
 	group.Add(2)
 
@@ -808,8 +808,11 @@ func (s *DockerCLIRunSuite) TestRunTwoConcurrentContainers(c *testing.T) {
 	for range 2 {
 		go func() {
 			defer group.Done()
-			_, _, err := dockerCmdWithError("run", "busybox", "sleep", sleepTime)
-			errChan <- err
+			// Concurrent docker CLI processes dialing the Windows named pipe can
+			// intermittently fail with a connect-time EOF under CI load
+			// (https://github.com/moby/moby/issues/53343). Retry only that
+			// transient transport error so the test still exercises concurrency.
+			errChan <- runBusyboxSleepRetryConnectEOF(sleepTime)
 		}()
 	}
 
@@ -819,6 +822,32 @@ func (s *DockerCLIRunSuite) TestRunTwoConcurrentContainers(c *testing.T) {
 	for err := range errChan {
 		assert.NilError(c, err)
 	}
+}
+
+// runBusyboxSleepRetryConnectEOF starts a short-lived busybox container, retrying
+// only docker CLI "error during connect ... EOF" failures (Windows npipe flake).
+func runBusyboxSleepRetryConnectEOF(sleepTime string) error {
+	const maxAttempts = 3
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		_, _, err = dockerCmdWithError("run", "busybox", "sleep", sleepTime)
+		if err == nil || !isTransientDockerConnectEOF(err) {
+			return err
+		}
+		time.Sleep(time.Duration(attempt) * 200 * time.Millisecond)
+	}
+	return err
+}
+
+// isTransientDockerConnectEOF reports the Windows named-pipe connect EOF pattern:
+//
+//	docker: error during connect: Post "http://.../pipe/docker_engine/...": EOF
+func isTransientDockerConnectEOF(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "error during connect") && strings.Contains(msg, "EOF")
 }
 
 func (s *DockerCLIRunSuite) TestRunEnvironment(c *testing.T) {


### PR DESCRIPTION
## Summary

Hardens flaky `TestDockerCLIRunSuite/TestRunTwoConcurrentContainers` on Windows.

### Failure

On windows-2022 CI, one of two concurrent `docker run` calls intermittently fails with:

```text
docker: error during connect: Post "http://%2F%2F.%2Fpipe%2Fdocker_engine/v1.44/containers/create": EOF.
```

Exit code 125 after ~60s. Same class of Windows named-pipe transport flake as #49348 / #53269 (concurrent engine API traffic over `//./pipe/docker_engine` under CI load).

### Fix

Keep the concurrent launches (that is what this test covers). Retry each `docker run` up to 3 times **only** when the error matches the transient connect EOF pattern (`error during connect` + `EOF`). All other failures still fail the test immediately.

### Residual risk

- This does **not** fix a possible daemon/snapshotter root cause (e.g. slow concurrent create / VHD+boltdb contention on WCOW that can idle the npipe until EOF).
- If every attempt hangs ~60s before EOF, the test can still be slow or fail after 3 attempts.
- A create that actually succeeded server-side while the client saw EOF could leave an extra anonymous container; suite teardown cleans those up.

Fixes #53343

## Test plan

- [x] Localized change to existing integration-cli test only
- [ ] Windows CI: `TestDockerCLIRunSuite/TestRunTwoConcurrentContainers`
- [ ] Confirm Linux path unchanged in behavior (retries only on connect EOF, which is Windows-specific in practice)