### PR TITLE
daemon: opt-in capture of exec output through the container's logging driver

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -18,9 +18,10 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /containers/json` now supports an `annotation` filter to filter
   containers by annotation, either by key (`annotation=key`) or by key and
   value (`annotation="key=value"`), similar to the existing `label` filter.
-* `POST /containers/{id}/exec` now accepts a `CaptureLogs` boolean to tee the
-  exec process's `stdout` and `stderr` into the container's logging driver,
-  and a `Labels` map holding user-defined metadata for the exec instance.
+* `POST /containers/{id}/exec` now accepts `CaptureStdout` and `CaptureStderr`
+  booleans to tee the exec process's `stdout` and/or `stderr` into the
+  container's logging driver, and a `Labels` map holding user-defined
+  metadata for the exec instance.
   Captured output is recorded on dedicated `exec-stdout` / `exec-stderr`
   streams, kept apart from the container's own output: `GET
   /containers/{id}/logs` returns them only when requested through the new

--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -21,10 +21,16 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /containers/{id}/exec` now accepts a `CaptureLogs` boolean to tee the
   exec process's `stdout` and `stderr` into the container's logging driver,
   and a `Labels` map holding user-defined metadata for the exec instance.
-  Captured log messages carry the exec's identity (`exec_id` and any labels)
-  as per-message attributes, surfaced by the log endpoints when `details` is
-  requested. Labels are reported by `GET /exec/{id}/json` and attached to the
-  exec's lifecycle events.
+  Captured output is recorded on dedicated `exec-stdout` / `exec-stderr`
+  streams, kept apart from the container's own output: `GET
+  /containers/{id}/logs` returns them only when requested through the new
+  `exec-stdout` and `exec-stderr` query parameters, and the multiplexed
+  stream format identifies their frames with the new stream types `4`
+  (exec stdout) and `5` (exec stderr). Captured log messages additionally
+  carry the exec's identity (`exec_id` and any labels) as per-message
+  attributes, surfaced by the log endpoints when `details` is requested.
+  Labels are reported by `GET /exec/{id}/json` and attached to the exec's
+  lifecycle events.
 
 ## v1.55 API changes
 

--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -18,6 +18,13 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /containers/json` now supports an `annotation` filter to filter
   containers by annotation, either by key (`annotation=key`) or by key and
   value (`annotation="key=value"`), similar to the existing `label` filter.
+* `POST /containers/{id}/exec` now accepts a `CaptureLogs` boolean to tee the
+  exec process's `stdout` and `stderr` into the container's logging driver,
+  and a `Labels` map holding user-defined metadata for the exec instance.
+  Captured log messages carry the exec's identity (`exec_id` and any labels)
+  as per-message attributes, surfaced by the log endpoints when `details` is
+  requested. Labels are reported by `GET /exec/{id}/json` and attached to the
+  exec's lifecycle events.
 
 ## v1.55 API changes
 

--- a/api/pkg/stdcopy/stdcopy.go
+++ b/api/pkg/stdcopy/stdcopy.go
@@ -16,6 +16,9 @@ const (
 	Stdout    StdType = 1 // Stdout represents standard output stream.
 	Stderr    StdType = 2 // Stderr represents standard error steam.
 	Systemerr StdType = 3 // Systemerr represents errors originating from the system. When reading the stream with [StdCopy] it is returned as an error.
+
+	ExecStdout StdType = 4 // ExecStdout represents the standard output stream of an exec process whose output is captured in the container's logs. When reading the stream with [StdCopy] it is output on [Stdout].
+	ExecStderr StdType = 5 // ExecStderr represents the standard error stream of an exec process whose output is captured in the container's logs. When reading the stream with [StdCopy] it is output on [Stderr].
 )
 
 const (
@@ -34,11 +37,13 @@ const (
 // two streams, previously multiplexed using a writer created with
 // [NewStdWriter].
 //
-// As it reads from "multiplexedSource", StdCopy writes [Stdout] messages
-// to "destOut", and [Stderr] message to "destErr]. For backward-compatibility,
-// [Stdin] messages are output to "destOut". The [Systemerr] stream provides
-// errors produced by the daemon. It is returned as an error, and terminates
-// processing the stream.
+// As it reads from "multiplexedSource", StdCopy writes [Stdout] and
+// [ExecStdout] messages to "destOut", and [Stderr] and [ExecStderr] messages
+// to "destErr". For backward-compatibility, [Stdin] messages are output to
+// "destOut". The [Systemerr] stream provides errors produced by the daemon.
+// It is returned as an error, and terminates processing the stream. Callers
+// that need to tell exec output apart from the container's own output must
+// demultiplex the stream themselves based on the frame headers.
 //
 // StdCopy it reads until it hits [io.EOF] on "multiplexedSource", after
 // which it returns a nil error. In other words: any error returned indicates
@@ -79,10 +84,10 @@ func StdCopy(destOut, destErr io.Writer, multiplexedSource io.Reader) (written i
 		switch stream {
 		case Stdin:
 			fallthrough
-		case Stdout:
+		case Stdout, ExecStdout:
 			// Write on stdout
 			out = destOut
-		case Stderr:
+		case Stderr, ExecStderr:
 			// Write on stderr
 			out = destErr
 		case Systemerr:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8724,6 +8724,22 @@ paths:
           description: "Return logs from `stderr`"
           type: "boolean"
           default: false
+        - name: "exec-stdout"
+          in: "query"
+          description: |
+            Return the `stdout` stream of execs whose output was captured in
+            the container's logs (execs created with `CaptureLogs`). In the
+            multiplexed stream format these frames use stream type `4`.
+          type: "boolean"
+          default: false
+        - name: "exec-stderr"
+          in: "query"
+          description: |
+            Return the `stderr` stream of execs whose output was captured in
+            the container's logs (execs created with `CaptureLogs`). In the
+            multiplexed stream format these frames use stream type `5`.
+          type: "boolean"
+          default: false
         - name: "since"
           in: "query"
           description: "Only return logs since this time, as a UNIX timestamp"
@@ -11207,7 +11223,10 @@ paths:
                 default: false
                 description: |
                   Tee the exec process's `stdout` and `stderr` into the
-                  container's logging driver. Captured messages carry the
+                  container's logging driver. Captured output is recorded on
+                  dedicated `exec-stdout` / `exec-stderr` streams, returned by
+                  the container logs endpoint on request (`exec-stdout` and
+                  `exec-stderr` query parameters). Captured messages carry the
                   exec's identity (`exec_id` and any `Labels`) as per-message
                   attributes, surfaced by the log endpoints when `details`
                   is requested.

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8728,7 +8728,7 @@ paths:
           in: "query"
           description: |
             Return the `stdout` stream of execs whose output was captured in
-            the container's logs (execs created with `CaptureLogs`). In the
+            the container's logs (execs created with `CaptureStdout` / `CaptureStderr`). In the
             multiplexed stream format these frames use stream type `4`.
           type: "boolean"
           default: false
@@ -8736,7 +8736,7 @@ paths:
           in: "query"
           description: |
             Return the `stderr` stream of execs whose output was captured in
-            the container's logs (execs created with `CaptureLogs`). In the
+            the container's logs (execs created with `CaptureStdout` / `CaptureStderr`). In the
             multiplexed stream format these frames use stream type `5`.
           type: "boolean"
           default: false
@@ -11218,18 +11218,28 @@ paths:
               AttachStderr:
                 type: "boolean"
                 description: "Attach to `stderr` of the exec command."
-              CaptureLogs:
+              CaptureStdout:
                 type: "boolean"
                 default: false
                 description: |
-                  Tee the exec process's `stdout` and `stderr` into the
-                  container's logging driver. Captured output is recorded on
-                  dedicated `exec-stdout` / `exec-stderr` streams, returned by
-                  the container logs endpoint on request (`exec-stdout` and
-                  `exec-stderr` query parameters). Captured messages carry the
-                  exec's identity (`exec_id` and any `Labels`) as per-message
-                  attributes, surfaced by the log endpoints when `details`
-                  is requested.
+                  Tee the exec process's `stdout` into the container's
+                  logging driver. Captured output is recorded on the
+                  dedicated `exec-stdout` stream, returned by the container
+                  logs endpoint on request (`exec-stdout` query parameter).
+                  Captured messages carry the exec's identity (`exec_id` and
+                  any `Labels`) as per-message attributes, surfaced by the
+                  log endpoints when `details` is requested.
+              CaptureStderr:
+                type: "boolean"
+                default: false
+                description: |
+                  Tee the exec process's `stderr` into the container's
+                  logging driver. Captured output is recorded on the
+                  dedicated `exec-stderr` stream, returned by the container
+                  logs endpoint on request (`exec-stderr` query parameter).
+                  Captured messages carry the exec's identity (`exec_id` and
+                  any `Labels`) as per-message attributes, surfaced by the
+                  log endpoints when `details` is requested.
               ConsoleSize:
                 type: "array"
                 description: "Initial console size, as an `[height, width]` array."
@@ -11266,7 +11276,7 @@ paths:
                   User-defined key/value metadata for the exec instance.
                   Reported by exec inspect, attached to the exec's lifecycle
                   events, and stamped on captured log messages when
-                  `CaptureLogs` is enabled.
+                  `CaptureStdout` or `CaptureStderr` is enabled.
                 additionalProperties:
                   type: "string"
               Privileged:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -11202,6 +11202,15 @@ paths:
               AttachStderr:
                 type: "boolean"
                 description: "Attach to `stderr` of the exec command."
+              CaptureLogs:
+                type: "boolean"
+                default: false
+                description: |
+                  Tee the exec process's `stdout` and `stderr` into the
+                  container's logging driver. Captured messages carry the
+                  exec's identity (`exec_id` and any `Labels`) as per-message
+                  attributes, surfaced by the log endpoints when `details`
+                  is requested.
               ConsoleSize:
                 type: "array"
                 description: "Initial console size, as an `[height, width]` array."
@@ -11231,6 +11240,15 @@ paths:
                 type: "array"
                 description: "Command to run, as a string or array of strings."
                 items:
+                  type: "string"
+              Labels:
+                type: "object"
+                description: |
+                  User-defined key/value metadata for the exec instance.
+                  Reported by exec inspect, attached to the exec's lifecycle
+                  events, and stamped on captured log messages when
+                  `CaptureLogs` is enabled.
+                additionalProperties:
                   type: "string"
               Privileged:
                 type: "boolean"
@@ -11395,6 +11413,13 @@ paths:
               Pid:
                 type: "integer"
                 description: "The system process ID for the exec process."
+              Labels:
+                type: "object"
+                description: |
+                  User-defined key/value metadata declared at exec create
+                  time.
+                additionalProperties:
+                  type: "string"
           examples:
             application/json:
               CanRemove: false

--- a/api/types/container/exec.go
+++ b/api/types/container/exec.go
@@ -22,6 +22,9 @@ type ExecInspectResponse struct {
 	ContainerID   string `json:"ContainerID"`
 	DetachKeys    []byte `json:"DetachKeys"`
 	Pid           int    `json:"Pid"`
+
+	// Labels holds the user-defined metadata declared at exec create time.
+	Labels map[string]string `json:"Labels,omitempty"`
 }
 
 // ExecProcessConfig holds information about the exec process

--- a/api/types/container/exec_create_request.go
+++ b/api/types/container/exec_create_request.go
@@ -14,4 +14,16 @@ type ExecCreateRequest struct {
 	Env          []string // Environment variables
 	WorkingDir   string   // Working directory
 	Cmd          []string // Execution commands and args
+
+	// CaptureLogs tees the exec process's stdout and stderr into the
+	// container's logging driver. Captured messages carry the exec's
+	// identity ("exec_id" and any Labels) as per-message attributes, so log
+	// readers can tell exec output apart from the container's main process
+	// output.
+	CaptureLogs bool `json:",omitempty"`
+
+	// Labels holds user-defined metadata for the exec instance. Labels are
+	// reported by exec inspect, attached to the exec's lifecycle events,
+	// and stamped on captured log messages when CaptureLogs is set.
+	Labels map[string]string `json:",omitempty"`
 }

--- a/api/types/container/exec_create_request.go
+++ b/api/types/container/exec_create_request.go
@@ -15,15 +15,23 @@ type ExecCreateRequest struct {
 	WorkingDir   string   // Working directory
 	Cmd          []string // Execution commands and args
 
-	// CaptureLogs tees the exec process's stdout and stderr into the
-	// container's logging driver. Captured messages carry the exec's
-	// identity ("exec_id" and any Labels) as per-message attributes, so log
-	// readers can tell exec output apart from the container's main process
-	// output.
-	CaptureLogs bool `json:",omitempty"`
+	// CaptureStdout tees the exec process's stdout into the container's
+	// logging driver, recorded on the dedicated "exec-stdout" stream.
+	// Captured messages carry the exec's identity ("exec_id" and any
+	// Labels) as per-message attributes, so log readers can tell exec
+	// output apart from the container's main process output.
+	CaptureStdout bool `json:",omitempty"`
+
+	// CaptureStderr tees the exec process's stderr into the container's
+	// logging driver, recorded on the dedicated "exec-stderr" stream.
+	// Captured messages carry the exec's identity ("exec_id" and any
+	// Labels) as per-message attributes, so log readers can tell exec
+	// output apart from the container's main process output.
+	CaptureStderr bool `json:",omitempty"`
 
 	// Labels holds user-defined metadata for the exec instance. Labels are
 	// reported by exec inspect, attached to the exec's lifecycle events,
-	// and stamped on captured log messages when CaptureLogs is set.
+	// and stamped on captured log messages when CaptureStdout or
+	// CaptureStderr is set.
 	Labels map[string]string `json:",omitempty"`
 }

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -24,10 +24,15 @@ type ExecCreateOptions struct {
 	WorkingDir   string      // Working directory
 	Cmd          []string    // Execution commands and args
 
-	// CaptureLogs tees the exec process's stdout and stderr into the
-	// container's logging driver, stamping each captured message with the
-	// exec's identity ("exec_id" and any Labels).
-	CaptureLogs bool
+	// CaptureStdout tees the exec process's stdout into the container's
+	// logging driver, recorded on the dedicated "exec-stdout" stream and
+	// stamped with the exec's identity ("exec_id" and any Labels).
+	CaptureStdout bool
+
+	// CaptureStderr tees the exec process's stderr into the container's
+	// logging driver, recorded on the dedicated "exec-stderr" stream and
+	// stamped with the exec's identity ("exec_id" and any Labels).
+	CaptureStderr bool
 
 	// Labels holds user-defined metadata for the exec instance.
 	Labels map[string]string
@@ -51,19 +56,20 @@ func (cli *Client) ExecCreate(ctx context.Context, containerID string, options E
 	}
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/exec", nil, nil, container.ExecCreateRequest{
-		User:         options.User,
-		Privileged:   options.Privileged,
-		Tty:          options.TTY,
-		ConsoleSize:  consoleSize,
-		AttachStdin:  options.AttachStdin,
-		AttachStderr: options.AttachStderr,
-		AttachStdout: options.AttachStdout,
-		DetachKeys:   options.DetachKeys,
-		Env:          options.Env,
-		WorkingDir:   options.WorkingDir,
-		Cmd:          options.Cmd,
-		CaptureLogs:  options.CaptureLogs,
-		Labels:       options.Labels,
+		User:          options.User,
+		Privileged:    options.Privileged,
+		Tty:           options.TTY,
+		ConsoleSize:   consoleSize,
+		AttachStdin:   options.AttachStdin,
+		AttachStderr:  options.AttachStderr,
+		AttachStdout:  options.AttachStdout,
+		DetachKeys:    options.DetachKeys,
+		Env:           options.Env,
+		WorkingDir:    options.WorkingDir,
+		Cmd:           options.Cmd,
+		CaptureStdout: options.CaptureStdout,
+		CaptureStderr: options.CaptureStderr,
+		Labels:        options.Labels,
 	})
 	defer ensureReaderClosed(resp)
 	if err != nil {

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -23,6 +23,14 @@ type ExecCreateOptions struct {
 	Env          []string    // Environment variables
 	WorkingDir   string      // Working directory
 	Cmd          []string    // Execution commands and args
+
+	// CaptureLogs tees the exec process's stdout and stderr into the
+	// container's logging driver, stamping each captured message with the
+	// exec's identity ("exec_id" and any Labels).
+	CaptureLogs bool
+
+	// Labels holds user-defined metadata for the exec instance.
+	Labels map[string]string
 }
 
 // ExecCreateResult holds the result of creating a container exec.
@@ -54,6 +62,8 @@ func (cli *Client) ExecCreate(ctx context.Context, containerID string, options E
 		Env:          options.Env,
 		WorkingDir:   options.WorkingDir,
 		Cmd:          options.Cmd,
+		CaptureLogs:  options.CaptureLogs,
+		Labels:       options.Labels,
 	})
 	defer ensureReaderClosed(resp)
 	if err != nil {
@@ -169,6 +179,9 @@ type ExecInspectResult struct {
 	Running     bool
 	ExitCode    int
 	PID         int
+
+	// Labels holds the user-defined metadata declared at exec create time.
+	Labels map[string]string
 }
 
 // ExecInspect returns information about a specific exec process on the docker host.
@@ -196,5 +209,6 @@ func (cli *Client) ExecInspect(ctx context.Context, execID string, options ExecI
 		Running:     response.Running,
 		ExitCode:    ec,
 		PID:         response.Pid,
+		Labels:      response.Labels,
 	}, nil
 }

--- a/client/container_logs.go
+++ b/client/container_logs.go
@@ -16,12 +16,14 @@ type ContainerLogsOptions struct {
 	ShowStderr bool
 
 	// ShowExecStdout requests the stdout stream of execs whose output was
-	// captured in the container's logs (execs created with CaptureLogs).
+	// captured in the container's logs (execs created with CaptureStdout /
+	// CaptureStderr).
 	// Requires API v1.56 or newer.
 	ShowExecStdout bool
 
 	// ShowExecStderr requests the stderr stream of execs whose output was
-	// captured in the container's logs (execs created with CaptureLogs).
+	// captured in the container's logs (execs created with CaptureStdout /
+	// CaptureStderr).
 	// Requires API v1.56 or newer.
 	ShowExecStderr bool
 

--- a/client/container_logs.go
+++ b/client/container_logs.go
@@ -14,6 +14,17 @@ import (
 type ContainerLogsOptions struct {
 	ShowStdout bool
 	ShowStderr bool
+
+	// ShowExecStdout requests the stdout stream of execs whose output was
+	// captured in the container's logs (execs created with CaptureLogs).
+	// Requires API v1.56 or newer.
+	ShowExecStdout bool
+
+	// ShowExecStderr requests the stderr stream of execs whose output was
+	// captured in the container's logs (execs created with CaptureLogs).
+	// Requires API v1.56 or newer.
+	ShowExecStderr bool
+
 	Since      string
 	Until      string
 	Timestamps bool
@@ -45,16 +56,19 @@ type ContainerLogsResult interface {
 //
 //	[8]byte{STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4}[]byte{OUTPUT}
 //
-// STREAM_TYPE can be 1 for [Stdout] and 2 for [Stderr]. Refer to [stdcopy.StdType]
-// for details. SIZE1, SIZE2, SIZE3, and SIZE4 are four bytes of uint32 encoded
-// as big endian, this is the size of OUTPUT. You can use [stdcopy.StdCopy]
-// to demultiplex this stream.
+// STREAM_TYPE can be 1 for [Stdout], 2 for [Stderr], and, when captured exec
+// output is requested (API v1.56+), 4 for [ExecStdout] and 5 for [ExecStderr].
+// Refer to [stdcopy.StdType] for details. SIZE1, SIZE2, SIZE3, and SIZE4 are
+// four bytes of uint32 encoded as big endian, this is the size of OUTPUT. You
+// can use [stdcopy.StdCopy] to demultiplex this stream.
 //
 // [stdcopy]: https://pkg.go.dev/github.com/moby/moby/api/pkg/stdcopy
 // [stdcopy.StdCopy]: https://pkg.go.dev/github.com/moby/moby/api/pkg/stdcopy#StdCopy
 // [stdcopy.StdType]: https://pkg.go.dev/github.com/moby/moby/api/pkg/stdcopy#StdType
 // [Stdout]: https://pkg.go.dev/github.com/moby/moby/api/pkg/stdcopy#Stdout
 // [Stderr]: https://pkg.go.dev/github.com/moby/moby/api/pkg/stdcopy#Stderr
+// [ExecStdout]: https://pkg.go.dev/github.com/moby/moby/api/pkg/stdcopy#ExecStdout
+// [ExecStderr]: https://pkg.go.dev/github.com/moby/moby/api/pkg/stdcopy#ExecStderr
 func (cli *Client) ContainerLogs(ctx context.Context, containerID string, options ContainerLogsOptions) (ContainerLogsResult, error) {
 	containerID, err := trimID("container", containerID)
 	if err != nil {
@@ -68,6 +82,18 @@ func (cli *Client) ContainerLogs(ctx context.Context, containerID string, option
 
 	if options.ShowStderr {
 		query.Set("stderr", "1")
+	}
+
+	if options.ShowExecStdout || options.ShowExecStderr {
+		if err := cli.requiresVersion(ctx, "1.56", "exec log streams"); err != nil {
+			return nil, err
+		}
+		if options.ShowExecStdout {
+			query.Set("exec-stdout", "1")
+		}
+		if options.ShowExecStderr {
+			query.Set("exec-stderr", "1")
+		}
 	}
 
 	if options.Since != "" {

--- a/daemon/container/exec.go
+++ b/daemon/container/exec.go
@@ -40,14 +40,17 @@ type ExecConfig struct {
 	Process      types.Process
 	ConsoleSize  *[2]uint
 
-	// CaptureLogs tees the exec's stdout and stderr into the container's
-	// logging driver, stamping each message with the exec's identity.
-	CaptureLogs bool
+	// CaptureStdout tees the exec's stdout into the container's logging
+	// driver, stamping each message with the exec's identity.
+	CaptureStdout bool
+	// CaptureStderr tees the exec's stderr into the container's logging
+	// driver, stamping each message with the exec's identity.
+	CaptureStderr bool
 	// Labels holds the user-defined metadata declared at exec create time.
 	Labels map[string]string
 	// LogCopier feeds the exec's output to the container's logging driver
-	// when CaptureLogs is set. Its copy goroutines terminate when the exec's
-	// streams are closed.
+	// when CaptureStdout or CaptureStderr is set. Its copy goroutines
+	// terminate when the exec's streams are closed.
 	LogCopier *logger.Copier
 }
 
@@ -63,7 +66,7 @@ func NewExecConfig(c *Container) *ExecConfig {
 
 // InitializeStdio is called by libcontainerd to connect the stdio.
 func (c *ExecConfig) InitializeStdio(iop *cio.DirectIO) (cio.IO, error) {
-	if c.CaptureLogs {
+	if c.CaptureStdout || c.CaptureStderr {
 		// Attach the log-capture pipes before the process's output starts
 		// flowing, so no early output is missed.
 		c.startLogCapture()

--- a/daemon/container/exec.go
+++ b/daemon/container/exec.go
@@ -11,6 +11,7 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/libcontainerd/types"
 	"github.com/moby/moby/v2/daemon/internal/stream"
 	"github.com/moby/moby/v2/daemon/internal/stringid"
+	"github.com/moby/moby/v2/daemon/logger"
 )
 
 // ExecConfig holds the configurations for execs. The Daemon keeps
@@ -38,6 +39,16 @@ type ExecConfig struct {
 	Env          []string
 	Process      types.Process
 	ConsoleSize  *[2]uint
+
+	// CaptureLogs tees the exec's stdout and stderr into the container's
+	// logging driver, stamping each message with the exec's identity.
+	CaptureLogs bool
+	// Labels holds the user-defined metadata declared at exec create time.
+	Labels map[string]string
+	// LogCopier feeds the exec's output to the container's logging driver
+	// when CaptureLogs is set. Its copy goroutines terminate when the exec's
+	// streams are closed.
+	LogCopier *logger.Copier
 }
 
 // NewExecConfig initializes the a new exec configuration
@@ -52,6 +63,11 @@ func NewExecConfig(c *Container) *ExecConfig {
 
 // InitializeStdio is called by libcontainerd to connect the stdio.
 func (c *ExecConfig) InitializeStdio(iop *cio.DirectIO) (cio.IO, error) {
+	if c.CaptureLogs {
+		// Attach the log-capture pipes before the process's output starts
+		// flowing, so no early output is missed.
+		c.startLogCapture()
+	}
 	c.StreamConfig.CopyToPipe(iop)
 
 	if c.StreamConfig.Stdin() == nil && !c.Tty && runtime.GOOS == "windows" {
@@ -67,7 +83,14 @@ func (c *ExecConfig) InitializeStdio(iop *cio.DirectIO) (cio.IO, error) {
 
 // CloseStreams closes the stdio streams for the exec
 func (c *ExecConfig) CloseStreams() error {
-	return c.StreamConfig.CloseStreams()
+	err := c.StreamConfig.CloseStreams()
+	if c.LogCopier != nil {
+		// Streams are closed: the copy goroutines drain to EOF; wait for
+		// them so every captured line reached the driver before the exec
+		// is reported as terminated.
+		c.LogCopier.Wait()
+	}
+	return err
 }
 
 // SetExitCode sets the exec config's exit code

--- a/daemon/container/exec_logs.go
+++ b/daemon/container/exec_logs.go
@@ -11,10 +11,10 @@ import (
 	"github.com/moby/moby/v2/daemon/server/backend"
 )
 
-// startLogCapture tees the exec's stdout and stderr into the container's
+// startLogCapture tees the exec's captured streams into the container's
 // logging driver, stamping each message with the exec's identity so log
 // readers can attribute the output. It is called from InitializeStdio when
-// the exec was created with CaptureLogs.
+// the exec was created with CaptureStdout or CaptureStderr.
 func (c *ExecConfig) startLogCapture() {
 	c.Container.Lock()
 	logDriver := c.Container.LogDriver
@@ -33,13 +33,19 @@ func (c *ExecConfig) startLogCapture() {
 
 	// The driver is shared with the container's own stdio copier; drivers
 	// already accept concurrent Log calls from the stdout and stderr copy
-	// goroutines, two more sources follow the same contract. Captured
-	// messages are recorded under dedicated stream names so log readers can
-	// serve exec output separately from the container's own output.
-	copier := logger.NewCopier(map[string]io.Reader{
-		"exec-stdout": c.StreamConfig.StdoutPipe(),
-		"exec-stderr": c.StreamConfig.StderrPipe(),
-	}, &execLogger{Logger: logDriver, attrs: attrs})
+	// goroutines, more sources follow the same contract. Captured messages
+	// are recorded under dedicated stream names so log readers can serve
+	// exec output separately from the container's own output. Pipes are
+	// only opened for the requested streams: an unread pipe would block the
+	// stream broadcaster.
+	srcs := make(map[string]io.Reader, 2)
+	if c.CaptureStdout {
+		srcs["exec-stdout"] = c.StreamConfig.StdoutPipe()
+	}
+	if c.CaptureStderr {
+		srcs["exec-stderr"] = c.StreamConfig.StderrPipe()
+	}
+	copier := logger.NewCopier(srcs, &execLogger{Logger: logDriver, attrs: attrs})
 	c.LogCopier = copier
 	copier.Run()
 }

--- a/daemon/container/exec_logs.go
+++ b/daemon/container/exec_logs.go
@@ -1,0 +1,57 @@
+package container
+
+import (
+	"context"
+	"io"
+	"maps"
+	"slices"
+
+	"github.com/containerd/log"
+	"github.com/moby/moby/v2/daemon/logger"
+	"github.com/moby/moby/v2/daemon/server/backend"
+)
+
+// startLogCapture tees the exec's stdout and stderr into the container's
+// logging driver, stamping each message with the exec's identity so log
+// readers can attribute the output. It is called from InitializeStdio when
+// the exec was created with CaptureLogs.
+func (c *ExecConfig) startLogCapture() {
+	c.Container.Lock()
+	logDriver := c.Container.LogDriver
+	c.Container.Unlock()
+	if logDriver == nil {
+		// Checked at exec create time; the driver can still be missing if
+		// the container is being torn down — nothing to capture into.
+		log.G(context.TODO()).WithField("exec", c.ID).Warn("no logging driver available, exec output will not be captured")
+		return
+	}
+
+	attrs := []backend.LogAttr{{Key: "exec_id", Value: c.ID}}
+	for _, k := range slices.Sorted(maps.Keys(c.Labels)) {
+		attrs = append(attrs, backend.LogAttr{Key: k, Value: c.Labels[k]})
+	}
+
+	// The driver is shared with the container's own stdio copier; drivers
+	// already accept concurrent Log calls from the stdout and stderr copy
+	// goroutines, two more sources follow the same contract.
+	copier := logger.NewCopier(map[string]io.Reader{
+		"stdout": c.StreamConfig.StdoutPipe(),
+		"stderr": c.StreamConfig.StderrPipe(),
+	}, &execLogger{Logger: logDriver, attrs: attrs})
+	c.LogCopier = copier
+	copier.Run()
+}
+
+// execLogger stamps the exec's identity on each captured message before
+// handing it to the container's logging driver.
+type execLogger struct {
+	logger.Logger
+	attrs []backend.LogAttr
+}
+
+// Log implements logger.Logger, decorating each message with the exec's
+// attributes.
+func (l *execLogger) Log(msg *logger.Message) error {
+	msg.Attrs = append(msg.Attrs, l.attrs...)
+	return l.Logger.Log(msg)
+}

--- a/daemon/container/exec_logs.go
+++ b/daemon/container/exec_logs.go
@@ -33,10 +33,12 @@ func (c *ExecConfig) startLogCapture() {
 
 	// The driver is shared with the container's own stdio copier; drivers
 	// already accept concurrent Log calls from the stdout and stderr copy
-	// goroutines, two more sources follow the same contract.
+	// goroutines, two more sources follow the same contract. Captured
+	// messages are recorded under dedicated stream names so log readers can
+	// serve exec output separately from the container's own output.
 	copier := logger.NewCopier(map[string]io.Reader{
-		"stdout": c.StreamConfig.StdoutPipe(),
-		"stderr": c.StreamConfig.StderrPipe(),
+		"exec-stdout": c.StreamConfig.StdoutPipe(),
+		"exec-stderr": c.StreamConfig.StderrPipe(),
 	}, &execLogger{Logger: logDriver, attrs: attrs})
 	c.LogCopier = copier
 	copier.Run()

--- a/daemon/container/exec_logs_test.go
+++ b/daemon/container/exec_logs_test.go
@@ -50,7 +50,8 @@ func TestStartLogCapture(t *testing.T) {
 	ctr.LogDriver = rec
 
 	ec := NewExecConfig(ctr)
-	ec.CaptureLogs = true
+	ec.CaptureStdout = true
+	ec.CaptureStderr = true
 	ec.Labels = map[string]string{"com.example.hook": "post_start"}
 	ec.startLogCapture()
 
@@ -76,10 +77,48 @@ func TestStartLogCapture(t *testing.T) {
 	assert.NilError(t, ec.CloseStreams())
 }
 
+// TestStartLogCaptureStderrOnly verifies that capture is per stream: with
+// only CaptureStderr set, stderr output is captured and stdout output is not.
+func TestStartLogCaptureStderrOnly(t *testing.T) {
+	rec := &recordingLogger{msgs: make(chan *logger.Message, 16)}
+	ctr := &Container{State: &State{}}
+	ctr.LogDriver = rec
+
+	ec := NewExecConfig(ctr)
+	ec.CaptureStderr = true
+	ec.startLogCapture()
+
+	_, err := ec.StreamConfig.Stdout().Write([]byte("ignored line\n"))
+	assert.NilError(t, err)
+	_, err = ec.StreamConfig.Stderr().Write([]byte("captured line\n"))
+	assert.NilError(t, err)
+
+	var msg *logger.Message
+	poll.WaitOn(t, func(poll.LogT) poll.Result {
+		select {
+		case msg = <-rec.msgs:
+			return poll.Success()
+		default:
+			return poll.Continue("no message captured yet")
+		}
+	})
+	assert.Check(t, is.Equal(string(msg.Line), "captured line"))
+	assert.Check(t, is.Equal(msg.Source, "exec-stderr"))
+
+	assert.NilError(t, ec.CloseStreams())
+	// the uncaptured stdout line never reached the driver
+	select {
+	case extra := <-rec.msgs:
+		t.Fatalf("unexpected captured message: %q from %s", extra.Line, extra.Source)
+	default:
+	}
+}
+
 func TestStartLogCaptureWithoutDriver(t *testing.T) {
 	ctr := &Container{State: &State{}}
 	ec := NewExecConfig(ctr)
-	ec.CaptureLogs = true
+	ec.CaptureStdout = true
+	ec.CaptureStderr = true
 	// no logging driver on the container: capture is skipped, not fatal
 	ec.startLogCapture()
 	assert.Check(t, ec.LogCopier == nil)

--- a/daemon/container/exec_logs_test.go
+++ b/daemon/container/exec_logs_test.go
@@ -1,0 +1,87 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/moby/moby/v2/daemon/logger"
+	"github.com/moby/moby/v2/daemon/server/backend"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/poll"
+)
+
+// recordingLogger captures every message handed to Log.
+type recordingLogger struct {
+	msgs chan *logger.Message
+}
+
+func (l *recordingLogger) Log(msg *logger.Message) error {
+	// Copy: the copier recycles messages through a pool after Log returns.
+	m := logger.NewMessage()
+	m.Line = append(m.Line, msg.Line...)
+	m.Source = msg.Source
+	m.Attrs = append(m.Attrs, msg.Attrs...)
+	l.msgs <- m
+	return nil
+}
+
+func (l *recordingLogger) Name() string { return "recording" }
+func (l *recordingLogger) Close() error { return nil }
+
+func TestExecLoggerStampsAttrs(t *testing.T) {
+	rec := &recordingLogger{msgs: make(chan *logger.Message, 1)}
+	l := &execLogger{Logger: rec, attrs: []backend.LogAttr{{Key: "exec_id", Value: "abc"}, {Key: "com.example.hook", Value: "post_start"}}}
+
+	err := l.Log(&logger.Message{Line: []byte("hello"), Source: "stdout"})
+	assert.NilError(t, err)
+	msg := <-rec.msgs
+	assert.Check(t, is.DeepEqual(msg.Attrs, []backend.LogAttr{
+		{Key: "exec_id", Value: "abc"},
+		{Key: "com.example.hook", Value: "post_start"},
+	}))
+}
+
+// TestStartLogCapture exercises the full capture path: bytes written to the
+// exec's stream reach the container's logging driver, stamped with the
+// exec's identity, and CloseStreams waits for the copy to drain.
+func TestStartLogCapture(t *testing.T) {
+	rec := &recordingLogger{msgs: make(chan *logger.Message, 16)}
+	ctr := &Container{State: &State{}}
+	ctr.LogDriver = rec
+
+	ec := NewExecConfig(ctr)
+	ec.CaptureLogs = true
+	ec.Labels = map[string]string{"com.example.hook": "post_start"}
+	ec.startLogCapture()
+
+	_, err := ec.StreamConfig.Stdout().Write([]byte("captured line\n"))
+	assert.NilError(t, err)
+
+	var msg *logger.Message
+	poll.WaitOn(t, func(poll.LogT) poll.Result {
+		select {
+		case msg = <-rec.msgs:
+			return poll.Success()
+		default:
+			return poll.Continue("no message captured yet")
+		}
+	})
+	assert.Check(t, is.Equal(string(msg.Line), "captured line"))
+	assert.Check(t, is.Equal(msg.Source, "stdout"))
+	assert.Check(t, is.DeepEqual(msg.Attrs, []backend.LogAttr{
+		{Key: "exec_id", Value: ec.ID},
+		{Key: "com.example.hook", Value: "post_start"},
+	}))
+
+	assert.NilError(t, ec.CloseStreams())
+}
+
+func TestStartLogCaptureWithoutDriver(t *testing.T) {
+	ctr := &Container{State: &State{}}
+	ec := NewExecConfig(ctr)
+	ec.CaptureLogs = true
+	// no logging driver on the container: capture is skipped, not fatal
+	ec.startLogCapture()
+	assert.Check(t, ec.LogCopier == nil)
+	assert.NilError(t, ec.CloseStreams())
+}

--- a/daemon/container/exec_logs_test.go
+++ b/daemon/container/exec_logs_test.go
@@ -67,7 +67,7 @@ func TestStartLogCapture(t *testing.T) {
 		}
 	})
 	assert.Check(t, is.Equal(string(msg.Line), "captured line"))
-	assert.Check(t, is.Equal(msg.Source, "stdout"))
+	assert.Check(t, is.Equal(msg.Source, "exec-stdout"))
 	assert.Check(t, is.DeepEqual(msg.Attrs, []backend.LogAttr{
 		{Key: "exec_id", Value: ec.ID},
 		{Key: "com.example.hook", Value: "post_start"},

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"runtime"
 	"strings"
 	"time"
@@ -92,6 +93,20 @@ func (daemon *Daemon) getActiveContainer(name string) (*container.Container, err
 	return ctr, nil
 }
 
+// execEventAttributes merges the exec's labels into event attributes.
+// Reserved keys (execID, exitCode) and container labels keep precedence over
+// exec labels: LogContainerEventWithAttributes copies container labels over
+// the attributes it receives, and the reserved keys are merged last here.
+func execEventAttributes(labels, attributes map[string]string) map[string]string {
+	if len(labels) == 0 {
+		return attributes
+	}
+	merged := make(map[string]string, len(labels)+len(attributes))
+	maps.Copy(merged, labels)
+	maps.Copy(merged, attributes)
+	return merged
+}
+
 // ContainerExecCreate sets up an exec in a running container.
 func (daemon *Daemon) ContainerExecCreate(name string, options *containertypes.ExecCreateRequest) (string, error) {
 	cntr, err := daemon.getActiveContainer(name)
@@ -156,9 +171,9 @@ func (daemon *Daemon) ContainerExecCreate(name string, options *containertypes.E
 	}
 
 	daemon.registerExecCommand(cntr, execConfig)
-	daemon.LogContainerEventWithAttributes(cntr, events.Action(string(events.ActionExecCreate)+": "+execConfig.Entrypoint+" "+strings.Join(execConfig.Args, " ")), map[string]string{
+	daemon.LogContainerEventWithAttributes(cntr, events.Action(string(events.ActionExecCreate)+": "+execConfig.Entrypoint+" "+strings.Join(execConfig.Args, " ")), execEventAttributes(execConfig.Labels, map[string]string{
 		"execID": execConfig.ID,
-	})
+	}))
 
 	return execConfig.ID, nil
 }
@@ -191,9 +206,9 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, optio
 	ec.Unlock()
 
 	log.G(ctx).Debugf("starting exec command %s in container %s", ec.ID, ec.Container.ID)
-	daemon.LogContainerEventWithAttributes(ec.Container, events.Action(string(events.ActionExecStart)+": "+ec.Entrypoint+" "+strings.Join(ec.Args, " ")), map[string]string{
+	daemon.LogContainerEventWithAttributes(ec.Container, events.Action(string(events.ActionExecStart)+": "+ec.Entrypoint+" "+strings.Join(ec.Args, " ")), execEventAttributes(ec.Labels, map[string]string{
 		"execID": ec.ID,
-	})
+	}))
 
 	defer func() {
 		if retErr != nil {
@@ -340,9 +355,9 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, optio
 			if _, ok := err.(term.EscapeError); !ok {
 				return errdefs.System(errors.Wrap(err, "exec attach failed"))
 			}
-			daemon.LogContainerEventWithAttributes(ec.Container, events.ActionExecDetach, map[string]string{
+			daemon.LogContainerEventWithAttributes(ec.Container, events.ActionExecDetach, execEventAttributes(ec.Labels, map[string]string{
 				"execID": ec.ID,
-			})
+			}))
 		}
 	}
 	return nil

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -135,6 +135,13 @@ func (daemon *Daemon) ContainerExecCreate(name string, options *containertypes.E
 	execConfig.Privileged = options.Privileged
 	execConfig.User = options.User
 	execConfig.WorkingDir = options.WorkingDir
+	execConfig.Labels = options.Labels
+	if options.CaptureLogs {
+		if cntr.HostConfig.LogConfig.Type == "none" {
+			return "", errdefs.InvalidParameter(errors.New("cannot capture exec output: container has no logging driver (log driver is \"none\")"))
+		}
+		execConfig.CaptureLogs = true
+	}
 
 	linkedEnv, err := daemon.setupLinkedContainers(cntr)
 	if err != nil {

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -151,11 +151,12 @@ func (daemon *Daemon) ContainerExecCreate(name string, options *containertypes.E
 	execConfig.User = options.User
 	execConfig.WorkingDir = options.WorkingDir
 	execConfig.Labels = options.Labels
-	if options.CaptureLogs {
+	if options.CaptureStdout || options.CaptureStderr {
 		if cntr.HostConfig.LogConfig.Type == "none" {
 			return "", errdefs.InvalidParameter(errors.New("cannot capture exec output: container has no logging driver (log driver is \"none\")"))
 		}
-		execConfig.CaptureLogs = true
+		execConfig.CaptureStdout = options.CaptureStdout
+		execConfig.CaptureStderr = options.CaptureStderr
 	}
 
 	linkedEnv, err := daemon.setupLinkedContainers(cntr)

--- a/daemon/exec_events_test.go
+++ b/daemon/exec_events_test.go
@@ -1,0 +1,27 @@
+package daemon
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestExecEventAttributes(t *testing.T) {
+	t.Run("labels merged under reserved keys", func(t *testing.T) {
+		got := execEventAttributes(
+			map[string]string{"com.example.hook": "post_start", "execID": "spoofed"},
+			map[string]string{"execID": "abc123"},
+		)
+		assert.Check(t, is.DeepEqual(got, map[string]string{
+			"com.example.hook": "post_start",
+			"execID":           "abc123",
+		}))
+	})
+
+	t.Run("no labels passes attributes through", func(t *testing.T) {
+		attrs := map[string]string{"execID": "abc123"}
+		got := execEventAttributes(nil, attrs)
+		assert.Check(t, is.DeepEqual(got, attrs))
+	})
+}

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -239,5 +239,6 @@ func (daemon *Daemon) ContainerExecInspect(id string) (*containertypes.ExecInspe
 		ContainerID: e.Container.ID,
 		DetachKeys:  e.DetachKeys,
 		Pid:         pid,
+		Labels:      e.Labels,
 	}, nil
 }

--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -129,11 +129,31 @@ func marshalMessage(msg *logger.Message, extra json.RawMessage, buf *bytes.Buffe
 	if msg.PLogMetaData == nil || (msg.PLogMetaData != nil && msg.PLogMetaData.Last) {
 		logLine = append(msg.Line, '\n')
 	}
+	rawAttrs := extra
+	if len(msg.Attrs) > 0 {
+		// Per-message attributes (e.g. an exec's identity) are merged over
+		// the static logger-level ones. The remarshal cost is only paid for
+		// messages that actually carry attributes.
+		attrs := make(map[string]string, len(msg.Attrs))
+		if len(extra) > 0 {
+			if err := json.Unmarshal(extra, &attrs); err != nil {
+				return errors.Wrap(err, "error decoding logger attributes")
+			}
+		}
+		for _, a := range msg.Attrs {
+			attrs[a.Key] = a.Value
+		}
+		merged, err := json.Marshal(attrs)
+		if err != nil {
+			return errors.Wrap(err, "error merging message attributes")
+		}
+		rawAttrs = merged
+	}
 	err := (&jsonlog.JSONLogs{
 		Log:      logLine,
 		Stream:   msg.Source,
 		Created:  msg.Timestamp,
-		RawAttrs: extra,
+		RawAttrs: rawAttrs,
 	}).MarshalJSONBuf(buf)
 	if err != nil {
 		return errors.Wrap(err, "error writing log message to buffer")

--- a/daemon/logger/jsonfilelog/jsonfilelog_test.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/logger/jsonfilelog/jsonlog"
+	"github.com/moby/moby/v2/daemon/server/backend"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -279,4 +280,37 @@ func TestJSONFileLoggerWithLabelsEnv(t *testing.T) {
 		"dc_region": "west",
 	}
 	assert.Check(t, is.DeepEqual(extra, expected))
+}
+
+// Per-message attributes must be merged over the logger-level static ones,
+// and messages without attributes must keep the zero-cost static path.
+func TestMarshalMessageMergesPerMessageAttrs(t *testing.T) {
+	extra := json.RawMessage(`{"static":"yes"}`)
+
+	var buf bytes.Buffer
+	msg := &logger.Message{
+		Line:      []byte("captured"),
+		Source:    "stdout",
+		Timestamp: time.Unix(0, 0).UTC(),
+		Attrs: []backend.LogAttr{
+			{Key: "exec_id", Value: "abc123"},
+			{Key: "com.example.hook", Value: "post_start"},
+		},
+	}
+	assert.NilError(t, marshalMessage(msg, extra, &buf))
+
+	var entry jsonlog.JSONLog
+	assert.NilError(t, json.Unmarshal(buf.Bytes(), &entry))
+	assert.DeepEqual(t, entry.Attrs, map[string]string{
+		"static":           "yes",
+		"exec_id":          "abc123",
+		"com.example.hook": "post_start",
+	})
+
+	// without per-message attrs, the static raw attributes are passed through
+	buf.Reset()
+	assert.NilError(t, marshalMessage(&logger.Message{Line: []byte("plain"), Source: "stdout"}, extra, &buf))
+	entry = jsonlog.JSONLog{}
+	assert.NilError(t, json.Unmarshal(buf.Bytes(), &entry))
+	assert.DeepEqual(t, entry.Attrs, map[string]string{"static": "yes"})
 }

--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -183,7 +183,19 @@ func messageToProto(msg *logger.Message, extra []*logdriver.LogAttr, proto *logd
 	} else {
 		proto.PartialLogMetadata = nil
 	}
-	proto.Attrs = extra
+	if len(msg.Attrs) > 0 {
+		// Per-message attributes (e.g. an exec's identity) are merged after
+		// the static logger-level ones. A fresh slice is required: appending
+		// to extra would mutate the shared backing array across messages.
+		attrs := make([]*logdriver.LogAttr, 0, len(extra)+len(msg.Attrs))
+		attrs = append(attrs, extra...)
+		for _, a := range msg.Attrs {
+			attrs = append(attrs, &logdriver.LogAttr{Key: a.Key, Value: a.Value})
+		}
+		proto.Attrs = attrs
+	} else {
+		proto.Attrs = extra
+	}
 }
 
 func protoToMessage(proto *logdriver.LogEntry) *logger.Message {

--- a/daemon/logger/local/local_test.go
+++ b/daemon/logger/local/local_test.go
@@ -140,3 +140,30 @@ func copyLogMessage(src *logger.Message) *logger.Message {
 	}
 	return dst
 }
+
+// Per-message attributes must be merged after the logger-level static ones
+// without mutating the shared static slice.
+func TestMessageToProtoMergesPerMessageAttrs(t *testing.T) {
+	static := []*logdriver.LogAttr{{Key: "static", Value: "yes"}}
+
+	var proto logdriver.LogEntry
+	var md logdriver.PartialLogEntryMetadata
+	msg := logger.Message{
+		Line:   []byte("captured"),
+		Source: "stdout",
+		Attrs:  []backend.LogAttr{{Key: "exec_id", Value: "abc123"}},
+	}
+	messageToProto(&msg, static, &proto, &md)
+
+	assert.Assert(t, is.Len(proto.Attrs, 2))
+	assert.Check(t, is.Equal(proto.Attrs[0].Key, "static"))
+	assert.Check(t, is.Equal(proto.Attrs[1].Key, "exec_id"))
+	assert.Check(t, is.Equal(proto.Attrs[1].Value, "abc123"))
+	// the shared static slice must be left untouched
+	assert.Assert(t, is.Len(static, 1))
+
+	// without per-message attrs, the static slice is used as-is
+	var proto2 logdriver.LogEntry
+	messageToProto(&logger.Message{Line: []byte("plain"), Source: "stdout"}, static, &proto2, &md)
+	assert.Assert(t, is.Len(proto2.Attrs, 1))
+}

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -35,7 +35,7 @@ func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, c
 		"container": containerName,
 	})
 
-	if !config.ShowStdout && !config.ShowStderr {
+	if !config.ShowStdout && !config.ShowStderr && !config.ShowExecStdout && !config.ShowExecStderr {
 		return nil, false, errdefs.InvalidParameter(errors.New("You must choose at least one stream"))
 	}
 	ctr, err := daemon.GetContainer(containerName)

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -209,6 +209,7 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei
 		}
 
 		exitCode := 127
+		var execLabels map[string]string
 		if execConfig := c.ExecCommands.Get(ei.ProcessID); execConfig != nil {
 			ec := int(ei.ExitCode)
 			execConfig.Lock()
@@ -232,6 +233,7 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei
 			}
 
 			exitCode = ec
+			execLabels = execConfig.Labels
 
 			// If the exec failed at start in such a way that containerd
 			// publishes an exit event for it, we will race processing the event
@@ -253,10 +255,10 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei
 				}()
 			}
 		}
-		daemon.LogContainerEventWithAttributes(c, events.ActionExecDie, map[string]string{
+		daemon.LogContainerEventWithAttributes(c, events.ActionExecDie, execEventAttributes(execLabels, map[string]string{
 			"execID":   ei.ProcessID,
 			"exitCode": strconv.Itoa(exitCode),
-		})
+		}))
 		return nil
 	case libcontainerdtypes.EventStart:
 		c.Lock()

--- a/daemon/server/backend/backend.go
+++ b/daemon/server/backend/backend.go
@@ -112,12 +112,18 @@ type ContainerListOptions struct {
 type ContainerLogsOptions struct {
 	ShowStdout bool
 	ShowStderr bool
-	Since      time.Time
-	Until      time.Time
-	Timestamps bool
-	Follow     bool
-	Tail       string
-	Details    bool
+	// ShowExecStdout selects the stdout stream of execs whose output was
+	// captured in the container's logs (execs created with CaptureLogs).
+	ShowExecStdout bool
+	// ShowExecStderr selects the stderr stream of execs whose output was
+	// captured in the container's logs (execs created with CaptureLogs).
+	ShowExecStderr bool
+	Since          time.Time
+	Until          time.Time
+	Timestamps     bool
+	Follow         bool
+	Tail           string
+	Details        bool
 }
 
 // ContainerStopOptions holds the options to stop or restart a container.

--- a/daemon/server/backend/backend.go
+++ b/daemon/server/backend/backend.go
@@ -113,10 +113,12 @@ type ContainerLogsOptions struct {
 	ShowStdout bool
 	ShowStderr bool
 	// ShowExecStdout selects the stdout stream of execs whose output was
-	// captured in the container's logs (execs created with CaptureLogs).
+	// captured in the container's logs (execs created with CaptureStdout /
+	// CaptureStderr).
 	ShowExecStdout bool
 	// ShowExecStderr selects the stderr stream of execs whose output was
-	// captured in the container's logs (execs created with CaptureLogs).
+	// captured in the container's logs (execs created with CaptureStdout /
+	// CaptureStderr).
 	ShowExecStderr bool
 	Since          time.Time
 	Until          time.Time

--- a/daemon/server/httputils/logstream/json_logstream.go
+++ b/daemon/server/httputils/logstream/json_logstream.go
@@ -45,6 +45,14 @@ func WriteJSON(ctx context.Context, w http.ResponseWriter, msgs <-chan *backend.
 				if config.ShowStderr {
 					jsonWriter.write(msg)
 				}
+			case "exec-stdout":
+				if config.ShowExecStdout {
+					jsonWriter.write(msg)
+				}
+			case "exec-stderr":
+				if config.ShowExecStderr {
+					jsonWriter.write(msg)
+				}
 			default:
 				// unknown source
 			}
@@ -77,7 +85,8 @@ type jsonLogMessage struct {
 	// When an alternate encoding is requested, this field is omitted.
 	Line string `json:"Line,omitempty"`
 
-	// Source identifies the originating stream ("stdout" or "stderr").
+	// Source identifies the originating stream ("stdout", "stderr",
+	// "exec-stdout" or "exec-stderr").
 	Source string `json:"Source,omitempty"`
 
 	// Timestamp is the time at which the log record was produced,

--- a/daemon/server/httputils/logstream/logstream.go
+++ b/daemon/server/httputils/logstream/logstream.go
@@ -33,9 +33,13 @@ func Write(ctx context.Context, w http.ResponseWriter, msgs <-chan *backend.LogM
 	outStream := io.Writer(wf)
 	errStream := outStream
 	sysErrStream := errStream
+	execOutStream := outStream
+	execErrStream := outStream
 	if mux {
 		sysErrStream = stdcopymux.NewStdWriter(outStream, stdcopy.Systemerr)
 		errStream = stdcopymux.NewStdWriter(outStream, stdcopy.Stderr)
+		execOutStream = stdcopymux.NewStdWriter(outStream, stdcopy.ExecStdout)
+		execErrStream = stdcopymux.NewStdWriter(outStream, stdcopy.ExecStderr)
 		outStream = stdcopymux.NewStdWriter(outStream, stdcopy.Stdout)
 	}
 
@@ -70,6 +74,16 @@ func Write(ctx context.Context, w http.ResponseWriter, msgs <-chan *backend.LogM
 			case "stderr":
 				if config.ShowStderr {
 					_, _ = errStream.Write(logLine)
+				}
+				continue
+			case "exec-stdout":
+				if config.ShowExecStdout {
+					_, _ = execOutStream.Write(logLine)
+				}
+				continue
+			case "exec-stderr":
+				if config.ShowExecStderr {
+					_, _ = execErrStream.Write(logLine)
 				}
 				continue
 			default:

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -200,8 +200,14 @@ func (c *containerRouter) getContainersLogs(ctx context.Context, w http.Response
 	// any error after the stream starts (i.e. container not found, wrong parameters)
 	// with the appropriate status code.
 	stdout, stderr := httputils.BoolValue(r, "stdout"), httputils.BoolValue(r, "stderr")
-	if !stdout && !stderr {
-		return errdefs.InvalidParameter(errors.New("must specify at least one of 'stdout' or 'stderr'"))
+	var execStdout, execStderr bool
+	if versions.GreaterThanOrEqualTo(httputils.VersionFromContext(ctx), "1.56") {
+		// Execs created with CaptureLogs record their output on dedicated
+		// "exec-stdout" / "exec-stderr" streams, returned only on request.
+		execStdout, execStderr = httputils.BoolValue(r, "exec-stdout"), httputils.BoolValue(r, "exec-stderr")
+	}
+	if !stdout && !stderr && !execStdout && !execStderr {
+		return errdefs.InvalidParameter(errors.New("must specify at least one of 'stdout', 'stderr', 'exec-stdout' or 'exec-stderr'"))
 	}
 
 	var since time.Time
@@ -241,14 +247,16 @@ func (c *containerRouter) getContainersLogs(ctx context.Context, w http.Response
 
 	containerName := vars["name"]
 	logsConfig := &backend.ContainerLogsOptions{
-		Follow:     httputils.BoolValue(r, "follow"),
-		Timestamps: httputils.BoolValue(r, "timestamps"),
-		Since:      since,
-		Until:      until,
-		Tail:       r.Form.Get("tail"),
-		ShowStdout: stdout,
-		ShowStderr: stderr,
-		Details:    httputils.BoolValue(r, "details"),
+		Follow:         httputils.BoolValue(r, "follow"),
+		Timestamps:     httputils.BoolValue(r, "timestamps"),
+		Since:          since,
+		Until:          until,
+		Tail:           r.Form.Get("tail"),
+		ShowStdout:     stdout,
+		ShowStderr:     stderr,
+		ShowExecStdout: execStdout,
+		ShowExecStderr: execStderr,
+		Details:        httputils.BoolValue(r, "details"),
 	}
 
 	msgs, tty, err := c.backend.ContainerLogs(ctx, containerName, logsConfig)

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -202,7 +202,7 @@ func (c *containerRouter) getContainersLogs(ctx context.Context, w http.Response
 	stdout, stderr := httputils.BoolValue(r, "stdout"), httputils.BoolValue(r, "stderr")
 	var execStdout, execStderr bool
 	if versions.GreaterThanOrEqualTo(httputils.VersionFromContext(ctx), "1.56") {
-		// Execs created with CaptureLogs record their output on dedicated
+		// Execs created with CaptureStdout / CaptureStderr record their output on dedicated
 		// "exec-stdout" / "exec-stderr" streams, returned only on request.
 		execStdout, execStderr = httputils.BoolValue(r, "exec-stdout"), httputils.BoolValue(r, "exec-stderr")
 	}

--- a/daemon/server/router/container/exec.go
+++ b/daemon/server/router/container/exec.go
@@ -54,6 +54,15 @@ func (c *containerRouter) postContainerExecCreate(ctx context.Context, w http.Re
 		// Not supported by API versions before 1.42
 		execConfig.ConsoleSize = nil
 	}
+	if versions.LessThan(version, "1.56") {
+		// CaptureLogs cannot be silently ignored: a client asking for the
+		// exec output to be captured must not believe it was when it wasn't.
+		if execConfig.CaptureLogs {
+			return errdefs.InvalidParameter(errors.New("CaptureLogs requires API v1.56 or newer"))
+		}
+		// Labels are pure metadata; dropped like ConsoleSize above.
+		execConfig.Labels = nil
+	}
 
 	// Register an instance of Exec in container.
 	id, err := c.backend.ContainerExecCreate(vars["name"], execConfig)

--- a/daemon/server/router/container/exec.go
+++ b/daemon/server/router/container/exec.go
@@ -55,10 +55,11 @@ func (c *containerRouter) postContainerExecCreate(ctx context.Context, w http.Re
 		execConfig.ConsoleSize = nil
 	}
 	if versions.LessThan(version, "1.56") {
-		// CaptureLogs cannot be silently ignored: a client asking for the
-		// exec output to be captured must not believe it was when it wasn't.
-		if execConfig.CaptureLogs {
-			return errdefs.InvalidParameter(errors.New("CaptureLogs requires API v1.56 or newer"))
+		// Capture requests cannot be silently ignored: a client asking for
+		// the exec output to be captured must not believe it was when it
+		// wasn't.
+		if execConfig.CaptureStdout || execConfig.CaptureStderr {
+			return errdefs.InvalidParameter(errors.New("CaptureStdout and CaptureStderr require API v1.56 or newer"))
 		}
 		// Labels are pure metadata; dropped like ConsoleSize above.
 		execConfig.Labels = nil

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -65,7 +65,7 @@ func (s *DockerAPISuite) TestLogsAPINoStdoutNorStderr(c *testing.T) {
 
 	_, err = apiClient.ContainerLogs(testutil.GetContext(c), name, client.ContainerLogsOptions{})
 	assert.ErrorType(c, err, cerrdefs.IsInvalidArgument)
-	assert.ErrorContains(c, err, "must specify at least one of 'stdout' or 'stderr'")
+	assert.ErrorContains(c, err, "must specify at least one of 'stdout', 'stderr', 'exec-stdout' or 'exec-stderr'")
 }
 
 // Regression test for #12704

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -436,10 +436,11 @@ func TestExecWithGroupAdd(t *testing.T) {
 	assert.Check(t, is.Equal(strings.TrimSpace(result.Stdout()), expected), "exec command not keeping additional groups w/ user")
 }
 
-// TestExecCaptureLogs exercises the CaptureLogs exec option: the exec's
-// stdout and stderr are teed into the container's logging driver on the
-// dedicated exec streams, each line stamped with the exec's identity,
-// retrievable through the container logs endpoint after the exec terminated.
+// TestExecCaptureLogs exercises the CaptureStdout/CaptureStderr exec
+// options: the exec's stdout and stderr are teed into the container's
+// logging driver on the dedicated exec streams, each line stamped with the
+// exec's identity, retrievable through the container logs endpoint after
+// the exec terminated.
 func TestExecCaptureLogs(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.56"), "requires API v1.56")
 	ctx := setupTest(t)
@@ -450,7 +451,8 @@ func TestExecCaptureLogs(t *testing.T) {
 	res, err := container.Exec(ctx, apiClient, cID,
 		[]string{"sh", "-c", "echo captured-stdout; echo captured-stderr >&2"},
 		func(o *client.ExecCreateOptions) {
-			o.CaptureLogs = true
+			o.CaptureStdout = true
+			o.CaptureStderr = true
 			o.Labels = map[string]string{"com.example.origin": "exec-capture-test"}
 		})
 	assert.NilError(t, err)

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -11,14 +12,17 @@ import (
 	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
+	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/api/types/common"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/pkg/versions"
 	"github.com/moby/moby/v2/integration/internal/build"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/internal/testutil/fakecontext"
 	req "github.com/moby/moby/v2/internal/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -430,4 +434,65 @@ func TestExecWithGroupAdd(t *testing.T) {
 
 	const expected = "uid=0(root) gid=0(root) groups=0(root),10(wheel),29(audio),50(staff),777"
 	assert.Check(t, is.Equal(strings.TrimSpace(result.Stdout()), expected), "exec command not keeping additional groups w/ user")
+}
+
+// TestExecCaptureLogs exercises the CaptureLogs exec option: the exec's
+// stdout and stderr are teed into the container's logging driver, each line
+// stamped with the exec's identity, retrievable through the container logs
+// endpoint after the exec terminated.
+func TestExecCaptureLogs(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.56"), "requires API v1.56")
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	cID := container.Run(ctx, t, apiClient)
+
+	res, err := container.Exec(ctx, apiClient, cID,
+		[]string{"sh", "-c", "echo captured-stdout; echo captured-stderr >&2"},
+		func(o *client.ExecCreateOptions) {
+			o.CaptureLogs = true
+			o.Labels = map[string]string{"com.example.origin": "exec-capture-test"}
+		})
+	assert.NilError(t, err)
+	res.AssertSuccess(t)
+
+	// the capture copier drains asynchronously from the exec's streams:
+	// poll the logs until both captured lines landed in the driver
+	var stdout, stderr string
+	poll.WaitOn(t, func(poll.LogT) poll.Result {
+		logs, err := apiClient.ContainerLogs(ctx, cID, client.ContainerLogsOptions{
+			ShowStdout: true,
+			ShowStderr: true,
+			Details:    true,
+		})
+		if err != nil {
+			return poll.Error(err)
+		}
+		defer logs.Close()
+		var outBuf, errBuf bytes.Buffer
+		if _, err := stdcopy.StdCopy(&outBuf, &errBuf, logs); err != nil {
+			return poll.Error(err)
+		}
+		stdout, stderr = outBuf.String(), errBuf.String()
+		if strings.Contains(stdout, "captured-stdout") && strings.Contains(stderr, "captured-stderr") {
+			return poll.Success()
+		}
+		return poll.Continue("captured exec output not in container logs yet")
+	})
+
+	// with details requested, the captured lines carry the exec's identity
+	for _, line := range []string{stdout, stderr} {
+		assert.Check(t, is.Contains(line, "com.example.origin=exec-capture-test"))
+		assert.Check(t, is.Contains(line, "exec_id="))
+	}
+
+	// exec inspect reports the labels
+	created, err := apiClient.ExecCreate(ctx, cID, client.ExecCreateOptions{
+		Cmd:    []string{"true"},
+		Labels: map[string]string{"com.example.origin": "exec-capture-test"},
+	})
+	assert.NilError(t, err)
+	inspect, err := apiClient.ExecInspect(ctx, created.ID, client.ExecInspectOptions{})
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(inspect.Labels, map[string]string{"com.example.origin": "exec-capture-test"}))
 }

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -437,9 +437,9 @@ func TestExecWithGroupAdd(t *testing.T) {
 }
 
 // TestExecCaptureLogs exercises the CaptureLogs exec option: the exec's
-// stdout and stderr are teed into the container's logging driver, each line
-// stamped with the exec's identity, retrievable through the container logs
-// endpoint after the exec terminated.
+// stdout and stderr are teed into the container's logging driver on the
+// dedicated exec streams, each line stamped with the exec's identity,
+// retrievable through the container logs endpoint after the exec terminated.
 func TestExecCaptureLogs(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.56"), "requires API v1.56")
 	ctx := setupTest(t)
@@ -461,9 +461,9 @@ func TestExecCaptureLogs(t *testing.T) {
 	var stdout, stderr string
 	poll.WaitOn(t, func(poll.LogT) poll.Result {
 		logs, err := apiClient.ContainerLogs(ctx, cID, client.ContainerLogsOptions{
-			ShowStdout: true,
-			ShowStderr: true,
-			Details:    true,
+			ShowExecStdout: true,
+			ShowExecStderr: true,
+			Details:        true,
 		})
 		if err != nil {
 			return poll.Error(err)
@@ -485,6 +485,20 @@ func TestExecCaptureLogs(t *testing.T) {
 		assert.Check(t, is.Contains(line, "com.example.origin=exec-capture-test"))
 		assert.Check(t, is.Contains(line, "exec_id="))
 	}
+
+	// the exec streams are opt-in: a plain stdout/stderr request returns
+	// only the container's own output
+	logs, err := apiClient.ContainerLogs(ctx, cID, client.ContainerLogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+	})
+	assert.NilError(t, err)
+	defer logs.Close()
+	var outBuf, errBuf bytes.Buffer
+	_, err = stdcopy.StdCopy(&outBuf, &errBuf, logs)
+	assert.NilError(t, err)
+	assert.Check(t, !strings.Contains(outBuf.String(), "captured-stdout"))
+	assert.Check(t, !strings.Contains(errBuf.String(), "captured-stderr"))
 
 	// exec inspect reports the labels
 	created, err := apiClient.ExecCreate(ctx, cID, client.ExecCreateOptions{

--- a/vendor/github.com/moby/moby/api/pkg/stdcopy/stdcopy.go
+++ b/vendor/github.com/moby/moby/api/pkg/stdcopy/stdcopy.go
@@ -16,6 +16,9 @@ const (
 	Stdout    StdType = 1 // Stdout represents standard output stream.
 	Stderr    StdType = 2 // Stderr represents standard error steam.
 	Systemerr StdType = 3 // Systemerr represents errors originating from the system. When reading the stream with [StdCopy] it is returned as an error.
+
+	ExecStdout StdType = 4 // ExecStdout represents the standard output stream of an exec process whose output is captured in the container's logs. When reading the stream with [StdCopy] it is output on [Stdout].
+	ExecStderr StdType = 5 // ExecStderr represents the standard error stream of an exec process whose output is captured in the container's logs. When reading the stream with [StdCopy] it is output on [Stderr].
 )
 
 const (
@@ -34,11 +37,13 @@ const (
 // two streams, previously multiplexed using a writer created with
 // [NewStdWriter].
 //
-// As it reads from "multiplexedSource", StdCopy writes [Stdout] messages
-// to "destOut", and [Stderr] message to "destErr]. For backward-compatibility,
-// [Stdin] messages are output to "destOut". The [Systemerr] stream provides
-// errors produced by the daemon. It is returned as an error, and terminates
-// processing the stream.
+// As it reads from "multiplexedSource", StdCopy writes [Stdout] and
+// [ExecStdout] messages to "destOut", and [Stderr] and [ExecStderr] messages
+// to "destErr". For backward-compatibility, [Stdin] messages are output to
+// "destOut". The [Systemerr] stream provides errors produced by the daemon.
+// It is returned as an error, and terminates processing the stream. Callers
+// that need to tell exec output apart from the container's own output must
+// demultiplex the stream themselves based on the frame headers.
 //
 // StdCopy it reads until it hits [io.EOF] on "multiplexedSource", after
 // which it returns a nil error. In other words: any error returned indicates
@@ -79,10 +84,10 @@ func StdCopy(destOut, destErr io.Writer, multiplexedSource io.Reader) (written i
 		switch stream {
 		case Stdin:
 			fallthrough
-		case Stdout:
+		case Stdout, ExecStdout:
 			// Write on stdout
 			out = destOut
-		case Stderr:
+		case Stderr, ExecStderr:
 			// Write on stderr
 			out = destErr
 		case Systemerr:

--- a/vendor/github.com/moby/moby/api/types/container/exec.go
+++ b/vendor/github.com/moby/moby/api/types/container/exec.go
@@ -22,6 +22,9 @@ type ExecInspectResponse struct {
 	ContainerID   string `json:"ContainerID"`
 	DetachKeys    []byte `json:"DetachKeys"`
 	Pid           int    `json:"Pid"`
+
+	// Labels holds the user-defined metadata declared at exec create time.
+	Labels map[string]string `json:"Labels,omitempty"`
 }
 
 // ExecProcessConfig holds information about the exec process

--- a/vendor/github.com/moby/moby/api/types/container/exec_create_request.go
+++ b/vendor/github.com/moby/moby/api/types/container/exec_create_request.go
@@ -14,4 +14,16 @@ type ExecCreateRequest struct {
 	Env          []string // Environment variables
 	WorkingDir   string   // Working directory
 	Cmd          []string // Execution commands and args
+
+	// CaptureLogs tees the exec process's stdout and stderr into the
+	// container's logging driver. Captured messages carry the exec's
+	// identity ("exec_id" and any Labels) as per-message attributes, so log
+	// readers can tell exec output apart from the container's main process
+	// output.
+	CaptureLogs bool `json:",omitempty"`
+
+	// Labels holds user-defined metadata for the exec instance. Labels are
+	// reported by exec inspect, attached to the exec's lifecycle events,
+	// and stamped on captured log messages when CaptureLogs is set.
+	Labels map[string]string `json:",omitempty"`
 }

--- a/vendor/github.com/moby/moby/api/types/container/exec_create_request.go
+++ b/vendor/github.com/moby/moby/api/types/container/exec_create_request.go
@@ -15,15 +15,23 @@ type ExecCreateRequest struct {
 	WorkingDir   string   // Working directory
 	Cmd          []string // Execution commands and args
 
-	// CaptureLogs tees the exec process's stdout and stderr into the
-	// container's logging driver. Captured messages carry the exec's
-	// identity ("exec_id" and any Labels) as per-message attributes, so log
-	// readers can tell exec output apart from the container's main process
-	// output.
-	CaptureLogs bool `json:",omitempty"`
+	// CaptureStdout tees the exec process's stdout into the container's
+	// logging driver, recorded on the dedicated "exec-stdout" stream.
+	// Captured messages carry the exec's identity ("exec_id" and any
+	// Labels) as per-message attributes, so log readers can tell exec
+	// output apart from the container's main process output.
+	CaptureStdout bool `json:",omitempty"`
+
+	// CaptureStderr tees the exec process's stderr into the container's
+	// logging driver, recorded on the dedicated "exec-stderr" stream.
+	// Captured messages carry the exec's identity ("exec_id" and any
+	// Labels) as per-message attributes, so log readers can tell exec
+	// output apart from the container's main process output.
+	CaptureStderr bool `json:",omitempty"`
 
 	// Labels holds user-defined metadata for the exec instance. Labels are
 	// reported by exec inspect, attached to the exec's lifecycle events,
-	// and stamped on captured log messages when CaptureLogs is set.
+	// and stamped on captured log messages when CaptureStdout or
+	// CaptureStderr is set.
 	Labels map[string]string `json:",omitempty"`
 }

--- a/vendor/github.com/moby/moby/client/container_exec.go
+++ b/vendor/github.com/moby/moby/client/container_exec.go
@@ -24,10 +24,15 @@ type ExecCreateOptions struct {
 	WorkingDir   string      // Working directory
 	Cmd          []string    // Execution commands and args
 
-	// CaptureLogs tees the exec process's stdout and stderr into the
-	// container's logging driver, stamping each captured message with the
-	// exec's identity ("exec_id" and any Labels).
-	CaptureLogs bool
+	// CaptureStdout tees the exec process's stdout into the container's
+	// logging driver, recorded on the dedicated "exec-stdout" stream and
+	// stamped with the exec's identity ("exec_id" and any Labels).
+	CaptureStdout bool
+
+	// CaptureStderr tees the exec process's stderr into the container's
+	// logging driver, recorded on the dedicated "exec-stderr" stream and
+	// stamped with the exec's identity ("exec_id" and any Labels).
+	CaptureStderr bool
 
 	// Labels holds user-defined metadata for the exec instance.
 	Labels map[string]string
@@ -51,19 +56,20 @@ func (cli *Client) ExecCreate(ctx context.Context, containerID string, options E
 	}
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/exec", nil, nil, container.ExecCreateRequest{
-		User:         options.User,
-		Privileged:   options.Privileged,
-		Tty:          options.TTY,
-		ConsoleSize:  consoleSize,
-		AttachStdin:  options.AttachStdin,
-		AttachStderr: options.AttachStderr,
-		AttachStdout: options.AttachStdout,
-		DetachKeys:   options.DetachKeys,
-		Env:          options.Env,
-		WorkingDir:   options.WorkingDir,
-		Cmd:          options.Cmd,
-		CaptureLogs:  options.CaptureLogs,
-		Labels:       options.Labels,
+		User:          options.User,
+		Privileged:    options.Privileged,
+		Tty:           options.TTY,
+		ConsoleSize:   consoleSize,
+		AttachStdin:   options.AttachStdin,
+		AttachStderr:  options.AttachStderr,
+		AttachStdout:  options.AttachStdout,
+		DetachKeys:    options.DetachKeys,
+		Env:           options.Env,
+		WorkingDir:    options.WorkingDir,
+		Cmd:           options.Cmd,
+		CaptureStdout: options.CaptureStdout,
+		CaptureStderr: options.CaptureStderr,
+		Labels:        options.Labels,
 	})
 	defer ensureReaderClosed(resp)
 	if err != nil {

--- a/vendor/github.com/moby/moby/client/container_exec.go
+++ b/vendor/github.com/moby/moby/client/container_exec.go
@@ -23,6 +23,14 @@ type ExecCreateOptions struct {
 	Env          []string    // Environment variables
 	WorkingDir   string      // Working directory
 	Cmd          []string    // Execution commands and args
+
+	// CaptureLogs tees the exec process's stdout and stderr into the
+	// container's logging driver, stamping each captured message with the
+	// exec's identity ("exec_id" and any Labels).
+	CaptureLogs bool
+
+	// Labels holds user-defined metadata for the exec instance.
+	Labels map[string]string
 }
 
 // ExecCreateResult holds the result of creating a container exec.
@@ -54,6 +62,8 @@ func (cli *Client) ExecCreate(ctx context.Context, containerID string, options E
 		Env:          options.Env,
 		WorkingDir:   options.WorkingDir,
 		Cmd:          options.Cmd,
+		CaptureLogs:  options.CaptureLogs,
+		Labels:       options.Labels,
 	})
 	defer ensureReaderClosed(resp)
 	if err != nil {
@@ -169,6 +179,9 @@ type ExecInspectResult struct {
 	Running     bool
 	ExitCode    int
 	PID         int
+
+	// Labels holds the user-defined metadata declared at exec create time.
+	Labels map[string]string
 }
 
 // ExecInspect returns information about a specific exec process on the docker host.
@@ -196,5 +209,6 @@ func (cli *Client) ExecInspect(ctx context.Context, execID string, options ExecI
 		Running:     response.Running,
 		ExitCode:    ec,
 		PID:         response.Pid,
+		Labels:      response.Labels,
 	}, nil
 }

--- a/vendor/github.com/moby/moby/client/container_logs.go
+++ b/vendor/github.com/moby/moby/client/container_logs.go
@@ -16,12 +16,14 @@ type ContainerLogsOptions struct {
 	ShowStderr bool
 
 	// ShowExecStdout requests the stdout stream of execs whose output was
-	// captured in the container's logs (execs created with CaptureLogs).
+	// captured in the container's logs (execs created with CaptureStdout /
+	// CaptureStderr).
 	// Requires API v1.56 or newer.
 	ShowExecStdout bool
 
 	// ShowExecStderr requests the stderr stream of execs whose output was
-	// captured in the container's logs (execs created with CaptureLogs).
+	// captured in the container's logs (execs created with CaptureStdout /
+	// CaptureStderr).
 	// Requires API v1.56 or newer.
 	ShowExecStderr bool
 

--- a/vendor/github.com/moby/moby/client/container_logs.go
+++ b/vendor/github.com/moby/moby/client/container_logs.go
@@ -14,6 +14,17 @@ import (
 type ContainerLogsOptions struct {
 	ShowStdout bool
 	ShowStderr bool
+
+	// ShowExecStdout requests the stdout stream of execs whose output was
+	// captured in the container's logs (execs created with CaptureLogs).
+	// Requires API v1.56 or newer.
+	ShowExecStdout bool
+
+	// ShowExecStderr requests the stderr stream of execs whose output was
+	// captured in the container's logs (execs created with CaptureLogs).
+	// Requires API v1.56 or newer.
+	ShowExecStderr bool
+
 	Since      string
 	Until      string
 	Timestamps bool
@@ -45,16 +56,19 @@ type ContainerLogsResult interface {
 //
 //	[8]byte{STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4}[]byte{OUTPUT}
 //
-// STREAM_TYPE can be 1 for [Stdout] and 2 for [Stderr]. Refer to [stdcopy.StdType]
-// for details. SIZE1, SIZE2, SIZE3, and SIZE4 are four bytes of uint32 encoded
-// as big endian, this is the size of OUTPUT. You can use [stdcopy.StdCopy]
-// to demultiplex this stream.
+// STREAM_TYPE can be 1 for [Stdout], 2 for [Stderr], and, when captured exec
+// output is requested (API v1.56+), 4 for [ExecStdout] and 5 for [ExecStderr].
+// Refer to [stdcopy.StdType] for details. SIZE1, SIZE2, SIZE3, and SIZE4 are
+// four bytes of uint32 encoded as big endian, this is the size of OUTPUT. You
+// can use [stdcopy.StdCopy] to demultiplex this stream.
 //
 // [stdcopy]: https://pkg.go.dev/github.com/moby/moby/api/pkg/stdcopy
 // [stdcopy.StdCopy]: https://pkg.go.dev/github.com/moby/moby/api/pkg/stdcopy#StdCopy
 // [stdcopy.StdType]: https://pkg.go.dev/github.com/moby/moby/api/pkg/stdcopy#StdType
 // [Stdout]: https://pkg.go.dev/github.com/moby/moby/api/pkg/stdcopy#Stdout
 // [Stderr]: https://pkg.go.dev/github.com/moby/moby/api/pkg/stdcopy#Stderr
+// [ExecStdout]: https://pkg.go.dev/github.com/moby/moby/api/pkg/stdcopy#ExecStdout
+// [ExecStderr]: https://pkg.go.dev/github.com/moby/moby/api/pkg/stdcopy#ExecStderr
 func (cli *Client) ContainerLogs(ctx context.Context, containerID string, options ContainerLogsOptions) (ContainerLogsResult, error) {
 	containerID, err := trimID("container", containerID)
 	if err != nil {
@@ -68,6 +82,18 @@ func (cli *Client) ContainerLogs(ctx context.Context, containerID string, option
 
 	if options.ShowStderr {
 		query.Set("stderr", "1")
+	}
+
+	if options.ShowExecStdout || options.ShowExecStderr {
+		if err := cli.requiresVersion(ctx, "1.56", "exec log streams"); err != nil {
+			return nil, err
+		}
+		if options.ShowExecStdout {
+			query.Set("exec-stdout", "1")
+		}
+		if options.ShowExecStderr {
+			query.Set("exec-stderr", "1")
+		}
 	}
 
 	if options.Since != "" {


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/53406

## Summary

The output of an exec exists only for whoever is attached while it runs: nothing reaches the container's logging driver, so there is no post-hoc way to know what an exec printed, nor to tell which exec a given line belonged to.

This implements the proposal from the issue above, in five self-contained commits:

- **api**: `POST /containers/{id}/exec` accepts `CaptureStdout` / `CaptureStderr` (opt-in tee of the exec's stdout and/or stderr into the container's logging driver, mirroring the `AttachStdout` / `AttachStderr` fields) and `Labels` (user-defined metadata, reported by exec inspect). Both gated on API v1.56: capture requests are rejected for older clients (a client asking for capture must not believe it happened when it didn't), `Labels` are dropped like `ConsoleSize` is for pre-1.42. Captured output is recorded on dedicated `exec-stdout` / `exec-stderr` log streams (stdcopy stream types 4 and 5), returned by `GET /containers/{id}/logs` only when requested through the new `exec-stdout` / `exec-stderr` query parameters.
- **daemon**: the capture mirrors the container's own `startLogging`: a `logger.Copier` attached to the exec's stream pipes in `InitializeStdio`, before output starts flowing. Each message is stamped with `exec_id` and the exec's labels as per-message attributes. `CloseStreams` drains the copier so every captured line reached the driver before the exec is reported terminated. Capture is rejected at create when the container's log driver is `none`. Healthcheck probes are execs too and do not opt in, keeping their periodic runs out of the logs.
- **daemon/logger**: `json-file` and `local` have per-entry attribute slots in their storage formats, but the write path only ever fed them the static logger-level attributes; per-message `Message.Attrs` are now merged over them (the read paths already decode them back, completing an existing round-trip). Messages without attributes keep the zero-cost static path.
- **daemon**: exec labels are attached to the `exec_create`/`exec_start`/`exec_detach`/`exec_die` events, so subscribers can attribute exec activity without correlating in-memory execIDs.
- **integration**: one success-case test — captured lines retrieved through the container logs endpoint on the right streams, stamped with the exec's identity under `details`; error cases are unit-tested.

Concrete consumer: Docker Compose lifecycle hooks (`post_start`/`pre_stop`) are execs; with this, `docker compose logs --hooks` becomes a stateless filter over the engine's own log stream (docker/compose#14088 / docker/compose#14091 carry that discussion).

## Release notes

```markdown changelog
Add `CaptureStdout`/`CaptureStderr` and `Labels` to exec create: opt in to capturing an exec's output through the container's logging driver, on dedicated log streams with per-message attribution.
```

Created with: Claude Code

## A picture of a cute animal

🦭

