### PR TITLE
vendor: github.com/mdlayher/socket v0.6.0, github.com/mdlayher/vsock v1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -233,7 +233,7 @@ require (
 	github.com/klauspost/compress v1.19.2 // indirect
 	github.com/knqyf263/go-plugin v0.9.0 // indirect
 	github.com/mdlayher/socket v0.6.0 // indirect
-	github.com/mdlayher/vsock v1.2.1 // indirect
+	github.com/mdlayher/vsock v1.3.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/sys/capability v0.4.0 // indirect
 	github.com/moby/sys/sequential v0.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -232,7 +232,7 @@ require (
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/klauspost/compress v1.19.2 // indirect
 	github.com/knqyf263/go-plugin v0.9.0 // indirect
-	github.com/mdlayher/socket v0.5.1 // indirect
+	github.com/mdlayher/socket v0.6.0 // indirect
 	github.com/mdlayher/vsock v1.2.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/sys/capability v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -508,8 +508,8 @@ github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxU
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mdlayher/netlink v1.7.2 h1:/UtM3ofJap7Vl4QWCPDGXY8d3GIY2UGSDbK+QWmY8/g=
 github.com/mdlayher/netlink v1.7.2/go.mod h1:xraEF7uJbxLhc5fpHL4cPe221LI2bdttWlU+ZGLfQSw=
-github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=
-github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
+github.com/mdlayher/socket v0.6.0 h1:ScZPaAGyO1icQnbFrhPM8mnXyMu9qukC1K4ZoM2IQKU=
+github.com/mdlayher/socket v0.6.0/go.mod h1:q7vozUAnxSqnjHc12Fik5yUKIzfZ8ITCfMkhOtE9z18=
 github.com/mdlayher/vsock v1.2.1 h1:pC1mTJTvjo1r9n9fbm7S1j04rCgCzhCOS5DY0zqHlnQ=
 github.com/mdlayher/vsock v1.2.1/go.mod h1:NRfCibel++DgeMD8z/hP+PPTjlNJsdPOmxcnENvE+SE=
 github.com/miekg/dns v1.1.73 h1:uhT8nJxmTrPJYClxVxTCX+CVn6qnzSiybRk72Z6DgrE=

--- a/go.sum
+++ b/go.sum
@@ -510,8 +510,8 @@ github.com/mdlayher/netlink v1.7.2 h1:/UtM3ofJap7Vl4QWCPDGXY8d3GIY2UGSDbK+QWmY8/
 github.com/mdlayher/netlink v1.7.2/go.mod h1:xraEF7uJbxLhc5fpHL4cPe221LI2bdttWlU+ZGLfQSw=
 github.com/mdlayher/socket v0.6.0 h1:ScZPaAGyO1icQnbFrhPM8mnXyMu9qukC1K4ZoM2IQKU=
 github.com/mdlayher/socket v0.6.0/go.mod h1:q7vozUAnxSqnjHc12Fik5yUKIzfZ8ITCfMkhOtE9z18=
-github.com/mdlayher/vsock v1.2.1 h1:pC1mTJTvjo1r9n9fbm7S1j04rCgCzhCOS5DY0zqHlnQ=
-github.com/mdlayher/vsock v1.2.1/go.mod h1:NRfCibel++DgeMD8z/hP+PPTjlNJsdPOmxcnENvE+SE=
+github.com/mdlayher/vsock v1.3.0 h1:bqQfZ1OznI03y6YiXp2sze05RVdzLn/zsfjnjd4+ivI=
+github.com/mdlayher/vsock v1.3.0/go.mod h1:WsuksavOvwCnV5UqGHUkvAvCy+Dqy81y4goKQTzxxNY=
 github.com/miekg/dns v1.1.73 h1:uhT8nJxmTrPJYClxVxTCX+CVn6qnzSiybRk72Z6DgrE=
 github.com/miekg/dns v1.1.73/go.mod h1:RW2Obtfd5NZHvOFe3zYG0W8koWOQtAzyHaLo8vASBuQ=
 github.com/mistifyio/go-zfs/v4 v4.0.0 h1:sU0+5dX45tdDK5xNZ3HBi95nxUc48FS92qbIZEvpAg4=

--- a/vendor/github.com/mdlayher/socket/.golangci.yml
+++ b/vendor/github.com/mdlayher/socket/.golangci.yml
@@ -1,0 +1,16 @@
+version: "2"
+linters:
+  enable:
+    - misspell
+    - modernize
+    - revive
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+formatters:
+  exclusions:
+    generated: lax

--- a/vendor/github.com/mdlayher/socket/CHANGELOG.md
+++ b/vendor/github.com/mdlayher/socket/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v0.5.2
+
+- [Improvement]: Bump build to Go 1.23.0. Note this is required for the latest
+  Go extended library versions.
+
 ## v0.5.1
 
 - [Improvement]: revert `go.mod` to Go 1.20 to [resolve an issue around Go

--- a/vendor/github.com/mdlayher/socket/accept4.go
+++ b/vendor/github.com/mdlayher/socket/accept4.go
@@ -1,5 +1,4 @@
 //go:build dragonfly || freebsd || illumos || linux
-// +build dragonfly freebsd illumos linux
 
 package socket
 

--- a/vendor/github.com/mdlayher/socket/conn.go
+++ b/vendor/github.com/mdlayher/socket/conn.go
@@ -120,7 +120,7 @@ func (c *Conn) ReadContext(ctx context.Context, b []byte) (int, error) {
 		b = b[:maxRW]
 	}
 
-	n, err := readT(c, ctx, "read", func(fd int) (int, error) {
+	n, err := readT(ctx, c, "read", func(fd int) (int, error) {
 		return unix.Read(fd, b)
 	})
 	if n == 0 && err == nil && c.facts.zeroReadIsEOF {
@@ -142,12 +142,12 @@ func (c *Conn) WriteContext(ctx context.Context, b []byte) (int, error) {
 	)
 
 	doErr := c.write(ctx, "write", func(fd int) error {
-		max := len(b)
-		if c.facts.isStream && max-nn > maxRW {
-			max = nn + maxRW
+		lenb := len(b)
+		if c.facts.isStream && lenb-nn > maxRW {
+			lenb = nn + maxRW
 		}
 
-		n, err = unix.Write(fd, b[nn:max])
+		n, err = unix.Write(fd, b[nn:lenb])
 		if n > 0 {
 			nn += n
 		}
@@ -418,7 +418,7 @@ func (c *Conn) Accept(ctx context.Context, flags int) (*Conn, unix.Sockaddr, err
 		sa  unix.Sockaddr
 	}
 
-	r, err := readT(c, ctx, sysAccept, func(fd int) (ret, error) {
+	r, err := readT(ctx, c, sysAccept, func(fd int) (ret, error) {
 		// Either accept(2) or accept4(2) depending on the OS.
 		nfd, sa, err := accept(fd, flags|socketFlags)
 		return ret{nfd, sa}, err
@@ -464,7 +464,7 @@ func (c *Conn) Connect(ctx context.Context, sa unix.Sockaddr) (unix.Sockaddr, er
 		// have an explicit WaitWrite call like internal/poll does, so we have
 		// to wait until the runtime calls the closure again to indicate we can
 		// write.
-		progress uint32
+		progress atomic.Uint32
 
 		// Capture closure sockaddr and error.
 		rsa unix.Sockaddr
@@ -472,7 +472,7 @@ func (c *Conn) Connect(ctx context.Context, sa unix.Sockaddr) (unix.Sockaddr, er
 	)
 
 	doErr := c.write(ctx, op, func(fd int) error {
-		if atomic.AddUint32(&progress, 1) == 1 {
+		if progress.Add(1) == 1 {
 			// First call: initiate connect.
 			return unix.Connect(fd, sa)
 		}
@@ -569,7 +569,7 @@ func (c *Conn) Recvmsg(ctx context.Context, p, oob []byte, flags int) (int, int,
 		from               unix.Sockaddr
 	}
 
-	r, err := readT(c, ctx, "recvmsg", func(fd int) (ret, error) {
+	r, err := readT(ctx, c, "recvmsg", func(fd int) (ret, error) {
 		n, oobn, recvflags, from, err := unix.Recvmsg(fd, p, oob, flags)
 		return ret{n, oobn, recvflags, from}, err
 	})
@@ -587,7 +587,7 @@ func (c *Conn) Recvfrom(ctx context.Context, p []byte, flags int) (int, unix.Soc
 		addr unix.Sockaddr
 	}
 
-	out, err := readT(c, ctx, "recvfrom", func(fd int) (ret, error) {
+	out, err := readT(ctx, c, "recvfrom", func(fd int) (ret, error) {
 		n, addr, err := unix.Recvfrom(fd, p, flags)
 		return ret{n, addr}, err
 	})
@@ -600,7 +600,7 @@ func (c *Conn) Recvfrom(ctx context.Context, p []byte, flags int) (int, unix.Soc
 
 // Sendmsg wraps sendmsg(2).
 func (c *Conn) Sendmsg(ctx context.Context, p, oob []byte, to unix.Sockaddr, flags int) (int, error) {
-	return writeT(c, ctx, "sendmsg", func(fd int) (int, error) {
+	return writeT(ctx, c, "sendmsg", func(fd int) (int, error) {
 		return unix.SendmsgN(fd, p, oob, to, flags)
 	})
 }
@@ -645,7 +645,7 @@ func (c *Conn) Shutdown(how int) error {
 // read wraps readT to execute a function and capture its error result. This is
 // a convenience wrapper for functions which don't return any extra values.
 func (c *Conn) read(ctx context.Context, op string, f func(fd int) error) error {
-	_, err := readT(c, ctx, op, func(fd int) (struct{}, error) {
+	_, err := readT(ctx, c, op, func(fd int) (struct{}, error) {
 		return struct{}{}, f(fd)
 	})
 	return err
@@ -654,7 +654,7 @@ func (c *Conn) read(ctx context.Context, op string, f func(fd int) error) error 
 // write executes f, a write function, against the associated file descriptor.
 // op is used to create an *os.SyscallError if the file descriptor is closed.
 func (c *Conn) write(ctx context.Context, op string, f func(fd int) error) error {
-	_, err := writeT(c, ctx, op, func(fd int) (struct{}, error) {
+	_, err := writeT(ctx, c, op, func(fd int) (struct{}, error) {
 		return struct{}{}, f(fd)
 	})
 	return err
@@ -662,7 +662,7 @@ func (c *Conn) write(ctx context.Context, op string, f func(fd int) error) error
 
 // readT executes c.rc.Read for op using the input function, returning a newly
 // allocated result T.
-func readT[T any](c *Conn, ctx context.Context, op string, f func(fd int) (T, error)) (T, error) {
+func readT[T any](ctx context.Context, c *Conn, op string, f func(fd int) (T, error)) (T, error) {
 	return rwT(c, rwContext[T]{
 		Context: ctx,
 		Type:    read,
@@ -673,7 +673,7 @@ func readT[T any](c *Conn, ctx context.Context, op string, f func(fd int) (T, er
 
 // writeT executes c.rc.Write for op using the input function, returning a newly
 // allocated result T.
-func writeT[T any](c *Conn, ctx context.Context, op string, f func(fd int) (T, error)) (T, error) {
+func writeT[T any](ctx context.Context, c *Conn, op string, f func(fd int) (T, error)) (T, error) {
 	return rwT(c, rwContext[T]{
 		Context: ctx,
 		Type:    write,
@@ -771,9 +771,7 @@ func rwT[T any](c *Conn, rw rwContext[T]) (T, error) {
 		//
 		// TODO(mdlayher): is it possible to detect a background context vs a
 		// context with possible future cancel?
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			select {
 			case <-rw.Context.Done():
@@ -784,7 +782,7 @@ func rwT[T any](c *Conn, rw rwContext[T]) (T, error) {
 			case <-doneC:
 				// Nothing to do.
 			}
-		}()
+		})
 	}
 
 	var (

--- a/vendor/github.com/mdlayher/socket/conn_linux.go
+++ b/vendor/github.com/mdlayher/socket/conn_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package socket
 

--- a/vendor/github.com/mdlayher/socket/netns_linux.go
+++ b/vendor/github.com/mdlayher/socket/netns_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package socket
 
@@ -65,7 +64,7 @@ func withNetNS(fd int, fn func() (*Conn, error)) (*Conn, error) {
 		// No more thread-local state manipulation; return the new Conn.
 		runtime.UnlockOSThread()
 		conn = c
-		return nil
+		return err
 	})
 
 	if err := eg.Wait(); err != nil {

--- a/vendor/github.com/mdlayher/socket/setbuffer_linux.go
+++ b/vendor/github.com/mdlayher/socket/setbuffer_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package socket
 

--- a/vendor/github.com/mdlayher/socket/typ_cloexec_nonblock.go
+++ b/vendor/github.com/mdlayher/socket/typ_cloexec_nonblock.go
@@ -1,5 +1,4 @@
 //go:build !darwin
-// +build !darwin
 
 package socket
 

--- a/vendor/github.com/mdlayher/vsock/.golangci.yml
+++ b/vendor/github.com/mdlayher/vsock/.golangci.yml
@@ -1,0 +1,21 @@
+version: "2"
+linters:
+  enable:
+    # - errorlint
+    - misspell
+    - modernize
+    - revive
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+        path: _test.go
+formatters:
+  exclusions:
+    generated: lax

--- a/vendor/github.com/mdlayher/vsock/CHANGELOG.md
+++ b/vendor/github.com/mdlayher/vsock/CHANGELOG.md
@@ -1,10 +1,16 @@
 # CHANGELOG
 
-# v1.2.1
+## v1.3.0
+
+- [Improvement]: Updated dependencies and now requires Go 1.25. (#63)
+- [Improvement]: Update to use net.ErrClosed error (#57)
+- [Tests]: Check for ENETUNREACH and ETIMEDOUT in tests (#54)
+
+## v1.2.1
 
 - [Improvement]: updated dependencies, test with Go 1.20.
 
-# v1.2.0
+## v1.2.0
 
 **This is the first release of package vsock that only supports Go 1.18+. Users
 on older versions of Go must use v1.1.1.**

--- a/vendor/github.com/mdlayher/vsock/conn_linux.go
+++ b/vendor/github.com/mdlayher/vsock/conn_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package vsock
 

--- a/vendor/github.com/mdlayher/vsock/fd_linux.go
+++ b/vendor/github.com/mdlayher/vsock/fd_linux.go
@@ -31,6 +31,6 @@ func isErrno(err error, errno int) bool {
 	}
 }
 
-func panicf(format string, a ...interface{}) {
+func panicf(format string, a ...any) {
 	panic(fmt.Sprintf(format, a...))
 }

--- a/vendor/github.com/mdlayher/vsock/listener_linux.go
+++ b/vendor/github.com/mdlayher/vsock/listener_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package vsock
 

--- a/vendor/github.com/mdlayher/vsock/vsock.go
+++ b/vendor/github.com/mdlayher/vsock/vsock.go
@@ -1,7 +1,6 @@
 package vsock
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -403,7 +402,7 @@ func opError(op string, err error, local, remote net.Addr) error {
 		//
 		// To rectify the differences, net.TCPConn uses an error with this text
 		// from internal/poll for the backing file already being closed.
-		err = errors.New("use of closed network connection")
+		err = net.ErrClosed
 	default:
 		// Nothing to do, return this directly.
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1047,8 +1047,8 @@ github.com/klauspost/compress/zstd/internal/xxhash
 # github.com/knqyf263/go-plugin v0.9.0
 ## explicit; go 1.24.0
 github.com/knqyf263/go-plugin/wasm
-# github.com/mdlayher/socket v0.5.1
-## explicit; go 1.20
+# github.com/mdlayher/socket v0.6.0
+## explicit; go 1.25.0
 github.com/mdlayher/socket
 # github.com/mdlayher/vsock v1.2.1
 ## explicit; go 1.20

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1050,8 +1050,8 @@ github.com/knqyf263/go-plugin/wasm
 # github.com/mdlayher/socket v0.6.0
 ## explicit; go 1.25.0
 github.com/mdlayher/socket
-# github.com/mdlayher/vsock v1.2.1
-## explicit; go 1.20
+# github.com/mdlayher/vsock v1.3.0
+## explicit; go 1.25.0
 github.com/mdlayher/vsock
 # github.com/miekg/dns v1.1.73
 ## explicit; go 1.25.0


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/53361

### vendor: github.com/mdlayher/socket v0.6.0

full diff: https://github.com/mdlayher/socket/compare/v0.5.1...v0.6.0

### vendor: github.com/mdlayher/vsock v1.3.0

full diff: https://github.com/mdlayher/vsock/compare/v1.2.1...v1.3.0



## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
