### PR TITLE
docs: add inspect.software health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The Moby Project
 ![GitHub License](https://img.shields.io/github/license/moby/moby)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/moby/moby/badge)](https://scorecard.dev/viewer/?uri=github.com/moby/moby)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10989/badge)](https://www.bestpractices.dev/projects/10989)
+[![inspect.software](https://raw.githubusercontent.com/inspect-software/badges/main/v1/m/moby/moby.svg)](https://inspect.software/software/moby/moby)
 
 
 ![Moby Project logo](docs/static_files/moby-project-logo.png "The Moby Project")


### PR DESCRIPTION
This PR adds the [inspect.software](https://inspect.software) health badge to the README.

**Why this PR?**
Your project ranks in the upper rating bands of our open-source health index (which measures maintainability, responsiveness, and security). This badge makes that standing objectively visible to your users. Our index is a free public good, and scores cannot be bought.

**Technical details:**
- **No tracking:** Static SVG served via GitHub's CDN. No JavaScript, no third-party tracking.
- **No maintenance:** The badge updates automatically after every inspection.
- **Transparent:** Links directly to [your full report](https://inspect.software/software/moby/moby), based on our open [methodology](https://inspect.software/methodology).

If you prefer to keep your README minimal, feel free to close this PR without replying. Your report will remain publicly available and up-to-date either way.
