### PR TITLE
[docker-29.x backport] update to go1.26.7

### DIFF
--- a/.github/workflows/.test-unit.yml
+++ b/.github/workflows/.test-unit.yml
@@ -22,7 +22,7 @@ on:
         required: false
 
 env:
-  GO_VERSION: "1.26.6"
+  GO_VERSION: "1.26.7"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   SETUP_BUILDX_VERSION: edge

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -30,7 +30,7 @@ on:
         required: false
 
 env:
-  GO_VERSION: "1.26.6"
+  GO_VERSION: "1.26.7"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   ITG_CLI_MATRIX_SIZE: 6

--- a/.github/workflows/.vm.yml
+++ b/.github/workflows/.vm.yml
@@ -19,7 +19,7 @@ on:
         default: ""
 
 env:
-  GO_VERSION: "1.26.6"
+  GO_VERSION: "1.26.7"
   TESTSTAT_VERSION: v0.1.25
   TEMPLATE_NAME: ${{ inputs.template }}
 

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -29,7 +29,7 @@ on:
         required: false
 
 env:
-  GO_VERSION: "1.26.6"
+  GO_VERSION: "1.26.7"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   WINDOWS_BASE_IMAGE: mcr.microsoft.com/windows/servercore

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -19,7 +19,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.26.6"
+  GO_VERSION: "1.26.7"
   DESTDIR: ./build
   SETUP_BUILDX_VERSION: edge
   SETUP_BUILDKIT_IMAGE: moby/buildkit:latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ on:
     - cron: '0 9 * * 4'
 
 env:
-  GO_VERSION: "1.26.6"
+  GO_VERSION: "1.26.7"
 
 jobs:
   codeql:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.26.6"
+  GO_VERSION: "1.26.7"
   GIT_PAGER: "cat"
   PAGER: "cat"
   SETUP_BUILDX_VERSION: edge

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ version: "2"
 
 run:
   # prevent golangci-lint from deducting the go version to lint for through go.mod,
-  go: "1.26.6"
+  go: "1.26.7"
   # Only supported with go modules enabled (build flag -mod=vendor only valid when using modules)
   # modules-download-mode: vendor
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.6
+ARG GO_VERSION=1.26.7
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"
 

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-ARG GO_VERSION=1.26.6
+ARG GO_VERSION=1.26.7
 
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -161,7 +161,7 @@ FROM ${WINDOWS_BASE_IMAGE}:${WINDOWS_BASE_IMAGE_TAG}
 # Use PowerShell as the default shell
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG GO_VERSION=1.26.6
+ARG GO_VERSION=1.26.7
 
 # GOTESTSUM_VERSION is the version of gotest.tools/gotestsum to install.
 ARG GOTESTSUM_VERSION=v1.13.0

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.6
+ARG GO_VERSION=1.26.7
 
 FROM golang:${GO_VERSION}-alpine AS base
 RUN apk add --no-cache bash make yamllint

--- a/hack/dockerfiles/generate-files.Dockerfile
+++ b/hack/dockerfiles/generate-files.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.6
+ARG GO_VERSION=1.26.7
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG PROTOC_VERSION=3.11.4
 

--- a/hack/dockerfiles/govulncheck.Dockerfile
+++ b/hack/dockerfiles/govulncheck.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.6
+ARG GO_VERSION=1.26.7
 ARG GOVULNCHECK_VERSION=v1.1.4
 ARG FORMAT=text
 


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/53413

- https://github.com/golang/go/issues?q=milestone%3AGo1.26.7+label%3ACherryPickApproved
- full diff: https://github.com/golang/go/compare/go1.26.6...go1.26.7

**- Description for the changelog**

```markdown changelog
Update Go runtime to [1.26.7](https://go.dev/doc/devel/release#go1.26.7)
```