### PR TITLE
daemon: only mark container manually-stopped on an actual stop signal

### DIFF
--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -78,6 +78,7 @@ func (daemon *Daemon) killWithSignal(ctx context.Context, container *containerpk
 	}
 
 	var unpause bool
+	var isStopSignal bool
 	if container.Config.StopSignal != "" && stopSignal != syscall.SIGKILL {
 		containerStopSignal, err := signal.ParseSignal(container.Config.StopSignal)
 		if err != nil {
@@ -86,13 +87,15 @@ func (daemon *Daemon) killWithSignal(ctx context.Context, container *containerpk
 		if containerStopSignal == stopSignal {
 			container.ExitOnNext()
 			unpause = container.State.Paused
+			isStopSignal = true
 		}
 	} else {
 		container.ExitOnNext()
 		unpause = container.State.Paused
+		isStopSignal = true
 	}
 
-	if !daemon.IsShuttingDown() {
+	if isStopSignal && !daemon.IsShuttingDown() {
 		container.HasBeenManuallyStopped = true
 		if err := container.CheckpointTo(ctx, daemon.containersReplica); err != nil {
 			log.G(ctx).WithFields(log.Fields{

--- a/daemon/kill_test.go
+++ b/daemon/kill_test.go
@@ -50,6 +50,69 @@ func (t *notFoundKillTask) Delete(ctx context.Context) (*containerd.ExitStatus, 
 	return nil, ctx.Err()
 }
 
+type noopKillTask struct {
+	libcontainerdtypes.Task
+}
+
+func (t *noopKillTask) Pid() uint32 {
+	return 1
+}
+
+func (t *noopKillTask) Kill(context.Context, syscall.Signal) error {
+	return nil
+}
+
+// TestKillWithSignalDoesNotMarkManuallyStoppedForNonStopSignal covers a real-world
+// pattern: a reverse proxy (docker-gen, nginx-proxy, etc.) sends a non-terminating
+// signal like SIGHUP via `docker kill` to trigger a config reload. That must not be
+// treated the same as a user running `docker stop` -- the container is still
+// running, and unless-stopped's restart policy relies on HasBeenManuallyStopped to
+// tell the two apart.
+func TestKillWithSignalDoesNotMarkManuallyStoppedForNonStopSignal(t *testing.T) {
+	task := &noopKillTask{}
+	ctr := container.NewBaseContainer(t.Name(), t.TempDir())
+	ctr.Config = &containertypes.Config{StopSignal: "SIGTERM"}
+	ctr.HostConfig = &containertypes.HostConfig{}
+	ctr.Lock()
+	ctr.State.SetRunning(nil, task, time.Now())
+	ctr.Unlock()
+
+	daemon := &Daemon{
+		EventsService: events.New(),
+	}
+
+	err := daemon.killWithSignal(t.Context(), ctr, syscall.SIGHUP)
+	assert.NilError(t, err)
+	assert.Equal(t, ctr.HasBeenManuallyStopped, false)
+}
+
+// TestKillWithSignalMarksManuallyStoppedForRealStopSignal is the flip side of
+// TestKillWithSignalDoesNotMarkManuallyStoppedForNonStopSignal: the container's
+// actual configured stop signal must still be treated as a real stop, so
+// unless-stopped correctly does not auto-restart it afterward.
+func TestKillWithSignalMarksManuallyStoppedForRealStopSignal(t *testing.T) {
+	task := &noopKillTask{}
+	ctr := container.NewBaseContainer(t.Name(), t.TempDir())
+	ctr.Config = &containertypes.Config{StopSignal: "SIGTERM"}
+	ctr.HostConfig = &containertypes.HostConfig{}
+	ctr.Lock()
+	ctr.State.SetRunning(nil, task, time.Now())
+	ctr.Unlock()
+
+	containersReplica, err := container.NewViewDB()
+	assert.NilError(t, err)
+	assert.NilError(t, containersReplica.Save(ctr))
+
+	daemon := &Daemon{
+		EventsService:     events.New(),
+		containersReplica: containersReplica,
+	}
+
+	err = daemon.killWithSignal(t.Context(), ctr, syscall.SIGTERM)
+	assert.NilError(t, err)
+	assert.Equal(t, ctr.HasBeenManuallyStopped, true)
+}
+
 func TestKillWithSignalWaitsIndefinitelyForDelayedExit(t *testing.T) {
 	task := &notFoundKillTask{deleteCalled: make(chan struct{})}
 	ctr := container.NewBaseContainer(t.Name(), t.TempDir())


### PR DESCRIPTION
## What this fixes

`killWithSignal()` in `daemon/kill.go` unconditionally sets `container.HasBeenManuallyStopped = true` for **any** signal sent through `docker kill` — including non-terminating ones like `SIGHUP`. `HasBeenManuallyStopped` is exactly the flag `unless-stopped`'s restart-policy check uses to decide "a human explicitly stopped this container, leave it alone." So a routine, non-terminating signal silently and permanently disables auto-restart for that container — both on a live crash and on daemon restore after being down — until a human manually runs `docker start`/`docker restart`.

A common real-world trigger: reverse-proxy / container-orchestration tools (`docker-gen`, `nginx-proxy`, and similar) send `SIGHUP` via `docker kill` to a running container to trigger a config reload — a completely normal, harmless action. Every such reload poisons that container's restart eligibility going forward.

## The code

The function already computes, a few lines earlier, whether a given signal is actually a terminating one — it's the same condition gating `container.ExitOnNext()`. This PR just reuses that computation for the flag instead of setting it unconditionally:

```go
 	var unpause bool
+	var isStopSignal bool
 	if container.Config.StopSignal != "" && stopSignal != syscall.SIGKILL {
 		containerStopSignal, err := signal.ParseSignal(container.Config.StopSignal)
 		if err != nil {
 			return err
 		}
 		if containerStopSignal == stopSignal {
 			container.ExitOnNext()
 			unpause = container.State.Paused
+			isStopSignal = true
 		}
 	} else {
 		container.ExitOnNext()
 		unpause = container.State.Paused
+		isStopSignal = true
 	}

-	if !daemon.IsShuttingDown() {
+	if isStopSignal && !daemon.IsShuttingDown() {
 		container.HasBeenManuallyStopped = true
 		...
```

That first commit still set the flag for every signal when the container has no `StopSignal` configured, which is most images (see the comment below). The second commit compares against `container.StopSignal()` there, which falls back to SIGTERM:

```go
	var isStopSignal bool
	if container.Config.StopSignal != "" && stopSignal != syscall.SIGKILL {
		containerStopSignal, err := signal.ParseSignal(container.Config.StopSignal)
		if err != nil {
			return err
		}
		isStopSignal = containerStopSignal == stopSignal
	} else {
		isStopSignal = stopSignal == syscall.SIGKILL || stopSignal == container.StopSignal()
	}

	var unpause bool
	if isStopSignal {
		container.ExitOnNext()
		unpause = container.State.Paused
	}

	if isStopSignal && !daemon.IsShuttingDown() {
		container.HasBeenManuallyStopped = true
		...
```

A `docker kill -s HUP` now leaves `HasBeenManuallyStopped` untouched unless HUP is the container's stop signal. SIGKILL, or the container's stop signal (SIGTERM when none is configured), still sets it.

## Why now

This is a long-standing, previously *partially* fixed bug:

- #11065 (2015) — original report: "Non-fatal signals break restart policies"
- #26087 (2016) — narrows it to `unless-stopped` specifically: "`unless-stopped` restart policy doesn't work well with `docker kill --signal`"
- #26464 — a fix landed, but explicitly scoped to `--restart=always` only; `unless-stopped` was left broken
- #41302 (2020) — same bug reported again, 4 years after the partial fix
- #47792 (2024) — same bug reported again, 9 years after the original report, still open

Four independent reports over a decade, one fix that explicitly excluded the affected policy. This PR closes the gap `#26464` left open.

## Testing

- Added `TestKillWithSignalDoesNotMarkManuallyStoppedForNonStopSignal` and `TestKillWithSignalMarksManuallyStoppedForRealStopSignal` in `daemon/kill_test.go`, covering both sides: a non-stop signal must not set the flag, and the container's stop signal or SIGKILL must still set it. Each runs with `StopSignal` set to `""`, `SIGTERM` and `SIGQUIT`. Both pass, along with the existing `TestKillWithSignalWaitsIndefinitelyForDelayedExit` / `TestKillWithSignalDetachesContext` (no regressions).
- Beyond the unit tests, this was built via the official `docker buildx bake binary` process and verified against a live `unless-stopped` container in production: `docker kill -s HUP` on a container with a different configured `StopSignal` left `HasBeenManuallyStopped` `false` (previously `true`), while a subsequent real `docker stop` correctly set it `true`. After the second commit, the same check passes on an `eclipse-mosquitto` container, which has no STOPSIGNAL.

