### PR TITLE
libn/d/overlay: don't remove in-use IPsec tunnels

### DIFF
--- a/daemon/libnetwork/drivers/overlay/ov_network.go
+++ b/daemon/libnetwork/drivers/overlay/ov_network.go
@@ -236,6 +236,12 @@ func (d *driver) DeleteNetwork(nid string) error {
 		}
 	}
 
+	// Endpoints are expected to have left before a network is deleted, which
+	// would have released the tunnel references via destroySandbox(). Nothing
+	// here enforces that, and the network object is about to become
+	// unreachable, so release anything it still holds.
+	n.releaseEncryptionRefs()
+
 	d.mu.Lock()
 	delete(d.networks, nid)
 	d.mu.Unlock()
@@ -327,6 +333,39 @@ func (n *network) destroySandbox() {
 		n.sbox.Destroy()
 		n.sbox = nil
 	}
+
+	// The kernel state the tunnel references were taken for is destroyed
+	// along with the sandbox, and the peer database is replayed through
+	// addNeighbor() the next time the sandbox is created, which takes fresh
+	// references.
+	n.releaseEncryptionRefs()
+}
+
+// releaseEncryptionRefs releases the IPsec tunnel references taken by
+// addNeighbor() for the peers programmed into the network's sandbox.
+//
+// addNeighbor() increments fdbCnt and takes a tunnel reference together, and
+// rolls both back together on failure, so fdbCnt is exactly the set of
+// references held by this network. They have to stay in lockstep: taking a
+// reference without incrementing fdbCnt, or vice versa, would break this.
+//
+// It is idempotent: a second call releases nothing.
+//
+// To be called while holding the network lock.
+func (n *network) releaseEncryptionRefs() {
+	if n.secure {
+		for k, cnt := range n.fdbCnt {
+			for range cnt {
+				if err := n.driver.removeEncryption(k.IP()); err != nil {
+					log.G(context.TODO()).WithFields(log.Fields{
+						"error": err,
+						"vtep":  k.IP(),
+					}).Warn("Failed to release encrypted tunnel reference")
+				}
+			}
+		}
+	}
+	clear(n.fdbCnt)
 }
 
 func populateVNITbl() {

--- a/daemon/libnetwork/drivers/overlay/ov_network_test.go
+++ b/daemon/libnetwork/drivers/overlay/ov_network_test.go
@@ -1,0 +1,129 @@
+//go:build linux
+
+package overlay
+
+import (
+	"errors"
+	"net/netip"
+	"testing"
+
+	"github.com/moby/moby/v2/daemon/libnetwork/internal/countmap"
+	"github.com/moby/moby/v2/daemon/libnetwork/internal/hashable"
+	"github.com/moby/moby/v2/daemon/libnetwork/osl"
+	"github.com/moby/moby/v2/internal/testutil/netnsutils"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+// newEncTestDriver returns a driver with the state setupEncryption and
+// removeEncryption need to run: an encryption key, and a data-plane address so
+// the driver can work out which iptables to program.
+func newEncTestDriver() *driver {
+	return &driver{
+		networks: networkTable{},
+		secMap:   encrMap{},
+		keys: []*key{
+			{value: []byte("0123456789abcdef0123456789abcdef"), tag: 1},
+		},
+		bindAddress:      netip.MustParseAddr("192.0.2.1"),
+		advertiseAddress: netip.MustParseAddr("192.0.2.1"),
+	}
+}
+
+func newEncTestNetwork(t *testing.T, d *driver, id string, secure bool) *network {
+	t.Helper()
+	n := &network{
+		id:     id,
+		driver: d,
+		secure: secure,
+		fdbCnt: countmap.Map[hashable.IPMAC]{},
+	}
+	d.networks[id] = n
+	return n
+}
+
+func mustMAC(s string) hashable.MACAddr {
+	mac, err := hashable.ParseMAC(s)
+	if err != nil {
+		panic(err)
+	}
+	return mac
+}
+
+// addPeer performs the bookkeeping addNeighbor does for a peer it programmed
+// successfully: one tunnel reference and one fdb reference.
+func addPeer(t *testing.T, n *network, vtep netip.Addr, mac hashable.MACAddr) {
+	t.Helper()
+	if n.secure {
+		assert.NilError(t, n.driver.setupEncryption(vtep))
+	}
+	n.fdbCnt.Add(hashable.IPMACFrom(vtep, mac), 1)
+}
+
+// withSandbox gives n a real network sandbox and a subnet, and marks both as
+// already initialised so joinSandbox is a no-op. The subnet names a VXLAN link
+// which does not exist, so programming a neighbor entry into the sandbox fails.
+func withSandbox(t *testing.T, n *network, key string) {
+	t.Helper()
+	sbox, err := osl.NewSandbox(osl.GenerateKey(key), true, false)
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = sbox.Destroy() })
+
+	n.sbox = sbox
+	n.sboxInit = true
+	n.subnets = []*subnet{{
+		sboxInit:  true,
+		vxlanName: "vx-absent",
+		subnetIP:  netip.MustParsePrefix("10.0.0.0/24"),
+	}}
+}
+
+// TestAddNeighborRollsBackEncryptionRef checks that addNeighbor does not leave
+// a tunnel reference behind when a later step fails.
+func TestAddNeighborRollsBackEncryptionRef(t *testing.T) {
+	defer netnsutils.SetupTestOSContext(t)()
+
+	d := newEncTestDriver()
+	n := newEncTestNetwork(t, d, "nid", true)
+	withSandbox(t, n, "addnbrollback")
+
+	vtep := netip.MustParseAddr("192.0.2.2")
+	err := n.addNeighbor(netip.MustParsePrefix("10.0.0.5/24"), mustMAC("02:42:0a:00:00:05"), vtep)
+
+	// The tunnel reference is taken before the neighbor entry is programmed,
+	// and the VXLAN link the entry needs does not exist.
+	assert.Check(t, is.ErrorContains(err, "could not add neighbor entry into the sandbox"))
+	assert.Check(t, is.Len(d.secMap, 0), "the tunnel reference should have been rolled back")
+	assert.Check(t, is.Len(n.fdbCnt, 0))
+}
+
+// TestDeleteNeighborUnprogrammedPeer checks that removing a peer entry whose
+// addNeighbor never succeeded does not release a tunnel reference it never
+// took. Releasing one would tear the tunnel down under an endpoint on the same
+// peer node which is still using it, putting its traffic on the wire in the
+// clear.
+func TestDeleteNeighborUnprogrammedPeer(t *testing.T) {
+	defer netnsutils.SetupTestOSContext(t)()
+
+	d := newEncTestDriver()
+	n := newEncTestNetwork(t, d, "nid", true)
+	withSandbox(t, n, "delnbunprog")
+
+	// A sibling endpoint on the same peer node was programmed successfully.
+	vtep := netip.MustParseAddr("192.0.2.2")
+	addPeer(t, n, vtep, mustMAC("02:42:0a:00:00:05"))
+	assert.Check(t, is.Equal(d.secMap[vtep].count, 1))
+
+	// This peer holds no references: its addNeighbor never got that far.
+	err := n.deleteNeighbor(netip.MustParsePrefix("10.0.0.6/24"), mustMAC("02:42:0a:00:00:06"), vtep)
+
+	// The reference check must run before any kernel state is touched, so the
+	// failure has to come from it and not from the neighbor delete below it.
+	assert.Check(t, is.ErrorContains(err, "fdb entry was not programmed into sandbox"))
+
+	var nserr osl.NeighborSearchError
+	assert.Check(t, errors.As(err, &nserr), "peerDelete keys its transient-case handling off this error type")
+	assert.Check(t, !nserr.Present)
+	assert.Check(t, is.Equal(d.secMap[vtep].count, 1), "the sibling's tunnel must not be torn down")
+	assert.Check(t, is.Len(n.fdbCnt, 1))
+}

--- a/daemon/libnetwork/drivers/overlay/ov_network_test.go
+++ b/daemon/libnetwork/drivers/overlay/ov_network_test.go
@@ -127,3 +127,115 @@ func TestDeleteNeighborUnprogrammedPeer(t *testing.T) {
 	assert.Check(t, is.Equal(d.secMap[vtep].count, 1), "the sibling's tunnel must not be torn down")
 	assert.Check(t, is.Len(n.fdbCnt, 1))
 }
+
+func TestReleaseEncryptionRefs(t *testing.T) {
+	defer netnsutils.SetupTestOSContext(t)()
+
+	d := newEncTestDriver()
+	n := newEncTestNetwork(t, d, "nid", true)
+
+	vtepA := netip.MustParseAddr("192.0.2.2")
+	vtepB := netip.MustParseAddr("192.0.2.3")
+
+	// Two endpoints hosted on peer A, one on peer B.
+	addPeer(t, n, vtepA, mustMAC("02:42:c0:00:02:0a"))
+	addPeer(t, n, vtepA, mustMAC("02:42:c0:00:02:0b"))
+	addPeer(t, n, vtepB, mustMAC("02:42:c0:00:02:0c"))
+
+	assert.Check(t, is.Equal(d.secMap[vtepA].count, 2))
+	assert.Check(t, is.Equal(d.secMap[vtepB].count, 1))
+	assert.Check(t, is.Len(n.fdbCnt, 3))
+
+	n.releaseEncryptionRefs()
+
+	assert.Check(t, is.Len(d.secMap, 0), "every tunnel reference should have been released")
+	assert.Check(t, is.Len(n.fdbCnt, 0))
+
+	// A second call must not release references the network no longer holds.
+	n.releaseEncryptionRefs()
+	assert.Check(t, is.Len(d.secMap, 0))
+}
+
+// TestReleaseEncryptionRefsScopedToNetwork checks that a network releases only
+// the references it took, not every reference outstanding for the peer. secMap
+// is scoped to the driver, so peers shared with another overlay network must
+// keep their tunnel.
+func TestReleaseEncryptionRefsScopedToNetwork(t *testing.T) {
+	defer netnsutils.SetupTestOSContext(t)()
+
+	d := newEncTestDriver()
+	n1 := newEncTestNetwork(t, d, "nid1", true)
+	n2 := newEncTestNetwork(t, d, "nid2", true)
+
+	vtep := netip.MustParseAddr("192.0.2.2")
+	addPeer(t, n1, vtep, mustMAC("02:42:c0:00:02:0a"))
+	addPeer(t, n2, vtep, mustMAC("02:42:c0:00:02:0b"))
+	assert.Check(t, is.Equal(d.secMap[vtep].count, 2))
+
+	n1.releaseEncryptionRefs()
+
+	assert.Check(t, is.Equal(d.secMap[vtep].count, 1), "the other network's reference should survive")
+	assert.Check(t, is.Len(n1.fdbCnt, 0))
+	assert.Check(t, is.Len(n2.fdbCnt, 1))
+}
+
+// TestReleaseEncryptionRefsUnencryptedNetwork checks that an unencrypted
+// network releases nothing: it never took a reference, and secMap is shared
+// with the encrypted networks on the same driver.
+func TestReleaseEncryptionRefsUnencryptedNetwork(t *testing.T) {
+	defer netnsutils.SetupTestOSContext(t)()
+
+	d := newEncTestDriver()
+	secure := newEncTestNetwork(t, d, "secure", true)
+	plain := newEncTestNetwork(t, d, "plain", false)
+
+	// Both networks have an endpoint on the same peer node.
+	vtep := netip.MustParseAddr("192.0.2.2")
+	addPeer(t, secure, vtep, mustMAC("02:42:c0:00:02:0a"))
+	addPeer(t, plain, vtep, mustMAC("02:42:c0:00:02:0b"))
+	assert.Check(t, is.Equal(d.secMap[vtep].count, 1))
+
+	plain.releaseEncryptionRefs()
+
+	assert.Check(t, is.Equal(d.secMap[vtep].count, 1), "an unencrypted network must not release tunnel references")
+	assert.Check(t, is.Len(plain.fdbCnt, 0))
+}
+
+// TestDestroySandboxReleasesEncryptionRefs checks that the references are
+// released even when there is no sandbox to tear down, so a network which
+// failed to create one cannot hold them forever.
+func TestDestroySandboxReleasesEncryptionRefs(t *testing.T) {
+	defer netnsutils.SetupTestOSContext(t)()
+
+	d := newEncTestDriver()
+	n := newEncTestNetwork(t, d, "nid", true)
+
+	vtep := netip.MustParseAddr("192.0.2.2")
+	addPeer(t, n, vtep, mustMAC("02:42:c0:00:02:0a"))
+	assert.Check(t, is.Equal(d.secMap[vtep].count, 1))
+
+	assert.Check(t, is.Nil(n.sbox))
+	n.destroySandbox()
+
+	assert.Check(t, is.Len(d.secMap, 0))
+	assert.Check(t, is.Len(n.fdbCnt, 0))
+}
+
+// TestDeleteNetworkReleasesEncryptionRefs checks the belt-and-braces release in
+// DeleteNetwork: the network object becomes unreachable once it is dropped from
+// d.networks, so anything it still holds has to go with it.
+func TestDeleteNetworkReleasesEncryptionRefs(t *testing.T) {
+	defer netnsutils.SetupTestOSContext(t)()
+
+	d := newEncTestDriver()
+	n := newEncTestNetwork(t, d, "nid", true)
+
+	vtep := netip.MustParseAddr("192.0.2.2")
+	addPeer(t, n, vtep, mustMAC("02:42:c0:00:02:0a"))
+	assert.Check(t, is.Equal(d.secMap[vtep].count, 1))
+
+	assert.NilError(t, d.DeleteNetwork("nid"))
+
+	assert.Check(t, is.Len(d.secMap, 0))
+	assert.Check(t, is.Len(d.networks, 0))
+}

--- a/daemon/libnetwork/drivers/overlay/peerdb.go
+++ b/daemon/libnetwork/drivers/overlay/peerdb.go
@@ -125,7 +125,8 @@ func (n *network) peerAdd(eid string, peerIP netip.Prefix, peerMac hashable.MACA
 	}
 	if vtep.IsValid() {
 		if err := n.addNeighbor(peerIP, peerMac, vtep); err != nil {
-			if dbEntries > 1 && errors.As(err, &osl.NeighborSearchError{}) {
+			var nserr osl.NeighborSearchError
+			if dbEntries > 1 && errors.As(err, &nserr) && nserr.Present {
 				// Conflicting neighbor entries are already programmed into the kernel and we are in the transient case.
 				// Upon deletion if the active configuration is deleted the next one from the database will be restored.
 				return nil
@@ -137,7 +138,7 @@ func (n *network) peerAdd(eid string, peerIP netip.Prefix, peerMac hashable.MACA
 }
 
 // addNeighbor programs the kernel so the given peer is reachable through the VXLAN tunnel.
-func (n *network) addNeighbor(peerIP netip.Prefix, peerMac hashable.MACAddr, vtep netip.Addr) error {
+func (n *network) addNeighbor(peerIP netip.Prefix, peerMac hashable.MACAddr, vtep netip.Addr) (retErr error) {
 	if n.sbox == nil {
 		// We are hitting this case for all the events that are arriving before that the sandbox
 		// is being created. The peer got already added into the database and the sandbox init will
@@ -156,18 +157,33 @@ func (n *network) addNeighbor(peerIP netip.Prefix, peerMac hashable.MACAddr, vte
 
 	if n.secure {
 		if err := n.driver.setupEncryption(vtep); err != nil {
-			log.G(context.TODO()).Warn(err)
+			return fmt.Errorf("could not setup encryption for peer %v: %w", vtep, err)
 		}
+		defer func() {
+			if retErr != nil {
+				if err := n.driver.removeEncryption(vtep); err != nil {
+					retErr = errors.Join(retErr, fmt.Errorf("could not roll back encryption for peer %v: %w", vtep, err))
+				}
+			}
+		}()
 	}
 
 	// Add neighbor entry for the peer IP
 	if err := n.sbox.AddNeighbor(peerIP.Addr().AsSlice(), peerMac.AsSlice(), osl.WithLinkName(s.vxlanName)); err != nil {
 		return fmt.Errorf("could not add neighbor entry into the sandbox: %w", err)
 	}
+	defer func() {
+		if retErr != nil {
+			if err := n.sbox.DeleteNeighbor(peerIP.Addr().AsSlice(), peerMac.AsSlice(), osl.WithLinkName(s.vxlanName)); err != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("could not roll back sandbox neighbor entry for %v: %w", peerIP, err))
+			}
+		}
+	}()
 
 	// Add fdb entry to the bridge for the peer mac
-	if n.fdbCnt.Add(hashable.IPMACFrom(vtep, peerMac), 1) == 1 {
-		if err := n.sbox.AddNeighbor(vtep.AsSlice(), peerMac.AsSlice(), osl.WithLinkName(s.vxlanName), osl.WithFamily(syscall.AF_BRIDGE)); err != nil {
+	if v := hashable.IPMACFrom(vtep, peerMac); n.fdbCnt.Add(v, 1) == 1 {
+		if err := n.sbox.SetNeighbor(vtep.AsSlice(), peerMac.AsSlice(), osl.WithLinkName(s.vxlanName), osl.WithFamily(syscall.AF_BRIDGE)); err != nil {
+			n.fdbCnt.Add(v, -1)
 			return fmt.Errorf("could not add fdb entry into the sandbox: %w", err)
 		}
 	}
@@ -228,26 +244,55 @@ func (n *network) deleteNeighbor(peerIP netip.Prefix, peerMac hashable.MACAddr, 
 		return nil
 	}
 
-	if n.secure {
-		if err := n.driver.removeEncryption(vtep); err != nil {
-			log.G(context.TODO()).Warn(err)
-		}
-	}
-
 	s := n.getSubnetforIP(peerIP)
 	if s == nil {
 		return fmt.Errorf("could not find the subnet %q in network %q", peerIP.String(), n.id)
 	}
-	// Remove fdb entry to the bridge for the peer mac
-	if n.fdbCnt.Add(hashable.IPMACFrom(vtep, peerMac), -1) == 0 {
-		if err := n.sbox.DeleteNeighbor(vtep.AsSlice(), peerMac.AsSlice(), osl.WithLinkName(s.vxlanName), osl.WithFamily(syscall.AF_BRIDGE)); err != nil {
-			return fmt.Errorf("could not delete fdb entry in the sandbox: %w", err)
-		}
+
+	fdbKey := hashable.IPMACFrom(vtep, peerMac)
+	if n.fdbCnt[fdbKey] == 0 {
+		err := osl.NeighborSearchError{IP: vtep.AsSlice(), MAC: peerMac.AsSlice(), LinkName: s.vxlanName, Present: false}
+		return fmt.Errorf("fdb entry was not programmed into sandbox: %w", err)
 	}
 
 	// Delete neighbor entry for the peer IP
 	if err := n.sbox.DeleteNeighbor(peerIP.Addr().AsSlice(), peerMac.AsSlice(), osl.WithLinkName(s.vxlanName)); err != nil {
-		return fmt.Errorf("could not delete neighbor entry in the sandbox:%v", err)
+		// If the entry is missing we can't be sure if it is because the
+		// neighbor entry we programmed disappeared out from under us,
+		// or because this entry was never programmed into the kernel
+		// and the fdbCnt reference belongs to another peer entry with
+		// the same MAC and VTEP. That entry would have to be for a
+		// different peer IP as the kernel matches neighbor deletes on
+		// the IP alone; the delete would have succeeded if the entry
+		// was for this peer's IP.
+		//
+		// Assume the latter and return early, without decrementing
+		// fdbCnt, so we don't risk decrementing another entry's
+		// reference and tear down an IPsec tunnel that is still in use.
+		// We leak the tunnel if our assumption is wrong, which is safer
+		// than breaking confidentiality.
+		return fmt.Errorf("could not delete neighbor entry in the sandbox: %w", err)
+	}
+
+	// Remove fdb entry to the bridge for the peer mac
+	if n.fdbCnt.Add(fdbKey, -1) == 0 {
+		err := n.sbox.DeleteNeighbor(vtep.AsSlice(), peerMac.AsSlice(), osl.WithLinkName(s.vxlanName), osl.WithFamily(syscall.AF_BRIDGE))
+		if err != nil && !errors.As(err, &osl.NeighborSearchError{}) {
+			// Deletion failed for a reason other than the entry
+			// being absent from the fdb.
+			n.fdbCnt.Add(fdbKey, 1)
+			return fmt.Errorf("could not delete fdb entry in the sandbox: %w", err)
+		}
+	}
+
+	// Decrement the reference count for the encrypted tunnel last so there
+	// is no opportunity for VXLAN datagrams to be sent in the clear. Note
+	// that control flow can only reach here if we succeeded in deleting the
+	// neighbor entry (and fdb entry, if applicable).
+	if n.secure {
+		if err := n.driver.removeEncryption(vtep); err != nil {
+			return fmt.Errorf("could not remove encryption for peer %v: %w", vtep, err)
+		}
 	}
 
 	return nil

--- a/daemon/libnetwork/osl/neigh_linux.go
+++ b/daemon/libnetwork/osl/neigh_linux.go
@@ -12,29 +12,29 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-// NeighborSearchError indicates that the neighbor is already present
+// NeighborSearchError indicates that the neighbor is missing or already present.
 type NeighborSearchError struct {
-	ip       net.IP
-	mac      net.HardwareAddr
-	linkName string
-	present  bool
+	IP       net.IP
+	MAC      net.HardwareAddr
+	LinkName string
+	Present  bool
 }
 
 func (n NeighborSearchError) Error() string {
 	var b strings.Builder
 	b.WriteString("neighbor entry ")
-	if n.present {
+	if n.Present {
 		b.WriteString("already exists ")
 	} else {
 		b.WriteString("not found ")
 	}
 	b.WriteString("for IP ")
-	b.WriteString(n.ip.String())
+	b.WriteString(n.IP.String())
 	b.WriteString(", mac ")
-	b.WriteString(n.mac.String())
-	if n.linkName != "" {
+	b.WriteString(n.MAC.String())
+	if n.LinkName != "" {
 		b.WriteString(", link ")
-		b.WriteString(n.linkName)
+		b.WriteString(n.LinkName)
 	}
 	return b.String()
 }
@@ -57,7 +57,7 @@ func (n *Namespace) DeleteNeighbor(dstIP net.IP, dstMac net.HardwareAddr, option
 			"error": err,
 		}).Warn("error deleting neighbor entry")
 		if errors.Is(err, os.ErrNotExist) {
-			return NeighborSearchError{dstIP, dstMac, linkName, false}
+			return NeighborSearchError{IP: dstIP, MAC: dstMac, LinkName: linkName}
 		}
 		return fmt.Errorf("could not delete neighbor %+v: %w", nlnh, err)
 	}
@@ -99,7 +99,7 @@ func (n *Namespace) AddNeighbor(dstIP net.IP, dstMac net.HardwareAddr, options .
 				"ifc":   linkName,
 				"neigh": fmt.Sprintf("%+v", nlnh),
 			}).Warn("Neighbor entry already present")
-			return NeighborSearchError{dstIP, dstMac, linkName, true}
+			return NeighborSearchError{IP: dstIP, MAC: dstMac, LinkName: linkName, Present: true}
 		} else {
 			return fmt.Errorf("could not add neighbor entry %+v: %w", nlnh, err)
 		}
@@ -110,6 +110,26 @@ func (n *Namespace) AddNeighbor(dstIP net.IP, dstMac net.HardwareAddr, options .
 		"mac": dstMac,
 		"ifc": linkName,
 	}).Debug("Neighbor entry added")
+
+	return nil
+}
+
+// SetNeighbor adds a neighbor entry into the sandbox or replaces an existing one.
+func (n *Namespace) SetNeighbor(dstIP net.IP, dstMac net.HardwareAddr, options ...NeighOption) error {
+	nlnh, linkName, err := n.nlNeigh(dstIP, dstMac, options...)
+	if err != nil {
+		return err
+	}
+
+	if err := n.nlHandle.NeighSet(nlnh); err != nil {
+		return fmt.Errorf("could not set neighbor entry %+v: %w", nlnh, err)
+	}
+
+	log.G(context.TODO()).WithFields(log.Fields{
+		"ip":  dstIP,
+		"mac": dstMac,
+		"ifc": linkName,
+	}).Debug("Neighbor entry set")
 
 	return nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

Encrypted overlay-network traffic flows to endpoints hosted on a peer node are sent through a single shared IPsec tunnel per peer. A tunnel to a peer is established the first time the local node learns of an encrypted-overlay endpoint hosted on that peer, and is torn down when no more encrypted-overlay endpoints exist on that peer. The overlay network driver implements this behaviour by maintaining reference counts: `removeEncryption()` only tears down the tunnel when called the same number of times for a peer as `setupEncryption()`. Both commits fix ways in which those reference counts got out of step with reality.

### `libn/d/overlay: don't remove in-use IPsec tunnels`

`addNeighbor()` and `deleteNeighbor()` were not a balanced pair. `addNeighbor()` could return without ever calling `setupEncryption()` on failure, while `deleteNeighbor()` called `removeEncryption()` unconditionally. Since `addNeighbor()` and `deleteNeighbor()` are called whenever an entry is added to and removed from `overlay_peer_table`, respectively, the removal of a peer entry whose setup failed would release a reference it never took. Consequently, the reference count for the encryption parameters could drop to zero while an endpoint on the same node was still using the tunnel. The security associations and policy would be removed out from under it, allowing VXLAN datagrams encapsulating traffic from the local endpoint to go out on the wire in cleartext.

Make `addNeighbor()` transactional: any failure after `setupEncryption()` rolls it back, along with the neighbor entry and the FDB entry's reference count, so a reference to the tunnel is held iff `addNeighbor()` returned successfully. Make `deleteNeighbor()` check the FDB reference count before mutating any kernel state and bail out if no reference is outstanding for the peer's MAC and VTEP, so a peer whose `addNeighbor()` failed cannot release a reference it never took.

Make `deleteNeighbor()` release the encryption reference last so nothing can be transmitted between the FDB entry being removed and the tunnel being torn down.

Export the fields of `NeighborSearchError` so the overlay driver can report a missing FDB entry in the form its callers already expect.

### `libn/d/overlay: release tunnel refs on sandbox destroy`

The tunnel references taken by `addNeighbor()` for remote peers were never released when the network sandbox was destroyed. `leaveSandbox()` tears the sandbox down and `initSandbox()` resets the FDB reference counts, but nothing released the tunnel references, which are held in the driver-scoped `secMap` rather than in any per-sandbox state.

The peer database is replayed through `addNeighbor()` the next time the sandbox is created, so every peer takes a second reference with no matching `removeEncryption()`. The counts drift upwards by one per peer per leave/rejoin cycle and the tunnels are never torn down. This errs in the safe direction — a leaked tunnel keeps traffic encrypted — so it is a resource leak rather than a confidentiality issue.

Release the references when the sandbox is destroyed, and again in `DeleteNetwork()` as the network object becomes unreachable once it is dropped from `d.networks`. `addNeighbor()` increments `fdbCnt` and takes a tunnel reference together, and rolls both back together on failure, so `fdbCnt` is exactly the set of references held by the network and can be used to release them.

### Tests

Seven unit tests covering the reference accounting, each commit carrying its own: rollback of the tunnel reference when `addNeighbor()` fails partway; refusal to release a reference for a peer that was never programmed; release on sandbox destroy and on network delete; and that the release is scoped to the network taking it, so peers shared with another overlay network keep their tunnel and an unencrypted network releases nothing.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
- Fix an issue where errors programming the kernel to encrypt the overlay network data-plane could in some circumstances lead to encrypted-overlay-network traffic to some nodes being transmitted in cleartext. As the receiving peer would drop cleartext packets for encrypted overlay networks as spoofed, the loss of confidentiality is limited to unidirectional flows (e.g. UDP DNS queries) and handshake attempts that never proceed (e.g. TCP SYN).
- Release a node's IPsec security associations and policies when the last container leaves an encrypted overlay network, instead of leaking them until the daemon restarts.
```

## A picture of a cute animal (not mandatory but encouraged)

Created with: Claude Opus 5
