### PR TITLE
fix: persist TaskDefaults.LogDriver in swarm spec via Engine API

### DIFF
--- a/daemon/cluster/convert/swarm.go
+++ b/daemon/cluster/convert/swarm.go
@@ -80,6 +80,8 @@ func SwarmFromGRPC(c swarmapi.Cluster) types.Swarm {
 	// Annotations
 	swarm.Spec.Annotations = annotationsFromGRPC(c.Spec.Annotations)
 
+	swarm.Spec.TaskDefaults.LogDriver = driverFromGRPC(c.Spec.TaskDefaults.LogDriver)
+
 	return swarm
 }
 
@@ -147,6 +149,11 @@ func MergeSwarmSpecToGRPC(s types.Spec, spec swarmapi.ClusterSpec) (swarmapi.Clu
 	}
 
 	spec.EncryptionConfig.AutoLockManagers = s.EncryptionConfig.AutoLockManagers
+
+
+	if s.TaskDefaults.LogDriver != nil {
+		spec.TaskDefaults.LogDriver = driverToGRPC(s.TaskDefaults.LogDriver)
+	}
 
 	return spec, nil
 }


### PR DESCRIPTION
Fixes #53396

**What this PR does**

`TaskDefaults.LogDriver` is exposed as part of the swarm spec in the Engine API
(`api/types/swarm/swarm.go`), and the underlying SwarmKit cluster spec supports
it (`vendor/github.com/moby/swarmkit/v2/api/types.proto`), but the Engine
conversion layer (`daemon/cluster/convert/swarm.go`) does not map it in either
direction.

As a result, `POST /swarm/update` silently drops `TaskDefaults.LogDriver`
(returns success but never persists the value), and `GET /swarm` never returns
the TaskDefaults field.

**Changes**

- `SwarmFromGRPC()`: copy `c.Spec.TaskDefaults.LogDriver` into the Engine API
  `types.Spec.TaskDefaults` via the existing `driverFromGRPC()` helper.
- `MergeSwarmSpecToGRPC()`: copy `s.TaskDefaults.LogDriver` into the SwarmKit
  `ClusterSpec` via the existing `driverToGRPC()` helper, only when non-nil
  (matching the existing merge-if-set pattern used by the other spec fields).

**Verification**

- `git diff --check` clean
- `go build ./daemon/cluster/convert/` compiles

Signed-off-by: waterWang <waterwang@proton.me>