### PR TITLE
daemon/nri: populate Container.Args with full resolved process argv

### DIFF
--- a/daemon/internal/nri/nri.go
+++ b/daemon/internal/nri/nri.go
@@ -310,7 +310,7 @@ func containerToNRI(ctr *container.Container) (*adaptation.PodSandbox, *adaptati
 		State:        stateToNRI(ctr.State),
 		Labels:       ctr.Config.Labels,
 		Annotations:  ctr.HostConfig.Annotations,
-		Args:         ctr.Config.Cmd,
+		Args:         append([]string{ctr.Path}, ctr.Args...),
 		Env:          ctr.Config.Env,
 		Hooks:        nil,
 		Linux: &adaptation.LinuxContainer{

--- a/daemon/internal/nri/nri_test.go
+++ b/daemon/internal/nri/nri_test.go
@@ -1,0 +1,89 @@
+package nri
+
+import (
+	"testing"
+
+	containertypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/v2/daemon/container"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+// newTestContainer returns a minimal container with the resolved process path
+// and arguments set the same way daemon.newContainer resolves them from the
+// merged Entrypoint/Cmd config. At least one of entrypoint or cmd must be
+// non-empty, matching the precondition validated before container creation.
+func newTestContainer(entrypoint, cmd []string) *container.Container {
+	ctr := container.NewBaseContainer("test-id", "/tmp/test-root")
+	ctr.Config = &containertypes.Config{
+		Entrypoint: entrypoint,
+		Cmd:        cmd,
+	}
+	ctr.HostConfig = &containertypes.HostConfig{}
+	// Mirror daemon.getEntrypointAndArgs, which resolves the process path and
+	// args before the container is passed to NRI.
+	if len(entrypoint) == 0 {
+		ctr.Path = cmd[0]
+		ctr.Args = cmd[1:]
+	} else {
+		ctr.Path = entrypoint[0]
+		ctr.Args = append(entrypoint[1:], cmd...)
+	}
+	return ctr
+}
+
+func TestContainerToNRIArgs(t *testing.T) {
+	tests := []struct {
+		name       string
+		entrypoint []string
+		cmd        []string
+		expArgs    []string
+	}{
+		{
+			name:       "entrypoint override",
+			entrypoint: []string{"echo"},
+			cmd:        []string{"hello"},
+			expArgs:    []string{"echo", "hello"},
+		},
+		{
+			name:       "entrypoint with args plus cmd",
+			entrypoint: []string{"/usr/bin/tool", "--mode"},
+			cmd:        []string{"input"},
+			expArgs:    []string{"/usr/bin/tool", "--mode", "input"},
+		},
+		{
+			name:    "cmd only",
+			cmd:     []string{"/bin/sh", "-c", "true"},
+			expArgs: []string{"/bin/sh", "-c", "true"},
+		},
+		{
+			name:       "entrypoint only",
+			entrypoint: []string{"/entrypoint.sh"},
+			expArgs:    []string{"/entrypoint.sh"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctr := newTestContainer(tc.entrypoint, tc.cmd)
+			_, nriCtr, err := containerToNRI(ctr)
+			assert.NilError(t, err)
+			assert.Check(t, is.DeepEqual(nriCtr.Args, tc.expArgs))
+			// The NRI args must match the process args placed in the OCI spec,
+			// which are constructed as append([]string{c.Path}, c.Args...).
+			assert.Check(t, is.DeepEqual(nriCtr.Args, append([]string{ctr.Path}, ctr.Args...)))
+		})
+	}
+}
+
+func TestContainerToNRIArgsNoAliasing(t *testing.T) {
+	ctr := newTestContainer([]string{"echo"}, []string{"hello"})
+	_, nriCtr, err := containerToNRI(ctr)
+	assert.NilError(t, err)
+
+	// Mutating the NRI args must not modify the container's resolved args.
+	for i := range nriCtr.Args {
+		nriCtr.Args[i] = "mutated"
+	}
+	assert.Check(t, is.Equal(ctr.Path, "echo"))
+	assert.Check(t, is.DeepEqual(ctr.Args, []string{"hello"}))
+}


### PR DESCRIPTION
## Summary

NRI plugins receive container metadata whose `Args` field was populated from `Config.Cmd` only, omitting the entrypoint/executable. Plugins therefore couldn't determine the actual launched process, and the metadata diverged from the argv Moby places in the OCI runtime spec:

```console
docker run --rm --entrypoint echo alpine hello
# launched process: ["echo", "hello"]
# NRI plugin saw:   ["hello"]
```

## Changes

- **`daemon/internal/nri/nri.go`** — `containerToNRI` now builds `Args` from the container's resolved launch fields:

  ```diff
  - Args:         ctr.Config.Cmd,
  + Args:         append([]string{ctr.Path}, ctr.Args...),
  ```

  - `ctr.Path`/`ctr.Args` are resolved from Entrypoint/Cmd by `daemon.newContainer` (`getEntrypointAndArgs`) before `daemon.nri.CreateContainer` runs, so they are always populated at conversion time.
  - Construction matches the OCI process args exactly (`daemon/oci_linux.go`, `daemon/oci_windows.go`: `append([]string{c.Path}, c.Args...)`).
  - Appending onto a fresh slice literal allocates a new backing array, so NRI metadata does not alias the container's mutable argument slices.
  - Empty/invalid-command semantics are unchanged; such configs are rejected before container creation.

- **`daemon/internal/nri/nri_test.go`** (new) — unit tests for `containerToNRI` covering:
  - explicit entrypoint override (`["echo"]` + `["hello"]` → `["echo", "hello"]`)
  - image entrypoint with args plus cmd (`["/usr/bin/tool", "--mode"]` + `["input"]`)
  - cmd-only and entrypoint-only containers (no dropped/duplicated `argv[0]`)
  - consistency with the OCI-spec argv construction
  - slice ownership: mutating NRI args does not modify the container's resolved args

## Backward compatibility

Behavior change for plugins that assumed `Args[0]` was the first Docker `Cmd` argument — `Args` now includes the executable at index zero. Docker's NRI support is experimental; this aligns the metadata with the launched process. `ContainerAdjustment.Args` handling and CLI Entrypoint/Cmd semantics are untouched.

## Release notes (optional)

```markdown changelog
Fix NRI container metadata so `Container.Args` includes the resolved executable as `argv[0]`, matching the process launched in the container instead of only the Docker `Cmd`.
```

Created with: GitHub Copilot Task Agent