### PR TITLE
Fix overlayfs image inspect returning compressed size instead of disk usage

### DIFF
--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -47,14 +47,24 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts im
 	}
 
 	platform := i.matchRequestedOrDefault(platforms.OnlyStrict, requestedPlatform)
+
+	multi, err := i.multiPlatformSummary(ctx, c8dImg, platform)
+	if err != nil {
+		return nil, err
+	}
+
 	size, err := i.size(ctx, target, platform)
 	if err != nil {
 		return nil, err
 	}
 
-	multi, err := i.multiPlatformSummary(ctx, c8dImg, platform)
-	if err != nil {
-		return nil, err
+	if multi.Best != nil {
+		snapshotUsage, err := multi.Best.SnapshotUsage(ctx, i.snapshotterService(i.snapshotter))
+		if err != nil {
+			log.G(ctx).WithFields(log.Fields{"image": c8dImg.Name, "error": err}).Warn("failed to calculate unpacked size for image inspect")
+		} else {
+			size += snapshotUsage.Size
+		}
 	}
 
 	if multi.Best == nil && requestedPlatform != nil {


### PR DESCRIPTION
The Size field in `docker inspect` was returning only the compressed content size for the overlayfs storage driver, instead of the actual on-disk usage. This happened because the `size()` function only sums blob sizes from the content store, missing the unpacked snapshot sizes.

This fix adds the unpacked snapshot usage to the reported size, making `docker inspect` consistent with `docker image ls` output.

The fix follows the same pattern used in `singlePlatformImage()` for the image list, which correctly computes `totalSize` as `contentSize + unpackedSize`.

Fixes: https://github.com/moby/moby/issues/53398

## Summary

The `docker inspect` command now returns the real disk usage of images (unpacked snapshots + compressed content) for the overlayfs storage driver, matching the behavior of `docker image ls` and the legacy overlay2 driver.

## Release notes

- Fix `docker inspect` returning compressed size instead of real disk usage with the overlayfs storage driver.