### PR TITLE
daemon/containerd: Include unpacked snapshot usage in image inspect size

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1942,7 +1942,18 @@ definitions:
         x-nullable: true
       Size:
         description: |
-          Total size of the image including all layers it is composed of.
+          Total size of the image variant, including all layers it is composed of.
+
+          For multi-platform images, this is the size of the platform variant
+          selected by the `platform` query parameter. If no platform is specified,
+          the daemon selects a platform as described in the `platform` parameter.
+
+          When using the containerd image store, this includes both the image content
+          that's present locally and the unpacked snapshot data for the selected
+          variant.
+
+          Image data may be shared between images, so this size does not indicate
+          how much space would be reclaimed by deleting the image.
         type: "integer"
         format: "int64"
         x-nullable: false

--- a/api/types/image/image_inspect.go
+++ b/api/types/image/image_inspect.go
@@ -72,7 +72,11 @@ type InspectResponse struct {
 	// run on (especially for Windows).
 	OsVersion string `json:",omitempty"`
 
-	// Size is the total size of the image including all layers it is composed of.
+	// Size is the total size of the selected image variant, including all layers
+	// it is composed of.
+	//
+	// When using the containerd image store, this includes both the image content
+	// that's present locally and the unpacked snapshot data.
 	Size int64
 
 	// GraphDriver holds information about the storage driver used to store the

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -3,7 +3,6 @@ package containerd
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	c8dimages "github.com/containerd/containerd/v2/core/images"
@@ -16,8 +15,6 @@ import (
 	"github.com/moby/moby/api/types/storage"
 	"github.com/moby/moby/v2/daemon/server/imagebackend"
 	"github.com/moby/moby/v2/internal/sliceutil"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"golang.org/x/sync/semaphore"
 )
 
 func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts imagebackend.ImageInspectOpts) (*imagebackend.InspectData, error) {
@@ -47,11 +44,6 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts im
 	}
 
 	platform := i.matchRequestedOrDefault(platforms.OnlyStrict, requestedPlatform)
-	size, err := i.size(ctx, target, platform)
-	if err != nil {
-		return nil, err
-	}
-
 	multi, err := i.multiPlatformSummary(ctx, c8dImg, platform)
 	if err != nil {
 		return nil, err
@@ -78,6 +70,15 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts im
 
 	if requestedPlatform != nil {
 		target = multi.Best.Target()
+	}
+
+	var size int64
+	if multi.Best != nil {
+		size = multi.BestManifest.Size.Total
+	} else {
+		// No image manifest matched the platform matcher - fall back to the
+		// summarized TotalSize, consistent with image list.
+		size = multi.TotalSize
 	}
 
 	var identity *imagetypes.Identity
@@ -183,32 +184,4 @@ func collectRepoTagsAndDigests(ctx context.Context, tagged []c8dimages.Image) (r
 		repoDigests = append(repoDigests, reference.FamiliarString(digested))
 	}
 	return sliceutil.Dedup(repoTags), sliceutil.Dedup(repoDigests)
-}
-
-// size returns the total size of the image's packed resources.
-func (i *ImageService) size(ctx context.Context, desc ocispec.Descriptor, platform platforms.MatchComparer) (int64, error) {
-	var size atomic.Int64
-
-	cs := i.content
-	handler := c8dimages.LimitManifests(c8dimages.ChildrenHandler(cs), platform, 1)
-
-	var wh c8dimages.HandlerFunc = func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-		children, err := handler(ctx, desc)
-		if err != nil {
-			if !cerrdefs.IsNotFound(err) {
-				return nil, err
-			}
-		}
-
-		size.Add(desc.Size)
-
-		return children, nil
-	}
-
-	l := semaphore.NewWeighted(3)
-	if err := c8dimages.Dispatch(ctx, wh, l, desc); err != nil {
-		return 0, err
-	}
-
-	return size.Load(), nil
 }

--- a/daemon/containerd/image_inspect_test.go
+++ b/daemon/containerd/image_inspect_test.go
@@ -6,10 +6,12 @@ import (
 	"testing"
 
 	c8dimages "github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/log/logtest"
 	"github.com/moby/moby/v2/daemon/server/imagebackend"
 	"github.com/moby/moby/v2/internal/testutil/specialimage"
+	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -87,20 +89,55 @@ func TestImageInspect(t *testing.T) {
 		assert.Check(t, is.Len(inspect.RootFS.Layers, len(mfst.Layers)))
 	})
 
-	t.Run("inspect image with platform parameter", func(t *testing.T) {
+	t.Run("inspect image size by platform", func(t *testing.T) {
 		ctx := logtest.WithT(ctx, t)
 		service := fakeImageService(t, ctx, cs)
 
-		multiPlatformImage := toContainerdImage(t, func(dir string) (*ocispec.Index, error) {
-			idx, _, err := specialimage.MultiPlatform(dir, "multiplatform:latest", []ocispec.Platform{
-				{OS: "linux", Architecture: "amd64"},
-				{OS: "linux", Architecture: "arm64"},
-			})
-			return idx, err
+		idx, manifestDescs, err := specialimage.MultiPlatform(blobsDir, "multiplatform:latest", []ocispec.Platform{
+			{OS: "linux", Architecture: "amd64"},
+			{OS: "linux", Architecture: "arm64"},
 		})
-
-		_, err := service.images.Create(ctx, multiPlatformImage)
 		assert.NilError(t, err)
+		multiPlatformImage := imagesFromIndex(idx)[0]
+
+		_, err = service.images.Create(ctx, multiPlatformImage)
+		assert.NilError(t, err)
+
+		snapshotSizeByArch := map[string]int64{
+			"amd64": 10_000_000,
+			"arm64": 20_000_000,
+		}
+		snapshotter, ok := service.snapshotterServices[service.snapshotter].(*testSnapshotterService)
+		assert.Assert(t, ok)
+		snapshotter.usageByKey = make(map[string]snapshots.Usage, len(manifestDescs))
+		for _, desc := range manifestDescs {
+			assert.Assert(t, desc.Platform != nil)
+			platformImage, err := service.NewImageManifest(ctx, multiPlatformImage, desc)
+			assert.NilError(t, err)
+			diffIDs, err := platformImage.RootFS(ctx)
+			assert.NilError(t, err)
+			snapshotter.usageByKey[identity.ChainID(diffIDs).String()] = snapshots.Usage{
+				Size: snapshotSizeByArch[desc.Platform.Architecture],
+			}
+		}
+
+		inspectAll, err := service.ImageInspect(ctx, multiPlatformImage.Name, imagebackend.ImageInspectOpts{Manifests: true})
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(inspectAll.Manifests, 2))
+
+		totalSizeByArch := make(map[string]int64, len(inspectAll.Manifests))
+		for _, manifest := range inspectAll.Manifests {
+			assert.Assert(t, manifest.ImageData != nil)
+			arch := manifest.ImageData.Platform.Architecture
+			snapshotSize, ok := snapshotSizeByArch[arch]
+			assert.Assert(t, ok)
+			assert.Equal(t, manifest.ImageData.Size.Unpacked, snapshotSize)
+			assert.Equal(t, manifest.Size.Total, manifest.Size.Content+snapshotSize)
+			totalSizeByArch[arch] = manifest.Size.Total
+		}
+		selectedSize, ok := totalSizeByArch[inspectAll.Architecture]
+		assert.Assert(t, ok)
+		assert.Equal(t, inspectAll.Size, selectedSize)
 
 		// Test with amd64 platform
 		amd64Platform := &ocispec.Platform{OS: "linux", Architecture: "amd64"}
@@ -110,6 +147,7 @@ func TestImageInspect(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, inspectAmd64.Architecture, "amd64")
 		assert.Equal(t, inspectAmd64.Os, "linux")
+		assert.Equal(t, inspectAmd64.Size, totalSizeByArch["amd64"])
 
 		// Test with arm64 platform
 		arm64Platform := &ocispec.Platform{OS: "linux", Architecture: "arm64"}
@@ -119,5 +157,6 @@ func TestImageInspect(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, inspectArm64.Architecture, "arm64")
 		assert.Equal(t, inspectArm64.Os, "linux")
+		assert.Equal(t, inspectArm64.Size, totalSizeByArch["arm64"])
 	})
 }

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -248,6 +248,9 @@ type multiPlatformSummary struct {
 	// Best is the single platform image manifest preferred by the platform matcher.
 	Best *ImageManifest
 
+	// BestManifest is the summary of the best image.
+	BestManifest imagetypes.ManifestSummary
+
 	// BestPlatform is the platform of the best image.
 	BestPlatform ocispec.Platform
 
@@ -394,6 +397,7 @@ func (i *ImageService) multiPlatformSummary(ctx context.Context, img c8dimages.I
 
 		if summary.Best == nil || platformMatcher.Less(platform, summary.BestPlatform) {
 			summary.Best = img
+			summary.BestManifest = mfstSummary
 			summary.BestPlatform = platform
 		}
 

--- a/daemon/containerd/image_test.go
+++ b/daemon/containerd/image_test.go
@@ -298,6 +298,7 @@ func newTestDB(ctx context.Context, t testing.TB) *metadata.DB {
 
 type testSnapshotterService struct {
 	snapshots.Snapshotter
+	usageByKey map[string]snapshots.Usage
 }
 
 func (s *testSnapshotterService) Stat(ctx context.Context, key string) (snapshots.Info, error) {
@@ -305,5 +306,5 @@ func (s *testSnapshotterService) Stat(ctx context.Context, key string) (snapshot
 }
 
 func (s *testSnapshotterService) Usage(ctx context.Context, key string) (snapshots.Usage, error) {
-	return snapshots.Usage{}, nil
+	return s.usageByKey[key], nil
 }

--- a/vendor/github.com/moby/moby/api/types/image/image_inspect.go
+++ b/vendor/github.com/moby/moby/api/types/image/image_inspect.go
@@ -72,7 +72,11 @@ type InspectResponse struct {
 	// run on (especially for Windows).
 	OsVersion string `json:",omitempty"`
 
-	// Size is the total size of the image including all layers it is composed of.
+	// Size is the total size of the selected image variant, including all layers
+	// it is composed of.
+	//
+	// When using the containerd image store, this includes both the image content
+	// that's present locally and the unpacked snapshot data.
 	Size int64
 
 	// GraphDriver holds information about the storage driver used to store the


### PR DESCRIPTION
- fix: https://github.com/moby/moby/issues/53398

## Summary

With the containerd image store, image inspect calculated `Size` from the selected manifest's packed descriptors only. It therefore underreported locally stored data and differed from image list, whose `Size` also includes unpacked snapshot usage.

This difference came from the two paths using separate size calculations. https://github.com/moby/moby/pull/43815 added packed and unpacked accounting to image list, and https://github.com/moby/moby/pull/45347 later combined both values in image-list `Size`. The corresponding inspect calculation was not updated, and https://github.com/moby/moby/pull/48240 preserved its packed-only behavior when extracting `ImageInspect` from `GetImage`.

Use the selected manifest summary total for inspect `Size`. The summary already accounts for locally present content and unpacked snapshot usage for the selected platform, so image inspect now uses the same accounting basis as image list.

When no image manifest matches the platform matcher and no platform was requested, inspect falls back to the combined size of all manifests, consistent with image list.

## Release notes (optional)

```markdown changelog
containerd image store: Fix `docker image inspect` reporting a smaller image size than `docker image ls`.
Fix `GET /images/{name}/json` not including unpacked snapshot usage in `Size` when using the containerd image store.
```