### PR TITLE
fix: skip in-use leases during image prune to avoid corrupting concurrent pulls

### DIFF
--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -70,7 +70,18 @@ func (i *ImageService) ImagePrune(ctx context.Context, fltrs filters.Args) (*ima
 	if err != nil {
 		return nil, err
 	}
+
+	// Take a snapshot of active leases. Leases that are still in use by
+	// an in-flight operation must not be deleted, otherwise the GC triggered
+	// by SynchronousDelete will remove content that is still being written,
+	// corrupting concurrent operations.
+	activeLeases := i.activeLeaseSnapshot()
+
 	for i, lease := range pullLeases {
+		if _, active := activeLeases[lease.ID]; active {
+			log.G(ctx).WithFields(log.Fields{"lease": lease.ID}).Debug("Skipping lease in use by an active operation")
+			continue
+		}
 		var opts []leases.DeleteOpt
 		if i == len(pullLeases)-1 {
 			opts = append(opts, leases.SynchronousDelete)

--- a/daemon/containerd/leases.go
+++ b/daemon/containerd/leases.go
@@ -40,7 +40,16 @@ func (i *ImageService) withLease(ctx context.Context, cancellable bool) (context
 	}
 
 	ctx = leases.WithLease(ctx, l.ID)
+
+	// Track the lease as active so that ImagePrune does not delete it while
+	// it is protecting content being written (e.g. an in-flight pull).
+	i.trackLease(l.ID)
+
 	return ctx, func() {
+		// Mark the lease as inactive so it becomes eligible for pruning
+		// once the operation that created it has finished.
+		i.untrackLease(l.ID)
+
 		if ctx.Err() != nil && cancellable {
 			log.G(ctx).WithFields(log.Fields{"lease": l.ID, "expires_at": expireAt}).Info("Cancel with lease, leased resources will remain until expiration")
 			return

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -42,6 +42,12 @@ type ImageService struct {
 	registryService     distribution.RegistryResolver
 	eventsService       *daemonevents.Events
 	pruneRunning        atomic.Bool
+	// activeLeasesMu guards activeLeases. Leases created by withLease that
+	// are still in use (e.g. an in-flight pull) are tracked so that
+	// ImagePrune can skip them, avoiding deletion of leases that protect
+	// content being written.
+	activeLeasesMu sync.Mutex
+	activeLeases   map[string]struct{}
 	refCountMounter     snapshotter.Mounter
 	idMapping           user.IdentityMapping
 	policyVerifier      func() (*policyverifier.Verifier, error)
@@ -109,6 +115,7 @@ func NewService(config ImageServiceConfig) *ImageService {
 				return identitycache.NewNopBackend()
 			}(),
 		},
+		activeLeases: map[string]struct{}{},
 	}
 	service.setTransferLimits(config.MaxConcurrentDownloads, config.MaxConcurrentUploads)
 	service.startImageIdentityCacheRefresh()
@@ -119,6 +126,38 @@ func (i *ImageService) setTransferLimits(maxDownloads, maxUploads int) {
 	i.maxConcurrentDownloads = maxDownloads
 	i.downloadLimiter = newTransferLimiter(maxDownloads)
 	i.uploadLimiter = newTransferLimiter(maxUploads)
+}
+
+// trackLease adds a lease ID to the set of active leases.
+// It is safe to call even if activeLeases has not been initialized
+// (e.g. in tests that construct ImageService directly).
+func (i *ImageService) trackLease(id string) {
+	i.activeLeasesMu.Lock()
+	defer i.activeLeasesMu.Unlock()
+	if i.activeLeases == nil {
+		i.activeLeases = make(map[string]struct{})
+	}
+	i.activeLeases[id] = struct{}{}
+}
+
+// untrackLease removes a lease ID from the set of active leases.
+func (i *ImageService) untrackLease(id string) {
+	i.activeLeasesMu.Lock()
+	defer i.activeLeasesMu.Unlock()
+	if i.activeLeases != nil {
+		delete(i.activeLeases, id)
+	}
+}
+
+// activeLeaseSnapshot returns a snapshot of the current active lease IDs.
+func (i *ImageService) activeLeaseSnapshot() map[string]struct{} {
+	i.activeLeasesMu.Lock()
+	defer i.activeLeasesMu.Unlock()
+	active := make(map[string]struct{}, len(i.activeLeases))
+	for id := range i.activeLeases {
+		active[id] = struct{}{}
+	}
+	return active
 }
 
 func (i *ImageService) snapshotterService(snapshotter string) snapshots.Snapshotter {


### PR DESCRIPTION
### Description

Fixes #53321

With the containerd image store enabled, `docker image prune` deletes **all** leases carrying the `moby/prune.images` label — including leases that are still actively held by in-flight `docker pull` operations. The last deleted lease uses `leases.SynchronousDelete`, which runs GC inline. Once the victim pull's lease is gone, its ingest records are no longer GC roots, so the sweep aborts the in-flight ingest (removing `/ingest/<id>` on disk) and deletes unreferenced blobs. The victim's writer still holds the file descriptor, so writes keep succeeding until `Commit()` runs `os.Rename(ingest, target)` → `ENOENT` ("failed commit on ref …"), or fails with `lease does not exist: not found` / `NotFound: content digest …` / `failed to extract layer …`.

### Root cause

`ImagePrune` (`daemon/containerd/image_prune.go`) lists leases by `pruneLeaseFilter` and deletes every one — with no check for whether a pull currently holds the lease.

### Fix

Track active leases in `ImageService`:

- `withLease` registers the new lease ID as active on creation and deregisters it in the cleanup closure, so a lease is only eligible for pruning once the operation that created it has finished (or was cancelled).
- `ImagePrune` snapshots the active lease set and skips any lease still in use, so the synchronous GC never removes content that is still being written.

### Changes

- `daemon/containerd/service.go` — add `activeLeasesMu`/`activeLeases` fields + `trackLease`/`untrackLease`/`activeLeaseSnapshot` helpers (nil-safe for direct test construction).
- `daemon/containerd/leases.go` — register/deregister leases in `withLease`.
- `daemon/containerd/image_prune.go` — skip in-use leases in `ImagePrune`.

Signed-off-by: waterWang <waterWang@users.noreply.github.com>