### PR TITLE
fix: align swagger ContainerSpec Healthcheck field name with Go struct

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4542,7 +4542,7 @@ definitions:
               forcefully killing it.
             type: "integer"
             format: "int64"
-          HealthCheck:
+          Healthcheck:
             $ref: "#/definitions/HealthConfig"
           Hosts:
             type: "array"


### PR DESCRIPTION
Fixes moby/moby#53422

The `ContainerSpec` type in the swagger spec declares `HealthCheck` (uppercase C), but the Go implementation uses `Healthcheck` (lowercase c). Go's `encoding/json` unmarshalling is case-insensitive, so creating/updating services with the documented field name is silently accepted — but responses always carry `Healthcheck`, causing a round-trip mismatch for generated clients.

**Change**

- `api/swagger.yaml`: `HealthCheck` → `Healthcheck` in `ContainerSpec` properties

This aligns the spec with the actual Go struct in `api/types/swarm/container.go` and matches the spelling already used by `Config` and `ImageConfig` in the same spec.

Signed-off-by: waterWang <waterWang@example.com>