### PR TITLE
libnetwork/iptables: Initialize native commands without firewalld

### DIFF
--- a/daemon/libnetwork/iptables/firewalld.go
+++ b/daemon/libnetwork/iptables/firewalld.go
@@ -331,6 +331,11 @@ func AddInterfaceFirewalld(intf string) error {
 	log.G(context.TODO()).Debugf("Firewalld: adding %s interface to %s zone", intf, dockerZone)
 	// Runtime
 	if err := connection.sysObj.Call(dbusInterface+".zone.addInterface", 0, dockerZone, intf).Err; err != nil {
+		var derr dbus.Error
+		if errors.As(err, &derr) && derr.Name == dbusInterface+".Exception" && strings.HasPrefix(err.Error(), "ZONE_ALREADY_SET:") {
+			log.G(context.TODO()).Infof("Firewalld: interface %s already part of %s zone, returning", intf, dockerZone)
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/daemon/libnetwork/iptables/firewalld.go
+++ b/daemon/libnetwork/iptables/firewalld.go
@@ -313,7 +313,7 @@ func setupDockerForwardingPolicy() (bool, error) {
 // AddInterfaceFirewalld adds the interface to the trusted zone. It is a
 // no-op if firewalld is not running.
 func AddInterfaceFirewalld(intf string) error {
-	if !firewalldRunning.Load() {
+	if !UsingFirewalld() {
 		return nil
 	}
 
@@ -339,7 +339,7 @@ func AddInterfaceFirewalld(intf string) error {
 // DelInterfaceFirewalld removes the interface from the trusted zone It is a
 // no-op if firewalld is not running.
 func DelInterfaceFirewalld(intf string) error {
-	if !firewalldRunning.Load() {
+	if !UsingFirewalld() {
 		return nil
 	}
 

--- a/daemon/libnetwork/iptables/firewalld.go
+++ b/daemon/libnetwork/iptables/firewalld.go
@@ -36,7 +36,8 @@ type Conn struct {
 var (
 	connection *Conn
 
-	firewalldRunning bool // is Firewalld service running
+	firewalldRunning atomic.Bool // is firewalld service running
+	firewalldOnce    sync.Once
 	// Time of the last firewalld reload.
 	firewalldReloadedAt atomic.Value
 	// Mutex to serialise firewalld reload callbacks.
@@ -47,8 +48,8 @@ var (
 // UsingFirewalld returns true if iptables rules will be applied via firewalld's
 // passthrough interface.
 func UsingFirewalld() bool {
-	_ = initCheck()
-	return firewalldRunning
+	firewalldOnce.Do(initFirewalld)
+	return firewalldRunning.Load()
 }
 
 // FirewalldReloadedAt returns the time at which the daemon last completed a
@@ -77,8 +78,8 @@ func firewalldInit() error {
 	if connection, err = newConnection(); err != nil {
 		return fmt.Errorf("Failed to connect to D-Bus system bus: %v", err)
 	}
-	firewalldRunning = checkRunning()
-	if !firewalldRunning {
+	firewalldRunning.Store(checkRunning())
+	if !firewalldRunning.Load() {
 		connection.sysconn.Close()
 		connection = nil
 	}
@@ -133,7 +134,7 @@ func signalHandler() {
 	for signal := range connection.signal {
 		switch {
 		case strings.Contains(signal.Name, "NameOwnerChanged"):
-			firewalldRunning = checkRunning()
+			firewalldRunning.Store(checkRunning())
 			dbusConnectionChanged(signal.Body)
 
 		case strings.Contains(signal.Name, "Reloaded"):
@@ -312,7 +313,7 @@ func setupDockerForwardingPolicy() (bool, error) {
 // AddInterfaceFirewalld adds the interface to the trusted zone. It is a
 // no-op if firewalld is not running.
 func AddInterfaceFirewalld(intf string) error {
-	if !firewalldRunning {
+	if !firewalldRunning.Load() {
 		return nil
 	}
 
@@ -338,7 +339,7 @@ func AddInterfaceFirewalld(intf string) error {
 // DelInterfaceFirewalld removes the interface from the trusted zone It is a
 // no-op if firewalld is not running.
 func DelInterfaceFirewalld(intf string) error {
-	if !firewalldRunning {
+	if !firewalldRunning.Load() {
 		return nil
 	}
 

--- a/daemon/libnetwork/iptables/firewalld_test.go
+++ b/daemon/libnetwork/iptables/firewalld_test.go
@@ -16,8 +16,6 @@ func skipIfNoFirewalld(t *testing.T) {
 	if err != nil {
 		t.Skipf("cannot connect to D-bus system bus: %v", err)
 	}
-	defer conn.Close()
-
 	var zone string
 	err = conn.Object(dbusInterface, dbusPath).Call(dbusInterface+".getDefaultZone", 0).Store(&zone)
 	if err != nil {
@@ -25,10 +23,10 @@ func skipIfNoFirewalld(t *testing.T) {
 	}
 }
 
-func TestFirewalldInit(t *testing.T) {
+func TestUsingFirewalld(t *testing.T) {
 	skipIfNoFirewalld(t)
-	if err := firewalldInit(); err != nil {
-		t.Fatal(err)
+	if !UsingFirewalld() {
+		t.Fatal("firewalld is running, but UsingFirewalld() is false")
 	}
 }
 
@@ -97,11 +95,10 @@ func TestPassthrough(t *testing.T) {
 		"-j", "ACCEPT",
 	}
 
-	err := firewalldInit()
-	if err != nil {
-		t.Fatal(err)
+	if !UsingFirewalld() {
+		t.Fatal("firewalld is running, but UsingFirewalld() is false")
 	}
-	_, err = passthrough(IPv4, rule1...)
+	_, err := passthrough(IPv4, rule1...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/libnetwork/iptables/iptables.go
+++ b/daemon/libnetwork/iptables/iptables.go
@@ -65,11 +65,23 @@ const (
 	IPv6 IPVersion = "ipv6"
 )
 
-var (
-	iptablesPath  string
-	ip6tablesPath string
-	initOnce      sync.Once
-)
+var iptablesPath = sync.OnceValues(func() (string, error) {
+	path, err := exec.LookPath("iptables")
+	if err != nil {
+		log.G(context.TODO()).WithError(err).Warnf("failed to find iptables")
+		return "", errors.New("iptables not found")
+	}
+	return path, nil
+})
+
+var ip6tablesPath = sync.OnceValues(func() (string, error) {
+	path, err := exec.LookPath("ip6tables")
+	if err != nil {
+		log.G(context.TODO()).WithError(err).Warnf("failed to find ip6tables")
+		return "", errors.New("ip6tables not found")
+	}
+	return path, nil
+})
 
 // IPTable defines struct with [IPVersion].
 type IPTable struct {
@@ -106,22 +118,6 @@ func loopbackAddress(version IPVersion) string {
 	}
 }
 
-func detectIptables() {
-	path, err := exec.LookPath("iptables")
-	if err != nil {
-		log.G(context.TODO()).WithError(err).Warnf("failed to find iptables")
-		return
-	}
-	iptablesPath = path
-
-	path, err = exec.LookPath("ip6tables")
-	if err != nil {
-		log.G(context.TODO()).WithError(err).Warnf("unable to find ip6tables")
-	} else {
-		ip6tablesPath = path
-	}
-}
-
 func initFirewalld() {
 	// When running with RootlessKit, firewalld is running as the root outside our network namespace
 	// https://github.com/moby/moby/issues/43781
@@ -132,20 +128,6 @@ func initFirewalld() {
 	if err := firewalldInit(); err != nil {
 		log.G(context.TODO()).WithError(err).Debugf("unable to initialize firewalld; using raw iptables instead")
 	}
-}
-
-func initDependencies() {
-	initFirewalld()
-	detectIptables()
-}
-
-func initCheck() error {
-	initOnce.Do(initDependencies)
-
-	if iptablesPath == "" {
-		return errors.New("iptables not found")
-	}
-	return nil
 }
 
 // GetIptable returns an instance of IPTable with specified version ([IPv4]
@@ -292,12 +274,6 @@ func (iptable IPTable) ExistsNative(table Table, chain string, rule ...string) b
 }
 
 func (iptable IPTable) exists(native bool, table Table, chain string, rule ...string) bool {
-	if err := initCheck(); err != nil {
-		// The exists() signature does not allow us to return an error, but at least
-		// we can skip the (likely invalid) exec invocation.
-		return false
-	}
-
 	f := iptable.Raw
 	if native {
 		f = iptable.raw
@@ -336,7 +312,7 @@ func filterOutput(start time.Time, output []byte, args ...string) []byte {
 
 // Raw calls 'iptables' system command, passing supplied arguments.
 func (iptable IPTable) Raw(args ...string) ([]byte, error) {
-	if firewalldRunning {
+	if UsingFirewalld() {
 		startTime := time.Now()
 		output, err := passthrough(iptable.ipVersion, args...)
 		if err == nil || !strings.Contains(err.Error(), "was not provided by any .service files") {
@@ -347,17 +323,17 @@ func (iptable IPTable) Raw(args ...string) ([]byte, error) {
 }
 
 func (iptable IPTable) raw(args ...string) ([]byte, error) {
-	if err := initCheck(); err != nil {
-		return nil, err
-	}
-	path := iptablesPath
+	var path string
 	commandName := "iptables"
+	var err error
 	if iptable.ipVersion == IPv6 {
-		if ip6tablesPath == "" {
-			return nil, errors.New("ip6tables is missing")
-		}
-		path = ip6tablesPath
+		path, err = ip6tablesPath()
 		commandName = "ip6tables"
+	} else {
+		path, err = iptablesPath()
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	args = append([]string{"--wait"}, args...)

--- a/daemon/libnetwork/iptables/iptables_test.go
+++ b/daemon/libnetwork/iptables/iptables_test.go
@@ -311,7 +311,6 @@ func mustDumpChain(t *testing.T, table Table, chain string) string {
 }
 
 func TestFlushChain(t *testing.T) {
-	_ = firewalldInit()
 	if UsingFirewalld() {
 		t.Skip("firewalld in host netns cannot create rules in the test's netns")
 	}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->
 
- related to: https://github.com/moby/moby/pull/53434

## Summary

ExistsNative and RawCombinedOutputNative promise direct binary execution, but their shared initialization also initialized firewalld. Calling them in a child network namespace could therefore change firewall state in firewalld's parent namespace before invoking iptables locally.

Use independent once guards for binary detection and firewalld setup. Raw and UsingFirewalld retain lazy firewalld initialization, while native operations only detect the binaries they invoke.


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
