### PR TITLE
libnetwork/iptables: Keep TestExistsRaw rules in its netns

### DIFF
--- a/daemon/libnetwork/iptables/iptables_test.go
+++ b/daemon/libnetwork/iptables/iptables_test.go
@@ -211,26 +211,17 @@ func TestCleanup(t *testing.T) {
 }
 
 func TestExistsRaw(t *testing.T) {
+	defer netnsutils.SetupTestOSContext(t)()
+
 	const testChain1 = "ABCD"
 	const testChain2 = "EFGH"
 
 	iptable := GetIptable(IPv4)
-
-	_, err := iptable.NewChain(testChain1, Filter)
-	if err != nil {
-		t.Fatal(err)
+	for _, chain := range []string{testChain1, testChain2} {
+		if err := iptable.RawCombinedOutputNative("-t", string(Filter), "-N", chain); err != nil {
+			t.Fatal(err)
+		}
 	}
-	defer func() {
-		iptable.RemoveExistingChain(testChain1, Filter)
-	}()
-
-	_, err = iptable.NewChain(testChain2, Filter)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		iptable.RemoveExistingChain(testChain2, Filter)
-	}()
 
 	// Test detection over full and truncated rule string
 	input := []struct{ rule []string }{
@@ -242,18 +233,18 @@ func TestExistsRaw(t *testing.T) {
 
 	for i, r := range input {
 		ruleAdd := append([]string{"-t", string(Filter), "-A", testChain1}, r.rule...)
-		err = iptable.RawCombinedOutput(ruleAdd...)
+		err := iptable.RawCombinedOutputNative(ruleAdd...)
 		if err != nil {
 			t.Fatalf("i=%d, err: %v", i, err)
 		}
-		if !iptable.exists(true, Filter, testChain1, r.rule...) {
+		if !iptable.ExistsNative(Filter, testChain1, r.rule...) {
 			t.Fatalf("Failed to detect rule. i=%d", i)
 		}
 		// Truncate the rule
 		trg := r.rule[len(r.rule)-1]
 		trg = trg[:len(trg)-2]
 		r.rule[len(r.rule)-1] = trg
-		if iptable.exists(true, Filter, testChain1, r.rule...) {
+		if iptable.ExistsNative(Filter, testChain1, r.rule...) {
 			t.Fatalf("Invalid detection. i=%d", i)
 		}
 	}


### PR DESCRIPTION
- fix: https://github.com/moby/moby/issues/42469

TestExistsRaw created chains through firewalld-aware helpers but checked them through native iptables. Adding a test namespace alone would send setup to firewalld's parent namespace and checks to the test namespace.

Create chains and rules with native commands after entering the disposable namespace. Namespace teardown removes all test state even after a failure, without changing parent firewall rules.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
