### PR TITLE
daemon/libnetwork/networkdb: improve repeatability of the convergence property test

### DIFF
--- a/daemon/libnetwork/networkdb/cluster.go
+++ b/daemon/libnetwork/networkdb/cluster.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	golog "log"
+	"maps"
 	"net"
 	"net/netip"
 	"slices"
@@ -349,6 +350,10 @@ func (nDB *NetworkDB) reconnectNode() {
 	}
 	nDB.RUnlock()
 
+	// Built by ranging failedNodes, so unsorted the same offset names a
+	// different node on each run.
+	slices.SortFunc(nodes, func(a, b *node) int { return strings.Compare(a.Name, b.Name) })
+
 	nDB.rngMu.Lock()
 	offset := nDB.rng.IntN(len(nodes))
 	nDB.rngMu.Unlock()
@@ -469,7 +474,11 @@ func (nDB *NetworkDB) gossip() {
 		nDB.lastHealthTimestamp = time.Now()
 	}
 
-	for nid, nodes := range networkNodes {
+	// Sorted: the draws mRandomNodes makes below are consumed in visitation
+	// order, so ranging the map would hand a given network a different draw on
+	// each run.
+	for _, nid := range slices.Sorted(maps.Keys(networkNodes)) {
+		nodes := networkNodes[nid]
 		mNodes := nDB.mRandomNodes(3, nodes)
 		bytesAvail := nDB.config.PacketBufferSize - compoundHeaderOverhead
 
@@ -539,6 +548,23 @@ func (nDB *NetworkDB) bulkSyncTables() {
 		networks = append(networks, nid)
 	}
 	nDB.RUnlock()
+	// Sorted for a canonical starting point -- ranging thisNodeNetworks would
+	// otherwise hand each network a different bulk-sync draw on each run -- and
+	// then permuted, because the order this loop visits networks in has to keep
+	// varying between cycles.
+	//
+	// bulkSync returns every network it found in common with the peer it chose,
+	// and the loop below strikes all of them off. A network which is always
+	// visited after one it overlaps with is therefore always struck off before it
+	// selects a peer of its own, and never syncs with the members it does not
+	// share that first network with. Two groups overlapping on one network can
+	// then stay partitioned for good: anti-entropy never crosses between them.
+	slices.Sort(networks)
+	nDB.rngMu.Lock()
+	nDB.rng.Shuffle(len(networks), func(i, j int) {
+		networks[i], networks[j] = networks[j], networks[i]
+	})
+	nDB.rngMu.Unlock()
 
 	for len(networks) != 0 {
 		nid := networks[0]
@@ -759,6 +785,14 @@ func (nDB *NetworkDB) mRandomNodes(m int, nodes []string) []string {
 		}
 		mNodes = append(mNodes, node)
 	}
+
+	// networkNodes is in the order attachments were learned, which follows
+	// gossip arrival and so differs between nodes and between runs. The draws
+	// below select by index, so without a total order the same draw picks a
+	// different peer. Sorting a copy -- mNodes already is one -- makes peer
+	// selection a function of the RNG alone. Both callers reach the RNG through
+	// here, so this is the one place it has to happen.
+	slices.Sort(mNodes)
 
 	if len(mNodes) < m {
 		nDB.rngMu.Lock()

--- a/daemon/libnetwork/networkdb/cluster_test.go
+++ b/daemon/libnetwork/networkdb/cluster_test.go
@@ -49,6 +49,59 @@ func TestTriggerFuncStagger(t *testing.T) {
 	})
 }
 
+// TestBulkSyncTablesCrossesOverlappingNetworks guards the order bulkSyncTables
+// visits networks in.
+//
+// bulkSync returns every network it found in common with the peer it picked, and
+// bulkSyncTables strikes all of them off its worklist. So a network which is
+// always visited after one it overlaps with is always struck off before it picks
+// a peer of its own, and only ever syncs with the members it shares that earlier
+// network with. Two groups overlapping on a single network stay partitioned:
+// gossip which misses an entry is never repaired by anti-entropy.
+//
+// Here nodes 0 and 1 share a-left, nodes 2 and 3 share b-right, and all four
+// share z-shared, which sorts last. Visiting networks in a fixed order leaves the
+// entry stranded in the first group.
+func TestBulkSyncTablesCrossesOverlappingNetworks(t *testing.T) {
+	requireSynctest(t)
+	synctest.Test(t, func(t *testing.T) {
+		c := newMemCluster(t, 4, "node", DefaultConfig())
+		members := func(indices ...int) []string {
+			out := make([]string, 0, len(indices))
+			for _, i := range indices {
+				out = append(out, c.dbs[i].config.NodeID)
+			}
+			return out
+		}
+		for _, i := range []int{0, 1} {
+			assert.NilError(t, c.dbs[i].JoinNetwork("a-left"))
+		}
+		for _, i := range []int{2, 3} {
+			assert.NilError(t, c.dbs[i].JoinNetwork("b-right"))
+		}
+		for _, db := range c.dbs {
+			assert.NilError(t, db.JoinNetwork("z-shared"))
+		}
+		c.settle(t, "a-left", members(0, 1))
+		c.settle(t, "b-right", members(2, 3))
+		c.settle(t, "z-shared", members(0, 1, 2, 3))
+
+		assert.NilError(t, c.dbs[0].CreateEntry(tableUnderTest, "z-shared", "key", []byte("value")))
+		// Enough rounds that every node has visited z-shared first several times
+		// over; one round is not enough even when the order does vary.
+		for range 20 {
+			for _, db := range c.dbs {
+				db.bulkSyncTables()
+			}
+			synctest.Wait()
+		}
+		for i, db := range c.dbs {
+			_, err := db.GetEntry(tableUnderTest, "z-shared", "key")
+			assert.NilError(t, err, "node %d never received the entry", i)
+		}
+	})
+}
+
 func TestMRandomNodes(t *testing.T) {
 	cfg := DefaultConfig()
 	// The easiest way to ensure that we don't accidentally generate node

--- a/daemon/libnetwork/networkdb/memcluster_test.go
+++ b/daemon/libnetwork/networkdb/memcluster_test.go
@@ -109,6 +109,10 @@ func newMemCluster(t TestingT, num int, namePrefix string, conf *Config) *memClu
 		synctest.Wait()
 	})
 
+	// Configs first, and sequentially: memNetwork hands out addresses from a
+	// counter, so allocating them concurrently would leave a node's address
+	// decided by the scheduler and stop a recorded failure from replaying.
+	configs := make([]Config, num)
 	for i := range num {
 		tr := c.mn.NewTransport()
 		addr := tr.AddrPort()
@@ -134,16 +138,76 @@ func newMemCluster(t TestingT, num int, namePrefix string, conf *Config) *memClu
 		localConfig.AdvertiseAddr = localConfig.BindAddr
 		localConfig.BindPort = int(addr.Port())
 
-		db := launchNode(t, localConfig)
-		if i != 0 {
-			prev := c.dbs[i-1]
-			assert.Check(t, db.Join([]string{net.JoinHostPort(prev.config.AdvertiseAddr, strconv.Itoa(prev.config.BindPort))}))
-		}
-		c.dbs = append(c.dbs, db)
+		configs[i] = localConfig
 	}
 
-	// Chain-joining tells each node about one peer; wait for gossip to give
-	// every node all of them before handing the cluster over.
+	// Then bring every node up from its own goroutine, all at one virtual
+	// instant. Creating them together is deliberate, and here is the only place
+	// it can be decided: Create calls memberlist's schedule(), which builds the
+	// probe and gossip tickers, and clusterInit starts NetworkDB's own triggers,
+	// so the instant a node is created fixes the phase of every periodic task it
+	// will ever run, and nothing afterwards moves it -- memberlist's randStagger
+	// cannot, since schedule() builds the ticker before the goroutine which reads
+	// it, and a stagger shorter than the interval never even skips a tick.
+	//
+	// Launching one at a time left those phases to whatever each Join happened to
+	// cost, which came out a multiple of the gossip interval: they landed in
+	// phase by accident rather than by intent, and would have drifted the moment
+	// a join got faster or slower.
+	dbs := make([]*NetworkDB, num)
+	errs := make([]error, num)
+	var wg sync.WaitGroup
+	for i := range num {
+		wg.Go(func() {
+			dbs[i], errs[i] = New(&configs[i])
+		})
+	}
+	wg.Wait()
+	// Register whatever came up before reporting any failure, so the cleanup
+	// above closes it either way. The reporting happens here and not inside the
+	// goroutines because t.Fatal has to run on the test's own goroutine.
+	for _, db := range dbs {
+		if db != nil {
+			c.dbs = append(c.dbs, db)
+		}
+	}
+	for _, err := range errs {
+		assert.NilError(t, err)
+	}
+
+	for i, db := range c.dbs {
+		if i > 0 {
+			// Seed the newcomer with every node already up, not just the
+			// previous one. Join push/pulls with each seed synchronously, so
+			// all of them learn the newcomer before Join returns and formation
+			// never waits on an epidemic to spread it. That is not the same as
+			// costing no clock -- a join spends a few hundred milliseconds of
+			// it, and forming nineteen nodes some seconds in total -- but what
+			// it costs does not turn on a race.
+			//
+			// Chain-joining left the newcomer known only to its one seed, and
+			// its spread to everyone else rode memberlist's alive broadcast:
+			// a one-shot epidemic whose budget is
+			// RetransmitMult*ceil(log10(N+1)) transmissions, spent one per
+			// recipient, so gossiping to GossipNodes peers costs that many at
+			// once. At N=9 the budget is 4 against 8 peers -- the worst ratio
+			// in the range these tests use, since the ceil(log10) step to 8
+			// lands at N=10 -- and roughly 10% of formations lost the race and
+			// fell back to memberlist's push/pull anti-entropy: one random
+			// peer per node per 30s, several rounds to spread from a single
+			// origin, 15-60s of virtual time. That tail sat right on
+			// formationTimeout, so about 1 run in 171 timed out here.
+			seeds := make([]string, 0, i)
+			for _, prev := range c.dbs[:i] {
+				seeds = append(seeds, net.JoinHostPort(prev.config.AdvertiseAddr, strconv.Itoa(prev.config.BindPort)))
+			}
+			assert.Check(t, db.Join(seeds))
+		}
+	}
+
+	// Formation is synchronous now, so this should pass on its first look. It
+	// stays as a guard: if a future change makes membership depend on gossip
+	// again, this reports it here rather than as a puzzling failure later.
 	incomplete := func(db *NetworkDB) bool { return len(db.ClusterPeers()) != len(c.dbs) }
 	start := time.Now()
 	for {

--- a/daemon/libnetwork/networkdb/memcluster_test.go
+++ b/daemon/libnetwork/networkdb/memcluster_test.go
@@ -2,6 +2,7 @@ package networkdb
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"net"
 	"net/netip"
@@ -120,6 +121,14 @@ func newMemCluster(t TestingT, num int, namePrefix string, conf *Config) *memClu
 		// one more thing a replay cannot reproduce. Twelve characters, matching
 		// what TruncateID would have produced, and never all-digits.
 		localConfig.NodeID = fmt.Sprintf("node%08d", i+1)
+		if conf.rngSeed != nil {
+			// One stream per node, all derived from the template's seed, so a
+			// single recorded value reproduces the whole cluster's gossip
+			// without every node making identical choices.
+			seed := *conf.rngSeed
+			binary.LittleEndian.PutUint64(seed[24:], uint64(i))
+			localConfig.rngSeed = &seed
+		}
 		localConfig.transport = tr
 		localConfig.BindAddr = addr.Addr().String()
 		localConfig.AdvertiseAddr = localConfig.BindAddr

--- a/daemon/libnetwork/networkdb/memcluster_test.go
+++ b/daemon/libnetwork/networkdb/memcluster_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/hashicorp/memberlist"
-	"github.com/moby/moby/v2/daemon/internal/stringid"
 	"gotest.tools/v3/assert"
 )
 
@@ -115,7 +114,12 @@ func newMemCluster(t TestingT, num int, namePrefix string, conf *Config) *memClu
 
 		localConfig := *conf
 		localConfig.Hostname = fmt.Sprintf("%s%d", namePrefix, i+1)
-		localConfig.NodeID = stringid.TruncateID(stringid.GenerateRandomID())
+		// Derived from the index, not stringid.GenerateRandomID, which reads
+		// crypto/rand: identical clusters across runs make a failure dump
+		// diffable against the next run's, and stop node identity from being
+		// one more thing a replay cannot reproduce. Twelve characters, matching
+		// what TruncateID would have produced, and never all-digits.
+		localConfig.NodeID = fmt.Sprintf("node%08d", i+1)
 		localConfig.transport = tr
 		localConfig.BindAddr = addr.Addr().String()
 		localConfig.AdvertiseAddr = localConfig.BindAddr

--- a/daemon/libnetwork/networkdb/networkdb.go
+++ b/daemon/libnetwork/networkdb/networkdb.go
@@ -262,6 +262,22 @@ type Config struct {
 	// Only set by tests.
 	tableEventObserver func(nodeID, networkID, tableName, key string, viaBulkSync bool)
 
+	// rngSeed, when non-nil, seeds the RNG which picks gossip and bulk-sync
+	// peers, in place of a seed read from crypto/rand, so that a test can fix
+	// what is otherwise drawn from a source it can neither control nor record.
+	//
+	// It does not make a cluster's gossip reproducible. Which peer a node picks
+	// also depends on which peers it has heard of by the time it draws, and that
+	// follows from goroutine scheduling; memberlist draws from the math/rand
+	// global for its own shuffling and probe timing, and offers no way to inject
+	// an RNG. Seeding removes one uncontrolled input of several.
+	//
+	// Note this is the seed, not the RNG: every instance still gets its own
+	// stream, so nodes do not make identical choices.
+	//
+	// Only set by tests.
+	rngSeed *[32]byte
+
 	// StatsPrintPeriod the period to use to print queue stats
 	// Default is 5min
 	StatsPrintPeriod time.Duration
@@ -335,7 +351,11 @@ func newNetworkDB(c *Config) *NetworkDB {
 	c.reapNetworkInterval = c.reapEntryInterval + 5*reapPeriod
 
 	var rngSeed [32]byte
-	_, _ = cryptorand.Read(rngSeed[:]) // Documented never to return an error
+	if c.rngSeed != nil {
+		rngSeed = *c.rngSeed
+	} else {
+		_, _ = cryptorand.Read(rngSeed[:]) // Documented never to return an error
+	}
 
 	return &NetworkDB{
 		config: c,

--- a/daemon/libnetwork/networkdb/networkdb_property_test.go
+++ b/daemon/libnetwork/networkdb/networkdb_property_test.go
@@ -91,7 +91,7 @@ func testConvergence(t *rapid.T) {
 
 	t.Logf("Waiting for NetworkDB state to converge to %#v", converged)
 	for i, st := range fsm.state {
-		t.Logf("Node #%d (%s): %v", i, c.dbs[i].config.NodeID, slices.Collect(maps.Keys(st)))
+		t.Logf("Node #%d (%s): %v", i, c.dbs[i].config.NodeID, slices.Sorted(maps.Keys(st)))
 	}
 	t.Log("Mutations:")
 	for _, m := range fsm.mutations {
@@ -252,7 +252,13 @@ func (u *networkDBFSM) drawJoinedNodeAndNetwork(t *rapid.T) (nodeidx int, nw str
 	}
 	nodeidx = rapid.SampledFrom(nodes).Draw(t, "node")
 
-	nw = rapid.SampledFrom(slices.Collect(maps.Keys(u.state[nodeidx]))).Draw(t, "network")
+	// Sorted, not merely collected. SampledFrom records the index it chose,
+	// and map iteration order is randomised per run, so an unsorted candidate
+	// list makes that index resolve to a different element on replay. The
+	// model then diverges, later candidate lists differ in size, draws consume
+	// different widths, and the rest of the stream desynchronises -- which is
+	// why an unsorted list defeats both failfile replay and shrinking.
+	nw = rapid.SampledFrom(slices.Sorted(maps.Keys(u.state[nodeidx]))).Draw(t, "network")
 	return nodeidx, nw
 }
 
@@ -284,7 +290,7 @@ func (u *networkDBFSM) CreateEntry(t *rapid.T) {
 
 // drawOwnedDBKey returns a random key in nw owned by the node at nodeidx.
 func (u *networkDBFSM) drawOwnedDBKey(t *rapid.T, nodeidx int, nw string) string {
-	keys := slices.Collect(maps.Keys(u.state[nodeidx][nw]))
+	keys := slices.Sorted(maps.Keys(u.state[nodeidx][nw])) // sorted: see drawJoinedNodeAndNetwork
 	if len(keys) == 0 {
 		t.Skipf("Node %v owns no entries in network %s", nodeidx, nw)
 		panic("unreachable")

--- a/daemon/libnetwork/networkdb/networkdb_property_test.go
+++ b/daemon/libnetwork/networkdb/networkdb_property_test.go
@@ -1,6 +1,7 @@
 package networkdb
 
 import (
+	"encoding/binary"
 	"fmt"
 	"maps"
 	"slices"
@@ -50,7 +51,19 @@ func testConvergence(t *rapid.T) {
 	numNodes := rapid.IntRange(2, 25).Draw(t, "numNodes")
 	numNetworks := rapid.IntRange(1, 5).Draw(t, "numNetworks")
 
-	c := newMemCluster(t, numNodes, "node", DefaultConfig())
+	// Draw the gossip seed rather than letting each node read crypto/rand, so
+	// that it is recorded and shrunk like any other draw instead of being
+	// invented. It does not pin the interleaving -- memberlist's own randomness
+	// is unseedable and synctest orders the clock, not the scheduler -- but it
+	// takes one uncontrolled input out of the picture. A fixed seed would be
+	// worse than either: every run would gossip alike, and the point of this
+	// test is to explore that space.
+	conf := DefaultConfig()
+	var seed [32]byte
+	binary.LittleEndian.PutUint64(seed[:], rapid.Uint64().Draw(t, "rngSeed"))
+	conf.rngSeed = &seed
+
+	c := newMemCluster(t, numNodes, "node", conf)
 
 	fsm := &networkDBFSM{
 		nDB:      c.dbs,


### PR DESCRIPTION
- Follow up to: https://github.com/moby/moby/pull/53333

## Summary

`TestNetworkDBAlwaysConverges` draws a scenario, runs it, and asserts that every
node converges on the same table. When it failed, replaying the recorded failfile
ran a *different* scenario from the one that had failed.

This makes the drawn scenario a deterministic function of rapid's draw buffer, so
a failfile or a `-rapid.seed` replays the same actions. It does **not** make a
failure reproduce, and it does not let rapid shrink one; see below.

**The FSM's draw stream was not deterministic.** `drawJoinedNodeAndNetwork` and
`drawOwnedDBKey` built their candidate lists with
`slices.Collect(maps.Keys(...))`, and `rapid.SampledFrom` records the index it
chose rather than the value. Go randomises map iteration order per run, so on
replay that index resolved to a different network or key. The damage compounds: a
different key changes the model, the next candidate list differs in size, its draw
consumes a different number of bits, and the remainder of the stream
desynchronises. Isolating the replay with `-rapid.checks=0`, four replays of one
failfile consumed 558, 303, 527 and 594 draws.

The evidence this was the cause rather than gossip timing: at one draw slot a
recorded failure applied the value `"vhrblimc"` to key `"etd"`, while a replay
applied the same value to key `"wkayzkkd"`. `StringMatching` values derive purely
from the draw bits and replayed faithfully; only the `SampledFrom` index resolved
differently.

**Other uncontrolled inputs.** Every NetworkDB seeded its peer-selection RNG from
`crypto/rand`, and `triggerFunc` staggered its tickers from the `math/rand/v2`
global — the former cannot be seeded in-process, the latter has no `Seed` function
at all. Node IDs came from `stringid.GenerateRandomID`, also `crypto/rand`. And
cluster formation raced its own gossip, timing out about 1 run in 171.

So: sort the candidate lists; derive test node IDs from the loop index; add an
unexported `Config.rngSeed`, in the same spirit as the existing `Config.transport`
and `Config.tableEventObserver`, with the ticker stagger moved onto the instance's
own RNG so one seed covers it; and seed each newcomer with every node already up,
so formation completes without the clock advancing.

With the same `-rapid.seed`, three runs of five checks now produce a
byte-identical draw stream — 925 draws each, where before the same seed gave 1073,
1009 and 1101. That is evidence for the sorting specifically: it is rapid's own
draw log, so it shows the scenario is now a function of the buffer. It says
nothing about the gossip interleaving, which is not reproducible and is not made
so here.

## What this does not fix

A failure still will not reproduce, and rapid still cannot shrink one. Three
reasons, none of them addressed by this PR:

1. **The failure message varies.** rapid decides whether a replay reproduced the
   failure by comparing `err.Error()` text — see `sameError` — and this test's
   message embeds a `cmp.Diff` of the two table states and a dump of every node's
   table, both of which differ with the interleaving. So a failure is reported as
   "flaky test, can not reproduce a failure" whatever the draw stream does, and
   shrinking is never reached.

2. **Convergence depends on goroutine scheduling.** `testing/synctest` virtualises
   the clock, not the scheduler, and memberlist draws from the `math/rand` global
   for `shuffleNodes`, `randomOffset` and its probe staggers, with no way to inject
   an RNG. With everything here applied and the same seed, per-node peer selections
   still diverge: 0 of 16 nodes produced the same sequence across three runs.

3. **Shrinking needs a reliable verdict.** rapid judges a candidate by running it
   once and reads a passing run as a no, so a failure which shows up one execution
   in fifty stalls the search even once its message is stable.

They will be addressed in a follow-up.

A seeded source consumed in a fixed order is worth having regardless: it removes
real nondeterminism from the test, and it is the precondition for the rest.

Note this invalidates failfiles recorded before it — the extra draw shifts the
buffer.

## Release notes (optional)

```markdown changelog

```

Created with: Claude Code (Opus 5)
