### PR TITLE
daemon/nri: Block plugin sync while creating a container

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -250,9 +250,11 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 	}
 	daemon.updateContainerNetworkSettings(ctr, endpointsConfigs)
 
-	if err := daemon.nri.CreateContainer(ctx, ctr); err != nil {
+	releaseNRI, err := daemon.nri.CreateContainer(ctx, ctr)
+	if err != nil {
 		return nil, err
 	}
+	defer releaseNRI()
 
 	if err := daemon.registerMountPoints(ctr, opts.params.DefaultReadOnlyNonRecursive); err != nil {
 		return nil, err
@@ -281,6 +283,7 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 	if err := daemon.register(ctx, ctr); err != nil {
 		return nil, err
 	}
+	releaseNRI()
 	metrics.StateCtr.Set(ctr.ID, "stopped")
 	daemon.LogContainerEvent(ctr, events.ActionCreate)
 	return ctr, nil

--- a/daemon/internal/nri/nri.go
+++ b/daemon/internal/nri/nri.go
@@ -162,43 +162,82 @@ func (n *NRI) PrepareReload(nriCfg opts.NRIOpts) (func() error, error) {
 
 // CreateContainer notifies plugins of a "creation" NRI-lifecycle event for a container,
 // allowing the plugin to adjust settings before the container is created.
+// The returned function is safe to defer unconditionally and call earlier
+// after the container is registered.
+// Subsequent calls are no-ops.
 //
 // No lock is acquired on ctr, CreateContainer the caller must ensure it cannot be
 // accessed from other threads.
-func (n *NRI) CreateContainer(ctx context.Context, ctr *container.Container) error {
-	n.mu.RLock()
-	defer n.mu.RUnlock()
-	if n.adap == nil {
-		return nil
+func (n *NRI) CreateContainer(ctx context.Context, ctr *container.Container) (_ func(), retErr error) {
+	var (
+		adap            *adaptation.Adaptation
+		pluginSyncBlock *adaptation.PluginSyncBlock
+	)
+	for {
+		n.mu.RLock()
+		adap = n.adap
+		n.mu.RUnlock()
+
+		// Plugin registration takes the adaptation sync lock before calling
+		// syncFn, which takes n.mu. Take the locks in the same order.
+		if adap != nil {
+			pluginSyncBlock = adap.BlockPluginSync()
+		}
+
+		n.mu.RLock()
+		if adap == n.adap {
+			break
+		}
+		n.mu.RUnlock()
+		if pluginSyncBlock != nil {
+			pluginSyncBlock.Unblock()
+			pluginSyncBlock = nil
+		}
+	}
+
+	release := sync.OnceFunc(func() {
+		n.mu.RUnlock()
+		if pluginSyncBlock != nil {
+			pluginSyncBlock.Unblock()
+		}
+	})
+	defer func() {
+		if retErr != nil {
+			release()
+		}
+	}()
+
+	if adap == nil {
+		return release, nil
 	}
 	// ctr.State can safely be locked here, but there's no need because it's expected
 	// to be newly created and not yet accessible in any other thread.
 
 	nriPod, nriCtr, err := containerToNRI(ctr)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// TODO(robmry): call RunPodSandbox?
 
-	resp, err := n.adap.CreateContainer(ctx, &adaptation.CreateContainerRequest{
+	resp, err := adap.CreateContainer(ctx, &adaptation.CreateContainerRequest{
 		Pod:       nriPod,
 		Container: nriCtr,
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if resp.GetUpdate() != nil {
-		return errors.New("container update is not supported")
+		return nil, errors.New("container update is not supported")
 	}
 	if resp.GetEvict() != nil {
-		return errors.New("container eviction is not supported")
+		return nil, errors.New("container eviction is not supported")
 	}
 	if err := applyAdjustments(ctx, ctr, resp.GetAdjust()); err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return release, nil
 }
 
 // syncFn is called when a plugin registers, allowing the plugin to learn the


### PR DESCRIPTION

- fix: https://github.com/moby/moby/issues/52755
- fix: https://github.com/moby/moby/issues/52755

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

A registering plugin is added to the adaptation's plugin list only after its Synchronize request completes. A container created between those steps is offered to no plugin, so its adjustments are lost.

Hold the adaptation's plugin-sync block across CreateContainer so registration cannot complete until the hook has been offered the container.


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
