### PR TITLE
daemon/libnetwork/networkdb: carry network attachments in bulk syncs

### DIFF
--- a/daemon/libnetwork/networkdb/broadcast.go
+++ b/daemon/libnetwork/networkdb/broadcast.go
@@ -11,14 +11,26 @@ import (
 const broadcastTimeout = 5 * time.Second
 
 type networkEventMessage struct {
-	id   string
-	node string
-	msg  []byte
+	id    string
+	node  string
+	ltime serf.LamportTime
+	msg   []byte
 }
 
 func (m *networkEventMessage) Invalidates(other memberlist.Broadcast) bool {
 	otherm := other.(*networkEventMessage)
-	return m.id == otherm.id && m.node == otherm.node
+	if m.id != otherm.id || m.node != otherm.node {
+		return false
+	}
+	// Supersede an event only if this one is no older. handleNetworkMessage
+	// queues a relay after releasing the lock it applied the event under, and
+	// the two paths that deliver events do not share a goroutine: gossip is
+	// handled by memberlist's single packetHandler, bulk syncs arrive over
+	// streams with one goroutine per connection. Two handlers can therefore
+	// apply in Lamport order and reach the queue in the opposite order.
+	// Matching on (network, node) alone would let the straggler evict the
+	// fresher relay and put a stale attachment on the wire in its place.
+	return m.ltime >= otherm.ltime
 }
 
 func (m *networkEventMessage) Message() []byte {
@@ -42,9 +54,10 @@ func (nDB *NetworkDB) sendNetworkEvent(nid string, event NetworkEvent_Type, ltim
 	}
 
 	nDB.networkBroadcasts.QueueBroadcast(&networkEventMessage{
-		msg:  raw,
-		id:   nid,
-		node: nDB.config.NodeID,
+		msg:   raw,
+		id:    nid,
+		ltime: ltime,
+		node:  nDB.config.NodeID,
 	})
 	return nil
 }

--- a/daemon/libnetwork/networkdb/broadcast_test.go
+++ b/daemon/libnetwork/networkdb/broadcast_test.go
@@ -141,3 +141,29 @@ func TestOwnNodeEventSurvivesRelayedEvents(t *testing.T) {
 	slices.Sort(got)
 	assert.DeepEqual(t, got, []string{"own", "relay"})
 }
+
+// A queued network event may only be superseded by one which is at least as
+// fresh. handleNetworkMessage queues a relay after releasing the lock it
+// applied the event under, and gossip and bulk sync do not share a goroutine,
+// so a stale relay can reach the queue behind a fresher one.
+func TestNetworkEventMessageInvalidates(t *testing.T) {
+	msg := func(nid, node string, ltime serf.LamportTime) *networkEventMessage {
+		return &networkEventMessage{id: nid, node: node, ltime: ltime}
+	}
+
+	for _, tc := range []struct {
+		name       string
+		m, other   *networkEventMessage
+		invalidate bool
+	}{
+		{"fresher supersedes staler", msg("nw", "n1", 7), msg("nw", "n1", 5), true},
+		{"same ltime is a duplicate", msg("nw", "n1", 5), msg("nw", "n1", 5), true},
+		{"staler must not evict fresher", msg("nw", "n1", 5), msg("nw", "n1", 7), false},
+		{"another node's attachment", msg("nw", "n1", 9), msg("nw", "n2", 1), false},
+		{"another network", msg("nw2", "n1", 9), msg("nw", "n1", 1), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.m.Invalidates(tc.other), tc.invalidate)
+		})
+	}
+}

--- a/daemon/libnetwork/networkdb/cluster.go
+++ b/daemon/libnetwork/networkdb/cluster.go
@@ -671,6 +671,12 @@ func (nDB *NetworkDB) bulkSyncNode(networks []string, node string, unsolicited b
 		return fmt.Errorf("cannot bulk sync with unknown node %s", node)
 	}
 
+	// Carry the attachment view for the networks being synced, ahead of the
+	// entries which depend on it, for any peer which can take it.
+	if mnode.canReceiveNetworkEvents() {
+		msgs = nDB.appendNetworkEvents(msgs, networks, node)
+	}
+
 	for _, nid := range networks {
 		nDB.indexes[byNetwork].Root().WalkPrefix([]byte("/"+nid), func(path []byte, v *entry) bool {
 			eType := TableEventTypeCreate
@@ -693,7 +699,7 @@ func (nDB *NetworkDB) bulkSyncNode(networks []string, node string, unsolicited b
 
 			msg, err := encodeMessage(MessageTypeTableEvent, &tEvent)
 			if err != nil {
-				log.G(context.TODO()).Errorf("Encode failure during bulk sync: %#v", tEvent)
+				log.G(context.TODO()).WithError(err).Errorf("Encode failure during bulk sync: %#v", tEvent)
 				return false
 			}
 
@@ -813,4 +819,74 @@ func (nDB *NetworkDB) mRandomNodes(m int, nodes []string) []string {
 	}
 
 	return sample
+}
+
+// appendNetworkEvents appends the attachment view for networks: which nodes this
+// one believes participate in each of them. Call with nDB's read lock held.
+//
+// handleTableEvent will not accept an entry from a node it does not believe
+// participates in the network, and attachments are otherwise disseminated only
+// by one-shot NetworkEvent broadcasts with a bounded number of retransmits. A
+// node which misses those has no way back: a bulk sync hands it the entries
+// every round and it rejects every one of them, for as long as its view stays
+// stale. Sending the attachments those entries are predicated on makes the sync
+// self-sufficient, so anti-entropy converges the membership it needs rather
+// than assuming it.
+//
+// The volume is bounded by the membership of the networks being synced, not by
+// cluster history: changeNodeState drops a peer's attachments as soon as it goes
+// failed or left, and reapNetworks collects those marked leaving, so nDB.networks
+// holds live peers plus a short tail of departures.
+//
+// Departures are included on purpose. A node which missed a Leave is the mirror
+// image of the case above -- it holds a departed owner in networkNodes and keeps
+// accepting and serving its entries -- and handleNetworkEvent's Leave path is
+// what clears that. Filtering on !n.leaving here would trade one stale view for
+// the other.
+//
+// These are ordinary network events, so handleNetworkEvent applies its usual
+// Lamport-time check and a receiver which is already up to date does nothing.
+func (nDB *NetworkDB) appendNetworkEvents(msgs [][]byte, networks []string, node string) [][]byte {
+	for _, nid := range networks {
+		if n, ok := nDB.thisNodeNetworks[nid]; ok {
+			msgs = appendNetworkEventMsg(msgs, nDB.config.NodeID, nid, n.network)
+		}
+	}
+	for owner, nws := range nDB.networks {
+		if owner == node {
+			// The peer is authoritative for its own attachments, so
+			// handleNetworkEvent drops anything we tell it about itself. Skipping
+			// it is not just a saving: findCommonNetworks only returns networks
+			// this node records the peer as attached to, so without this every
+			// network in the sync would carry one event guaranteed to be
+			// discarded -- after the receiver had taken the write lock to
+			// discard it.
+			continue
+		}
+		for _, nid := range networks {
+			if n, ok := nws[nid]; ok {
+				msgs = appendNetworkEventMsg(msgs, owner, nid, *n)
+			}
+		}
+	}
+	return msgs
+}
+
+// appendNetworkEventMsg appends an encoded NetworkEvent describing one node's
+// attachment to a network. Used to make a bulk sync carry the membership its
+// table entries are predicated on.
+func appendNetworkEventMsg(msgs [][]byte, nodeName, nid string, n network) [][]byte {
+	nEvent := NetworkEvent{
+		Type:      networkEventType(n.leaving),
+		LTime:     n.ltime,
+		NodeName:  nodeName,
+		NetworkID: nid,
+	}
+
+	msg, err := encodeMessage(MessageTypeNetworkEvent, &nEvent)
+	if err != nil {
+		log.G(context.TODO()).WithError(err).Errorf("Encode failure during bulk sync: %#v", nEvent)
+		return msgs
+	}
+	return append(msgs, msg)
 }

--- a/daemon/libnetwork/networkdb/convergence_test.go
+++ b/daemon/libnetwork/networkdb/convergence_test.go
@@ -913,3 +913,113 @@ func (g *churnGenerator) step() {
 	}
 	g.joined = !g.joined
 }
+
+// TestNetworkDBBulkSyncCarriesAttachments pins the invariant that a bulk sync
+// carries the network attachments its table entries are predicated on, and
+// carries them first.
+//
+// handleTableEvent rejects an entry from a node it does not record as
+// participating in the network, and that record is otherwise disseminated only
+// by a one-shot NetworkEvent broadcast with a bounded retransmit budget. A node
+// which misses that broadcast rejects the owner's entries indefinitely --
+// including the ones every bulk sync hands it -- unless the sync repairs the
+// membership too.
+//
+// Driving exactly one bulkSyncNode is what makes this a test of ordering rather
+// than merely of presence. handleCompound processes a compound message's parts
+// in order, so attachments appended after the entries would leave those entries
+// rejected on this sync and accepted only on a later one -- which a test that
+// waited for eventual convergence would pass without noticing.
+func TestNetworkDBBulkSyncCarriesAttachments(t *testing.T) {
+	requireSynctest(t)
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			nw  = "nw0"
+			key = "k0"
+		)
+
+		c := newMemCluster(t, 2, "node", DefaultConfig())
+		a, b := c.dbs[0], c.dbs[1]
+		aID, bID := a.config.NodeID, b.config.NodeID
+
+		for _, db := range c.dbs {
+			assert.NilError(t, db.JoinNetwork(nw))
+		}
+		c.settle(t, nw, []string{aID, bID})
+
+		// Make a forget that b participates in nw, leaving it exactly as
+		// deleteNodeFromNetworks does: the attachment record gone and the owner
+		// out of the per-network peer list. Dropping only the peer list would
+		// not reproduce anything reachable -- a would still hold an attachment
+		// record no staler than the repair, and handleNetworkEvent would
+		// discard the repair as stale.
+		a.Lock()
+		delete(a.networks[bID], nw)
+		a.deleteNetworkNode(nw, bID)
+		a.Unlock()
+
+		// b writes after the divergence. The clock is not advanced from here
+		// on, so no gossip round, push/pull or periodic sync runs: the entry
+		// has exactly one way to reach a, and it is the sync below. Advancing
+		// the clock instead would make this flaky, since memberlist staggers
+		// the first push/pull uniformly over PushPullInterval and that would
+		// sometimes repair a on its own.
+		assert.NilError(t, b.CreateEntry(tableUnderTest, nw, key, []byte("v0")))
+		synctest.Wait()
+		_, err := a.GetEntry(tableUnderTest, nw, key)
+		assert.Check(t, err != nil, "a already holds the entry, so this test would pass without proving anything")
+
+		// Solicited, not unsolicited: an unsolicited sync makes a answer with
+		// one of its own, and bulkSyncNode then blocks on the ack.
+		assert.NilError(t, b.bulkSyncNode([]string{nw}, aID, false))
+		synctest.Wait()
+
+		got, err := a.GetEntry(tableUnderTest, nw, key)
+		assert.NilError(t, err, "a rejected the bulk-synced entry: the sync did not carry b's attachment ahead of it")
+		assert.Equal(t, string(got), "v0")
+	})
+}
+
+// TestNetworkDBBulkSyncSkipsAttachmentsForOldPeers is the counterpart to the
+// test above. A daemon which does not advertise Lamport-time-aware invalidation
+// must not be sent network events in a bulk sync: it would queue relays it can
+// then evict out of order, gossiping a stale attachment. It keeps the
+// convergence gap the sync would have closed until it is upgraded, which is the
+// conservative side to err on during a rolling upgrade.
+func TestNetworkDBBulkSyncSkipsAttachmentsForOldPeers(t *testing.T) {
+	requireSynctest(t)
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			nw  = "nw0"
+			key = "k0"
+		)
+
+		c := newMemCluster(t, 2, "node", DefaultConfig())
+		a, b := c.dbs[0], c.dbs[1]
+		aID, bID := a.config.NodeID, b.config.NodeID
+
+		for _, db := range c.dbs {
+			assert.NilError(t, db.JoinNetwork(nw))
+		}
+		c.settle(t, nw, []string{aID, bID})
+
+		// Let b see a as a daemon from before node metadata carried a version.
+		b.Lock()
+		b.nodes[aID].Meta = nil
+		b.Unlock()
+
+		a.Lock()
+		delete(a.networks[bID], nw)
+		a.deleteNetworkNode(nw, bID)
+		a.Unlock()
+
+		assert.NilError(t, b.CreateEntry(tableUnderTest, nw, key, []byte("v0")))
+		synctest.Wait()
+		assert.NilError(t, b.bulkSyncNode([]string{nw}, aID, false))
+		synctest.Wait()
+
+		_, err := a.GetEntry(tableUnderTest, nw, key)
+		assert.Check(t, err != nil,
+			"a accepted the entry, so the sync carried attachments to a peer which cannot safely take them")
+	})
+}

--- a/daemon/libnetwork/networkdb/delegate.go
+++ b/daemon/libnetwork/networkdb/delegate.go
@@ -13,8 +13,47 @@ type delegate struct {
 	nDB *NetworkDB
 }
 
+// Node metadata, which memberlist carries in alive messages and push/pull state
+// and hands back on every [memberlist.Node]. It is opaque to memberlist and
+// ignored by daemons which do not understand it, which is what makes it usable
+// here at all: memberlist's own DelegateProtocolVersion is not, because
+// verifyProtocol -- reached from mergeRemoteState on every push/pull, not just
+// joins -- rejects any node whose DCur exceeds the cluster-wide minimum DMax,
+// and daemons predating this advertise DMax=0. Raising it would have their
+// push/pulls, and a new node's join, refused outright.
+const (
+	// nodeMetaLTimeInvalidation marks a daemon whose networkEventMessage
+	// invalidation compares Lamport times, and which may therefore be sent
+	// network events in a bulk sync. See (*node).canReceiveNetworkEvents.
+	nodeMetaLTimeInvalidation = 1
+
+	// nodeMetaVersion is what this daemon advertises. NodeMeta has returned an
+	// empty slice ever since networkdb was introduced, so empty metadata
+	// identifies a daemon from before any of this existed.
+	nodeMetaVersion = nodeMetaLTimeInvalidation
+)
+
 func (d *delegate) NodeMeta(limit int) []byte {
-	return []byte{}
+	return []byte{nodeMetaVersion}
+}
+
+// canReceiveNetworkEvents reports whether network events may be included in a
+// bulk sync to n.
+//
+// The receiver applies them through handleNetworkMessage, which queues a relay
+// after releasing the lock it applied the event under. Bulk syncs arrive on a
+// goroutine per connection while gossip is handled by memberlist's single
+// packetHandler, so two handlers can apply in Lamport order and reach the queue
+// in the opposite order. A daemon which invalidates queued network events on
+// (network, node) alone lets the straggler evict the fresher relay and gossip a
+// stale attachment in its place.
+//
+// This daemon compares Lamport times and is safe either way, but older ones do
+// not, and sending to them would make that flaw reachable for the length of a
+// rolling upgrade. They keep the convergence gap this is all meant to close
+// until they are upgraded, which is the more conservative of the two.
+func (n *node) canReceiveNetworkEvents() bool {
+	return len(n.Meta) > 0 && n.Meta[0] >= nodeMetaLTimeInvalidation
 }
 
 func (nDB *NetworkDB) handleNodeEvent(nEvent *NodeEvent) bool {
@@ -365,9 +404,10 @@ func (nDB *NetworkDB) handleNetworkMessage(buf []byte) {
 		}
 
 		nDB.networkBroadcasts.QueueBroadcast(&networkEventMessage{
-			msg:  buf,
-			id:   nEvent.NetworkID,
-			node: nEvent.NodeName,
+			msg:   buf,
+			id:    nEvent.NetworkID,
+			ltime: nEvent.LTime,
+			node:  nEvent.NodeName,
 		})
 	}
 }
@@ -529,17 +569,11 @@ func (d *delegate) MergeRemoteState(buf []byte, isJoin bool) {
 	d.nDB.handleNodeEvent(nodeEvent)
 
 	for _, n := range pp.Networks {
-		nEvent := &NetworkEvent{
+		d.nDB.handleNetworkEvent(&NetworkEvent{
 			LTime:     n.LTime,
 			NodeName:  n.NodeName,
 			NetworkID: n.NetworkID,
-			Type:      NetworkEventTypeJoin,
-		}
-
-		if n.Leaving {
-			nEvent.Type = NetworkEventTypeLeave
-		}
-
-		d.nDB.handleNetworkEvent(nEvent)
+			Type:      networkEventType(n.Leaving),
+		})
 	}
 }

--- a/daemon/libnetwork/networkdb/delegate_test.go
+++ b/daemon/libnetwork/networkdb/delegate_test.go
@@ -1,0 +1,35 @@
+package networkdb
+
+import (
+	"testing"
+
+	"github.com/hashicorp/memberlist"
+	"gotest.tools/v3/assert"
+)
+
+func TestNodeCanReceiveNetworkEvents(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		meta []byte
+		want bool
+	}{
+		{"no metadata at all", nil, false},
+		{"empty metadata, as every daemon before this sent", []byte{}, false},
+		{"advertises ltime-aware invalidation", []byte{nodeMetaLTimeInvalidation}, true},
+		{"advertises something later", []byte{nodeMetaLTimeInvalidation + 1}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &node{Node: memberlist.Node{Meta: tc.meta}}
+			assert.Equal(t, n.canReceiveNetworkEvents(), tc.want)
+		})
+	}
+}
+
+// What this daemon advertises has to satisfy its own predicate, or a cluster of
+// current daemons would never send each other attachments at all.
+func TestNodeMetaAdvertisesOwnCapability(t *testing.T) {
+	d := &delegate{}
+	n := &node{Node: memberlist.Node{Meta: d.NodeMeta(memberlist.MetaMaxSize)}}
+	assert.Check(t, n.canReceiveNetworkEvents())
+	assert.Check(t, len(n.Meta) <= memberlist.MetaMaxSize)
+}

--- a/daemon/libnetwork/networkdb/networkdb.go
+++ b/daemon/libnetwork/networkdb/networkdb.go
@@ -155,6 +155,15 @@ type network struct {
 	reapTime time.Duration
 }
 
+// networkEventType returns the [NetworkEvent_Type] which announces an
+// attachment that is, or is not, in the process of leaving.
+func networkEventType(leaving bool) NetworkEvent_Type {
+	if leaving {
+		return NetworkEventTypeLeave
+	}
+	return NetworkEventTypeJoin
+}
+
 // thisNodeNetwork describes a network attachment on the local node.
 type thisNodeNetwork struct {
 	network


### PR DESCRIPTION
- Related to: https://github.com/moby/moby/pull/53142
- Related to: https://github.com/moby/moby/issues/53141

## Summary

`handleTableEvent` refuses a table entry from a node it does not believe participates in the network. That is a hard precondition for accepting an entry, but the state it consults — who is attached to what — arrives only as a `NetworkEvent` broadcast, and that is a *terminating* epidemic. A broadcast's budget is `RetransmitMult * ceil(log10(N+1))` transmissions, and `gossip()` charges one per recipient, so a single tick to `GossipNodes=3` peers spends three of it. Once every infected node has spent its budget the fact stops moving, permanently.

Usually it reaches everyone. When it does not, the node that missed it rejects every entry that owner ever writes to that network, for the lifetime of the cluster — and nothing recovers it. `bulkSyncTables` hands that node those very entries every `PushPullInterval` and it rejects every one, because the sync carries the entries but not the membership they are predicated on. I measured this directly on a diverged run: the entries arrived 54 times, 8 of them by bulk sync, and every single delivery was rejected for the owner not being attached, while 14 other nodes held the attachment.

The only other channel is memberlist's push/pull, which is pairwise and random — one peer per node per 30s — so it diffuses an attachment held by a minority slowly and with no guarantee. On that run, 39 of 124 push/pull payloads carried the attachment, and the diverged node's single exchange with the owner predated the owner's join.

**Fix:** send the attachment view for the networks being synced ahead of their entries, so a bulk sync converges the membership it needs rather than assuming it. These are ordinary network events, already dispatched from a bulk sync's compound payload, so `handleNetworkEvent` applies its usual Lamport-time check and a receiver that is already up to date does nothing. Ordering is load-bearing: `handleCompound` processes parts in order, so attachments land before the entries that depend on them.

### Why here and not by turning the gossip up

Raising `RetransmitMult` only moves the tail probability, and I measured how far. Attachment dissemination on a deterministically-formed cluster, share of rounds that outlived the epidemic and had to wait for anti-entropy:

| nodes | as-is | `RetransmitMult` doubled |
|---|---|---|
| 9 | 37.5% | 0.0% |
| 20 | 16.0% | 2.0% |
| 32 | 58.0% | 26.0% |
| 40 | 75.0% | 46.0% |

It shifts the curve rather than removing it, and it leaves the failure unrecoverable when it does happen. Bulk sync is the right home for the repair because it is already the channel carrying the dependent entries, and it repeats.

### Effect

Measured against the merge base, using `TestNetworkDBAlwaysConverges` from #50345: the failure reproduced 2 times in 25 runs before, and 0 times in 121 runs after — roughly 12,000 property cases. Separately, on a probe that measures attachment convergence directly over 1400 rounds, the repair tail drops from a maximum of 1m1s to 29.8s, because recovery is now bounded by one NetworkDB `PushPullInterval` instead of several rounds of pairwise push/pull.

[More details](https://claude.ai/code/artifact/46ea55f7-6ae2-424c-8a30-2d6f67165cf0)

### Known limitation

The repair is scoped to the sync's network list, which `findCommonNetworks` computes from the *initiator's* view. So it fixes the case where the receiver is the ignorant party, which is the case that showed up in practice — but a sender that does not know the receiver is attached will not sync that network with it at all, and so will not repair it either. Closing that too would mean reconciling the peer's advertised attachments in `handleBulkSync` before computing the response, which is a larger change than this one.

### Relationship to #53142

#53142 fixes a different route into the same rejection: attachment state that NetworkDB *deliberately discarded* when memberlist declared a peer failed. This one fixes attachment state that was *never received*, with no node failure involved. The divergence here reproduces on the merge base with #53142 absent, so they are independent, and #53142's bulk-sync change carries a failed node's entries but still not the attachments they are predicated on.

## Release notes (optional)

```markdown changelog
Fix Swarm service names failing to resolve on a node indefinitely after it misses a network membership announcement.
```

## A picture of a cute animal (not mandatory but encouraged)

🦫

Created with: Claude Code (Opus 5)
