### PR TITLE
daemon/logger/awslogs: avoid user-agent test race

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -19,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/logger/loggerutils"
 	"github.com/moby/moby/v2/dockerversion"
@@ -120,22 +122,22 @@ func TestNewStreamConfig(t *testing.T) {
 }
 
 func TestNewAWSLogsClientUserAgentHandler(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userAgent := r.Header.Get("User-Agent")
-		assert.Check(t, is.Contains(userAgent, "Docker/"+dockerversion.Version))
-		fmt.Fprintln(w, "{}")
-	}))
-	defer ts.Close()
-
 	info := logger.Info{
 		Config: map[string]string{
-			regionKey:   "us-east-1",
-			endpointKey: ts.URL,
+			regionKey: "us-east-1",
 		},
 	}
 
 	client, err := newAWSLogsClient(
 		info,
+		config.WithHTTPClient(smithyhttp.ClientDoFunc(func(r *http.Request) (*http.Response, error) {
+			assert.Check(t, is.Contains(r.Header.Get("User-Agent"), "Docker/"+dockerversion.Version))
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}, nil
+		})),
 		config.WithCredentialsProvider(credentials.StaticCredentialsProvider{
 			Value: aws.Credentials{AccessKeyID: "AKID", SecretAccessKey: "SECRET", SessionToken: "SESSION"},
 		}),


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/53273

## Summary

Make the AWS logs user-agent unit test inspect the SDK-built request through an injected synchronous HTTP client.

The real `net/http` transport serializes request headers on a separate goroutine, which can race with AWS middleware header mutation — the failure seen on Windows in `TestNewAWSLogsClientUserAgentHandler`, where `net/http.(*persistConn).writeLoop` was reading the request header map in `Header.sortedKeyValues` while the middleware wrote to it.

The test only needs to verify the final `User-Agent` header, so replacing the `httptest.Server` with `config.WithHTTPClient` and a `smithyhttp.ClientDoFunc` inspects the actual SDK-built request synchronously and avoids the transport concurrency entirely. The AWS middleware path under test is unchanged.

## Scope

One test file changes. No production code or behavior is touched.

## Testing

- `go test -race -run '^TestNewAWSLogsClientUserAgentHandler$' -count=100 ./daemon/logger/awslogs` — ok
- `go test -race ./daemon/logger/awslogs` — ok
- `GOOS=windows GOARCH=amd64 go test -c ./daemon/logger/awslogs` — ok
- `git diff --check` — clean

## Risks

The revised test no longer exercises Go's real HTTP transport. That transport is outside the behavior under test; the AWS middleware still builds the actual request that the injected client inspects.

Created with: Codex
