### PR TITLE
hack/make: skip missing nested binaries instead of copying empty path

### DIFF
--- a/hack/make/binary-daemon
+++ b/hack/make/binary-daemon
@@ -15,7 +15,12 @@ copy_binaries() {
 	fi
 	echo "Copying nested executables into $dir"
 	for file in containerd containerd-shim-runc-v2 ctr runc docker-init rootlesskit dockerd-rootless.sh dockerd-rootless-setuptool.sh; do
-		cp -f "$(command -v "$file")" "$dir/"
+		bin_path=$(command -v "$file" 2>/dev/null || true)
+		if [ -z "$bin_path" ]; then
+			echo "Skipping $file: not found in PATH" >&2
+			continue
+		fi
+		cp -f "$bin_path" "$dir/"
 	done
 }
 


### PR DESCRIPTION
Fixes #53442

### Problem

`hack/make/binary-daemon:copy_binaries()` gates on `[[ -x /usr/local/bin/runc ]]` but then assumes every nested binary is in `PATH`:

```bash
cp -f "$(command -v "$file")" "$dir/"
```

Newer GitHub-hosted Ubuntu runners ship a static Podman bundle that provides `/usr/local/bin/runc` without `ctr`, `containerd-shim-runc-v2`, etc. `command -v` then returns an empty string and the script runs `cp -f "" "$dir/"` → `cp: cannot stat '': No such file or directory` and the openwrt `dockerd` build aborts.

### Change

Resolve each binary first and skip it with a warning when not found:

```bash
bin_path=$(command -v "$file" 2>/dev/null || true)
if [ -z "$bin_path" ]; then
  echo "Skipping $file: not found in PATH" >&2
  continue
fi
cp -f "$bin_path" "$dir/"
```

`|| true` keeps `set -e` from exiting on the missing case, and the `2>/dev/null` silences the shell's "not found" noise while the explicit warning stays.

### Validation

- `bash -n hack/make/binary-daemon` passes
- Manual repro with a minimal `PATH` containing only `runc`/`containerd`: before → `cp: cannot stat ''`; after → skips the 6 missing binaries and copies the 2 present ones
- `git diff --check` clean
