### PR TITLE
api/docs: fix Secret.Spec ref and config names filter

### DIFF
--- a/api/docs/v1.25.yaml
+++ b/api/docs/v1.25.yaml
@@ -2532,7 +2532,7 @@ definitions:
         type: "string"
         format: "dateTime"
       Spec:
-        $ref: "#/definitions/ServiceSpec"
+        $ref: "#/definitions/SecretSpec"
 paths:
   /containers/json:
     get:

--- a/api/docs/v1.26.yaml
+++ b/api/docs/v1.26.yaml
@@ -2536,7 +2536,7 @@ definitions:
         type: "string"
         format: "dateTime"
       Spec:
-        $ref: "#/definitions/ServiceSpec"
+        $ref: "#/definitions/SecretSpec"
 paths:
   /containers/json:
     get:

--- a/api/docs/v1.27.yaml
+++ b/api/docs/v1.27.yaml
@@ -2604,7 +2604,7 @@ definitions:
         type: "string"
         format: "dateTime"
       Spec:
-        $ref: "#/definitions/ServiceSpec"
+        $ref: "#/definitions/SecretSpec"
 paths:
   /containers/json:
     get:

--- a/api/docs/v1.28.yaml
+++ b/api/docs/v1.28.yaml
@@ -2691,7 +2691,7 @@ definitions:
         type: "string"
         format: "dateTime"
       Spec:
-        $ref: "#/definitions/ServiceSpec"
+        $ref: "#/definitions/SecretSpec"
 paths:
   /containers/json:
     get:

--- a/api/docs/v1.29.yaml
+++ b/api/docs/v1.29.yaml
@@ -2724,7 +2724,7 @@ definitions:
         type: "string"
         format: "dateTime"
       Spec:
-        $ref: "#/definitions/ServiceSpec"
+        $ref: "#/definitions/SecretSpec"
 paths:
   /containers/json:
     get:

--- a/api/docs/v1.30.yaml
+++ b/api/docs/v1.30.yaml
@@ -8670,7 +8670,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.31.yaml
+++ b/api/docs/v1.31.yaml
@@ -8800,7 +8800,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.32.yaml
+++ b/api/docs/v1.32.yaml
@@ -9758,7 +9758,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.33.yaml
+++ b/api/docs/v1.33.yaml
@@ -9766,7 +9766,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.34.yaml
+++ b/api/docs/v1.34.yaml
@@ -9806,7 +9806,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.35.yaml
+++ b/api/docs/v1.35.yaml
@@ -9840,7 +9840,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.36.yaml
+++ b/api/docs/v1.36.yaml
@@ -9889,7 +9889,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.37.yaml
+++ b/api/docs/v1.37.yaml
@@ -9932,7 +9932,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.38.yaml
+++ b/api/docs/v1.38.yaml
@@ -9992,7 +9992,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.39.yaml
+++ b/api/docs/v1.39.yaml
@@ -11351,7 +11351,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.40.yaml
+++ b/api/docs/v1.40.yaml
@@ -11667,7 +11667,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.41.yaml
+++ b/api/docs/v1.41.yaml
@@ -11971,7 +11971,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.42.yaml
+++ b/api/docs/v1.42.yaml
@@ -12351,7 +12351,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.43.yaml
+++ b/api/docs/v1.43.yaml
@@ -12369,7 +12369,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.44.yaml
+++ b/api/docs/v1.44.yaml
@@ -12508,7 +12508,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.45.yaml
+++ b/api/docs/v1.45.yaml
@@ -12488,7 +12488,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.46.yaml
+++ b/api/docs/v1.46.yaml
@@ -12609,7 +12609,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.47.yaml
+++ b/api/docs/v1.47.yaml
@@ -12759,7 +12759,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.48.yaml
+++ b/api/docs/v1.48.yaml
@@ -13382,7 +13382,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.49.yaml
+++ b/api/docs/v1.49.yaml
@@ -13403,7 +13403,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.50.yaml
+++ b/api/docs/v1.50.yaml
@@ -13245,7 +13245,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.51.yaml
+++ b/api/docs/v1.51.yaml
@@ -13266,7 +13266,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -13430,7 +13430,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.53.yaml
+++ b/api/docs/v1.53.yaml
@@ -13679,7 +13679,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.54.yaml
+++ b/api/docs/v1.54.yaml
@@ -13691,7 +13691,6 @@ paths:
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
             - `name=<config name>`
-            - `names=<config name>`
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/docs/v1.55.yaml
+++ b/api/docs/v1.55.yaml
@@ -13590,8 +13590,8 @@ paths:
 
             - `id=<secret id>`
             - `label=<key> or label=<key>=value`
-            - `name=<secret name>`
-            - `names=<secret name>`
+            - `name=<secret name>` matches all or part of a secret name (prefix match)
+            - `names=<secret name>` matches a secret name (exact match)
       tags: ["Secret"]
   /secrets/create:
     post:
@@ -13797,8 +13797,7 @@ paths:
 
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
-            - `name=<config name>`
-            - `names=<config name>`
+            - `name=<config name>` matches all or part of a config name (prefix match)
       tags: ["Config"]
   /configs/create:
     post:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -13590,8 +13590,8 @@ paths:
 
             - `id=<secret id>`
             - `label=<key> or label=<key>=value`
-            - `name=<secret name>`
-            - `names=<secret name>`
+            - `name=<secret name>` matches all or part of a secret name (prefix match)
+            - `names=<secret name>` matches a secret name (exact match)
       tags: ["Secret"]
   /secrets/create:
     post:
@@ -13797,8 +13797,7 @@ paths:
 
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
-            - `name=<config name>`
-            - `names=<config name>`
+            - `name=<config name>` matches all or part of a config name (prefix match)
       tags: ["Config"]
   /configs/create:
     post:


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/33509

## Summary

Fixes two long-standing API documentation errors reported in #33509, plus one
related error found while investigating:

- **`Secret.Spec` referenced `ServiceSpec`** — already fixed in the current
  `swagger.yaml`, but still present in the archived specs `api/docs/v1.25.yaml`
  through `v1.29.yaml`. Changed to `SecretSpec` (the definition exists in all
  five files, and the API never returned a `ServiceSpec` there).
- **`GET /configs` documented a `names` filter that the daemon rejects** —
  `newListConfigsFilters` (`daemon/cluster/filters.go`) has only ever accepted
  `name`, `id` and `label`, since configs were introduced in API v1.30. Removed
  the `names=<config name>` line from `swagger.yaml` and `v1.30`–`v1.55`.
- **`GET /secrets` filters were ambiguous** — both `name` (prefix match) and
  `names` (exact match) are valid (`newListSecretsFilters`), but the docs
  listed them without explanation. Added the match semantics. Note the issue
  suggested removing `names`, but it is a valid filter, so it is kept.

The archived version files are only touched where the documentation was never
true for that API version, so this corrects the record rather than rewriting
API history. `api/swagger.yaml` and `api/docs/v1.55.yaml` remain identical.

**How to verify:** `diff api/swagger.yaml api/docs/v1.55.yaml` is empty;
`grep -rn 'names=<config name>' api/` returns nothing; all 32 files parse as
valid YAML.

## Release notes (optional)

```markdown changelog
Fix API reference documenting an unsupported `names` filter for `GET /configs`.
```

