### PR TITLE
quota: skip mountpoints when scanning for used project IDs

### DIFF
--- a/daemon/internal/quota/projectquota.go
+++ b/daemon/internal/quota/projectquota.go
@@ -326,6 +326,15 @@ func (q *Control) findNextProjectID(home string, baseID uint32) error {
 	state.Lock()
 	defer state.Unlock()
 
+	// Get the device of the home directory so we can detect mount points
+	// (e.g. overlayfs "merged" directories of still-mounted containers) and
+	// skip them. FS_IOC_FSGETXATTR is XFS specific and returns ENOTTY on
+	// non-XFS mounts, which must not abort project quota detection.
+	var homeStat unix.Stat_t
+	if err := unix.Stat(home, &homeStat); err != nil {
+		return errors.Wrapf(err, "failed to stat %s", home)
+	}
+
 	checkProjID := func(path string) (uint32, error) {
 		projid, err := getProjectID(path)
 		if err != nil {
@@ -340,6 +349,18 @@ func (q *Control) findNextProjectID(home string, baseID uint32) error {
 		return projid, nil
 	}
 
+	// skipMountpoint reports whether path is on a different device than home,
+	// i.e. it is a mount point such as an overlay "merged" directory. The XFS
+	// project quota ioctl does not apply to such paths, so they must be skipped.
+	skipMountpoint := func(path string) bool {
+		var st unix.Stat_t
+		if err := unix.Stat(path, &st); err != nil {
+			// If we cannot stat it, let the caller handle the error.
+			return false
+		}
+		return st.Dev != homeStat.Dev
+	}
+
 	files, err := os.ReadDir(home)
 	if err != nil {
 		return errors.Errorf("read directory failed: %s", home)
@@ -349,8 +370,16 @@ func (q *Control) findNextProjectID(home string, baseID uint32) error {
 			continue
 		}
 		path := filepath.Join(home, file.Name())
+		if skipMountpoint(path) {
+			log.G(context.TODO()).Debugf("findNextProjectID: skipping mount point %s", path)
+			continue
+		}
 		projid, err := checkProjID(path)
 		if err != nil {
+			if isUnsupportedQuotaErr(err) {
+				log.G(context.TODO()).WithError(err).Debugf("findNextProjectID: skipping %s (project quota ioctl not supported on this path)", path)
+				continue
+			}
 			return err
 		}
 		if projid > 0 && projid != baseID {
@@ -365,14 +394,38 @@ func (q *Control) findNextProjectID(home string, baseID uint32) error {
 				continue
 			}
 			subpath := filepath.Join(path, subfile.Name())
+			if skipMountpoint(subpath) {
+				log.G(context.TODO()).Debugf("findNextProjectID: skipping mount point %s", subpath)
+				continue
+			}
 			_, err := checkProjID(subpath)
 			if err != nil {
+				if isUnsupportedQuotaErr(err) {
+					log.G(context.TODO()).WithError(err).Debugf("findNextProjectID: skipping %s (project quota ioctl not supported on this path)", subpath)
+					continue
+				}
 				return err
 			}
 		}
 	}
 
 	return nil
+}
+
+// isUnsupportedQuotaErr reports whether err is caused by a project quota ioctl
+// that is not supported on the given path (e.g. ENOTTY on a non-XFS mount such
+// as an overlayfs "merged" directory). Such errors must not abort project quota
+// detection for the underlying filesystem, which is validated separately by
+// hasQuotaSupport via quotactl on the backing device node.
+func isUnsupportedQuotaErr(err error) bool {
+	cause := errors.Cause(err)
+	if en, ok := cause.(unix.Errno); ok {
+		switch en {
+		case unix.ENOTTY, unix.EINVAL, unix.ENOTDIR, unix.ENOSYS, unix.EOPNOTSUPP:
+			return true
+		}
+	}
+	return false
 }
 
 func free(p *C.char) {


### PR DESCRIPTION
Fixes: https://github.com/moby/moby/issues/42832

## Summary

`NewControl()` can fail to initialize XFS project quota support (and, when
`overlay2.size` is set, prevent the daemon from starting) after a
`systemctl restart docker`.

The root cause is in `findNextProjectID()`: it walks the storage driver home
directory and issues the XFS-specific `FS_IOC_FSGETXATTR` ioctl on every
sub-directory to discover already-used project IDs. The failure happens when a
layer directory that has no project ID yet -- for example a container created
without `overlay2.size` -- still has its `merged` directory mounted as
overlayfs at scan time. overlayfs does not implement that ioctl and returns
`ENOTTY` ("inappropriate ioctl for device"). `findNextProjectID()` treated any
such error as fatal and returned it from `NewControl()`, which `overlay.go` then
surfaces as "Filesystem does not support Project Quota".

Note that `findNextProjectID()` first reads each layer directory's own project
ID and, if one is already set, skips scanning that layer's sub-directories. So
containers already created with a quota (their layer directory already carries a
project ID) never reach the `merged` probe and do not trigger the error -- only
no-quota layers with a still-mounted `merged` do. This is why the failure is
not always seen even with `live-restore: true`: it only reproduces when a
no-quota container is running at restart time.

With `live-restore: false` the old daemon stops containers and unmounts their
overlays, but the new daemon's quota scan can race ahead of those unmounts and
catch a still-mounted `merged`, which is why the failure is intermittent
("sometimes").

This change:
- skips mount points (directories whose device differs from the home directory)
  during the scan, so overlay `merged` mounts are never probed with the XFS
  ioctl;
- treats per-directory "operation not supported" ioctl errors (`ENOTTY`,
  `EINVAL`, `ENOTDIR`, `ENOSYS`, `EOPNOTSUPP`) as skippable instead of
  aborting the whole scan.

The underlying filesystem's project quota capability is already validated
separately by `hasQuotaSupport()` via `quotactl` on the backing device node, so
ignoring an individual unreadable directory is safe.

## Release notes (optional)

```markdown changelog
Fix a failure to start the daemon with `overlay2.size` set when a container overlay `merged` mount is still present during a `systemctl restart docker`.
