### PR TITLE
daemon/pkg/oci: accept "a" (all) as a device cgroup rule

### DIFF
--- a/daemon/pkg/oci/oci.go
+++ b/daemon/pkg/oci/oci.go
@@ -8,19 +8,29 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
-// TODO verify if this regex is correct for "a" (all);
-//
-// The docs (https://github.com/torvalds/linux/blob/v5.10/Documentation/admin-guide/cgroup-v1/devices.rst) describe:
-// "'all' means it applies to all types and all major and minor numbers", and shows an example
-// that *only* passes `a` as value: `echo a > /sys/fs/cgroup/1/devices.allow, which would be
-// the "implicit" equivalent of "a *:* rwm". Source-code also looks to confirm this, and returns
-// early for "a" (all); https://github.com/torvalds/linux/blob/v5.10/security/device_cgroup.c#L614-L642
 var deviceCgroupRuleRegex = lazyregexp.New("^([acb]) ([0-9]+|\\*):([0-9]+|\\*) ([rwm]{1,3})$")
 
 // AppendDevicePermissionsFromCgroupRules takes rules for the devices cgroup to append to the default set
 func AppendDevicePermissionsFromCgroupRules(devPermissions []specs.LinuxDeviceCgroup, rules []string) ([]specs.LinuxDeviceCgroup, error) {
 	for _, deviceCgroupRule := range rules {
-		ss := deviceCgroupRuleRegex.FindAllStringSubmatch(deviceCgroupRule, -1)
+		rule := deviceCgroupRule
+
+		// "a" (all) is a wildcard type; it applies to all device types, all
+		// major and minor numbers, and all permissions, so those fields may
+		// be omitted, and the kernel ignores them if they are given. The
+		// kernel documentation describes it as such, and shows an example
+		// passing only the type; "echo a > /sys/fs/cgroup/1/devices.allow";
+		// https://github.com/torvalds/linux/blob/v5.10/Documentation/admin-guide/cgroup-v1/devices.rst
+		// and the implementation returns early for it;
+		// https://github.com/torvalds/linux/blob/v5.10/security/device_cgroup.c#L614-L642
+		//
+		// Expand the shorthand to the equivalent explicit form, so that the
+		// rest of the parsing below is unchanged.
+		if rule == "a" {
+			rule = "a *:* rwm"
+		}
+
+		ss := deviceCgroupRuleRegex.FindAllStringSubmatch(rule, -1)
 		if len(ss) == 0 || len(ss[0]) != 5 {
 			return nil, fmt.Errorf("invalid device cgroup rule format: '%s'", deviceCgroupRule)
 		}

--- a/daemon/pkg/oci/oci_test.go
+++ b/daemon/pkg/oci/oci_test.go
@@ -97,9 +97,31 @@ func TestAppendDevicePermissionsFromCgroupRules(t *testing.T) {
 			expectedErr: `invalid minor value in device cgroup rule format: 'c 1:18446744073709551616 rwm'`,
 		},
 		{
+			doc:         "char (c) devices without major-minor and permissions",
+			rule:        "c",
+			expectedErr: `invalid device cgroup rule format: 'c'`,
+		},
+		{
+			doc:         "block (b) devices without major-minor and permissions",
+			rule:        "b",
+			expectedErr: `invalid device cgroup rule format: 'b'`,
+		},
+		{
+			doc:         "all (a) devices with trailing space",
+			rule:        "a ",
+			expectedErr: `invalid device cgroup rule format: 'a '`,
+		},
+		{
 			doc:      "all (a) devices",
 			rule:     "a 1:1 rwm",
 			expected: specs.LinuxDeviceCgroup{Allow: true, Type: "a", Major: ptr(1), Minor: ptr(1), Access: "rwm"},
+		},
+		{
+			// "a" (all) is a wildcard, and major-minor and permissions may
+			// be omitted; it is equivalent to "a *:* rwm".
+			doc:      "all (a) devices without major-minor and permissions",
+			rule:     "a",
+			expected: specs.LinuxDeviceCgroup{Allow: true, Type: "a", Major: ptr(-1), Minor: ptr(-1), Access: "rwm"},
 		},
 		{
 			doc:      "char (c) devices",


### PR DESCRIPTION
Related to #41920.

`a` is a wildcard device type: the kernel ignores the other fields for it, and runc's `devices.Rule` says the same. But our regex required the full form, so `--device-cgroup-rule a` got rejected with `invalid device cgroup rule format: 'a'` while `a *:* rwm`, the same rule, was fine. This expands the shorthand before matching; `c` and `b` still need major, minor and permissions. The regex had a TODO asking about exactly this, so it goes away.

Rules like `a 1:2 r` still pass through as-is, normalising those is a behavior change and belongs to the "silently ignored fields" item in #41920.

Docs for the flag live in docker/cli; happy to follow up there once this lands.

```markdown changelog
Accept `a` as shorthand for `a *:* rwm` in `--device-cgroup-rule`.
```

Created with: Claude Code
