### PR TITLE
integration/service: Wait for tasks with swarm.ServicePoll

### DIFF
--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -289,7 +289,7 @@ func TestCreateServiceConfigFileMode(t *testing.T) {
 		}),
 	)
 
-	poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, serviceID, instances))
+	poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, serviceID, instances), swarm.ServicePoll)
 
 	res, err := apiClient.ServiceLogs(ctx, serviceID, client.ServiceLogsOptions{
 		Tail:       "1",
@@ -304,7 +304,7 @@ func TestCreateServiceConfigFileMode(t *testing.T) {
 
 	_, err = apiClient.ServiceRemove(ctx, serviceID, client.ServiceRemoveOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, swarm.NoTasksForService(ctx, apiClient, serviceID))
+	poll.WaitOn(t, swarm.NoTasksForService(ctx, apiClient, serviceID), swarm.ServicePoll)
 
 	_, err = apiClient.ConfigRemove(ctx, configName, client.ConfigRemoveOptions{})
 	assert.NilError(t, err)
@@ -354,7 +354,7 @@ func TestCreateServiceSysctls(t *testing.T) {
 		)
 
 		// wait for the service to converge to 1 running task as expected
-		poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, serviceID, instances))
+		poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, serviceID, instances), swarm.ServicePoll)
 
 		// we're going to check 3 things:
 		//
@@ -426,7 +426,7 @@ func TestCreateServiceCapabilities(t *testing.T) {
 	)
 
 	// wait for the service to converge to 1 running task as expected
-	poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, serviceID, instances))
+	poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, serviceID, instances), swarm.ServicePoll)
 
 	// we're going to check 3 things:
 	//
@@ -516,7 +516,7 @@ func TestCreateServiceMemorySwap(t *testing.T) {
 				ctx, t, d,
 				swarm.ServiceWithMemorySwap(testCase.swapSpec, testCase.limitSpec),
 			)
-			poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, serviceID, 1))
+			poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, serviceID, 1), swarm.ServicePoll)
 
 			inspect, err := apiClient.ServiceInspect(ctx, serviceID, client.ServiceInspectOptions{})
 			assert.NilError(t, err)
@@ -588,7 +588,7 @@ func TestCreateServiceMemorySwappiness(t *testing.T) {
 				ctx, t, d,
 				swarm.ServiceWithMemorySwappiness(testCase.swappinessSpec),
 			)
-			poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, serviceID, 1))
+			poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, serviceID, 1), swarm.ServicePoll)
 
 			filter := make(client.Filters)
 			filter.Add("service", serviceID)

--- a/integration/service/inspect_test.go
+++ b/integration/service/inspect_test.go
@@ -37,7 +37,7 @@ func TestInspect(t *testing.T) {
 	assert.NilError(t, err)
 
 	id := resp.ID
-	poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, id, instances))
+	poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, id, instances), swarm.ServicePoll)
 
 	result, err := apiClient.ServiceInspect(ctx, id, client.ServiceInspectOptions{})
 	assert.NilError(t, err)


### PR DESCRIPTION
Some of the poll.WaitOn calls in this package do not pass swarm.ServicePoll, and so wait for gotest.tools' default of 10 seconds instead of the 15 seconds (90 on arm) every other wait in the same files allows.

This makes them consistent; it is not a fix for a race. A run that needs more than ten seconds to start a task is usually already in trouble for reasons an extra five seconds will not help with.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
