### PR TITLE
daemon/containerd: lower log level for image signature validation

### DIFF
--- a/daemon/containerd/image_identity.go
+++ b/daemon/containerd/image_identity.go
@@ -167,7 +167,11 @@ func (i *ImageService) computeSignatureIdentity(ctx context.Context, desc ocispe
 
 	signatureIdentity, err := i.signatureIdentity(ctx, desc, multi.Best, multi.BestPlatform)
 	if err != nil {
-		log.G(ctx).WithError(err).Error("failed to validate image signature")
+		if signatureVerificationErrorIsTransient(err) {
+			log.G(ctx).WithError(err).Warn("failed to validate image signature")
+		} else {
+			log.G(ctx).WithError(err).Debug("failed to validate image signature")
+		}
 		return nil, signatureVerificationErrorIsTransient(err)
 	}
 


### PR DESCRIPTION
Fixes #53455

## Problem

With the containerd image store, image-identity resolution logs at `level=error` for every locally stored image whose top-level descriptor is not an OCI image index — and repeats indefinitely every 48h because the condition is structural.

`ResolveSignatureChain` rejects anything not `MediaTypeImageIndex` (`policy-helpers/image/resolve.go:120`), and `computeSignatureIdentity` logs that unconditionally at `Error` (`daemon/containerd/image_identity.go:170`):

```go
log.G(ctx).WithError(err).Error("failed to validate image signature")
```

Two common shapes hit this:

- `application/vnd.oci.image.manifest.v1+json` — any single-arch image built via Engine API `POST /build`
- `application/vnd.docker.distribution.manifest.list.v2+json` — Docker media type multi-arch lists still published on Docker Hub

The error is deterministic, so `signatureVerificationErrorIsTransient` returns false and the 48h cache TTL still applies, but the journal still gets an `level=error` line every cycle.

## Change

- Lower the log level in `computeSignatureIdentity`: transient (network/context) failures → `Warn`, deterministic (non-transient, e.g., non-index media type) → `Debug`
- Keeps the `signatureVerificationErrorIsTransient` return for caching unchanged; only the log level changes
- Keep unrelated cleanup out of this PR

## Why this approach

Single-arch and Docker-list images are expected, not exceptional, so `Error` is too severe. `Debug` for deterministic cases silences the 48h noise while remaining visible with debug logging. `Warn` for transient retains visibility for real network issues.

## Testing

```text
command: git diff --check
result: clean

command: go vet ./daemon/containerd (on macOS)
result: same pre-existing failures as clean main (linux-tagged files: runtimeArchitecture, possibleCPUs, safepath.Join, etc.), no new vet errors in changed file

command: grep -n "failed to validate image signature" daemon/containerd/image_identity.go
result: 170-173: conditional Warn/Debug branching
```

No new tests needed; behavior is log-level only.

## Documentation and release impact

- [ ] User-facing documentation updated
- [ ] Changelog/release note needed
- [ ] Migration or compatibility note needed
- [x] No documentation impact

## Review notes

- Known limitations: none
- Follow-up issue, if any: none
- Security/licensing considerations: none
