### PR TITLE
c8d/resolver: reuse per-host authorizers across a pull

### DIFF
--- a/daemon/containerd/resolver.go
+++ b/daemon/containerd/resolver.go
@@ -3,6 +3,7 @@ package containerd
 import (
 	"context"
 	"net/http"
+	"sync"
 
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
@@ -38,6 +39,14 @@ func hostsWrapper(hostsFn docker.RegistryHosts, optAuthConfig *registrytypes.Aut
 		return hostsFn
 	}
 
+	type hostKey struct {
+		scheme string
+		host   string
+		path   string
+	}
+	var mu sync.Mutex
+	authorizers := make(map[hostKey]docker.Authorizer)
+
 	return func(n string) ([]docker.RegistryHost, error) {
 		hosts, err := hostsFn(n)
 		if err != nil {
@@ -45,7 +54,19 @@ func hostsWrapper(hostsFn docker.RegistryHosts, optAuthConfig *registrytypes.Aut
 		}
 
 		for i := range hosts {
-			hosts[i].Authorizer = authorizerFromAuthConfig(*optAuthConfig, ref, hosts[i].Client)
+			key := hostKey{
+				scheme: hosts[i].Scheme,
+				host:   hosts[i].Host,
+				path:   hosts[i].Path,
+			}
+			mu.Lock()
+			authorizer, ok := authorizers[key]
+			if !ok {
+				authorizer = authorizerFromAuthConfig(*optAuthConfig, ref, hosts[i].Client)
+				authorizers[key] = authorizer
+			}
+			mu.Unlock()
+			hosts[i].Authorizer = authorizer
 		}
 		return hosts, nil
 	}

--- a/daemon/containerd/resolver_test.go
+++ b/daemon/containerd/resolver_test.go
@@ -1,0 +1,86 @@
+package containerd
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/distribution/reference"
+	registrytypes "github.com/moby/moby/api/types/registry"
+	"gotest.tools/v3/assert"
+)
+
+func TestHostsWrapperReusesAuthorizers(t *testing.T) {
+	ref, err := reference.ParseNormalizedNamed("example.com/library/test:latest")
+	assert.NilError(t, err)
+
+	hostsCalls := 0
+	tokenRequests := 0
+	hostsFn := func(host string) ([]docker.RegistryHost, error) {
+		assert.Equal(t, host, "example.com")
+		hostsCalls++
+		call := hostsCalls
+		return []docker.RegistryHost{
+			{
+				Host: "example.com",
+				Client: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					assert.Equal(t, call, 1, "token request used a client from a later hosts call")
+					assert.Equal(t, req.URL.Host, "auth.example.com")
+					tokenRequests++
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": {"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(`{"access_token":"cached-token","expires_in":3600}`)),
+						Request:    req,
+					}, nil
+				})},
+			},
+			{Host: "mirror.example.com", Client: &http.Client{}},
+		}, nil
+	}
+	wrapper := hostsWrapper(hostsFn, &registrytypes.AuthConfig{
+		ServerAddress: "example.com",
+		Username:      "user",
+		Password:      "password",
+	}, ref)
+
+	first, err := wrapper("example.com")
+	assert.NilError(t, err)
+	second, err := wrapper("example.com")
+	assert.NilError(t, err)
+
+	assert.Assert(t, first[0].Client != second[0].Client, "test must return fresh clients on each hosts call")
+	assert.Assert(t, first[0].Authorizer == second[0].Authorizer, "authorizer was not reused for the same registry host")
+	assert.Assert(t, first[1].Authorizer == second[1].Authorizer, "authorizer was not reused for the same mirror host")
+	assert.Assert(t, first[0].Authorizer != first[1].Authorizer, "different registry hosts must not share an authorizer")
+
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodHead, "https://example.com/v2/library/test/manifests/latest", nil)
+	assert.NilError(t, err)
+	challenge := &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Header: http.Header{
+			"Www-Authenticate": {`Bearer realm="https://auth.example.com/token",service="example.com",scope="repository:library/test:pull"`},
+		},
+		Body:    io.NopCloser(strings.NewReader("")),
+		Request: request,
+	}
+	assert.NilError(t, first[0].Authorizer.AddResponses(t.Context(), []*http.Response{challenge}))
+
+	assert.NilError(t, first[0].Authorizer.Authorize(t.Context(), request))
+	assert.Equal(t, request.Header.Get("Authorization"), "Bearer cached-token")
+	assert.Equal(t, tokenRequests, 1)
+
+	reusedRequest, err := http.NewRequestWithContext(t.Context(), http.MethodHead, request.URL.String(), nil)
+	assert.NilError(t, err)
+	assert.NilError(t, second[0].Authorizer.Authorize(t.Context(), reusedRequest))
+	assert.Equal(t, reusedRequest.Header.Get("Authorization"), "Bearer cached-token")
+	assert.Equal(t, tokenRequests, 1, "cached token was fetched again")
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}


### PR DESCRIPTION
## Summary

Fixes #53334: since 29.5.0, containerd (c8d) pulls re-authenticate at the
registry token endpoint on every host-resolution call within a single pull,
adding ~0.5-1.2s per pull on networks where a fresh TLS handshake isn't free
(the issue includes a bisect showing the step at 29.5.0, flat across 29.5.3
and 29.7.2).

## Root cause (confirmed)

#52600 fixed a real bug: token/OAuth requests used a single shared
`*http.Client` instead of each registry host's own client (needed for
host-specific TLS settings — custom CAs, insecure-registries; see #52361,
docker/desktop-feedback#155, #51771). To do that, it moved
`authorizerFromAuthConfig` construction from once-per-`hostsWrapper`-call
(i.e. once per resolver/pull) to once-per-invocation of the closure
`hostsWrapper` returns.

containerd's `dockerAuthorizer` caches fetched bearer tokens on its own
instance state (`scopedTokens`, see
`vendor/github.com/containerd/containerd/v2/core/remotes/docker/authorizer.go`).
A single pull invokes that closure more than once — containerd's
`Resolve` and `Fetcher` paths each call `r.hosts(host)` independently
(`vendor/.../core/remotes/docker/resolver.go`, `vendor/.../client/pull.go`).
Since #52600, each of those calls builds a brand-new authorizer with an
empty token cache, so the pull pays a fresh `401 -> token-fetch` round
every time instead of once — matching the two separate re-auth rounds
(HEAD manifest, HEAD layer) shown in the issue's debug log.

Verified with a regression test (`TestHostsWrapperReusesAuthorizers`)
that fails against the pre-fix code — asserting `first[0].Authorizer ==
second[0].Authorizer` across two calls to the closure fails, and a second
token fetch is observed where only one should occur.

## Fix

Cache authorizers inside `hostsWrapper`'s closure, keyed by registry
scheme/host/path, so repeated calls for the same host reuse both the
authorizer and its token cache. Distinct hosts still get distinct
authorizers, each built with that host's own `*http.Client`, so #52600's
per-host TLS fix is preserved — this does not reintroduce the bug it
fixed.

## Test plan

- [x] `go build ./daemon/containerd/...`
- [x] `go test ./daemon/containerd/... -count=1`
- [x] `go test ./daemon/containerd -run '^TestHostsWrapperReusesAuthorizers$' -count=1` (new regression test; fails on pre-fix code, passes on fix)
- [x] `git diff --check`