### PR TITLE
bridge: repair stale WSL2Mirrored loopback0 drop rules

### DIFF
--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -187,7 +187,7 @@ func newDriver(store *datastore.Store, config Configuration, pms *drvregistry.Po
 		IPv6:               config.EnableIP6Tables,
 		Hairpin:            !config.EnableProxy,
 		AllowDirectRouting: config.AllowDirectRouting,
-		WSL2Mirrored:       isRunningUnderWSL2MirroredMode(context.Background()),
+		WSL2Mirrored:       isRunningUnderWSL2MirroredMode,
 	})
 	if err != nil {
 		return nil, err

--- a/daemon/libnetwork/drivers/bridge/internal/firewaller/firewaller.go
+++ b/daemon/libnetwork/drivers/bridge/internal/firewaller/firewaller.go
@@ -29,8 +29,16 @@ type Config struct {
 	// AllowDirectRouting means packets addressed directly to a container's IP address will be
 	// accepted, regardless of which network interface they are from.
 	AllowDirectRouting bool
-	// WSL2Mirrored is true if running under WSL2 with mirrored networking enabled.
-	WSL2Mirrored bool
+	// WSL2Mirrored reports whether the host is running under WSL2 with mirrored
+	// networking enabled. It is called when firewall rules are programmed because
+	// the interface used to detect mirrored mode may appear after daemon startup.
+	WSL2Mirrored func(context.Context) bool
+}
+
+// IsWSL2Mirrored reports whether the host is running under WSL2 with mirrored
+// networking enabled.
+func (c Config) IsWSL2Mirrored(ctx context.Context) bool {
+	return c.WSL2Mirrored != nil && c.WSL2Mirrored(ctx)
 }
 
 // NetworkConfig contains settings for a single bridge network.

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/iptabler.go
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/iptabler.go
@@ -220,7 +220,7 @@ func setupIPChains(ctx context.Context, version iptables.IPVersion, iptCfg firew
 		return err
 	}
 
-	if err := mirroredWSL2Workaround(version, !iptCfg.Hairpin && iptCfg.WSL2Mirrored); err != nil {
+	if err := mirroredWSL2Workaround(version, version == iptables.IPv4 && !iptCfg.Hairpin && iptCfg.IsWSL2Mirrored(ctx)); err != nil {
 		return err
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/iptabler_test.go
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/iptabler_test.go
@@ -95,11 +95,14 @@ func TestIptabler(t *testing.T) {
 	for i := range 1 << numBoolParams {
 		p := func(n int64) bool { return (i & (1 << n)) != 0 }
 		for _, gwmode := range []string{"nat", "nat-unprotected", "routed"} {
+			isWSL2Mirrored := p(wsl2Mirrored)
 			config := firewaller.Config{
-				IPv4:         p(ipv4),
-				IPv6:         p(ipv6),
-				Hairpin:      p(hairpin),
-				WSL2Mirrored: p(wsl2Mirrored),
+				IPv4:    p(ipv4),
+				IPv6:    p(ipv6),
+				Hairpin: p(hairpin),
+				WSL2Mirrored: func(context.Context) bool {
+					return isWSL2Mirrored
+				},
 			}
 			netConfig := firewaller.NetworkConfig{
 				IfName:     "br-dummy",
@@ -189,7 +192,7 @@ func testIptabler(t *testing.T, tn string, config firewaller.Config, netConfig f
 	// WSL2Mirrored should only affect IPv4 results, and only if there's a port binding
 	// to a loopback address or docker-proxy is disabled. Share other results files.
 	rnWSL2Mirrored := func(resName string) string {
-		if config.IPv4 && config.WSL2Mirrored && (bindLocalhost || !config.Hairpin) {
+		if config.IPv4 && config.IsWSL2Mirrored(context.Background()) && (bindLocalhost || !config.Hairpin) {
 			return resName + ",wsl2mirrored=true"
 		}
 		return resName
@@ -237,4 +240,49 @@ func testIptabler(t *testing.T, tn string, config firewaller.Config, netConfig f
 	assert.NilError(t, err)
 	checkResults("iptables", rnWSL2Mirrored(fmt.Sprintf("%s/cleaned,hairpin=%v", tn, config.Hairpin)), config.IPv4)
 	checkResults("ip6tables", fmt.Sprintf("%s/cleaned,hairpin=%v", tn, config.Hairpin), config.IPv6)
+}
+
+func TestLoopbackFilteringRepairsStaleDropAfterWSL2MirroredDetection(t *testing.T) {
+	skip.If(t, iptables.UsingFirewalld(), "firewalld is running in the host netns, it can't modify rules in the test's netns")
+	defer netnsutils.SetupTestOSContext(t, netnsutils.WithSetNsHandles(false))()
+
+	ctx := context.Background()
+	wsl2Mirrored := false
+	fw, err := NewIptabler(ctx, firewaller.Config{
+		IPv4:    true,
+		Hairpin: true,
+		WSL2Mirrored: func(context.Context) bool {
+			return wsl2Mirrored
+		},
+	})
+	assert.NilError(t, err)
+	nw, err := fw.NewNetwork(ctx, firewaller.NetworkConfig{
+		IfName: "br-dummy",
+		Config4: firewaller.NetworkConfigFam{
+			Prefix: netip.MustParsePrefix("192.168.0.0/24"),
+		},
+	})
+	assert.NilError(t, err)
+	pb := types.PortBinding{
+		Proto:    types.TCP,
+		IP:       net.ParseIP("192.168.0.2"),
+		Port:     80,
+		HostIP:   net.ParseIP("127.0.0.1"),
+		HostPort: 8080,
+	}
+
+	assert.NilError(t, nw.AddPorts(ctx, []types.PortBinding{pb}))
+	rules, err := iptables.GetIptable(iptables.IPv4).Raw("-t", "raw", "-S", "PREROUTING")
+	assert.NilError(t, err)
+	assert.Check(t, !strings.Contains(string(rules), "-i loopback0"), string(rules))
+	assert.Check(t, strings.Contains(string(rules), "! -i lo"), string(rules))
+
+	wsl2Mirrored = true
+	assert.NilError(t, nw.AddPorts(ctx, []types.PortBinding{pb}))
+	rules, err = iptables.GetIptable(iptables.IPv4).Raw("-t", "raw", "-S", "PREROUTING")
+	assert.NilError(t, err)
+	acceptPos := strings.Index(string(rules), "-i loopback0")
+	dropPos := strings.Index(string(rules), "! -i lo")
+	assert.Assert(t, acceptPos >= 0, string(rules))
+	assert.Assert(t, dropPos > acceptPos, string(rules))
 }

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/port.go
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/port.go
@@ -47,7 +47,7 @@ func (n *network) setPerPortIptables(ctx context.Context, b types.PortBinding, e
 		return nil
 	}
 
-	if err := filterPortMappedOnLoopback(ctx, b, b.HostIP, n.ipt.config.WSL2Mirrored, enable); err != nil {
+	if err := n.filterPortMappedOnLoopback(ctx, b, b.HostIP, enable); err != nil {
 		return err
 	}
 
@@ -149,24 +149,12 @@ func setPerPortForwarding(b types.PortBinding, ipv iptables.IPVersion, bridgeNam
 // This is a no-op if the portBinding is for IPv6 (IPv6 loopback address is
 // non-routable), or over a network with gw_mode=routed (PBs in routed mode
 // don't map ports on the host).
-func filterPortMappedOnLoopback(ctx context.Context, b types.PortBinding, hostIP net.IP, wsl2Mirrored, enable bool) error {
+func (n *network) filterPortMappedOnLoopback(ctx context.Context, b types.PortBinding, hostIP net.IP, enable bool) error {
 	if rawRulesDisabled(ctx) {
 		return nil
 	}
 	if b.HostPort == 0 || !hostIP.IsLoopback() || hostIP.To4() == nil {
 		return nil
-	}
-
-	acceptMirrored := iptables.Rule{IPVer: iptables.IPv4, Table: iptables.Raw, Chain: "PREROUTING", Args: []string{
-		"-p", b.Proto.String(),
-		"-d", hostIP.String(),
-		"--dport", strconv.Itoa(int(b.HostPort)),
-		"-i", "loopback0",
-		"-j", "ACCEPT",
-	}}
-	enableMirrored := enable && wsl2Mirrored
-	if err := appendOrDelChainRule(acceptMirrored, "LOOPBACK FILTERING - ACCEPT MIRRORED", enableMirrored); err != nil {
-		return err
 	}
 
 	drop := iptables.Rule{IPVer: iptables.IPv4, Table: iptables.Raw, Chain: "PREROUTING", Args: []string{
@@ -176,6 +164,33 @@ func filterPortMappedOnLoopback(ctx context.Context, b types.PortBinding, hostIP
 		"!", "-i", "lo",
 		"-j", "DROP",
 	}}
+
+	wsl2Mirrored := enable && n.ipt.config.IsWSL2Mirrored(ctx)
+	if wsl2Mirrored && !n.ipt.config.Hairpin {
+		if err := mirroredWSL2Workaround(iptables.IPv4, true); err != nil {
+			return err
+		}
+	}
+
+	acceptMirrored := iptables.Rule{IPVer: iptables.IPv4, Table: iptables.Raw, Chain: "PREROUTING", Args: []string{
+		"-p", b.Proto.String(),
+		"-d", hostIP.String(),
+		"--dport", strconv.Itoa(int(b.HostPort)),
+		"-i", "loopback0",
+		"-j", "ACCEPT",
+	}}
+	if wsl2Mirrored {
+		// The DROP may have been added before loopback0 appeared. Move it behind
+		// the ACCEPT, otherwise iptables' first-match semantics make the ACCEPT
+		// ineffective.
+		if err := appendOrDelChainRule(drop, "LOOPBACK FILTERING - DROP", false); err != nil {
+			return err
+		}
+	}
+	if err := appendOrDelChainRule(acceptMirrored, "LOOPBACK FILTERING - ACCEPT MIRRORED", wsl2Mirrored); err != nil {
+		return err
+	}
+
 	if err := appendOrDelChainRule(drop, "LOOPBACK FILTERING - DROP", enable); err != nil {
 		return err
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/endpoint.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/endpoint.go
@@ -70,7 +70,7 @@ func (n *network) filterDirectAccess(updater func(nftables.Obj), fam nftables.Fa
 	ifNames := strings.Join(n.config.TrustedHostInterfaces, ", ")
 	updater(nftables.Rule{
 		Chain: rawPreroutingChain,
-		Group: rawPreroutingPortsRuleGroup,
+		Group: rawPreroutingDirectAccessRuleGroup,
 		Rule: []string{
 			string(fam), "daddr", epIP.String(),
 			"iifname != {", n.config.IfName, ",", ifNames, `} counter drop comment "DROP DIRECT ACCESS"`,

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
@@ -33,6 +33,11 @@ const (
 )
 
 const (
+	natWSL2LoopbackRuleGroup = iota + initialRuleGroup
+	natPortsRuleGroup
+)
+
+const (
 	fwdInAcceptFwMarkRuleGroup = iota + initialRuleGroup + 1
 	fwdInLegacyLinksRuleGroup
 	fwdInICCRuleGroup
@@ -41,7 +46,11 @@ const (
 )
 
 const (
-	rawPreroutingPortsRuleGroup = iota + initialRuleGroup + 1
+	// The WSL2 ACCEPT rules must precede the DROP rules even when mirrored mode
+	// is first detected after the DROP rules were added.
+	rawPreroutingDirectAccessRuleGroup = iota + initialRuleGroup + 1
+	rawPreroutingLoopbackAcceptRuleGroup
+	rawPreroutingLoopbackDropRuleGroup
 )
 
 type Nftabler struct {
@@ -211,7 +220,7 @@ func (nft *Nftabler) init(ctx context.Context, family nftables.Family) (*nftable
 	})
 
 	// WSL2 does not (currently) support Windows<->Linux communication via ::1.
-	if !nft.config.Hairpin && nft.config.WSL2Mirrored && table.Family() == nftables.IPv4 {
+	if table.Family() == nftables.IPv4 && !nft.config.Hairpin && nft.config.IsWSL2Mirrored(ctx) {
 		mirroredWSL2Workaround(&tm)
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler_test.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler_test.go
@@ -38,11 +38,14 @@ func TestNftabler(t *testing.T) {
 	for i := range uint64(1) << numBoolParams {
 		p := func(n uint64) bool { return (i & n) == n }
 		for _, gwmode := range []string{"nat", "nat-unprotected", "routed"} {
+			isWSL2Mirrored := p(wsl2Mirrored)
 			config := firewaller.Config{
-				IPv4:         p(ipv4),
-				IPv6:         p(ipv6),
-				Hairpin:      p(hairpin),
-				WSL2Mirrored: p(wsl2Mirrored),
+				IPv4:    p(ipv4),
+				IPv6:    p(ipv6),
+				Hairpin: p(hairpin),
+				WSL2Mirrored: func(context.Context) bool {
+					return isWSL2Mirrored
+				},
 			}
 			netConfig := firewaller.NetworkConfig{
 				IfName:     "br-dummy",
@@ -121,7 +124,7 @@ func testNftabler(t *testing.T, tn string, config firewaller.Config, netConfig f
 	// WSL2Mirrored should only affect IPv4 results, and only if there's a port binding
 	// to a loopback address or docker-proxy is disabled. Share other results files.
 	rnWSL2Mirrored := func(resName string) string {
-		if config.IPv4 && config.WSL2Mirrored && (bindLocalhost || !config.Hairpin) {
+		if config.IPv4 && config.IsWSL2Mirrored(context.Background()) && (bindLocalhost || !config.Hairpin) {
 			return resName + ",wsl2mirrored=true"
 		}
 		return resName
@@ -171,4 +174,51 @@ func testNftabler(t *testing.T, tn string, config firewaller.Config, netConfig f
 	assert.NilError(t, err)
 	checkResults("ip", rnWSL2Mirrored(fmt.Sprintf("%s/cleaned,hairpin=%v", tn, config.Hairpin)), config.IPv4)
 	checkResults("ip6", fmt.Sprintf("%s/cleaned,hairpin=%v", tn, config.Hairpin), config.IPv6)
+}
+
+func TestLoopbackFilteringRepairsStaleDropAfterWSL2MirroredDetection(t *testing.T) {
+	nftables.Enable()
+	t.Cleanup(func() { nftables.Disable() })
+	defer netnsutils.SetupTestOSContext(t, netnsutils.WithSetNsHandles(false))()
+
+	ctx := context.Background()
+	wsl2Mirrored := false
+	fw, err := NewNftabler(ctx, firewaller.Config{
+		IPv4:    true,
+		Hairpin: true,
+		WSL2Mirrored: func(context.Context) bool {
+			return wsl2Mirrored
+		},
+	})
+	assert.NilError(t, err)
+	defer func() { assert.NilError(t, fw.Close()) }()
+	nw := &network{fw: fw}
+	pbs := []types.PortBinding{{
+		Proto:    types.TCP,
+		IP:       net.ParseIP("192.168.0.2"),
+		Port:     80,
+		HostIP:   net.ParseIP("127.0.0.1"),
+		HostPort: 8080,
+	}}
+
+	applyLoopbackRules := func() string {
+		t.Helper()
+		tm := nftables.Modifier{}
+		nw.filterPortMappedOnLoopback(ctx, pbs, &tm, nftables.IPv4, true)
+		assert.NilError(t, fw.table4.Apply(ctx, tm))
+		res := icmd.RunCommand("nft", "list", "table", "ip", dockerTable)
+		assert.Assert(t, res.Error, res.Combined())
+		return res.Combined()
+	}
+
+	rules := applyLoopbackRules()
+	assert.Check(t, !strings.Contains(rules, "ACCEPT WSL2 LOOPBACK"), rules)
+	assert.Check(t, strings.Contains(rules, "DROP REMOTE LOOPBACK"), rules)
+
+	wsl2Mirrored = true
+	rules = applyLoopbackRules()
+	acceptPos := strings.Index(rules, "ACCEPT WSL2 LOOPBACK")
+	dropPos := strings.Index(rules, "DROP REMOTE LOOPBACK")
+	assert.Assert(t, acceptPos >= 0, rules)
+	assert.Assert(t, dropPos > acceptPos, rules)
 }

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/port.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/port.go
@@ -69,7 +69,7 @@ func (n *network) setPerPortRules(ctx context.Context, pbs []types.PortBinding, 
 	}
 	n.setPerPortDNAT(pbs, updater, ipv)
 	n.setPerPortHairpinMasq(pbs, updater, ipv)
-	n.filterPortMappedOnLoopback(pbs, updater, ipv)
+	n.filterPortMappedOnLoopback(ctx, pbs, &tm, ipv, enable)
 	if err := table.Apply(ctx, tm); err != nil {
 		return fmt.Errorf("adding rules for bridge %s: %w", n.config.IfName, err)
 	}
@@ -124,7 +124,7 @@ func (n *network) setPerPortDNAT(pbs []types.PortBinding, updater func(nftables.
 		}
 		updater(nftables.Rule{
 			Chain: natChain,
-			Group: initialRuleGroup,
+			Group: natPortsRuleGroup,
 			Rule: []string{
 				proxySkip, v6LLSkip, daddrMatch, pb.Proto.String(), "dport", strconv.Itoa(int(pb.HostPort)), "counter dnat to",
 				net.JoinHostPort(pb.IP.String(), strconv.Itoa(int(pb.Port))), "comment DNAT",
@@ -177,10 +177,16 @@ func (n *network) setPerPortHairpinMasq(pbs []types.PortBinding, updater func(nf
 // This is a no-op if the portBinding is for IPv6 (IPv6 loopback address is
 // non-routable), or over a network with gw_mode=routed (PBs in routed mode
 // don't map ports on the host).
-func (n *network) filterPortMappedOnLoopback(pbs []types.PortBinding, updater func(nftables.Obj), ipv nftables.Family) {
+func (n *network) filterPortMappedOnLoopback(ctx context.Context, pbs []types.PortBinding, tm *nftables.Modifier, ipv nftables.Family, enable bool) {
 	if ipv == nftables.IPv6 {
 		return
 	}
+	updater := tm.Create
+	if !enable {
+		updater = tm.Delete
+	}
+	wsl2Mirrored := false
+	detectedWSL2Mirrored := false
 	for _, pb := range pbs {
 		// Nothing to do if not binding to the loopback address.
 		if pb.HostPort == 0 || !pb.HostIP.IsLoopback() {
@@ -190,25 +196,34 @@ func (n *network) filterPortMappedOnLoopback(pbs []types.PortBinding, updater fu
 		if pb.HostIP.To4() == nil {
 			continue
 		}
-		if n.fw.config.WSL2Mirrored {
+		if enable && !detectedWSL2Mirrored {
+			wsl2Mirrored = n.fw.config.IsWSL2Mirrored(ctx)
+			detectedWSL2Mirrored = true
+			if wsl2Mirrored && !n.fw.config.Hairpin {
+				mirroredWSL2Workaround(tm)
+			}
+		}
+		if wsl2Mirrored || !enable {
 			updater(nftables.Rule{
 				Chain: rawPreroutingChain,
-				Group: rawPreroutingPortsRuleGroup,
+				Group: rawPreroutingLoopbackAcceptRuleGroup,
 				Rule: []string{
 					"iifname loopback0 ip daddr", pb.HostIP.String(), pb.Proto.String(),
 					"dport", strconv.Itoa(int(pb.HostPort)),
 					`counter accept comment "ACCEPT WSL2 LOOPBACK"`,
 				},
+				IgnoreExist: true,
 			})
 		}
 		updater(nftables.Rule{
 			Chain: rawPreroutingChain,
-			Group: rawPreroutingPortsRuleGroup,
+			Group: rawPreroutingLoopbackDropRuleGroup,
 			Rule: []string{
 				`iifname != lo ip daddr`, pb.HostIP.String(), pb.Proto.String(),
 				"dport", strconv.Itoa(int(pb.HostPort)),
 				`counter drop comment "DROP REMOTE LOOPBACK"`,
 			},
+			IgnoreExist: true,
 		})
 	}
 }

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/wsl2.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/wsl2.go
@@ -39,8 +39,9 @@ import (
 // destination 127.0.0.0/8.
 func mirroredWSL2Workaround(tm *nftables.Modifier) {
 	tm.Create(nftables.Rule{
-		Chain: natChain,
-		Group: initialRuleGroup,
-		Rule:  []string{`iifname "loopback0" ip daddr 127.0.0.0/8 counter return`},
+		Chain:       natChain,
+		Group:       natWSL2LoopbackRuleGroup,
+		Rule:        []string{`iifname "loopback0" ip daddr 127.0.0.0/8 counter return`},
+		IgnoreExist: true,
 	})
 }


### PR DESCRIPTION
Fixes #53382

## Problem

Under WSL2 mirrored networking, `loopback0` is created by `hv_netvsc` and
renamed into existence during boot — under systemd this can happen **after**
dockerd has already started. `WSL2Mirrored` was sampled once at daemon
startup (`bridge_linux.go`, `newDriver`) and frozen for the process
lifetime.

If `loopback0` appears after that one-shot sample:
- the per-port raw-PREROUTING `-i loopback0 ... ACCEPT` exception is never
  programmed for 127.0.0.1-published ports
- the per-port raw-PREROUTING `! -i lo -d 127.0.0.1 --dport N DROP` rule is
  programmed alone
- every 127.0.0.1-published port becomes unreachable from inside WSL2
- this does **not** self-heal on a later daemon restart: rules are
  appended if-not-exists, so a restart (with `loopback0` now present and
  correctly detected) only *appends* the ACCEPT rule *below* the
  already-present stale DROP. Under iptables first-match semantics, the
  DROP still wins and the ACCEPT is dead code.

Root cause confirmed by a maintainer on the issue.

## Fix

- `WSL2Mirrored` is no longer a bool sampled once at startup. It's now a
  `func(context.Context) bool` (`firewaller.Config.WSL2Mirrored`,
  `Config.IsWSL2Mirrored`) that's called when per-port loopback rules are
  (re)programmed, so a `loopback0` interface that appears after daemon
  start is picked up the next time rules are touched (including a plain
  daemon restart, which reprograms rules for all restored port bindings).
- When mirrored mode is detected for a binding that may already have a
  stale DROP-only rule set, order is repaired:
  - **iptabler**: the existing DROP rule (if present) is deleted, the
    ACCEPT rule is (re)appended, then DROP is re-appended — since `-A`
    only appends, this guarantees ACCEPT precedes DROP in the chain.
  - **nftabler**: dedicated ordered rule groups
    (`rawPreroutingDirectAccessRuleGroup` /
    `rawPreroutingLoopbackAcceptRuleGroup` /
    `rawPreroutingLoopbackDropRuleGroup`) guarantee ACCEPT rules are
    applied before DROP rules regardless of add order.
- No new watcher, goroutine, or polling loop — detection is cheap
  (one netlink `LinkByName` + one `os.Stat`) and piggybacks on the
  existing port-programming path.

## Tests

Added false→true `WSL2Mirrored` transition regression tests for both
backends (`iptabler_test.go`, `nftabler_test.go`), covering the
stale-DROP-before-ACCEPT repair.

## Verification

- `go build ./daemon/libnetwork/drivers/bridge/...` and
  `go build ./daemon/libnetwork/... ./daemon/...` (GOOS=linux
  cross-compile) — pass
- `go vet ./daemon/libnetwork/drivers/bridge/...` — pass
- Linux test-binary compilation for the bridge/iptabler/nftabler packages
  — pass

I was not able to actually *execute* `go test` for these Linux-only
(`//go:build linux`) packages, or reproduce the scenario end-to-end under
real WSL2 mirrored networking, from this environment (Windows host;
cross-compiled test binaries can't run natively, and WSL/Docker access
was not available for a full runtime repro). Verification here is limited
to code review, cross-compilation, `go vet`, and reasoning through the
existing golden-file rule ordering plus the new regression tests — not a
live-execution run. Flagging this explicitly so reviewers weigh it
accordingly.