### PR TITLE
fix: add TaskDefaults.LogDriver mapping in SwarmFromGRPC and MergeSwarmSpecToGRPC

### DIFF
--- a/daemon/cluster/convert/swarm.go
+++ b/daemon/cluster/convert/swarm.go
@@ -63,6 +63,9 @@ func SwarmFromGRPC(c swarmapi.Cluster) types.Swarm {
 
 	swarm.Spec.CAConfig.NodeCertExpiry, _ = gogotypes.DurationFromProto(c.Spec.CAConfig.NodeCertExpiry)
 
+	// TaskDefaults
+	swarm.Spec.TaskDefaults.LogDriver = driverFromGRPC(c.Spec.TaskDefaults.LogDriver)
+
 	for _, ca := range c.Spec.CAConfig.ExternalCAs {
 		swarm.Spec.CAConfig.ExternalCAs = append(swarm.Spec.CAConfig.ExternalCAs, &types.ExternalCA{
 			Protocol: types.ExternalCAProtocol(strings.ToLower(ca.Protocol.String())),
@@ -147,6 +150,10 @@ func MergeSwarmSpecToGRPC(s types.Spec, spec swarmapi.ClusterSpec) (swarmapi.Clu
 	}
 
 	spec.EncryptionConfig.AutoLockManagers = s.EncryptionConfig.AutoLockManagers
+
+	if s.TaskDefaults.LogDriver != nil {
+		spec.TaskDefaults.LogDriver = driverToGRPC(s.TaskDefaults.LogDriver)
+	}
 
 	return spec, nil
 }


### PR DESCRIPTION
### Description

`TaskDefaults.LogDriver` is exposed as part of the swarm spec in the Engine API (`api/types/swarm/swarm.go`), and SwarmKit supports it in its cluster spec (`api/types.pb.go`), but the Engine conversion layer (`daemon/cluster/convert/swarm.go`) never maps this field in either direction.

As a result, `POST /swarm/update` accepts a spec containing `TaskDefaults.LogDriver` and returns success, but the value is silently dropped — a subsequent `GET /swarm` returns an empty `TaskDefaults`.

### Changes

- **`SwarmFromGRPC`**: Map `c.Spec.TaskDefaults.LogDriver` to the Engine API types via `driverFromGRPC()`, so that `GET /swarm` returns the configured `TaskDefaults.LogDriver`.
- **`MergeSwarmSpecToGRPC`**: Map `s.TaskDefaults.LogDriver` to the SwarmKit cluster spec via `driverToGRPC()`, so that `POST /swarm/update` persists the value.

Both functions use the existing `driverFromGRPC`/`driverToGRPC` helpers that are already defined in `service.go` and are accessible from the same package.

### Related issue

Closes #53396