### PR TITLE
Add umask support

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -18,6 +18,10 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /containers/json` now supports an `annotation` filter to filter
   containers by annotation, either by key (`annotation=key`) or by key and
   value (`annotation="key=value"`), similar to the existing `label` filter.
+* `POST /containers/create` now supports `HostConfig.Umask` to set the initial
+  umask for a Unix container. When set, the daemon includes the value in the OCI
+  process configuration for the container's entrypoint, exec processes, and
+  healthchecks. When omitted, the runtime's default behavior applies.
 
 ## v1.55 API changes
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1280,6 +1280,18 @@ definitions:
             x-nullable: true
             description: |-
               Runtime to use with this container.
+          Umask:
+            type: "integer"
+            format: "uint32"
+            x-nullable: true
+            description: |-
+              Set the initial umask for a Unix container.
+
+              If omitted, the daemon does not set a umask in the OCI process
+              specification, and the runtime's default behavior applies.
+
+              JSON integers are decimal. For example, use `18` for the octal
+              umask `0022`, and `511` for the octal umask `0777`.
           # Applicable to Windows
           Isolation:
             type: "string"

--- a/api/types/container/hostconfig.go
+++ b/api/types/container/hostconfig.go
@@ -454,6 +454,7 @@ type HostConfig struct {
 	ShmSize         int64             // Total shm memory usage
 	Sysctls         map[string]string `json:",omitempty"` // List of Namespaced sysctls used for the container
 	Runtime         string            `json:",omitempty"` // Runtime to use with this container
+	Umask           *uint32           `json:",omitempty"` // Initial process umask
 
 	// Applicable to Windows
 	Isolation Isolation // Isolation technology of the container (e.g. default, hyperv)

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -171,6 +171,9 @@ func verifyPlatformContainerSettings(daemon *Daemon, daemonCfg *configStore, hos
 	if hostConfig == nil {
 		return nil, nil
 	}
+	if hostConfig.Umask != nil {
+		return nil, errors.New("invalid option: Windows does not support Umask")
+	}
 	return verifyPlatformContainerResources(&hostConfig.Resources, daemon.runAsHyperVContainer(hostConfig))
 }
 

--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -43,18 +43,19 @@ func getUserFromContainerd(ctx context.Context, containerdCli *containerd.Client
 
 func (daemon *Daemon) execSetPlatformOpt(ctx context.Context, daemonCfg *config.Config, ec *container.ExecConfig, p *specs.Process) error {
 	if ec.User != "" {
+		var user specs.User
 		var err error
 		if daemon.UsesSnapshotter() {
-			p.User, err = getUserFromContainerd(ctx, daemon.containerdClient, ec)
-			if err != nil {
-				return err
-			}
+			user, err = getUserFromContainerd(ctx, daemon.containerdClient, ec)
 		} else {
-			p.User, err = getUser(ec.Container, ec.User)
-			if err != nil {
-				return err
-			}
+			user, err = getUser(ec.Container, ec.User)
 		}
+		if err != nil {
+			return err
+		}
+		// Preserve the umask inherited from the container's process spec.
+		user.Umask = p.User.Umask
+		p.User = user
 	}
 
 	if ec.Privileged {

--- a/daemon/exec_linux_test.go
+++ b/daemon/exec_linux_test.go
@@ -4,6 +4,8 @@ package daemon
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	containertypes "github.com/moby/moby/api/types/container"
@@ -11,6 +13,32 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"gotest.tools/v3/assert"
 )
+
+func TestExecSetPlatformOptPreservesUmaskWhenResolvingUser(t *testing.T) {
+	root := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(root, "etc"), 0o755))
+	assert.NilError(t, os.WriteFile(filepath.Join(root, "etc/passwd"), []byte("test:x:1234:5678::/:/bin/sh\n"), 0o644))
+	assert.NilError(t, os.WriteFile(filepath.Join(root, "etc/group"), []byte("test:x:5678:\n"), 0o644))
+
+	c := &container.Container{
+		BaseFS: root,
+		SecurityOptions: container.SecurityOptions{
+			AppArmorProfile: unconfinedAppArmorProfile,
+		},
+		HostConfig: &containertypes.HostConfig{},
+	}
+	ec := &container.ExecConfig{Container: c, User: "1234:5678"}
+	umask := uint32(0o027)
+	p := &specs.Process{User: specs.User{Umask: &umask}}
+	cfg := &configStore{}
+
+	err := (&Daemon{}).execSetPlatformOpt(context.Background(), &cfg.Config, ec, p)
+	assert.NilError(t, err)
+	assert.Equal(t, p.User.UID, uint32(1234))
+	assert.Equal(t, p.User.GID, uint32(5678))
+	assert.Assert(t, p.User.Umask != nil)
+	assert.Equal(t, *p.User.Umask, umask)
+}
 
 func TestExecSetPlatformOptAppArmor(t *testing.T) {
 	appArmorEnabled := appArmorSupported()

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -997,9 +997,22 @@ func WithUser(c *container.Container) coci.SpecOpts {
 		if s.Process == nil {
 			s.Process = &specs.Process{}
 		}
-		var err error
-		s.Process.User, err = getUser(c, c.Config.User)
+		user, err := getUser(c, c.Config.User)
+		// Preserve fields already set on the process user, such as Umask.
+		s.Process.User.UID = user.UID
+		s.Process.User.GID = user.GID
+		s.Process.User.AdditionalGids = user.AdditionalGids
 		return err
+	}
+}
+
+// WithUmask sets the container's umask.
+func WithUmask(c *container.Container) coci.SpecOpts {
+	return func(ctx context.Context, client coci.Client, ctr *containers.Container, s *coci.Spec) error {
+		if c.HostConfig.Umask == nil {
+			return nil
+		}
+		return coci.WithUmask(*c.HostConfig.Umask)(ctx, client, ctr, s)
 	}
 }
 
@@ -1015,6 +1028,7 @@ func (daemon *Daemon) createSpec(ctx context.Context, daemonCfg *configStore, c 
 		WithSysctls(c),
 		// Set the user before CDI device injection, which may append supplementary groups.
 		WithUser(c),
+		WithUmask(c),
 		WithDevices(daemon, c),
 		withRlimits(daemon, &daemonCfg.Config, c),
 		WithNamespaces(daemon, c),

--- a/daemon/oci_linux_test.go
+++ b/daemon/oci_linux_test.go
@@ -78,6 +78,28 @@ func (i *fakeImageService) StorageDriver() string {
 	return "overlay"
 }
 
+func TestWithUmask(t *testing.T) {
+	t.Run("omitted", func(t *testing.T) {
+		c := &container.Container{HostConfig: &containertypes.HostConfig{}}
+		s := daemonoci.DefaultSpec()
+
+		err := WithUmask(c)(t.Context(), nil, nil, &s)
+		assert.NilError(t, err)
+		assert.Assert(t, s.Process.User.Umask == nil)
+	})
+
+	t.Run("set", func(t *testing.T) {
+		umask := uint32(0o027)
+		c := &container.Container{HostConfig: &containertypes.HostConfig{Umask: &umask}}
+		s := daemonoci.DefaultSpec()
+
+		err := WithUmask(c)(t.Context(), nil, nil, &s)
+		assert.NilError(t, err)
+		assert.Assert(t, s.Process.User.Umask != nil)
+		assert.Equal(t, *s.Process.User.Umask, umask)
+	})
+}
+
 func TestWithCommonOptionsDockerInit(t *testing.T) {
 	initPath := filepath.Join(t.TempDir(), "docker-init")
 	err := os.WriteFile(initPath, []byte("#!/bin/sh\n"), 0o755)

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -777,6 +777,11 @@ func (c *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 		hostConfig.PidsLimit = nil
 	}
 
+	if versions.LessThan(version, "1.56") {
+		// Ignore Umask because it was added in API v1.56.
+		hostConfig.Umask = nil
+	}
+
 	ccr, err := c.backend.ContainerCreate(ctx, backend.ContainerCreateConfig{
 		Name:                        name,
 		Config:                      config,

--- a/daemon/server/router/container/inspect.go
+++ b/daemon/server/router/container/inspect.go
@@ -35,6 +35,10 @@ func (c *containerRouter) getContainersByName(ctx context.Context, w http.Respon
 	if versions.LessThan(version, "1.48") {
 		ctr.ImageManifestDescriptor = nil
 	}
+	if versions.LessThan(version, "1.56") && ctr.HostConfig != nil {
+		// Ignore Umask because it was added in API v1.56.
+		ctr.HostConfig.Umask = nil
+	}
 
 	var wrapOpts []compat.Option
 	if versions.LessThan(version, "1.52") {

--- a/integration/container/exec_linux_test.go
+++ b/integration/container/exec_linux_test.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -64,5 +65,54 @@ func TestFailedExecExitCode(t *testing.T) {
 
 			assert.Equal(t, result.ExitCode, tc.expectedExitCode)
 		})
+	}
+}
+
+func TestContainerExecWithUmask(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.56"), "requires API v1.56")
+
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	users := []string{"", "1000", "nobody"}
+	prettyUser := func(s string) string {
+		if s == "" {
+			return "unspecified"
+		}
+		return s
+	}
+
+	tests := []struct {
+		umask    uint32
+		expected string
+	}{
+		{
+			umask:    0o000,
+			expected: "0000",
+		},
+		{
+			umask:    0o777,
+			expected: "0777",
+		},
+	}
+	prettyUmask := func(u uint32) string {
+		return fmt.Sprintf("%04o", u)
+	}
+
+	for _, runUser := range users {
+		for _, execUser := range users {
+			for _, tc := range tests {
+				t.Run(fmt.Sprintf("user_%s_%s_umask_%s", prettyUser(runUser), prettyUser(execUser), prettyUmask(tc.umask)), func(t *testing.T) {
+					cID := container.Run(ctx, t, apiClient, container.WithUser(runUser), func(c *container.TestContainerConfig) {
+						c.HostConfig.Umask = &tc.umask
+					})
+					result, err := container.Exec(ctx, apiClient, cID, []string{"sh", "-c", "umask"}, func(ec *client.ExecCreateOptions) {
+						ec.User = execUser
+					})
+					assert.NilError(t, err)
+					assert.Equal(t, tc.expected, strings.TrimSpace(result.Stdout()))
+				})
+			}
+		}
 	}
 }

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -8,6 +8,7 @@ import (
 
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/pkg/versions"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/poll"
@@ -212,6 +213,55 @@ func pollForHealthStatus(ctx context.Context, apiClient client.APIClient, contai
 			return poll.Success()
 		default:
 			return poll.Continue("waiting for container to become %s", healthStatus)
+		}
+	}
+}
+
+func TestHealthCheckUmask(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "Windows does not support umask")
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.56"), "requires API v1.56")
+
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	users := []string{"", "1000", "nobody"}
+	prettyUser := func(s string) string {
+		if s == "" {
+			return "unspecified"
+		}
+		return s
+	}
+
+	tests := []struct {
+		umask    uint32
+		expected string
+	}{
+		{
+			umask:    0o000,
+			expected: "0000",
+		},
+		{
+			umask:    0o777,
+			expected: "0777",
+		},
+	}
+	prettyUmask := func(u uint32) string {
+		return fmt.Sprintf("%04o", u)
+	}
+
+	for _, user := range users {
+		for _, tc := range tests {
+			t.Run(fmt.Sprintf("user_%s_umask_%s", prettyUser(user), prettyUmask(tc.umask)), func(t *testing.T) {
+				cID := container.Run(ctx, t, apiClient, container.WithUser(user), func(c *container.TestContainerConfig) {
+					c.HostConfig.Umask = &tc.umask
+					c.Config.Healthcheck = &containertypes.HealthConfig{
+						Test:     []string{"CMD-SHELL", "umask"},
+						Interval: time.Millisecond,
+						Retries:  1,
+					}
+				})
+				poll.WaitOn(t, pollForHealthCheckLog(ctx, apiClient, cID, tc.expected+"\n"), poll.WithTimeout(3*time.Second))
+			})
 		}
 	}
 }

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -618,4 +619,55 @@ func createLegacyContainer(ctx context.Context, t *testing.T, apiClient client.A
 	err = json.Unmarshal(buf, &resp)
 	assert.NilError(t, err)
 	return resp.ID
+}
+
+func TestContainerRunWithUmask(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.56"), "requires API v1.56")
+
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	users := []string{"", "1000", "nobody"}
+	prettyUser := func(s string) string {
+		if s == "" {
+			return "unspecified"
+		}
+		return s
+	}
+
+	tests := []struct {
+		umask    uint32
+		expected string
+	}{
+		{
+			umask:    0o000,
+			expected: "0000",
+		},
+		{
+			umask:    0o777,
+			expected: "0777",
+		},
+	}
+	prettyUmask := func(u uint32) string {
+		return fmt.Sprintf("%04o", u)
+	}
+
+	for _, user := range users {
+		for _, tc := range tests {
+			t.Run(fmt.Sprintf("user_%s_umask_%s", prettyUser(user), prettyUmask(tc.umask)), func(t *testing.T) {
+				cID := container.Run(ctx, t, apiClient, container.WithUser(user), container.WithCmd("sh", "-c", "umask"), func(c *container.TestContainerConfig) {
+					c.HostConfig.Umask = &tc.umask
+				})
+				poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID))
+
+				out, err := apiClient.ContainerLogs(ctx, cID, client.ContainerLogsOptions{ShowStdout: true})
+				assert.NilError(t, err)
+				defer out.Close()
+				var b bytes.Buffer
+				_, err = stdcopy.StdCopy(&b, io.Discard, out)
+				assert.NilError(t, err)
+				assert.Equal(t, tc.expected, strings.TrimSpace(b.String()))
+			})
+		}
+	}
 }

--- a/vendor/github.com/moby/moby/api/types/container/hostconfig.go
+++ b/vendor/github.com/moby/moby/api/types/container/hostconfig.go
@@ -454,6 +454,7 @@ type HostConfig struct {
 	ShmSize         int64             // Total shm memory usage
 	Sysctls         map[string]string `json:",omitempty"` // List of Namespaced sysctls used for the container
 	Runtime         string            `json:",omitempty"` // Runtime to use with this container
+	Umask           *uint32           `json:",omitempty"` // Initial process umask
 
 	// Applicable to Windows
 	Isolation Isolation // Isolation technology of the container (e.g. default, hyperv)


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/19189

## Summary

moby/moby#19189 requested this feature in 2016. (labeled [milestone 29.8.0](https://github.com/moby/moby/milestone/248) at the time of writing)
opencontainers/runtime-spec#941 added `Spec.Process.User.Umask` in 2019.
containers/crun#217 added umask support in 2019.
opencontainers/runc#2527 added umask support in 2020.
opencontainers/runc#3661 added umask support for exec in 2023.

This PR adds the HostConfig.Umask field in moby API, wiring it to OCI runtime spec, allowing user to set the initial umask value for a Unix container. The behavior is unchanged when this field is not set.

The OCI runtime spec requires that
> If unspecified, the umask should not be changed from the calling process' umask.

Implementations do not follow the spec closely.

For runc:
| Umask | entrypoint | exec/healthcheck |
|---|---|---|
| nil | 022 | inherit parent |
| non-nil | use Umask | use Umask |

The CLI changes is ready to review at docker/cli#7108. (It is marked WIP due to a pending bump of api package, once this PR landed and a new release of moby is ready.)

This PR is a re-post of #53083. Previous PR is closed due to a change to branch name, in order to follow the `XXXX-something` convention required by `CONTRIBUTING.md`.

## Release notes (optional)

```markdown changelog
Add `HostConfig.Umask` option and a corresponding `--umask <octal>` flag to `docker create`/`docker run` to set the umask for a container's main process, execs, and healthchecks.
```