### PR TITLE
daemon/cluster: Retry generated service names on conflict

### DIFF
--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -8,7 +8,6 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	types "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/v2/daemon/cluster/internal/runtime"
-	"github.com/moby/moby/v2/internal/namesgenerator"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/api/genericresource"
 	"github.com/pkg/errors"
@@ -167,11 +166,6 @@ func serviceSpecFromGRPC(spec *swarmapi.ServiceSpec) (*types.ServiceSpec, error)
 
 // ServiceSpecToGRPC converts a ServiceSpec to a grpc ServiceSpec.
 func ServiceSpecToGRPC(s types.ServiceSpec) (swarmapi.ServiceSpec, error) {
-	name := s.Name
-	if name == "" {
-		name = namesgenerator.GetRandomName(0)
-	}
-
 	taskNetworks := make([]*swarmapi.NetworkAttachmentConfig, 0, len(s.TaskTemplate.Networks))
 	for _, n := range s.TaskTemplate.Networks {
 		netConfig := &swarmapi.NetworkAttachmentConfig{Target: n.Target, Aliases: n.Aliases, DriverAttachmentOpts: n.DriverOpts}
@@ -185,7 +179,7 @@ func ServiceSpecToGRPC(s types.ServiceSpec) (swarmapi.ServiceSpec, error) {
 
 	spec := swarmapi.ServiceSpec{
 		Annotations: swarmapi.Annotations{
-			Name:   name,
+			Name:   s.Name,
 			Labels: s.Labels,
 		},
 		Task: swarmapi.TaskSpec{

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -17,6 +17,7 @@ import (
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/daemon/server/swarmbackend"
 	"github.com/moby/moby/v2/errdefs"
+	"github.com/moby/moby/v2/internal/namesgenerator"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -205,13 +206,6 @@ func (c *Cluster) CreateService(s swarm.ServiceSpec, encodedAuth string, queryRe
 			default:
 				return fmt.Errorf("unsupported runtime type: %q", serviceSpec.Task.GetGeneric().Kind)
 			}
-
-			r, err := state.controlClient.CreateService(ctx, &swarmapi.CreateServiceRequest{Spec: &serviceSpec})
-			if err != nil {
-				return err
-			}
-
-			resp.ID = r.Service.ID
 		case *swarmapi.TaskSpec_Container:
 			ctnr := serviceSpec.Task.GetContainer()
 			if ctnr == nil {
@@ -259,14 +253,16 @@ func (c *Cluster) CreateService(s swarm.ServiceSpec, encodedAuth string, queryRe
 				ctx, cancel = context.WithTimeout(ctx, swarmRequestTimeout)
 				defer cancel()
 			}
-
-			r, err := state.controlClient.CreateService(ctx, &swarmapi.CreateServiceRequest{Spec: &serviceSpec})
-			if err != nil {
-				return err
-			}
-
-			resp.ID = r.Service.ID
 		}
+
+		if serviceSpec.Annotations.Name == "" {
+			serviceSpec.Annotations.Name = namesgenerator.GetRandomName(0)
+		}
+		r, err := state.controlClient.CreateService(ctx, &swarmapi.CreateServiceRequest{Spec: &serviceSpec})
+		if err != nil {
+			return err
+		}
+		resp.ID = r.Service.ID
 		return nil
 	})
 

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -22,6 +22,8 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // GetServices returns all services of a managed swarm cluster.
@@ -255,10 +257,18 @@ func (c *Cluster) CreateService(s swarm.ServiceSpec, encodedAuth string, queryRe
 			}
 		}
 
-		if serviceSpec.Annotations.Name == "" {
-			serviceSpec.Annotations.Name = namesgenerator.GetRandomName(0)
+		generatedName := serviceSpec.Annotations.Name == ""
+		var r *swarmapi.CreateServiceResponse
+		// Use the same six-attempt limit as automatic container names.
+		for retry := range 6 {
+			if generatedName {
+				serviceSpec.Annotations.Name = namesgenerator.GetRandomName(retry)
+			}
+			r, err = state.controlClient.CreateService(ctx, &swarmapi.CreateServiceRequest{Spec: &serviceSpec})
+			if !generatedName || status.Code(err) != codes.AlreadyExists {
+				break
+			}
 		}
-		r, err := state.controlClient.CreateService(ctx, &swarmapi.CreateServiceRequest{Spec: &serviceSpec})
 		if err != nil {
 			return err
 		}

--- a/daemon/cluster/services_test.go
+++ b/daemon/cluster/services_test.go
@@ -1,0 +1,44 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moby/moby/api/types/swarm"
+	swarmapi "github.com/moby/swarmkit/v2/api"
+	"google.golang.org/grpc"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+type fakeServiceCreator struct {
+	swarmapi.ControlClient
+	name string
+}
+
+func (f *fakeServiceCreator) CreateService(_ context.Context, req *swarmapi.CreateServiceRequest, _ ...grpc.CallOption) (*swarmapi.CreateServiceResponse, error) {
+	f.name = req.Spec.Annotations.Name
+	return &swarmapi.CreateServiceResponse{Service: &swarmapi.Service{ID: "serviceid"}}, nil
+}
+
+func TestCreateServiceName(t *testing.T) {
+	for _, name := range []string{"", "chosen_name"} {
+		t.Run(name, func(t *testing.T) {
+			client := new(fakeServiceCreator)
+			cluster := &Cluster{nr: &nodeRunner{nodeState: nodeState{controlClient: client}}}
+			resp, err := cluster.CreateService(swarm.ServiceSpec{
+				Annotations: swarm.Annotations{Name: name},
+				TaskTemplate: swarm.TaskSpec{
+					ContainerSpec: &swarm.ContainerSpec{Image: "image"},
+				},
+			}, "", false)
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(resp.ID, "serviceid"))
+			if name == "" {
+				assert.Check(t, client.name != "")
+			} else {
+				assert.Check(t, is.Equal(client.name, name))
+			}
+		})
+	}
+}

--- a/daemon/cluster/services_test.go
+++ b/daemon/cluster/services_test.go
@@ -7,37 +7,85 @@ import (
 	"github.com/moby/moby/api/types/swarm"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
 
 type fakeServiceCreator struct {
 	swarmapi.ControlClient
-	name string
+
+	conflicts int
+	err       error
+	names     []string
 }
 
 func (f *fakeServiceCreator) CreateService(_ context.Context, req *swarmapi.CreateServiceRequest, _ ...grpc.CallOption) (*swarmapi.CreateServiceResponse, error) {
-	f.name = req.Spec.Annotations.Name
+	name := req.Spec.Annotations.Name
+	f.names = append(f.names, name)
+	if len(f.names) <= f.conflicts {
+		if f.err != nil {
+			return nil, f.err
+		}
+		return nil, status.Errorf(codes.AlreadyExists, "name conflicts with an existing object: service %s already exists", name)
+	}
 	return &swarmapi.CreateServiceResponse{Service: &swarmapi.Service{ID: "serviceid"}}, nil
 }
 
-func TestCreateServiceName(t *testing.T) {
-	for _, name := range []string{"", "chosen_name"} {
-		t.Run(name, func(t *testing.T) {
-			client := new(fakeServiceCreator)
+func TestCreateServiceNameConflict(t *testing.T) {
+	tests := []struct {
+		doc       string
+		name      string
+		conflicts int
+		err       error
+		expCalls  int
+		expErr    codes.Code
+	}{
+		{
+			doc:       "generated name is redrawn on conflict",
+			conflicts: 1,
+			expCalls:  2,
+		},
+		{
+			doc:       "gives up after six draws",
+			conflicts: 100,
+			expCalls:  6,
+			expErr:    codes.AlreadyExists,
+		},
+		{
+			doc:       "caller-chosen name is not redrawn",
+			name:      "bold_lichterman",
+			conflicts: 1,
+			expCalls:  1,
+			expErr:    codes.AlreadyExists,
+		},
+		{
+			doc:       "other errors are not retried",
+			conflicts: 1,
+			err:       status.Error(codes.InvalidArgument, "invalid spec"),
+			expCalls:  1,
+			expErr:    codes.InvalidArgument,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			client := &fakeServiceCreator{conflicts: tc.conflicts, err: tc.err}
 			cluster := &Cluster{nr: &nodeRunner{nodeState: nodeState{controlClient: client}}}
 			resp, err := cluster.CreateService(swarm.ServiceSpec{
-				Annotations: swarm.Annotations{Name: name},
+				Annotations: swarm.Annotations{Name: tc.name},
 				TaskTemplate: swarm.TaskSpec{
 					ContainerSpec: &swarm.ContainerSpec{Image: "image"},
 				},
 			}, "", false)
-			assert.NilError(t, err)
-			assert.Check(t, is.Equal(resp.ID, "serviceid"))
-			if name == "" {
-				assert.Check(t, client.name != "")
-			} else {
-				assert.Check(t, is.Equal(client.name, name))
+
+			assert.Check(t, is.Len(client.names, tc.expCalls))
+			assert.Check(t, is.Equal(status.Code(err), tc.expErr))
+			if tc.expErr == codes.OK {
+				assert.Check(t, is.Equal(resp.ID, "serviceid"))
+			}
+			if len(client.names) > 1 {
+				assert.Check(t, client.names[1] != client.names[0])
 			}
 		})
 	}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

- fix: https://github.com/moby/moby/issues/53102

Services created without an explicit name receive a random name from the name generator. That name was previously sent to SwarmKit only once, so a collision with an existing service caused creation to fail with an AlreadyExists error.

When SwarmKit reports a name conflict for an automatically generated name, generate another name and retry. Limit service creation to six name-generation attempts to match the existing container name generation path. Names explicitly selected by callers and errors unrelated to name conflicts are not retried.


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
- Fix Swarm service creation failing when an automatically generated name is already in use.
```

## A picture of a cute animal (not mandatory but encouraged)
