### PR TITLE
daemon/reload: Fix OnRollback appending to the wrong slice

### DIFF
--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -43,7 +43,7 @@ func (tx *reloadTxn) OnCommit(cb func() error) {
 // OnRollback defers a function to be called when a config reload is aborted.
 // The error returned from cb is purely informational.
 func (tx *reloadTxn) OnRollback(cb func() error) {
-	tx.onCommit = append(tx.onRollback, cb)
+	tx.onRollback = append(tx.onRollback, cb)
 }
 
 func (tx *reloadTxn) run(cbs []func() error) error {

--- a/daemon/reload_test.go
+++ b/daemon/reload_test.go
@@ -447,3 +447,43 @@ func TestDaemonReloadPreservesDNSConfig(t *testing.T) {
 		assert.Check(t, addr.IsValid(), "HostGatewayIPs[%d] should be valid, got %q", i, addr)
 	}
 }
+
+func TestReloadTxn(t *testing.T) {
+	// Count callback sets without making execution order part of the contract.
+	type calls struct {
+		commit   int
+		rollback int
+	}
+	newTxn := func() (*reloadTxn, *calls) {
+		var tx reloadTxn
+		called := new(calls)
+		commit := func() error {
+			called.commit++
+			return nil
+		}
+		rollback := func() error {
+			called.rollback++
+			return nil
+		}
+		// Interleave duplicates to catch replacement and cross-execution.
+		tx.OnCommit(commit)
+		tx.OnRollback(rollback)
+		tx.OnCommit(commit)
+		tx.OnRollback(rollback)
+		return &tx, called
+	}
+
+	t.Run("Commit", func(t *testing.T) {
+		tx, called := newTxn()
+		assert.NilError(t, tx.Commit())
+		assert.Equal(t, called.commit, 2)
+		assert.Equal(t, called.rollback, 0)
+	})
+
+	t.Run("Rollback", func(t *testing.T) {
+		tx, called := newTxn()
+		assert.NilError(t, tx.Rollback())
+		assert.Equal(t, called.commit, 0)
+		assert.Equal(t, called.rollback, 2)
+	})
+}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

OnRollback assigned the result of appending to onRollback back to onCommit, so it replaced commit callbacks and left Rollback with nothing to execute.

Fortunately, no reload step currently registers a rollback callback yet, so the bug wasn't actually being hit.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
