### PR TITLE
d/libnetwork/networkdb: really stagger triggerFuncs

### DIFF
--- a/daemon/libnetwork/networkdb/cluster.go
+++ b/daemon/libnetwork/networkdb/cluster.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	golog "log"
-	"math/rand/v2"
 	"net"
 	"net/netip"
 	"slices"
@@ -168,9 +167,7 @@ func (nDB *NetworkDB) clusterInit() error {
 		{nodeReapPeriod, nDB.reapDeadNode},
 		{nDB.config.rejoinClusterInterval, nDB.rejoinClusterBootStrap},
 	} {
-		t := time.NewTicker(trigger.interval)
-		go nDB.triggerFunc(trigger.interval, t.C, trigger.fn)
-		nDB.tickers = append(nDB.tickers, t)
+		nDB.goTriggerFunc(nDB.ctx.Done(), trigger.interval, trigger.fn)
 	}
 
 	return nil
@@ -229,31 +226,33 @@ func (nDB *NetworkDB) clusterLeave() error {
 	// cancel the context
 	nDB.cancelCtx()
 
-	for _, t := range nDB.tickers {
-		t.Stop()
-	}
-
 	return mlist.Shutdown()
 }
 
-func (nDB *NetworkDB) triggerFunc(stagger time.Duration, C <-chan time.Time, f func()) {
-	if stagger > 0 {
-		// Use a random stagger to avoid synchronizing.
-		randStagger := time.Duration(rand.Int64N(int64(stagger))) // #nosec G404 -- use of math/rand/v2 is fine for this purpose.
+// goTriggerFunc starts a background goroutine which calls f every interval
+// until ch is closed. The first call is additionally delayed by a random
+// stagger to avoid synchronizing with other nodes.
+func (nDB *NetworkDB) goTriggerFunc(ch <-chan struct{}, interval time.Duration, f func()) {
+	nDB.rngMu.Lock()
+	randStagger := time.Duration(nDB.rng.Int64N(int64(interval))) // #nosec G404 -- use of math/rand/v2 is fine for this purpose.
+	nDB.rngMu.Unlock()
+	go func() {
 		select {
 		case <-time.After(randStagger):
-		case <-nDB.ctx.Done():
+		case <-ch:
 			return
 		}
-	}
-	for {
-		select {
-		case <-C:
-			f()
-		case <-nDB.ctx.Done():
-			return
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-t.C:
+				f()
+			case <-ch:
+				return
+			}
 		}
-	}
+	}()
 }
 
 func (nDB *NetworkDB) reapDeadNode() {

--- a/daemon/libnetwork/networkdb/cluster_test.go
+++ b/daemon/libnetwork/networkdb/cluster_test.go
@@ -5,14 +5,49 @@ import (
 	"maps"
 	"math"
 	"math/bits"
+	"math/rand/v2"
 	"slices"
 	"strings"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"pgregory.net/rapid"
 )
+
+func TestTriggerFuncStagger(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		epoch := time.Now()
+
+		ndb := &NetworkDB{
+			rng: rand.New(new(rand.PCG)),
+		}
+		var calls []time.Duration
+		ndb.goTriggerFunc(t.Context().Done(), time.Second, func() {
+			calls = append(calls, time.Since(epoch))
+		})
+
+		time.Sleep(10 * time.Second)
+		synctest.Wait()
+
+		assert.Check(t, is.Len(calls, 9))
+		if len(calls) > 0 {
+			assert.Check(t, calls[0] > time.Second, "first call was not staggered: called after %v delay", calls[0])
+			assert.Check(t, calls[0] < 2*time.Second, "first call was staggered by more than interval: called after %v delay", calls[0])
+		}
+
+		for i := 1; i < len(calls); i++ {
+			delta := calls[i] - calls[i-1]
+			jitter := delta - time.Second
+			if jitter < 0 {
+				jitter = -jitter
+			}
+			assert.Check(t, jitter < time.Millisecond, "calls were not spaced by interval: call %d was %v after call %d, want ~1s", i, delta, i-1)
+		}
+	})
+}
 
 func TestMRandomNodes(t *testing.T) {
 	cfg := DefaultConfig()

--- a/daemon/libnetwork/networkdb/networkdb.go
+++ b/daemon/libnetwork/networkdb/networkdb.go
@@ -107,10 +107,6 @@ type NetworkDB struct {
 	// events.
 	broadcaster *events.Broadcaster
 
-	// List of all tickers which needed to be stopped when
-	// cleaning up.
-	tickers []*time.Ticker
-
 	// Reference to the memberlist's keyring to add & remove keys
 	keyring *memberlist.Keyring
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary
The ticker for each triggerFunc is started before the stagger-delay timer and so runs concurrently with it, making the stagger delay ineffective as it is always less than the interval in practice. Move the creation of the ticker to after the stagger delay elapses so it actually offsets the phase of the ticker as intended.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
- Spread the daemon's periodic Swarm overlay network gossip and synchronization work over time, avoiding recurring bursts of CPU and network usage.
```

## A picture of a cute animal (not mandatory but encouraged)
