### PR TITLE
daemon/plugins: Confine plugin mount paths to scoped roots

### DIFF
--- a/daemon/pkg/plugin/v2/plugin.go
+++ b/daemon/pkg/plugin/v2/plugin.go
@@ -48,9 +48,11 @@ func (e ErrInadequateCapability) Error() string {
 
 // ScopedPath returns the path scoped to the plugin rootfs
 func (p *Plugin) ScopedPath(s string) string {
-	if p.PluginObj.Config.PropagatedMount != "" && strings.HasPrefix(s, p.PluginObj.Config.PropagatedMount) {
-		// re-scope to the propagated mount path on the host
-		return filepath.Join(filepath.Dir(p.Rootfs), "propagated-mount", strings.TrimPrefix(s, p.PluginObj.Config.PropagatedMount))
+	s = filepath.Join("/", s)
+	if p.PluginObj.Config.PropagatedMount != "" {
+		if rel, err := filepath.Rel(p.PluginObj.Config.PropagatedMount, s); err == nil && filepath.IsLocal(rel) {
+			return filepath.Join(filepath.Dir(p.Rootfs), "propagated-mount", rel)
+		}
 	}
 	return filepath.Join(p.Rootfs, s)
 }

--- a/daemon/pkg/plugin/v2/plugin_linux_test.go
+++ b/daemon/pkg/plugin/v2/plugin_linux_test.go
@@ -1,0 +1,88 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/moby/moby/api/types/plugin"
+	"gotest.tools/v3/assert"
+)
+
+func TestScopedPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		propagatedMount string
+		path            string
+		expected        string
+	}{
+		{
+			name:            "ordinary rootfs path",
+			propagatedMount: "/propagated",
+			path:            "/etc/plugin.json",
+			expected:        "/plugin/rootfs/etc/plugin.json",
+		},
+		{
+			name:            "exact propagated root",
+			propagatedMount: "/propagated",
+			path:            "/propagated",
+			expected:        "/plugin/propagated-mount",
+		},
+		{
+			name:            "propagated child",
+			propagatedMount: "/propagated",
+			path:            "/propagated/child",
+			expected:        "/plugin/propagated-mount/child",
+		},
+		{
+			name:            "in-subtree normalization",
+			propagatedMount: "/propagated",
+			path:            "/propagated/subtree/../child",
+			expected:        "/plugin/propagated-mount/child",
+		},
+		{
+			name:            "reported traversal escape",
+			propagatedMount: "/propagated",
+			path:            "/propagated/../../../volumes/victim/_data",
+			expected:        "/plugin/rootfs/volumes/victim/_data",
+		},
+		{
+			name:            "sibling prefix path",
+			propagatedMount: "/propagated",
+			path:            "/propagated-other/child",
+			expected:        "/plugin/rootfs/propagated-other/child",
+		},
+		{
+			name:            "relative dot-dot containment",
+			propagatedMount: "/propagated",
+			path:            "../../../outside",
+			expected:        "/plugin/rootfs/outside",
+		},
+		{
+			name:            "trailing separator",
+			propagatedMount: "/propagated/",
+			path:            "/propagated/",
+			expected:        "/plugin/propagated-mount",
+		},
+		{
+			name:            "propagated root slash",
+			propagatedMount: "/",
+			path:            "/var/lib",
+			expected:        "/plugin/propagated-mount/var/lib",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &Plugin{
+				Rootfs: "/plugin/rootfs",
+				PluginObj: plugin.Plugin{
+					Config: plugin.Config{PropagatedMount: tc.propagatedMount},
+				},
+			}
+			assert.Equal(t, p.ScopedPath(tc.path), tc.expected)
+		})
+	}
+}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- Fixes: https://github.com/moby/moby/issues/53023
- replace / close: https://github.com/moby/moby/pull/53095

## Summary

A managed volume plugin could return a path containing dot-dot elements that passed the propagated-mount string prefix check, then escaped the host mount root when filepath.Join cleaned it. Sibling paths sharing the same string prefix were also treated as propagated paths.

Normalize returned paths in the plugin's rooted namespace. Use filepath.Rel and filepath.IsLocal so only path-component descendants are mapped through the propagated mount. Other paths remain confined beneath the plugin rootfs.


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
