### PR TITLE
daemon/libnetwork/networkdb: compare Lamport times when invalidating queued broadcasts

### DIFF
--- a/daemon/libnetwork/networkdb/broadcast.go
+++ b/daemon/libnetwork/networkdb/broadcast.go
@@ -49,24 +49,74 @@ func (nDB *NetworkDB) sendNetworkEvent(nid string, event NetworkEvent_Type, ltim
 	return nil
 }
 
-type nodeEventMessage struct {
+// ownNodeEventMessage is this node announcing its own arrival or departure.
+//
+// It is a [memberlist.UniqueBroadcast] so that the queue will neither invalidate
+// it nor let it invalidate anything. sendNodeEvent waits to be told the message
+// went out and Finished is how it is told, but memberlist calls Finished on
+// whatever it invalidates -- so were this message invalidatable, that wait would
+// be released as though the event had been broadcast when it had in fact been
+// thrown away. There are only ever a handful of these in flight anyway:
+// sendNodeEvent is called on cluster join, rejoin and leave.
+type ownNodeEventMessage struct {
 	msg    []byte
 	notify chan<- struct{}
 }
 
-func (m *nodeEventMessage) Invalidates(other memberlist.Broadcast) bool {
-	return false
-}
+// The queue must treat this as unique; see ownNodeEventMessage.
+var _ memberlist.UniqueBroadcast = (*ownNodeEventMessage)(nil)
 
-func (m *nodeEventMessage) Message() []byte {
+func (m *ownNodeEventMessage) Invalidates(memberlist.Broadcast) bool { return false }
+
+// UniqueBroadcast marks this message as one the queue must not deduplicate.
+func (m *ownNodeEventMessage) UniqueBroadcast() {}
+
+func (m *ownNodeEventMessage) Message() []byte {
 	return m.msg
 }
 
-func (m *nodeEventMessage) Finished() {
+func (m *ownNodeEventMessage) Finished() {
 	if m.notify != nil {
 		close(m.notify)
 	}
 }
+
+// relayedNodeEventMessage is a peer's node event being passed on.
+type relayedNodeEventMessage struct {
+	node  string
+	ltime serf.LamportTime
+	msg   []byte
+}
+
+func (m *relayedNodeEventMessage) Invalidates(other memberlist.Broadcast) bool {
+	// Two message types share nDB.nodeBroadcasts, so this assertion is checked.
+	// The queue does not in fact offer a UniqueBroadcast up for invalidation,
+	// but nothing here should depend on that.
+	otherm, ok := other.(*relayedNodeEventMessage)
+	if !ok || m.node != otherm.node {
+		return false
+	}
+	// Collapse a peer's churn to the latest state known of it. A node which
+	// flaps queues a join and a leave on every cycle and only the newest of them
+	// tells a receiver anything, since handleNodeEvent discards any event no
+	// fresher than what it already holds -- so without this, a flapping peer
+	// fills every other node's queue with events that will be dropped on
+	// arrival.
+	//
+	// Comparing Lamport times rather than replacing unconditionally is what
+	// keeps that safe: handleNodeMessage queues its relay after releasing the
+	// lock handleNodeEvent applied the event under, so two handlers can apply in
+	// Lamport order and reach the queue in the opposite one. That is also why
+	// this cannot be a [memberlist.NamedBroadcast], whose deduplication is
+	// unconditionally last-one-wins and would drop the fresher event.
+	return m.ltime >= otherm.ltime
+}
+
+func (m *relayedNodeEventMessage) Message() []byte {
+	return m.msg
+}
+
+func (m *relayedNodeEventMessage) Finished() {}
 
 func (nDB *NetworkDB) sendNodeEvent(event NodeEvent_Type) error {
 	nEvent := NodeEvent{
@@ -81,7 +131,7 @@ func (nDB *NetworkDB) sendNodeEvent(event NodeEvent_Type) error {
 	}
 
 	notifyCh := make(chan struct{})
-	nDB.nodeBroadcasts.QueueBroadcast(&nodeEventMessage{
+	nDB.nodeBroadcasts.QueueBroadcast(&ownNodeEventMessage{
 		msg:    raw,
 		notify: notifyCh,
 	})

--- a/daemon/libnetwork/networkdb/broadcast.go
+++ b/daemon/libnetwork/networkdb/broadcast.go
@@ -109,12 +109,24 @@ type tableEventMessage struct {
 	id    string
 	tname string
 	key   string
+	ltime serf.LamportTime
 	msg   []byte
 }
 
 func (m *tableEventMessage) Invalidates(other memberlist.Broadcast) bool {
 	otherm := other.(*tableEventMessage)
-	return m.tname == otherm.tname && m.id == otherm.id && m.key == otherm.key
+	if m.tname != otherm.tname || m.id != otherm.id || m.key != otherm.key {
+		return false
+	}
+	// Supersede an event for this key only if this one is no older. Both paths
+	// which queue a table event do so after releasing the lock they mutated the
+	// entry under -- CreateEntry, UpdateEntry and DeleteEntry all Unlock before
+	// calling sendTableEvent, and handleTableMessage queues its relay after
+	// handleTableEvent returns -- so two writers to one key can take the lock in
+	// Lamport order and reach the queue in the opposite order. Matching on the
+	// key alone would then let the straggler evict the fresher event and gossip
+	// a superseded value in its place, until anti-entropy corrected it.
+	return m.ltime >= otherm.ltime
 }
 
 func (m *tableEventMessage) Message() []byte {
@@ -156,6 +168,7 @@ func (nDB *NetworkDB) sendTableEvent(event TableEvent_Type, nid string, tname st
 		id:    nid,
 		tname: tname,
 		key:   key,
+		ltime: entry.ltime,
 	})
 	return nil
 }

--- a/daemon/libnetwork/networkdb/broadcast_test.go
+++ b/daemon/libnetwork/networkdb/broadcast_test.go
@@ -67,3 +67,77 @@ func TestTableEventQueueKeepsFreshest(t *testing.T) {
 	// The ordinary case still collapses to one message.
 	assert.DeepEqual(t, queuedMessages(t, stale, fresh), []string{"fresh"})
 }
+
+func TestRelayedNodeEventMessageInvalidates(t *testing.T) {
+	msg := func(node string, ltime serf.LamportTime) *relayedNodeEventMessage {
+		return &relayedNodeEventMessage{node: node, ltime: ltime}
+	}
+
+	for _, tc := range []struct {
+		name       string
+		m, other   *relayedNodeEventMessage
+		invalidate bool
+	}{
+		{"fresher supersedes staler", msg("n1", 7), msg("n1", 5), true},
+		{"same ltime is a duplicate", msg("n1", 5), msg("n1", 5), true},
+		{"staler must not evict fresher", msg("n1", 5), msg("n1", 7), false},
+		{"another node", msg("n1", 9), msg("n2", 1), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.m.Invalidates(tc.other), tc.invalidate)
+		})
+	}
+
+	// It shares a queue with ownNodeEventMessage, so it must tolerate one.
+	assert.Check(t, !msg("n1", 9).Invalidates(&ownNodeEventMessage{}))
+}
+
+// A flapping peer's churn collapses to the newest event known of it, since
+// handleNodeEvent would discard the rest on arrival anyway.
+func TestRelayedNodeEventQueueCollapsesChurn(t *testing.T) {
+	relay := func(node string, ltime serf.LamportTime, body string) *relayedNodeEventMessage {
+		return &relayedNodeEventMessage{node: node, ltime: ltime, msg: []byte(body)}
+	}
+
+	assert.DeepEqual(t, queuedMessages(t,
+		relay("n1", 5, "join5"),
+		relay("n1", 6, "leave6"),
+		relay("n1", 7, "join7"),
+	), []string{"join7"})
+
+	// A straggler must not displace the event it lost the race to.
+	got := queuedMessages(t, relay("n1", 7, "join7"), relay("n1", 5, "join5"))
+	assert.Check(t, slices.Contains(got, "join7"), "queue dropped the fresher event: %v", got)
+
+	// Different peers do not collapse into each other.
+	assert.DeepEqual(t, queuedMessages(t,
+		relay("n1", 9, "n1-event"),
+		relay("n2", 1, "n2-event"),
+	), []string{"n1-event", "n2-event"})
+}
+
+// Queueing a relayed event must not release the wait in sendNodeEvent: the
+// queue calls Finished on whatever it invalidates, and this node's own message
+// signals that channel from Finished.
+func TestOwnNodeEventSurvivesRelayedEvents(t *testing.T) {
+	q := &memberlist.TransmitLimitedQueue{
+		NumNodes:       func() int { return 3 },
+		RetransmitMult: 4,
+	}
+	notify := make(chan struct{})
+	q.QueueBroadcast(&ownNodeEventMessage{msg: []byte("own"), notify: notify})
+	q.QueueBroadcast(&relayedNodeEventMessage{node: "n1", ltime: 9, msg: []byte("relay")})
+
+	select {
+	case <-notify:
+		t.Fatal("a relayed node event invalidated this node's own event, releasing sendNodeEvent as though it had been broadcast")
+	default:
+	}
+
+	var got []string
+	for _, raw := range q.GetBroadcasts(0, 1<<20) {
+		got = append(got, string(raw))
+	}
+	slices.Sort(got)
+	assert.DeepEqual(t, got, []string{"own", "relay"})
+}

--- a/daemon/libnetwork/networkdb/broadcast_test.go
+++ b/daemon/libnetwork/networkdb/broadcast_test.go
@@ -1,0 +1,69 @@
+package networkdb
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/hashicorp/memberlist"
+	"github.com/hashicorp/serf/serf"
+	"gotest.tools/v3/assert"
+)
+
+// queuedMessages returns what the queue would hand out after the given
+// broadcasts have been enqueued in order, sorted for comparison.
+func queuedMessages(t *testing.T, order ...memberlist.Broadcast) []string {
+	t.Helper()
+	q := &memberlist.TransmitLimitedQueue{
+		NumNodes:       func() int { return 3 },
+		RetransmitMult: 4,
+	}
+	for _, m := range order {
+		q.QueueBroadcast(m)
+	}
+	var got []string
+	for _, raw := range q.GetBroadcasts(0, 1<<20) {
+		got = append(got, string(raw))
+	}
+	slices.Sort(got)
+	return got
+}
+
+func TestTableEventMessageInvalidates(t *testing.T) {
+	msg := func(nid, tname, key string, ltime serf.LamportTime) *tableEventMessage {
+		return &tableEventMessage{id: nid, tname: tname, key: key, ltime: ltime}
+	}
+
+	for _, tc := range []struct {
+		name       string
+		m, other   *tableEventMessage
+		invalidate bool
+	}{
+		{"fresher supersedes staler", msg("nw", "t", "k", 7), msg("nw", "t", "k", 5), true},
+		{"same ltime is a duplicate", msg("nw", "t", "k", 5), msg("nw", "t", "k", 5), true},
+		{"staler must not evict fresher", msg("nw", "t", "k", 5), msg("nw", "t", "k", 7), false},
+		{"another key", msg("nw", "t", "k1", 9), msg("nw", "t", "k2", 1), false},
+		{"another table", msg("nw", "t1", "k", 9), msg("nw", "t2", "k", 1), false},
+		{"another network", msg("nw1", "t", "k", 9), msg("nw2", "t", "k", 1), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.m.Invalidates(tc.other), tc.invalidate)
+		})
+	}
+}
+
+// The same property through the real queue, which is what actually decides
+// which message survives. Queueing in the reverse of Lamport order is the
+// interleaving both write paths allow: they release the lock they mutated the
+// entry under before queueing, so a writer can win the lock and lose the race
+// to the queue.
+func TestTableEventQueueKeepsFreshest(t *testing.T) {
+	fresh := &tableEventMessage{id: "nw", tname: "t", key: "k", ltime: 7, msg: []byte("fresh")}
+	stale := &tableEventMessage{id: "nw", tname: "t", key: "k", ltime: 5, msg: []byte("stale")}
+
+	// Straggler arrives last and must not displace what beat it there.
+	got := queuedMessages(t, fresh, stale)
+	assert.Check(t, slices.Contains(got, "fresh"), "queue dropped the fresher event: %v", got)
+
+	// The ordinary case still collapses to one message.
+	assert.DeepEqual(t, queuedMessages(t, stale, fresh), []string{"fresh"})
+}

--- a/daemon/libnetwork/networkdb/delegate.go
+++ b/daemon/libnetwork/networkdb/delegate.go
@@ -321,6 +321,7 @@ func (nDB *NetworkDB) handleTableMessage(buf []byte, isBulkSync bool) {
 			id:    tEvent.NetworkID,
 			tname: tEvent.TableName,
 			key:   tEvent.Key,
+			ltime: tEvent.LTime,
 		})
 	}
 }

--- a/daemon/libnetwork/networkdb/delegate.go
+++ b/daemon/libnetwork/networkdb/delegate.go
@@ -341,8 +341,10 @@ func (nDB *NetworkDB) handleNodeMessage(buf []byte) {
 			return
 		}
 
-		nDB.nodeBroadcasts.QueueBroadcast(&nodeEventMessage{
-			msg: buf,
+		nDB.nodeBroadcasts.QueueBroadcast(&relayedNodeEventMessage{
+			msg:   buf,
+			node:  nEvent.NodeName,
+			ltime: nEvent.LTime,
 		})
 	}
 }


### PR DESCRIPTION
- Related to: https://github.com/moby/moby/pull/53437

## Summary

`memberlist.TransmitLimitedQueue` asks a broadcast whether it invalidates one already queued, and both of NetworkDB's answers ignored Lamport time. Nothing keeps queue order and Lamport order together, so "the last one queued wins" is not the same as "the newest one wins".

Every path which queues an event does so *after* releasing the lock it mutated state under:

- `CreateEntry`, `UpdateEntry` and `DeleteEntry` each `Unlock()` before calling `sendTableEvent`.
- `handleTableMessage` and `handleNodeMessage` queue their relay after `handleTableEvent` / `handleNodeEvent` has returned.

Two writers to one key can therefore take the lock in Lamport order and reach the queue in the opposite order. The node's own state is right either way — the Lamport check ran under the lock — so what is affected is what it tells everyone else.

### `tableEventMessage`

Matched on `(table, network, key)` alone, so a straggler evicted the fresher event and put a superseded value on the wire in its place, until anti-entropy corrected it a sync interval later. Now carries the event's Lamport time and refuses to supersede anything fresher. Equal times still collapse, so duplicate relays of one event do not accumulate.

### `nodeEventMessage`

Invalidated nothing at all, so a peer which flaps filled every other node's queue with its churn — a join and a leave per cycle, of which only the newest tells a receiver anything, since `handleNodeEvent` discards any event no fresher than what it already holds.

Invalidation could not simply be switched on, because the type was doing two jobs. `sendNodeEvent` waits to learn that this node's own announcement went out and `Finished()` is how it is told, but memberlist calls `Finished()` on whatever it invalidates — so an invalidatable own message would release that wait as though the event had been broadcast when it had in fact been dropped. Only relayed messages carried no notify channel, which made the distinction implicit and easy to lose.

So the type is split:

- `ownNodeEventMessage` — this node's own join or leave, and a `memberlist.UniqueBroadcast`, which the queue neither deduplicates nor offers up for invalidation. The hazard becomes structural rather than guarded. There are only ever a handful in flight; `sendNodeEvent` is called on cluster join, rejoin and leave.
- `relayedNodeEventMessage` — a peer's event being passed on, superseding an event for the same node which is no fresher than itself.

`memberlist.NamedBroadcast` would have given O(1) deduplication instead of the `Invalidates` scan, but its deduplication is unconditionally last-one-wins and would drop the fresher event — the very bug being fixed here.

## Testing

Each change is pinned by a test that fails without it, and the queue-level tests drive the real `TransmitLimitedQueue` rather than calling `Invalidates` directly:

| reverted to | test that fails |
| --- | --- |
| `(table, network, key)` matching | `staler_must_not_evict_fresher`, `TestTableEventQueueKeepsFreshest` (`queue dropped the fresher event: [stale]`) |
| own message not a `UniqueBroadcast`, with the unchecked type assertion this file's other types use | `TestOwnNodeEventSurvivesRelayedEvents` panics inside the queue |

Two notes for reviewers, since the tests do not make either obvious:

- `TestOwnNodeEventSurvivesRelayedEvents` passes if the `UniqueBroadcast` marker is dropped but the checked type assertion is kept — the two mechanisms are independent, and either alone prevents the invalidation. The `var _ memberlist.UniqueBroadcast = (*ownNodeEventMessage)(nil)` assertion is what pins the marker.
- `relayedNodeEventMessage.Invalidates` uses a checked type assertion because two message types now share `nDB.nodeBroadcasts`. The queue does not in fact offer a `UniqueBroadcast` up for invalidation, but with the unchecked form the marker becomes load-bearing for memory safety rather than just for correctness.

Full package green, plain and under `-race`.

## Release notes (optional)

```markdown changelog
Fix a node gossiping a superseded value for a Swarm service discovery entry after concurrent updates to the same key.
Reduce gossip traffic generated by a node that repeatedly disconnects and rejoins the cluster.
```

## A picture of a cute animal (not mandatory but encouraged)

🦔

Created with: Claude Code (Opus 5)
