### PR TITLE
daemon: Clarify error for short container names

### DIFF
--- a/daemon/names.go
+++ b/daemon/names.go
@@ -60,7 +60,11 @@ func (daemon *Daemon) generateIDAndName(name string) (string, string, error) {
 }
 
 func (daemon *Daemon) reserveName(id, name string) (string, error) {
-	if !validContainerNamePattern.MatchString(strings.TrimPrefix(name, "/")) {
+	effectiveName := strings.TrimPrefix(name, "/")
+	if len(effectiveName) < 2 {
+		return "", errdefs.InvalidParameter(errors.Errorf("Invalid container name (%s), names should be at least two alphanumeric characters", name))
+	}
+	if !validContainerNamePattern.MatchString(effectiveName) {
 		return "", errdefs.InvalidParameter(errors.Errorf("Invalid container name (%s), only %s are allowed", name, validContainerNameChars))
 	}
 	if name[0] != '/' {


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

A one-character container name uses allowed characters but still fails the minimum-length requirement.
Report that requirement directly instead of blaming the character set.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Fix `docker container create --name`  reporting a misleading validation error mentioning invalid characters instead of invalid name length.
```

## A picture of a cute animal (not mandatory but encouraged)
