### PR TITLE
client/pkg/jsonmessage: add custom message printer

### DIFF
--- a/client/pkg/jsonmessage/jsonmessage.go
+++ b/client/pkg/jsonmessage/jsonmessage.go
@@ -26,7 +26,8 @@ const RFC3339NanoFixed = "2006-01-02T15:04:05.000000000Z07:00"
 type DisplayOpt func(*displayOpts) error
 
 type displayOpts struct {
-	auxCallback func(jsonstream.Message)
+	auxCallback    func(jsonstream.Message)
+	messagePrinter func(jsonstream.Message, io.Writer) error
 }
 
 // WithAuxCallback registers a callback that is invoked for auxiliary
@@ -35,6 +36,18 @@ type displayOpts struct {
 func WithAuxCallback(fn func(jsonstream.Message)) DisplayOpt {
 	return func(opts *displayOpts) error {
 		opts.auxCallback = fn
+		return nil
+	}
+}
+
+// WithMessagePrinter sets a custom printer for non-auxiliary messages.
+// If set, [DisplayStream] and [DisplayMessages] pass each message to fn instead
+// of using the default terminal-aware presentation. The caller is responsible
+// for handling errors reported through [jsonstream.Message.Error] and any
+// terminal handling, including progress rendering and terminal-width detection.
+func WithMessagePrinter(fn func(jsonstream.Message, io.Writer) error) DisplayOpt {
+	return func(opts *displayOpts) error {
+		opts.messagePrinter = fn
 		return nil
 	}
 }
@@ -232,13 +245,19 @@ func displayJSONMessages(messages iter.Seq2[jsonstream.Message, error], out io.W
 		}
 	}
 	auxCallback := cfg.auxCallback
+	messagePrinter := cfg.messagePrinter
 
-	ids := make(map[string]uint)
-	var width uint16 = 200
-	if isTerminal {
-		ws, err := term.GetWinsize(terminalFd)
-		if err == nil {
-			width = ws.Width
+	var (
+		ids   map[string]uint
+		width uint16 = 200
+	)
+	if messagePrinter == nil {
+		ids = make(map[string]uint)
+		if isTerminal {
+			ws, err := term.GetWinsize(terminalFd)
+			if err == nil {
+				width = ws.Width
+			}
 		}
 	}
 
@@ -251,6 +270,13 @@ func displayJSONMessages(messages iter.Seq2[jsonstream.Message, error], out io.W
 		if jm.Aux != nil {
 			if auxCallback != nil {
 				auxCallback(jm)
+			}
+			continue
+		}
+
+		if messagePrinter != nil {
+			if err := messagePrinter(jm, out); err != nil {
+				return err
 			}
 			continue
 		}

--- a/client/pkg/jsonmessage/jsonmessage_test.go
+++ b/client/pkg/jsonmessage/jsonmessage_test.go
@@ -3,6 +3,7 @@ package jsonmessage
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -191,6 +192,80 @@ func TestDisplayStreamInvalidJSON(t *testing.T) {
 	exp := "invalid character "
 	if err := DisplayStream(reader, data); err == nil || !strings.HasPrefix(err.Error(), exp) {
 		t.Fatalf("Expected error (%s...), got %q", exp, err)
+	}
+}
+
+func TestDisplayStreamWithMessagePrinter(t *testing.T) {
+	testcases := []struct {
+		name        string
+		input       string
+		expected    string
+		expectedErr string
+		printer     func(jsonstream.Message, io.Writer) error
+		auxCallback func(jsonstream.Message)
+	}{
+		{
+			name:     "message",
+			input:    `{"status":"status"}`,
+			expected: "custom",
+			printer: func(jm jsonstream.Message, w io.Writer) error {
+				assert.Equal(t, jm.Status, "status")
+				_, err := fmt.Fprint(w, "custom")
+				return err
+			},
+		},
+		{
+			name:        "message error",
+			input:       `{"errorDetail":{"message":"boom"},"error":"boom"}`,
+			expectedErr: "boom",
+			printer: func(jm jsonstream.Message, _ io.Writer) error {
+				assert.Assert(t, jm.Error != nil)
+				assert.Equal(t, jm.Error.Message, "boom")
+				return jm.Error
+			},
+		},
+		{
+			name:     "auxiliary message",
+			input:    `{"aux":{"ID":"sha256:deadbeef"}}{"status":"status"}`,
+			expected: "custom",
+			printer: func(jm jsonstream.Message, w io.Writer) error {
+				assert.Equal(t, jm.Status, "status")
+				_, err := fmt.Fprint(w, "custom")
+				return err
+			},
+			auxCallback: func(jm jsonstream.Message) {
+				assert.Assert(t, jm.Aux != nil)
+			},
+		},
+		{
+			name:     "auxiliary message without callback",
+			input:    `{"aux":{"ID":"sha256:deadbeef"}}`,
+			expected: "",
+			printer: func(jsonstream.Message, io.Writer) error {
+				t.Fatal("message printer must not be called for auxiliary messages")
+				return nil
+			},
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			opts := []DisplayOpt{
+				WithMessagePrinter(testcase.printer),
+			}
+			if testcase.auxCallback != nil {
+				opts = append(opts, WithAuxCallback(testcase.auxCallback))
+			}
+
+			var out bytes.Buffer
+			err := DisplayStream(strings.NewReader(testcase.input), &out, opts...)
+			if testcase.expectedErr != "" {
+				assert.Error(t, err, testcase.expectedErr)
+			} else {
+				assert.NilError(t, err)
+			}
+			assert.Equal(t, out.String(), testcase.expected)
+		})
 	}
 }
 

--- a/vendor/github.com/moby/moby/client/pkg/jsonmessage/jsonmessage.go
+++ b/vendor/github.com/moby/moby/client/pkg/jsonmessage/jsonmessage.go
@@ -26,7 +26,8 @@ const RFC3339NanoFixed = "2006-01-02T15:04:05.000000000Z07:00"
 type DisplayOpt func(*displayOpts) error
 
 type displayOpts struct {
-	auxCallback func(jsonstream.Message)
+	auxCallback    func(jsonstream.Message)
+	messagePrinter func(jsonstream.Message, io.Writer) error
 }
 
 // WithAuxCallback registers a callback that is invoked for auxiliary
@@ -35,6 +36,18 @@ type displayOpts struct {
 func WithAuxCallback(fn func(jsonstream.Message)) DisplayOpt {
 	return func(opts *displayOpts) error {
 		opts.auxCallback = fn
+		return nil
+	}
+}
+
+// WithMessagePrinter sets a custom printer for non-auxiliary messages.
+// If set, [DisplayStream] and [DisplayMessages] pass each message to fn instead
+// of using the default terminal-aware presentation. The caller is responsible
+// for handling errors reported through [jsonstream.Message.Error] and any
+// terminal handling, including progress rendering and terminal-width detection.
+func WithMessagePrinter(fn func(jsonstream.Message, io.Writer) error) DisplayOpt {
+	return func(opts *displayOpts) error {
+		opts.messagePrinter = fn
 		return nil
 	}
 }
@@ -232,13 +245,19 @@ func displayJSONMessages(messages iter.Seq2[jsonstream.Message, error], out io.W
 		}
 	}
 	auxCallback := cfg.auxCallback
+	messagePrinter := cfg.messagePrinter
 
-	ids := make(map[string]uint)
-	var width uint16 = 200
-	if isTerminal {
-		ws, err := term.GetWinsize(terminalFd)
-		if err == nil {
-			width = ws.Width
+	var (
+		ids   map[string]uint
+		width uint16 = 200
+	)
+	if messagePrinter == nil {
+		ids = make(map[string]uint)
+		if isTerminal {
+			ws, err := term.GetWinsize(terminalFd)
+			if err == nil {
+				width = ws.Width
+			}
 		}
 	}
 
@@ -251,6 +270,13 @@ func displayJSONMessages(messages iter.Seq2[jsonstream.Message, error], out io.W
 		if jm.Aux != nil {
 			if auxCallback != nil {
 				auxCallback(jm)
+			}
+			continue
+		}
+
+		if messagePrinter != nil {
+			if err := messagePrinter(jm, out); err != nil {
+				return err
 			}
 			continue
 		}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/53042#discussion_r3578250383


Add WithMessagePrinter to allow callers of DisplayStream and DisplayMessages to customize presentation of non-auxiliary messages.

The custom printer replaces the default terminal-aware rendering, allowing callers to handle progress output, terminal sizing, and message errors as needed. Auxiliary messages continue to use WithAuxCallback.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
client: pkg/jsonmessage: add new WithMessagePrinter option to use a custom printer for messages.
```

## A picture of a cute animal (not mandatory but encouraged)
