### PR TITLE
libnetwork: batch port mapping firewall rules on bridge network

### DIFF
--- a/daemon/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/daemon/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -89,6 +89,11 @@ func (n *bridgeNetwork) addPortMappings(
 		toBind = toBind[:0]
 	}
 
+	fwPorts := collectFirewallPorts(bindings)
+	if err := n.firewallerNetwork.AddPorts(ctx, fwPorts); err != nil {
+		return nil, err
+	}
+
 	return bindings, nil
 }
 
@@ -123,22 +128,6 @@ func (n *bridgeNetwork) mapPorts(ctx context.Context, pms *drvregistry.PortMappe
 		// Make sure that Mapper is correctly set such that UnmapPorts call the right portmapper.
 		bindings[i].Mapper = mapper
 	}
-
-	fwPorts := collectFirewallPorts(bindings)
-	if err := n.firewallerNetwork.AddPorts(ctx, fwPorts); err != nil {
-		return nil, err
-	}
-	defer func() {
-		if retErr != nil {
-			if err := n.firewallerNetwork.DelPorts(ctx, fwPorts); err != nil {
-				log.G(ctx).WithFields(log.Fields{
-					"bindings": bindings,
-					"error":    err,
-					"origErr":  retErr,
-				}).Warn("Failed to remove firewall rules after error")
-			}
-		}
-	}()
 
 	// Start userland proxy processes.
 	defer func() {


### PR DESCRIPTION
Fixes https://github.com/moby/moby/issues/53466

**Description**

When multiple ports are mapped to a container, \ridgeNetwork.addPortMappings\ calls \mapPorts\ repeatedly for each port binding (due to \
eedSamePort\ returning false for different ports). Previously, \mapPorts\ invoked \
.firewallerNetwork.AddPorts(ctx, fwPorts)\ individually, applying firewall rules one-by-one.

For the nftables backend, each application of rules acts effectively as a full rewrite of the \docker-bridges\ ruleset, resulting in an (M \times N)$ time complexity where $ is the number of published ports for the container and $ is the number of existing rules on the host. This led to container start time scaling issues.

This PR batches the firewall rules addition. Instead of calling \AddPorts\ on each individual port during \mapPorts\, we collect all bindings and issue a single \AddPorts\ call at the end of \ddPortMappings\. 

**Rollback behavior:**
If the final \AddPorts\ call fails, the existing rollback logic via \ddPortMappings\ defer runs \unmapPBs\. \unmapPBs\ removes any userland proxy or socket mappings that were already established during \mapPorts\, and issues \DelPorts\ for the entire batch. This safely matches the prior functionality where failing inside \mapPorts\ would revert the individual firewall port addition.