### PR TITLE
daemon/containerd: lower image signature validation log level

### DIFF
--- a/daemon/containerd/image_identity.go
+++ b/daemon/containerd/image_identity.go
@@ -167,7 +167,7 @@ func (i *ImageService) computeSignatureIdentity(ctx context.Context, desc ocispe
 
 	signatureIdentity, err := i.signatureIdentity(ctx, desc, multi.Best, multi.BestPlatform)
 	if err != nil {
-		log.G(ctx).WithError(err).Error("failed to validate image signature")
+		log.G(ctx).WithError(err).Debug("failed to validate image signature")
 		return nil, signatureVerificationErrorIsTransient(err)
 	}
 


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/53455
closes https://github.com/moby/moby/pull/53456

## Summary

Image signature validation failures are now logged at debug level when computing image identity with the containerd image store. This avoids repeatedly emitting error-level logs for images whose descriptor type cannot carry the expected OCI signature chain, while preserving the existing fail-open behavior.

The previous error log was noisy for valid local image states such as single-architecture manifests and Docker media type manifest lists, where there is no operator action to take.

## Release notes (optional)

```markdown changelog
Do not log expected image signature identity misses as errors for containerd image store images.
```

## A picture of a cute animal (not mandatory but encouraged)
