### PR TITLE
c8d/resolver: Reuse registry auth tokens across pull phases

### DIFF
--- a/daemon/containerd/resolver.go
+++ b/daemon/containerd/resolver.go
@@ -3,6 +3,7 @@ package containerd
 import (
 	"context"
 	"net/http"
+	"sync"
 
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
@@ -21,8 +22,24 @@ func (i *ImageService) newResolverFromAuthConfig(ctx context.Context, authConfig
 
 	hosts := i.registryHosts
 	if authConfig != nil {
+		authConfig := *authConfig
+		var mu sync.Mutex
+		// Keep each host, client, and authorizer together so registry and token
+		// requests use matching transport settings across resolver phases.
+		hostsByName := map[string][]docker.RegistryHost{}
 		hosts = func(name string) ([]docker.RegistryHost, error) {
-			return hostsWrapper(i.registryHosts, *authConfig, ref, name)
+			mu.Lock()
+			defer mu.Unlock()
+
+			if hosts, ok := hostsByName[name]; ok {
+				return hosts, nil
+			}
+			hosts, err := hostsWrapper(i.registryHosts, authConfig, ref, name)
+			if err != nil {
+				return nil, err
+			}
+			hostsByName[name] = hosts
+			return hosts, nil
 		}
 	}
 	headers := http.Header{}

--- a/daemon/containerd/resolver.go
+++ b/daemon/containerd/resolver.go
@@ -19,7 +19,12 @@ import (
 func (i *ImageService) newResolverFromAuthConfig(ctx context.Context, authConfig *registrytypes.AuthConfig, ref reference.Named, metaHeaders http.Header) (remotes.Resolver, docker.StatusTracker) {
 	tracker := docker.NewInMemoryTracker()
 
-	hosts := hostsWrapper(i.registryHosts, authConfig, ref)
+	hosts := i.registryHosts
+	if authConfig != nil {
+		hosts = func(name string) ([]docker.RegistryHost, error) {
+			return hostsWrapper(i.registryHosts, *authConfig, ref, name)
+		}
+	}
 	headers := http.Header{}
 	if metaHeaders != nil {
 		headers = metaHeaders.Clone()
@@ -33,22 +38,15 @@ func (i *ImageService) newResolverFromAuthConfig(ctx context.Context, authConfig
 	}), tracker
 }
 
-func hostsWrapper(hostsFn docker.RegistryHosts, optAuthConfig *registrytypes.AuthConfig, ref reference.Named) docker.RegistryHosts {
-	if optAuthConfig == nil {
-		return hostsFn
+func hostsWrapper(hostsFn docker.RegistryHosts, authConfig registrytypes.AuthConfig, ref reference.Named, name string) ([]docker.RegistryHost, error) {
+	hosts, err := hostsFn(name)
+	if err != nil {
+		return nil, err
 	}
-
-	return func(n string) ([]docker.RegistryHost, error) {
-		hosts, err := hostsFn(n)
-		if err != nil {
-			return nil, err
-		}
-
-		for i := range hosts {
-			hosts[i].Authorizer = authorizerFromAuthConfig(*optAuthConfig, ref, hosts[i].Client)
-		}
-		return hosts, nil
+	for i := range hosts {
+		hosts[i].Authorizer = authorizerFromAuthConfig(authConfig, ref, hosts[i].Client)
 	}
+	return hosts, nil
 }
 
 func authorizerFromAuthConfig(authConfig registrytypes.AuthConfig, ref reference.Named, client *http.Client) docker.Authorizer {

--- a/daemon/containerd/resolver_test.go
+++ b/daemon/containerd/resolver_test.go
@@ -1,0 +1,133 @@
+package containerd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/distribution/reference"
+	registrytypes "github.com/moby/moby/api/types/registry"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"gotest.tools/v3/assert"
+)
+
+func TestResolverReusesRegistryHostsAndBearerTokensAcrossPhases(t *testing.T) {
+	t.Parallel()
+
+	manifest := []byte(`{"schemaVersion":2}`)
+	manifestDigest := digest.FromBytes(manifest)
+	type testRegistry struct {
+		server               *httptest.Server
+		token                string
+		service              string
+		rejectManifest       bool
+		tokenRequests        atomic.Int32
+		unauthorizedRequests atomic.Int32
+	}
+	registries := make([]*testRegistry, 2)
+	for i, config := range []struct {
+		token          string
+		service        string
+		rejectManifest bool
+	}{
+		{token: "first-token", service: "first-registry", rejectManifest: true},
+		{token: "second-token", service: "second-registry"},
+	} {
+		registry := &testRegistry{
+			token:          config.token,
+			service:        config.service,
+			rejectManifest: config.rejectManifest,
+		}
+		registry.server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.URL.Path == "/token":
+				registry.tokenRequests.Add(1)
+				if r.Method != http.MethodGet || r.URL.Query().Get("service") != registry.service || r.URL.Query().Get("scope") != "repository:repo:pull" {
+					http.Error(w, "unexpected token request", http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{"token":%q,"expires_in":300}`, registry.token)
+			case strings.HasPrefix(r.URL.Path, "/v2/repo/manifests/"):
+				if r.Header.Get("Authorization") != "Bearer "+registry.token {
+					registry.unauthorizedRequests.Add(1)
+					w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm=%q,service=%q,scope="repository:repo:pull"`, registry.server.URL+"/token", registry.service))
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				if registry.rejectManifest {
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Type", ocispec.MediaTypeImageManifest)
+				w.Header().Set("Content-Length", strconv.Itoa(len(manifest)))
+				w.Header().Set("Docker-Content-Digest", manifestDigest.String())
+				if r.Method == http.MethodGet {
+					_, _ = w.Write(manifest)
+				}
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(registry.server.Close)
+		registries[i] = registry
+	}
+
+	host := strings.TrimPrefix(registries[0].server.URL, "https://")
+	ref, err := reference.ParseNormalizedNamed(host + "/repo:latest")
+	assert.NilError(t, err)
+
+	newClient := func(server *httptest.Server) *http.Client {
+		transport := server.Client().Transport.(*http.Transport).Clone()
+		return &http.Client{Transport: transport}
+	}
+	var hostCalls atomic.Int32
+	hostsFn := func(string) ([]docker.RegistryHost, error) {
+		hostCalls.Add(1)
+		return []docker.RegistryHost{
+			{
+				Client:       newClient(registries[0].server),
+				Host:         strings.TrimPrefix(registries[0].server.URL, "https://"),
+				Scheme:       "https",
+				Path:         "v2",
+				Capabilities: docker.HostCapabilityPull,
+			},
+			{
+				Client:       newClient(registries[1].server),
+				Host:         strings.TrimPrefix(registries[1].server.URL, "https://"),
+				Scheme:       "https",
+				Path:         "v2",
+				Capabilities: docker.HostCapabilityPull | docker.HostCapabilityResolve,
+			},
+		}, nil
+	}
+	authConfig := registrytypes.AuthConfig{ServerAddress: registries[0].server.URL}
+	imageService := ImageService{registryHosts: hostsFn}
+	resolver, _ := imageService.newResolverFromAuthConfig(t.Context(), &authConfig, ref, nil)
+
+	_, desc, err := resolver.Resolve(t.Context(), ref.String())
+	assert.NilError(t, err)
+	assert.Equal(t, desc.Digest, manifestDigest)
+
+	fetcher, err := resolver.Fetcher(t.Context(), ref.String())
+	assert.NilError(t, err)
+	reader, err := fetcher.Fetch(t.Context(), desc)
+	assert.NilError(t, err)
+	content, err := io.ReadAll(reader)
+	assert.NilError(t, err)
+	assert.NilError(t, reader.Close())
+	assert.Equal(t, string(content), string(manifest))
+
+	assert.Equal(t, hostCalls.Load(), int32(1))
+	for _, registry := range registries {
+		assert.Equal(t, registry.tokenRequests.Load(), int32(1))
+		assert.Equal(t, registry.unauthorizedRequests.Load(), int32(1))
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- Fixes: https://github.com/moby/moby/issues/53334
- Replaces / closes : https://github.com/moby/moby/pull/53457

## Summary

Per-host authorizers were recreated whenever containerd requested registry hosts, which discarded bearer-token state between Resolve and Fetcher. This made pulls repeat the registry challenge and token request.

Cache successful host configurations for the resolver lifetime so each host keeps its TLS-configured client and authorizer across phases. The cache stays local to one resolver and keeps separate authorizers for separate hosts.
## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
containerd image store: Fix slower image pulls caused by repeated registry authentication within a single pull.
```

## A picture of a cute animal (not mandatory but encouraged)
