### PR TITLE
daemon/graphdriver/btrfs: Fix world-writable container root directory

### DIFF
--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -505,6 +505,23 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 		}
 	}
 
+	subvolPath := path.Join(subvolumes, id)
+
+	// if we have a remapped root (user namespaces enabled), change the created snapshot
+	// dir ownership to match
+	if uid != 0 || gid != 0 {
+		if err := os.Chown(subvolPath, uid, gid); err != nil {
+			return err
+		}
+	}
+
+	// Btrfs creates the subvolume's root inode with 0777&^umask, and the daemon
+	// runs with umask 0000, so set the mode explicitly, like the other
+	// graphdrivers do for the directories they create.
+	if err := os.Chmod(subvolPath, 0o755); err != nil {
+		return err
+	}
+
 	var storageOpt map[string]string
 	if opts != nil {
 		storageOpt = opts.StorageOpt
@@ -523,14 +540,6 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 			return err
 		}
 		if err := os.WriteFile(path.Join(quotas, id), []byte(strconv.FormatUint(driver.options.size, 10)), 0o644); err != nil {
-			return err
-		}
-	}
-
-	// if we have a remapped root (user namespaces enabled), change the created snapshot
-	// dir ownership to match
-	if uid != 0 || gid != 0 {
-		if err := os.Chown(path.Join(subvolumes, id), uid, gid); err != nil {
 			return err
 		}
 	}

--- a/daemon/graphdriver/graphtest/graphtest_unix.go
+++ b/daemon/graphdriver/graphtest/graphtest_unix.go
@@ -85,7 +85,11 @@ func DriverTestCreateEmpty(t testing.TB, drivername string, driverOptions ...str
 	driver := GetDriver(t, drivername, driverOptions...)
 	defer PutDriver(t)
 
+	// The daemon clears its umask, so drivers must set modes explicitly instead
+	// of relying on the umask to strip the group/other-write bits.
+	oldmask := unix.Umask(0)
 	err := driver.Create("empty", "", nil)
+	unix.Umask(oldmask)
 	assert.NilError(t, err)
 
 	defer func() {


### PR DESCRIPTION
- Related to: https://github.com/moby/moby/pull/52892

## Summary

On hosts using the `btrfs` storage driver, the root directory `/` inside every container is created world-writable (`0777`, no sticky bit) instead of `0755`.

Btrfs creates a subvolume's root inode with `0777&^umask`, and this driver's `Create()` only issues `BTRFS_IOC_SUBVOL_CREATE` / `BTRFS_IOC_SNAP_CREATE_V2` — it never sets the mode. Before aa9c2f20b8 ("daemon: Set umask to 0000", #52892) the daemon's `0022` umask happened to turn that into `0755`; now that the daemon clears its umask, the mode stays `0777`, and that is what the container sees as `/`.

`overlay2` and `vfs` are not affected, because they create their layer directories through `user.MkdirAndChown()`, which chmods to the requested mode instead of leaving it to the umask.

This looks like a creation site that the audit in 88df5b627e ("daemon: Adjust file permissions for umask 000") could not have found: the subvolume root is created by an ioctl rather than by a Go call carrying an explicit mode argument.

### Reproducer

With `Storage Driver: btrfs`, on 29.6.0 or later:

```console
$ docker rmi alpine; docker pull alpine
$ docker run --rm alpine stat -c %a /
777
```

The `rmi`/`pull` matters on an existing installation: subvolumes created before the daemon was restarted keep the mode they were created with.

The kernel behaviour this depends on, independent of dockerd:

```console
$ sh -c 'umask 000; btrfs subvolume create ./p0; stat -c %a ./p0'
777
$ sh -c 'umask 022; btrfs subvolume create ./p2; stat -c %a ./p2'
755
```

And the daemon's umask, which the systemd unit's `UMask=0022` no longer governs since `setDefaultUmask()` overrides it at startup:

```console
$ grep Umask /proc/$(pgrep -o dockerd)/status
Umask:  0000
```

### Impact

Every container on such a host has a world-writable, non-sticky `/`. Any process in the container, including an unprivileged one running as a non-root user, can create entries in `/` and rename or unlink existing top-level entries such as `/etc` or `/usr`. For containers that deliberately run as a non-root user this removes a boundary that is normally there.

### Testing

`DriverTestCreateEmpty` already asserted that the layer root is `0755`, but it created the layer under the umask inherited from the test process, so the assertion could never observe what the driver itself does. The first commit creates the layer with umask 0 instead; the second is the fix.

Before the fix:

```
=== RUN   TestBtrfsCreateEmpty
    testutil_unix.go:24: assertion failed: -rwxr-xr-x (mode & os.ModePerm fs.FileMode) != -rwxrwxrwx (actual & os.ModePerm fs.FileMode): .../btrfs/subvolumes/empty
--- FAIL: TestBtrfsCreateEmpty (0.00s)
```

After the fix:

```
=== RUN   TestBtrfsCreateEmpty
--- PASS: TestBtrfsCreateEmpty (0.00s)
```

### Not addressed here

`go-archive`'s `Unpack()` skips the archive's root entry:

```go
if fi.IsDir() && hdr.Name == "." {
    continue
}
```

so an image that does declare a mode for `/` has it discarded on the graphdriver path, and many images carry no root entry at all. That is a separate question in a separate repository; this PR only stops the daemon's umask from deciding the mode.

## Release notes (optional)

```markdown changelog
Fix the container root directory `/` being world-writable when using the `btrfs` storage driver.
```

Created with: Claude Code (Claude Opus 5)
