### PR TITLE
builder: Use base image platform for cache lookup

### DIFF
--- a/daemon/builder/builder.go
+++ b/daemon/builder/builder.go
@@ -95,7 +95,7 @@ type Image interface {
 	ImageID() string
 	RunConfig() *container.Config
 	MarshalJSON() ([]byte, error)
-	OperatingSystem() string
+	Platform() ocispec.Platform
 }
 
 // ROLayer is a reference to image rootfs layer

--- a/daemon/builder/dockerfile/evaluator.go
+++ b/daemon/builder/dockerfile/evaluator.go
@@ -22,6 +22,7 @@ package dockerfile
 import (
 	"context"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -216,7 +217,10 @@ func (s *dispatchState) hasFromImage() bool {
 func (s *dispatchState) beginStage(stageName string, img builder.Image) error {
 	s.stageName = stageName
 	s.imageID = img.ImageID()
-	s.operatingSystem = img.OperatingSystem()
+	s.operatingSystem = img.Platform().OS
+	if s.operatingSystem == "" {
+		s.operatingSystem = runtime.GOOS
+	}
 	if err := image.CheckOS(s.operatingSystem); err != nil {
 		return err
 	}

--- a/daemon/builder/dockerfile/internals.go
+++ b/daemon/builder/dockerfile/internals.go
@@ -381,6 +381,11 @@ func (b *Builder) getPlatform(state *dispatchState) ocispec.Platform {
 	if b.platform != nil {
 		out = *b.platform
 	}
+	if state.baseImage != nil {
+		if platform := state.baseImage.Platform(); platform.Architecture != "" {
+			out = platform
+		}
+	}
 
 	if state.operatingSystem != "" {
 		out.OS = state.operatingSystem

--- a/daemon/builder/dockerfile/mockbackend_test.go
+++ b/daemon/builder/dockerfile/mockbackend_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"runtime"
 
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/v2/daemon/builder"
@@ -95,8 +94,8 @@ func (i *mockImage) RunConfig() *container.Config {
 	return i.config
 }
 
-func (i *mockImage) OperatingSystem() string {
-	return runtime.GOOS
+func (i *mockImage) Platform() ocispec.Platform {
+	return ocispec.Platform{}
 }
 
 func (i *mockImage) MarshalJSON() ([]byte, error) {

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
 	"github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/image"
@@ -673,6 +674,50 @@ func TestBuildPlatformInvalid(t *testing.T) {
 
 	assert.Check(t, is.ErrorContains(err, "unknown operating system or architecture"))
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
+}
+
+func TestBuildCacheUsesDockerfilePlatform(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux", "test images are only available on linux")
+
+	platform := "linux/arm64/v8"
+	baseImage := "hello-world:arm64"
+	daemonPlatform := platforms.Normalize(ocispec.Platform{
+		OS:           "linux",
+		Architecture: testEnv.DaemonInfo.Architecture,
+	})
+	if daemonPlatform.Architecture == "arm64" {
+		platform = "linux/amd64"
+		baseImage = "hello-world:amd64"
+	}
+	requestedPlatform, err := platforms.Parse(platform)
+	assert.NilError(t, err)
+	assert.Assert(t, !platforms.Only(daemonPlatform).Match(requestedPlatform))
+
+	ctx := setupTest(t)
+	source := fakecontext.New(t, "", fakecontext.WithDockerfile(fmt.Sprintf(`
+FROM --platform=%s %s
+ENV CACHE_TEST=1
+`, platform, baseImage)))
+	defer source.Close()
+
+	buildImage := func() string {
+		resp, err := testEnv.APIClient().ImageBuild(ctx, source.AsTarReader(t), client.ImageBuildOptions{
+			Version: build.BuilderV1,
+		})
+		assert.NilError(t, err)
+		defer resp.Body.Close()
+
+		out := bytes.NewBuffer(nil)
+		_, err = io.Copy(out, resp.Body)
+		assert.NilError(t, err)
+		return out.String()
+	}
+
+	buildImage()
+	out := buildImage()
+	if !assert.Check(t, is.Contains(out, "Using cache")) {
+		t.Log(out)
+	}
 }
 
 // TestBuildWorkdirNoCacheMiss is a regression test for https://github.com/moby/moby/issues/47627


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- fix: https://github.com/moby/moby/issues/49947
- replace / close: https://github.com/moby/moby/pull/53204

## Summary

The classic builder used the global build platform when probing its image cache.

A per-stage FROM --platform could therefore probe with the host architecture and reject cached layers built from a foreign-architecture base image.

Read the platform directly from the loaded base image for cache probes.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Fix classic-builder cache for Dockerfile stages that select a non-host platform with `FROM --platform`.
```

## A picture of a cute animal (not mandatory but encouraged)
