### PR TITLE
api/types/plugin: fix Privileges Swap implementation

### DIFF
--- a/api/types/plugin/plugin_responses.go
+++ b/api/types/plugin/plugin_responses.go
@@ -1,9 +1,5 @@
 package plugin
 
-import (
-	"sort"
-)
-
 // ListResponse contains the response for the Engine API
 type ListResponse []Plugin
 
@@ -15,19 +11,20 @@ type Privilege struct {
 	Value       []string
 }
 
-// Privileges is a list of Privilege
+// Privileges is a list of Privilege.
 type Privileges []Privilege
 
+// Len implements [sort.Interface].
 func (s Privileges) Len() int {
 	return len(s)
 }
 
+// Less implements [sort.Interface].
 func (s Privileges) Less(i, j int) bool {
 	return s[i].Name < s[j].Name
 }
 
+// Swap implements [sort.Interface].
 func (s Privileges) Swap(i, j int) {
-	sort.Strings(s[i].Value)
-	sort.Strings(s[j].Value)
 	s[i], s[j] = s[j], s[i]
 }

--- a/api/types/plugin/plugin_responses_test.go
+++ b/api/types/plugin/plugin_responses_test.go
@@ -1,0 +1,47 @@
+package plugin_test
+
+import (
+	"slices"
+	"sort"
+	"testing"
+
+	"github.com/moby/moby/api/types/plugin"
+)
+
+func assertPrivilegesEqual(t *testing.T, got, want plugin.Privileges) {
+	t.Helper()
+
+	if !slices.EqualFunc(got, want, func(a, b plugin.Privilege) bool {
+		return a.Name == b.Name && slices.Equal(a.Value, b.Value)
+	}) {
+		t.Fatalf("unexpected privileges:\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestPrivilegesSort(t *testing.T) {
+	privileges := plugin.Privileges{
+		{Name: "write", Value: []string{"z", "a"}},
+		{Name: "read", Value: []string{"y", "b"}},
+	}
+
+	sort.Sort(privileges)
+
+	assertPrivilegesEqual(t, privileges, plugin.Privileges{
+		{Name: "read", Value: []string{"y", "b"}},
+		{Name: "write", Value: []string{"z", "a"}},
+	})
+}
+
+func TestPrivilegesSwap(t *testing.T) {
+	privileges := plugin.Privileges{
+		{Name: "foo", Value: []string{"z", "a"}},
+		{Name: "bar", Value: []string{"y", "b"}},
+	}
+
+	privileges.Swap(0, 1)
+
+	assertPrivilegesEqual(t, privileges, plugin.Privileges{
+		{Name: "bar", Value: []string{"y", "b"}},
+		{Name: "foo", Value: []string{"z", "a"}},
+	})
+}

--- a/vendor/github.com/moby/moby/api/types/plugin/plugin_responses.go
+++ b/vendor/github.com/moby/moby/api/types/plugin/plugin_responses.go
@@ -1,9 +1,5 @@
 package plugin
 
-import (
-	"sort"
-)
-
 // ListResponse contains the response for the Engine API
 type ListResponse []Plugin
 
@@ -15,19 +11,20 @@ type Privilege struct {
 	Value       []string
 }
 
-// Privileges is a list of Privilege
+// Privileges is a list of Privilege.
 type Privileges []Privilege
 
+// Len implements [sort.Interface].
 func (s Privileges) Len() int {
 	return len(s)
 }
 
+// Less implements [sort.Interface].
 func (s Privileges) Less(i, j int) bool {
 	return s[i].Name < s[j].Name
 }
 
+// Swap implements [sort.Interface].
 func (s Privileges) Swap(i, j int) {
-	sort.Strings(s[i].Value)
-	sort.Strings(s[j].Value)
 	s[i], s[j] = s[j], s[i]
 }


### PR DESCRIPTION
Make Privileges.Swap only swap the requested elements, as required by sort.Interface.

Previously, Swap also sorted the Value slices of both elements. Besides being an unexpected side effect, this did not reliably sort all privilege values, as elements that were never swapped could remain unsorted.

Also document the sort.Interface methods explicitly.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
