### PR TITLE
api/types/plugin: deprecate Privileges sort.Interface methods

### DIFF
--- a/api/types/plugin/plugin_responses.go
+++ b/api/types/plugin/plugin_responses.go
@@ -15,16 +15,22 @@ type Privilege struct {
 type Privileges []Privilege
 
 // Len implements [sort.Interface].
+//
+// Deprecated: use [slices.SortFunc] to sort privileges instead.
 func (s Privileges) Len() int {
 	return len(s)
 }
 
 // Less implements [sort.Interface].
+//
+// Deprecated: use [slices.SortFunc] to sort privileges instead.
 func (s Privileges) Less(i, j int) bool {
 	return s[i].Name < s[j].Name
 }
 
 // Swap implements [sort.Interface].
+//
+// Deprecated: use [slices.SortFunc] to sort privileges instead.
 func (s Privileges) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }

--- a/vendor/github.com/moby/moby/api/types/plugin/plugin_responses.go
+++ b/vendor/github.com/moby/moby/api/types/plugin/plugin_responses.go
@@ -15,16 +15,22 @@ type Privilege struct {
 type Privileges []Privilege
 
 // Len implements [sort.Interface].
+//
+// Deprecated: use [slices.SortFunc] to sort privileges instead.
 func (s Privileges) Len() int {
 	return len(s)
 }
 
 // Less implements [sort.Interface].
+//
+// Deprecated: use [slices.SortFunc] to sort privileges instead.
 func (s Privileges) Less(i, j int) bool {
 	return s[i].Name < s[j].Name
 }
 
 // Swap implements [sort.Interface].
+//
+// Deprecated: use [slices.SortFunc] to sort privileges instead.
 func (s Privileges) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }


### PR DESCRIPTION
- [x] stacked on https://github.com/moby/moby/pull/53510

### api/types/plugin: deprecate Privileges sort.Interface methods

Deprecate Len, Less, and Swap on Privileges in favor of slices.SortFunc.

The sort.Interface implementation is kept for compatibility, but new code can
sort Privileges directly using the generic slices helpers without relying on
the legacy methods.

For example:

```go
slices.SortFunc(privileges, func(a, b plugin.Privilege) int {
    return cmp.Compare(a.Name, b.Name)
})
```

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
api/types/plugin: Deprecated `plugin.Privileges` sorting methods in favor of `slices.SortFunc`.
```

## A picture of a cute animal (not mandatory but encouraged)
