### PR TITLE
Fix interrupted container removal leaving Dead:false residue that shadows replacement

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -62,6 +62,7 @@ import (
 	"github.com/moby/moby/v2/daemon/events"
 	_ "github.com/moby/moby/v2/daemon/graphdriver/register" // register graph drivers
 	"github.com/moby/moby/v2/daemon/images"
+	"github.com/moby/moby/v2/daemon/internal/containerfs"
 	"github.com/moby/moby/v2/daemon/internal/distribution"
 	dmetadata "github.com/moby/moby/v2/daemon/internal/distribution/metadata"
 	"github.com/moby/moby/v2/daemon/internal/idtools"
@@ -304,6 +305,7 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 	restartContainers := make(map[*container.Container]chan struct{})
 	activeSandboxes := make(map[string]any)
 
+	// Phase 1: load RWLayers in parallel.
 	for _, c := range containers {
 		group.Go(func() {
 			if err := sem.Acquire(context.WithoutCancel(ctx), 1); err != nil {
@@ -326,24 +328,67 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 				"running": c.State.IsRunning(),
 				"paused":  c.State.IsPaused(),
 			}).Debug("loaded container")
-
-			if err := daemon.registerName(c); err != nil {
-				logger.WithError(err).Errorf("failed to register container name: %s", c.Name)
-				mapLock.Lock()
-				delete(containers, c.ID)
-				mapLock.Unlock()
-				return
-			}
-			if err := daemon.register(ctx, c); err != nil {
-				logger.WithError(err).Error("failed to register container")
-				mapLock.Lock()
-				delete(containers, c.ID)
-				mapLock.Unlock()
-				return
-			}
 		})
 	}
 	group.Wait()
+
+	// Phase 2: deterministic registration. Containers with a valid RWLayer are
+	// registered first, so a healthy replacement is preferred over a broken
+	// residue with Dead:false that survived an interrupted removal (see #53481).
+	// This makes the "first wins" name race deterministic and allows us to
+	// clean up the residue that would otherwise shadow the replacement on every
+	// restart.
+	sorted := make([]*container.Container, 0, len(containers))
+	for _, c := range containers {
+		sorted = append(sorted, c)
+	}
+	slices.SortFunc(sorted, func(a, b *container.Container) int {
+		aValid := a.RWLayer != nil
+		bValid := b.RWLayer != nil
+		if aValid != bValid {
+			if aValid {
+				return -1
+			}
+			return 1
+		}
+		if a.ID < b.ID {
+			return -1
+		}
+		if a.ID > b.ID {
+			return 1
+		}
+		return 0
+	})
+	for _, c := range sorted {
+		logger := log.G(ctx).WithField("container", c.ID)
+		if err := daemon.registerName(c); err != nil {
+			logger.WithError(err).Errorf("failed to register container name: %s", c.Name)
+			// If a broken container (missing RWLayer) loses the name race to a
+			// healthy one, it is unambiguously a leftover from an interrupted
+			// removal. Remove its directory instead of silently dropping it from
+			// the in-memory map and leaving it on disk to re-race on every boot.
+			if c.RWLayer == nil {
+				if existingID, getErr := daemon.containersReplica.Snapshot().GetID(c.Name); getErr == nil {
+					if existingCtr, ok := containers[existingID]; ok && existingCtr.RWLayer != nil {
+						logger.Warnf("removing residue container %s with missing layer that conflicts on name %s with healthy container %s", c.ID, c.Name, existingID)
+						if rmErr := containerfs.EnsureRemoveAll(c.Root); rmErr != nil {
+							logger.WithError(rmErr).Errorf("failed to remove residue container directory %s", c.Root)
+						} else {
+							logger.Infof("removed residue container directory %s", c.Root)
+						}
+					}
+				}
+			}
+			delete(containers, c.ID)
+			continue
+		}
+		if err := daemon.register(ctx, c); err != nil {
+			logger.WithError(err).Error("failed to register container")
+			daemon.releaseName(c.Name)
+			delete(containers, c.ID)
+			continue
+		}
+	}
 
 	for _, c := range containers {
 		group.Add(1)

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -132,7 +132,17 @@ func (daemon *Daemon) cleanupContainer(ctr *container.Container, config backend.
 	// container meta file got removed from disk, then a restart of
 	// docker should not make a dead container alive.
 	if err := ctr.CheckpointTo(context.WithoutCancel(context.TODO()), daemon.containersReplica); err != nil && !os.IsNotExist(err) {
+		// Restore in-memory state before returning; the on-disk config still
+		// has Dead:false so a daemon restart will not consider this container
+		// dead. Proceeding to ReleaseLayer with Dead:false on disk would leave
+		// a Dead:false residue if the daemon crashes between layer removal and
+		// filesystem cleanup (see https://github.com/moby/moby/issues/53481).
+		ctr.State.Dead = false
+		ctr.RWLayer = rwLayer
+		ctr.Unlock()
 		log.G(context.TODO()).Errorf("Error saving dying container to disk: %v", err)
+		ctr.State.SetRemovalError(err)
+		return err
 	}
 	ctr.Unlock()
 


### PR DESCRIPTION
- Fixes https://github.com/moby/moby/issues/53481

## Summary
Container removal (`daemon/delete.go` `cleanupContainer`) is non-atomic:

1. stop container
2. `ctr.State.Dead = true; CheckpointTo(disk)` – write failure is logged and swallowed
3. `imageService.ReleaseLayer(rwLayer)` – deletes layerdb mount record + graphdriver storage
4. `containerfs.EnsureRemoveAll(ctr.Root)` – deletes `/var/lib/docker/containers/<id>/`

If the daemon dies between 3 and 4, the container directory (`config.v2.json` included) survives while its layer is gone. On next start `restore()` loads the leftover, `GetLayerByID` fails (`failed to load container mount ... mount does not exist`), and since #51724 the container is registered with nil `RWLayer`.

Startup cleanup added in #51692 removes leftovers only when `State.Dead` is true on disk. Two paths produce leftovers where it is false:

- Swallowed checkpoint failure (ENOSPC/I/O)
- Host crash where layer release persists but atomic-rename config does not

Because the replacement container (same name) and the leftover dir both claim one name, every restart re-races them – winner is nondeterministic and swaps between boots, causing `RWLayer of container <id> is unexpectedly nil`.

## What changed
- **`daemon/delete.go`**: Treat a failed `Dead=true` checkpoint as fatal. Restore in-memory `Dead`/`RWLayer` and return the error instead of swallowing it and proceeding to release the layer with `Dead:false` still on disk.
- **`daemon/daemon.go`**: Make restore deterministic and clean up the unambiguous residue. Load RWLayers in parallel, then register names sorted with healthy containers first. If a broken container (nil RWLayer) loses the name race to a healthy one, remove its stale directory via `containerfs.EnsureRemoveAll` instead of silently dropping it from the map.

## Release notes
<!-- markdown changelog -->
```markdown changelog
Fix a bug where an interrupted `docker rm` could leave a `Dead:false` container directory that survived daemon restarts and nondeterministically shadowed its replacement's name.
```

## Verification
- `GOOS=linux go vet ./daemon` passes
- Manual reasoning against #51692/#51724 prior fixes; sorted registration makes name race deterministic.

Created with: Human
