### PR TITLE
daemon: simplify network driver list deduplication

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/netip"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -607,28 +606,18 @@ func (daemon *Daemon) GetNetworkDriverList(ctx context.Context) []string {
 
 	pluginList := daemon.netController.BuiltinDrivers()
 
-	managedPlugins := daemon.PluginStore.GetAllManagedPluginsByCap(driverapi.NetworkPluginEndpointType)
-
-	for _, plugin := range managedPlugins {
+	for _, plugin := range daemon.PluginStore.GetAllManagedPluginsByCap(driverapi.NetworkPluginEndpointType) {
 		pluginList = append(pluginList, plugin.Name())
 	}
 
-	pluginMap := make(map[string]bool)
-	for _, plugin := range pluginList {
-		pluginMap[plugin] = true
-	}
-
-	networks := daemon.netController.Networks(ctx)
-
-	for _, nw := range networks {
-		if !pluginMap[nw.Type()] {
-			pluginList = append(pluginList, nw.Type())
-			pluginMap[nw.Type()] = true
+	pluginList = sliceutil.Dedup(pluginList)
+	for _, nw := range daemon.netController.Networks(ctx) {
+		if typ := nw.Type(); !slices.Contains(pluginList, typ) {
+			pluginList = append(pluginList, typ)
 		}
 	}
 
-	sort.Strings(pluginList)
-
+	slices.Sort(pluginList)
 	return pluginList
 }
 


### PR DESCRIPTION
Collect built-in, managed-plugin, and network driver names before deduplicating them with sliceutil.Dedup and sorting the result.

This also avoids returning duplicate managed-plugin driver names, which the previous implementation only filtered for drivers discovered from existing networks.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
