### PR TITLE
hack: treat Go sources as text when filtering tests

### DIFF
--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -27,7 +27,7 @@ setup_integration_test_filter() {
 
 	local dirs
 	local files
-	if files=$(grep -rIlE --include '*_test.go' "func .*${TEST_FILTER}.*\(. \*testing\.T\)" ./integration*/); then
+	if files=$(grep -ralE --include '*_test.go' "func .*${TEST_FILTER}.*\(. \*testing\.T\)" ./integration*/); then
 		dirs=$(echo "$files" | xargs -I file dirname file | uniq)
 	fi
 


### PR DESCRIPTION
Use grep's text mode when locating tests matching TEST_FILTER.

The search is restricted to *_test.go files, which are known to be text. Using -I allowed grep's binary-file detection heuristic to silently ignore matching source files, causing the corresponding integration test suites to be skipped.

For example, grep may report a Go test file:

    $ grep -nE 'func .*TestRunWriteSpecialFilesAndNotCommit.*' \
        integration-cli/docker_cli_run_test.go
    grep: integration-cli/docker_cli_run_test.go: binary file matches

Forcing text mode finds the expected test:

    $ grep -anE 'func .*TestRunWriteSpecialFilesAndNotCommit.*' \
        integration-cli/docker_cli_run_test.go
    1713:func (s *DockerCLIRunSuite) TestRunWriteSpecialFilesAndNotCommit(c *testing.T) {

This caused TEST_FILTER not to find a test, and skipping all tests;

    make TEST_FILTER=TestRunWriteSpecialFilesAndNotCommit test-integration
    ...
    ---> Making bundle: test-integration (in bundles/test-integration)
    Skipping integration tests since the supplied filter "TestRunWriteSpecialFilesAndNotCommit" omits all integration tests
    Skipping integration-cli tests since the supplied filter "TestRunWriteSpecialFilesAndNotCommit" omits all integration-cli tests
    integration and integration-cli skipped according to env vars

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
