### PR TITLE
Reap nft process on errors

### DIFF
--- a/daemon/libnetwork/internal/nftables/nft_exec_linux.go
+++ b/daemon/libnetwork/internal/nftables/nft_exec_linux.go
@@ -3,9 +3,9 @@
 package nftables
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os/exec"
 	"strings"
 	"sync"
@@ -64,45 +64,16 @@ func (*nftCtx) Apply(ctx context.Context, nftCmd []byte) error {
 		cmdArgs = append([]string{nsenterPath, "-n" + detachedNetNS, "-F", "--"}, cmdArgs...)
 	}
 	cmd := exec.CommandContext(ctx, cmdPath, cmdArgs[1:]...)
-	stdinPipe, err := cmd.StdinPipe()
-	if err != nil {
-		return fmt.Errorf("getting stdin pipe for nft: %w", err)
-	}
-	stdoutPipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return fmt.Errorf("getting stdout pipe for nft: %w", err)
-	}
-	stderrPipe, err := cmd.StderrPipe()
-	if err != nil {
-		return fmt.Errorf("getting stderr pipe for nft: %w", err)
-	}
-
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("starting nft: %w", err)
-	}
-	if _, err := stdinPipe.Write(nftCmd); err != nil {
-		return fmt.Errorf("sending nft commands: %w", err)
-	}
-	if err := stdinPipe.Close(); err != nil {
-		return fmt.Errorf("closing nft input pipe: %w", err)
-	}
-
 	stdoutBuf := strings.Builder{}
-	if _, err := io.Copy(&stdoutBuf, stdoutPipe); err != nil {
-		return fmt.Errorf("reading stdout of nft: %w", err)
-	}
-	stdout := stdoutBuf.String()
 	stderrBuf := strings.Builder{}
-	if _, err := io.Copy(&stderrBuf, stderrPipe); err != nil {
-		return fmt.Errorf("reading stderr of nft: %w", err)
-	}
-	stderr := stderrBuf.String()
+	cmd.Stdin = bytes.NewReader(nftCmd)
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
 
-	err = cmd.Wait()
-	if err != nil {
-		return fmt.Errorf("running nft: %s %w", stderr, err)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("running nft: %s %w", stderrBuf.String(), err)
 	}
-	log.G(ctx).WithFields(log.Fields{"stdout": stdout, "stderr": stderr}).Debug("nftables: updated")
+	log.G(ctx).WithFields(log.Fields{"stdout": stdoutBuf.String(), "stderr": stderrBuf.String()}).Debug("nftables: updated")
 	return nil
 }
 

--- a/daemon/libnetwork/internal/nftables/nft_exec_linux_test.go
+++ b/daemon/libnetwork/internal/nftables/nft_exec_linux_test.go
@@ -1,0 +1,58 @@
+//go:build !cgo || static_build || !libnftables
+
+package nftables
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+const nftStderrHelperEnv = "GO_WANT_NFT_STDERR_HELPER"
+
+func init() {
+	if os.Getenv(nftStderrHelperEnv) != "1" {
+		return
+	}
+	// This must be larger than a pipe buffer so that reading stdout before
+	// stderr would deadlock with this write.
+	_, _ = os.Stderr.Write(bytes.Repeat([]byte("x"), 4<<20))
+	os.Exit(1)
+}
+
+func TestApplyDrainsStderrConcurrently(t *testing.T) {
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalLookPathNft := lookPathNft
+	lookPathNft = sync.OnceValues(func() (string, error) {
+		return executable, nil
+	})
+	t.Cleanup(func() {
+		lookPathNft = originalLookPathNft
+	})
+	t.Setenv(nftStderrHelperEnv, "1")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- (&nftCtx{}).Apply(ctx, []byte("add table inet test"))
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Apply succeeded with a failing nft command")
+		}
+	case <-time.After(5 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("Apply deadlocked while nft was writing stderr")
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
 /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

Follow up to: https://github.com/moby/moby/pull/52886

## Summary

Fix process and pipe handling in the subprocess-based nftables backend.

Previously, dockerd created separate stdin, stdout, and stderr pipes for `nft`, then drained stdout completely before reading stderr. If `nft` produced enough stderr output to fill its pipe while stdout remained open, the child blocked writing stderr while dockerd blocked waiting for EOF on stdout.

Errors while writing stdin or reading either output stream also returned without calling `Wait`, potentially leaving the child process unreaped.

This change attaches the input and output buffers directly to `exec.Cmd` and uses `cmd.Run()`. The `os/exec` package drains stdout and stderr concurrently and waits for the child after it starts, including when copying input or output fails.

PR #52886 made this subprocess implementation the default to avoid crashes in the libnftables implementation, increasing the exposure of this path.

## Reproduction

Use a disposable test environment with the existing Docker daemon stopped.

Create an `nft` wrapper that writes more than a pipe buffer to stderr:

```console
$ test_bin="$(mktemp -d)"
$ cat > "$test_bin/nft" <<'EOF'
#!/bin/sh
head -c 1048576 /dev/zero >&2
exit 1
EOF
$ chmod +x "$test_bin/nft"
```

Start dockerd with the wrapper first in `PATH`:

```console
$ sudo env PATH="$test_bin:$PATH" dockerd \
    --debug \
    --firewall-backend=nftables
```

Before this change, dockerd becomes stuck while applying nftables rules: the wrapper blocks once its stderr pipe fills, while dockerd waits for EOF on stdout.

After this change, stdout and stderr are drained concurrently. The wrapper completes, and dockerd reports the `nft` failure instead of hanging.

## Testing

Added `TestApplyDrainsStderrConcurrently`. It runs the test binary as a fake `nft` command and writes 4 MiB to stderr, ensuring the output exceeds the pipe capacity.

Against the parent commit, the test reproduces the deadlock:

```console
$ go test ./daemon/libnetwork/internal/nftables -run '^TestApplyDrainsStderrConcurrently$' -count=1
--- FAIL: TestApplyDrainsStderrConcurrently (5.01s)
    nft_exec_linux_test.go:56: Apply deadlocked while nft was writing stderr
FAIL
```

With this change:

```console
$ go test ./daemon/libnetwork/internal/nftables -run '^TestApplyDrainsStderrConcurrently$' -count=1
ok  	github.com/moby/moby/v2/daemon/libnetwork/internal/nftables	0.020s

$ go test -race ./daemon/libnetwork/internal/nftables -run '^TestApplyDrainsStderrConcurrently$' -count=1
ok  	github.com/moby/moby/v2/daemon/libnetwork/internal/nftables	1.085s

$ CGO_ENABLED=0 go test ./daemon/libnetwork/internal/nftables -run '^TestApplyDrainsStderrConcurrently$' -count=1
ok  	github.com/moby/moby/v2/daemon/libnetwork/internal/nftables	0.017s

$ go test ./daemon/libnetwork/internal/nftables -count=1
ok  	github.com/moby/moby/v2/daemon/libnetwork/internal/nftables	0.033s
```


## Release notes (optional)

```markdown changelog
Prevent dockerd from hanging when the nft command produces enough stderr output to fill its pipe.
```

## Assistance disclosure

I found this bug using gohawk's [`processownership` analyzer](https://kojah.github.io/gohawk/analyzers/ownership-and-lifecycle/processownership/), part of a custom Go static-analysis suite I am writing. I used Codex to review the finding, verify that it was not a false positive, develop the reproduction, and add the regression test.

## A picture of a cute animal (not mandatory but encouraged)

🐳

Created with: Codex