### PR TITLE
daemon/nri: preserve workload args with init

### DIFF
--- a/daemon/internal/nri/nri.go
+++ b/daemon/internal/nri/nri.go
@@ -349,9 +349,11 @@ func containerToNRI(ctr *container.Container) (*adaptation.PodSandbox, *adaptati
 		State:        stateToNRI(ctr.State),
 		Labels:       ctr.Config.Labels,
 		Annotations:  ctr.HostConfig.Annotations,
-		Args:         append([]string{ctr.Path}, ctr.Args...),
-		Env:          ctr.Config.Env,
-		Hooks:        nil,
+		// Args is a fresh copy of the resolved workload argv. It intentionally
+		// excludes OCI-only wrappers such as Docker init.
+		Args:  append([]string{ctr.Path}, ctr.Args...),
+		Env:   ctr.Config.Env,
+		Hooks: nil,
 		Linux: &adaptation.LinuxContainer{
 			Namespaces:     nil,
 			Devices:        nil,

--- a/daemon/internal/nri/nri_test.go
+++ b/daemon/internal/nri/nri_test.go
@@ -1,6 +1,7 @@
 package nri
 
 import (
+	"slices"
 	"testing"
 
 	containertypes "github.com/moby/moby/api/types/container"
@@ -33,10 +34,13 @@ func newTestContainer(entrypoint, cmd []string) *container.Container {
 }
 
 func TestContainerToNRIArgs(t *testing.T) {
+	initEnabled := true
+	initDisabled := false
 	tests := []struct {
 		name       string
 		entrypoint []string
 		cmd        []string
+		init       *bool
 		expArgs    []string
 	}{
 		{
@@ -46,10 +50,24 @@ func TestContainerToNRIArgs(t *testing.T) {
 			expArgs:    []string{"echo", "hello"},
 		},
 		{
-			name:       "entrypoint with args plus cmd",
+			name:       "init enabled",
 			entrypoint: []string{"/usr/bin/tool", "--mode"},
-			cmd:        []string{"input"},
-			expArgs:    []string{"/usr/bin/tool", "--mode", "input"},
+			cmd:        []string{"input", "output"},
+			init:       &initEnabled,
+			expArgs:    []string{"/usr/bin/tool", "--mode", "input", "output"},
+		},
+		{
+			name:       "daemon init default possible",
+			entrypoint: []string{"/usr/bin/tool", "--mode"},
+			cmd:        []string{"input", "output"},
+			expArgs:    []string{"/usr/bin/tool", "--mode", "input", "output"},
+		},
+		{
+			name:       "init disabled",
+			entrypoint: []string{"/usr/bin/tool", "--mode"},
+			cmd:        []string{"input", "output"},
+			init:       &initDisabled,
+			expArgs:    []string{"/usr/bin/tool", "--mode", "input", "output"},
 		},
 		{
 			name:    "cmd only",
@@ -65,12 +83,15 @@ func TestContainerToNRIArgs(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctr := newTestContainer(tc.entrypoint, tc.cmd)
+			ctr.HostConfig.Init = tc.init
 			_, nriCtr, err := containerToNRI(ctr)
 			assert.NilError(t, err)
 			assert.Check(t, is.DeepEqual(nriCtr.Args, tc.expArgs))
-			// The NRI args must match the process args placed in the OCI spec,
-			// which are constructed as append([]string{c.Path}, c.Args...).
+			// NRI reports the resolved workload argv, not OCI-only wrappers.
 			assert.Check(t, is.DeepEqual(nriCtr.Args, append([]string{ctr.Path}, ctr.Args...)))
+			for _, initArg := range []string{"/sbin/docker-init", "--", "/usr/libexec/docker-init"} {
+				assert.Check(t, !slices.Contains(nriCtr.Args, initArg), "NRI args unexpectedly include init argument %q: %v", initArg, nriCtr.Args)
+			}
 		})
 	}
 }

--- a/daemon/oci_linux_test.go
+++ b/daemon/oci_linux_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork"
 	nwconfig "github.com/moby/moby/v2/daemon/libnetwork/config"
 	"github.com/moby/moby/v2/daemon/network"
+	daemonoci "github.com/moby/moby/v2/daemon/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
@@ -75,6 +76,94 @@ type fakeImageService struct {
 
 func (i *fakeImageService) StorageDriver() string {
 	return "overlay"
+}
+
+func TestWithCommonOptionsDockerInit(t *testing.T) {
+	initPath := filepath.Join(t.TempDir(), "docker-init")
+	err := os.WriteFile(initPath, []byte("#!/bin/sh\n"), 0o755)
+	assert.NilError(t, err)
+
+	initEnabled := true
+	initDisabled := false
+	workloadArgs := []string{"/usr/local/bin/workload", "--entrypoint-option", "cmd-arg-1", "cmd-arg-2"}
+	wrappedArgs := append([]string{inContainerInitPath, "--"}, workloadArgs...)
+
+	tests := []struct {
+		name          string
+		containerInit *bool
+		daemonInit    bool
+		pidMode       containertypes.PidMode
+		wantArgs      []string
+		wantInitMount bool
+	}{
+		{
+			name:          "container init enabled",
+			containerInit: &initEnabled,
+			wantArgs:      wrappedArgs,
+			wantInitMount: true,
+		},
+		{
+			name:          "daemon default init enabled",
+			daemonInit:    true,
+			wantArgs:      wrappedArgs,
+			wantInitMount: true,
+		},
+		{
+			name:          "container init explicitly disabled",
+			containerInit: &initDisabled,
+			daemonInit:    true,
+			wantArgs:      workloadArgs,
+		},
+		{
+			name:          "host PID namespace",
+			containerInit: &initEnabled,
+			pidMode:       containertypes.PidMode("host"),
+			wantArgs:      workloadArgs,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &container.Container{
+				BaseFS: t.TempDir(),
+				Path:   workloadArgs[0],
+				Args:   workloadArgs[1:],
+				Config: &containertypes.Config{
+					Entrypoint: workloadArgs[:2],
+					Cmd:        workloadArgs[2:],
+				},
+				HostConfig: &containertypes.HostConfig{
+					Init:    tc.containerInit,
+					PidMode: tc.pidMode,
+				},
+				NetworkSettings: &network.Settings{Networks: make(map[string]*network.EndpointSettings)},
+			}
+			d := &Daemon{linkIndex: newLinkIndex()}
+			daemonCfg := config.Config{Init: tc.daemonInit, InitPath: initPath}
+			s := daemonoci.DefaultSpec()
+
+			err := withCommonOptions(d, &daemonCfg, c)(t.Context(), nil, nil, &s)
+			assert.NilError(t, err)
+			assert.Check(t, is.DeepEqual(s.Process.Args, tc.wantArgs))
+
+			var initMounts []specs.Mount
+			for _, m := range s.Mounts {
+				if m.Destination == inContainerInitPath {
+					initMounts = append(initMounts, m)
+				}
+			}
+			if !tc.wantInitMount {
+				assert.Equal(t, len(initMounts), 0)
+				return
+			}
+			assert.Check(t, is.DeepEqual(initMounts, []specs.Mount{{
+				Destination: inContainerInitPath,
+				Type:        "bind",
+				Source:      initPath,
+				Options:     []string{"bind", "ro"},
+			}}))
+		})
+	}
 }
 
 func TestCreateSpecPreservesCDIAdditionalGIDs(t *testing.T) {


### PR DESCRIPTION
Follow up to: https://github.com/moby/moby/pull/53423#issuecomment-5417114992

## Summary

- document that NRI container arguments represent the resolved workload argv and exclude OCI-only wrappers
- add regression coverage for per-container init, daemon-default init, and explicit init disablement
- confirm the OCI spec still prefixes effective init argv and mounts the configured init binary
- preserve entrypoint/Cmd resolution and argument slice ownership without changing runtime or NRI adjustment behavior

Tests:

- `go test ./daemon/internal/nri`
- `go test ./daemon -run '^TestWithCommonOptionsDockerInit$' -count=1`
