### PR TITLE
integration, integration-cli:  rewrite asserts with slices and cmpopts

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"reflect"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -276,11 +274,11 @@ func (s *DockerCLIExecSuite) TestExecCgroup(c *testing.T) {
 	cli.DockerCmd(c, "run", "-d", "--name", "testing", "busybox", "top")
 
 	out := cli.DockerCmd(c, "exec", "testing", "cat", "/proc/1/cgroup").Stdout()
-	containerCgroups := sort.StringSlice(strings.Split(out, "\n"))
+	containerCgroups := strings.Split(out, "\n")
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	var execCgroups []sort.StringSlice
+	var execCgroups [][]string
 	errChan := make(chan error, 5)
 	// exec a few times concurrently to get consistent failure
 	for range 5 {
@@ -290,10 +288,9 @@ func (s *DockerCLIExecSuite) TestExecCgroup(c *testing.T) {
 				errChan <- err
 				return
 			}
-			cg := sort.StringSlice(strings.Split(out, "\n"))
 
 			mu.Lock()
-			execCgroups = append(execCgroups, cg)
+			execCgroups = append(execCgroups, strings.Split(out, "\n"))
 			mu.Unlock()
 		})
 	}
@@ -305,18 +302,7 @@ func (s *DockerCLIExecSuite) TestExecCgroup(c *testing.T) {
 	}
 
 	for _, cg := range execCgroups {
-		if !reflect.DeepEqual(cg, containerCgroups) {
-			fmt.Println("exec cgroups:")
-			for _, name := range cg {
-				fmt.Printf(" %s\n", name)
-			}
-
-			fmt.Println("container cgroups:")
-			for _, name := range containerCgroups {
-				fmt.Printf(" %s\n", name)
-			}
-			c.Fatal("cgroups mismatched")
-		}
+		assert.DeepEqual(c, cg, containerCgroups)
 	}
 }
 

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -228,24 +227,16 @@ func (s *DockerCLIImagesSuite) TestImagesFilterSpaceTrimCase(c *testing.T) {
 		"dangling = true",
 	}
 
-	imageListings := make([][]string, 5)
-	for idx, filter := range filters {
+	imageListings := make([][]string, len(filters))
+	for i, filter := range filters {
 		out := cli.DockerCmd(c, "images", "-q", "-f", filter).Stdout()
-		listing := strings.Split(out, "\n")
-		sort.Strings(listing)
-		imageListings[idx] = listing
+		imageListings[i] = strings.Fields(out)
+		slices.Sort(imageListings[i])
 	}
 
-	for idx, listing := range imageListings {
-		if idx < 4 && !reflect.DeepEqual(listing, imageListings[idx+1]) {
-			for idx, errListing := range imageListings {
-				fmt.Printf("out %d\n", idx)
-				for _, img := range errListing {
-					fmt.Print(img)
-				}
-				fmt.Print("")
-			}
-			c.Fatalf("All output must be the same")
+	for i := 1; i < len(imageListings); i++ {
+		if !slices.Equal(imageListings[0], imageListings[i]) {
+			c.Errorf("image listings differ:\nfirst: %v\n%s: %v", imageListings[0], filters[i], imageListings[i])
 		}
 	}
 }

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"sort"
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/moby/v2/integration-cli/cli"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -115,8 +115,9 @@ func (s *DockerCLILinksSuite) TestLinksInspectLinksStarted(c *testing.T) {
 		"/container1:/testinspectlink/alias1",
 		"/container2:/testinspectlink/alias2",
 	}
-	sort.Strings(result)
-	assert.DeepEqual(c, result, expected)
+	assert.DeepEqual(c, result, expected, cmpopts.SortSlices(func(a, b string) bool {
+		return a < b
+	}))
 }
 
 func (s *DockerCLILinksSuite) TestLinksInspectLinksStopped(c *testing.T) {
@@ -135,8 +136,9 @@ func (s *DockerCLILinksSuite) TestLinksInspectLinksStopped(c *testing.T) {
 		"/container1:/testinspectlink/alias1",
 		"/container2:/testinspectlink/alias2",
 	}
-	sort.Strings(result)
-	assert.DeepEqual(c, result, expected)
+	assert.DeepEqual(c, result, expected, cmpopts.SortSlices(func(a, b string) bool {
+		return a < b
+	}))
 }
 
 func (s *DockerCLILinksSuite) TestLinksNotStartedParentNotFail(c *testing.T) {

--- a/integration-cli/docker_cli_port_test.go
+++ b/integration-cli/docker_cli_port_test.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration-cli/cli"
 	"github.com/moby/moby/v2/internal/testutil"
@@ -167,27 +167,9 @@ func (s *DockerCLIPortSuite) TestPortList(c *testing.T) {
 
 func assertPortList(t *testing.T, out string, expected []string) {
 	t.Helper()
-	lines := strings.Split(strings.Trim(out, "\n "), "\n")
-	assert.Assert(t, is.Len(lines, len(expected)), "expected: %s", strings.Join(expected, ", "))
 
-	sort.Strings(lines)
-	sort.Strings(expected)
-
-	// "docker port" does not yet have a "--format" flag, and older versions
-	// of the CLI used an incorrect output format for mappings on IPv6 addresses
-	// for example, "80/tcp -> :::80" instead of "80/tcp -> [::]:80".
-	oldFormat := func(mapping string) string {
-		old := strings.Replace(mapping, "[", "", 1)
-		old = strings.Replace(old, "]:", ":", 1)
-		return old
-	}
-
-	for i := range expected {
-		if lines[i] == expected[i] {
-			continue
-		}
-		assert.Equal(t, lines[i], oldFormat(expected[i]))
-	}
+	actual := strings.Split(strings.TrimSpace(out), "\n")
+	assert.DeepEqual(t, actual, expected, cmpopts.SortSlices(func(a, b string) bool { return a < b }))
 }
 
 func assertPortRange(ctx context.Context, id string, expectedTCP, expectedUDP []int) error {

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -3,12 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/moby/client/pkg/stringid"
 	"github.com/moby/moby/v2/integration-cli/cli"
 	"github.com/moby/moby/v2/integration-cli/cli/build"
@@ -392,26 +392,13 @@ func (s *DockerCLIPsSuite) TestPsListContainersFilterAncestorImage(c *testing.T)
 	checkPsAncestorFilterOutput(c, RemoveOutputForExistingElements(out, existingContainers), imageName2+","+imageName1Tagged, []string{fourthID, fifthID})
 }
 
-func checkPsAncestorFilterOutput(t *testing.T, out string, filterName string, expectedIDs []string) {
-	var actualIDs []string
-	if out != "" {
-		actualIDs = strings.Split(out[:len(out)-1], "\n")
-	}
-	sort.Strings(actualIDs)
-	sort.Strings(expectedIDs)
+func checkPsAncestorFilterOutput(t *testing.T, out, filterName string, expectedIDs []string) {
+	t.Helper()
 
-	assert.Equal(t, len(actualIDs), len(expectedIDs), fmt.Sprintf("Expected filtered container(s) for %s ancestor filter to be %v:%v, got %v:%v", filterName, len(expectedIDs), expectedIDs, len(actualIDs), actualIDs))
-	if len(expectedIDs) > 0 {
-		same := true
-		for i := range expectedIDs {
-			if actualIDs[i] != expectedIDs[i] {
-				t.Logf("%s, %s", actualIDs[i], expectedIDs[i])
-				same = false
-				break
-			}
-		}
-		assert.Equal(t, same, true, fmt.Sprintf("Expected filtered container(s) for %s ancestor filter to be %v, got %v", filterName, expectedIDs, actualIDs))
-	}
+	actualIDs := strings.Fields(out)
+	assert.Assert(t, is.DeepEqual(actualIDs, expectedIDs, cmpopts.SortSlices(func(a, b string) bool {
+		return a < b
+	})), "unexpected containers for %s ancestor filter", filterName)
 }
 
 func (s *DockerCLIPsSuite) TestPsListContainersFilterLabel(c *testing.T) {

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -16,13 +16,13 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/stringid"
@@ -835,8 +835,6 @@ func (s *DockerCLIRunSuite) TestRunEnvironment(c *testing.T) {
 	result.Assert(c, icmd.Success)
 
 	actualEnv := strings.Split(strings.TrimSuffix(result.Stdout(), "\n"), "\n")
-	sort.Strings(actualEnv)
-
 	goodEnv := []string{
 		// The first two should not be tested here, those are "inherent" environment variable. This test validates
 		// the -e behavior, not the default environment variable (that could be subject to change)
@@ -849,15 +847,9 @@ func (s *DockerCLIRunSuite) TestRunEnvironment(c *testing.T) {
 		"",
 		"HOME=/root",
 	}
-	sort.Strings(goodEnv)
-	if len(goodEnv) != len(actualEnv) {
-		c.Fatalf("Wrong environment: should be %d variables, not %d: %q", len(goodEnv), len(actualEnv), strings.Join(actualEnv, ", "))
-	}
-	for i := range goodEnv {
-		if actualEnv[i] != goodEnv[i] {
-			c.Fatalf("Wrong environment variable: should be %s, not %s", goodEnv[i], actualEnv[i])
-		}
-	}
+	assert.DeepEqual(c, actualEnv, goodEnv, cmpopts.SortSlices(func(a, b string) bool {
+		return a < b
+	}))
 }
 
 func (s *DockerCLIRunSuite) TestRunEnvironmentErase(c *testing.T) {
@@ -876,21 +868,13 @@ func (s *DockerCLIRunSuite) TestRunEnvironmentErase(c *testing.T) {
 	result.Assert(c, icmd.Success)
 
 	actualEnv := strings.Split(strings.TrimSpace(result.Combined()), "\n")
-	sort.Strings(actualEnv)
-
 	goodEnv := []string{
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		"HOME=/root",
 	}
-	sort.Strings(goodEnv)
-	if len(goodEnv) != len(actualEnv) {
-		c.Fatalf("Wrong environment: should be %d variables, not %d: %q", len(goodEnv), len(actualEnv), strings.Join(actualEnv, ", "))
-	}
-	for i := range goodEnv {
-		if actualEnv[i] != goodEnv[i] {
-			c.Fatalf("Wrong environment variable: should be %s, not %s", goodEnv[i], actualEnv[i])
-		}
-	}
+	assert.DeepEqual(c, actualEnv, goodEnv, cmpopts.SortSlices(func(a, b string) bool {
+		return a < b
+	}))
 }
 
 func (s *DockerCLIRunSuite) TestRunEnvironmentOverride(c *testing.T) {
@@ -908,22 +892,14 @@ func (s *DockerCLIRunSuite) TestRunEnvironmentOverride(c *testing.T) {
 	result.Assert(c, icmd.Success)
 
 	actualEnv := strings.Split(strings.TrimSpace(result.Combined()), "\n")
-	sort.Strings(actualEnv)
-
 	goodEnv := []string{
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		"HOME=/root2",
 		"HOSTNAME=bar",
 	}
-	sort.Strings(goodEnv)
-	if len(goodEnv) != len(actualEnv) {
-		c.Fatalf("Wrong environment: should be %d variables, not %d: %q", len(goodEnv), len(actualEnv), strings.Join(actualEnv, ", "))
-	}
-	for i := range goodEnv {
-		if actualEnv[i] != goodEnv[i] {
-			c.Fatalf("Wrong environment variable: should be %s, not %s", goodEnv[i], actualEnv[i])
-		}
-	}
+	assert.DeepEqual(c, actualEnv, goodEnv, cmpopts.SortSlices(func(a, b string) bool {
+		return a < b
+	}))
 }
 
 func (s *DockerCLIRunSuite) TestRunContainerNetwork(c *testing.T) {
@@ -1735,48 +1711,38 @@ func (s *DockerCLIRunSuite) TestRunWriteSpecialFilesAndNotCommit(c *testing.T) {
 	// Cannot run on Windows as this files are not present in Windows
 	testRequires(c, DaemonIsLinux)
 
-	testRunWriteSpecialFilesAndNotCommit(c, "writehosts", "/etc/hosts")
-	testRunWriteSpecialFilesAndNotCommit(c, "writehostname", "/etc/hostname")
-	testRunWriteSpecialFilesAndNotCommit(c, "writeresolv", "/etc/resolv.conf")
-}
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{name: "writehosts", path: "/etc/hosts"},
+		{name: "writehostname", path: "/etc/hostname"},
+		{name: "writeresolv", path: "/etc/resolv.conf"},
+	} {
+		c.Run(tc.name, func(t *testing.T) {
+			command := fmt.Sprintf("echo test2267 >> %s && cat %s", tc.path, tc.path)
+			out := cli.DockerCmd(t, "run", "--name", tc.name, "busybox", "sh", "-c", command).Combined()
+			if !strings.Contains(out, "test2267") {
+				t.Fatalf("%s should contain 'test2267'", tc.path)
+			}
 
-func testRunWriteSpecialFilesAndNotCommit(t *testing.T, name, path string) {
-	command := fmt.Sprintf("echo test2267 >> %s && cat %s", path, path)
-	out := cli.DockerCmd(t, "run", "--name", name, "busybox", "sh", "-c", command).Combined()
-	if !strings.Contains(out, "test2267") {
-		t.Fatalf("%s should contain 'test2267'", path)
+			out = cli.DockerCmd(t, "diff", tc.name).Combined()
+			if strings.Trim(out, "\r\n") == "" {
+				return
+			}
+
+			baseName := "eqToBaseDiff" + testutil.RandomAlpha(32)
+			cli.DockerCmd(t, "run", "--name", baseName, "busybox", "echo", "hello")
+
+			baseID := getIDByName(t, baseName)
+			baseDiff := strings.Split(cli.DockerCmd(t, "diff", baseID).Combined(), "\n")
+			actualDiff := strings.Split(out, "\n")
+
+			assert.DeepEqual(t, actualDiff, baseDiff, cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			}))
+		})
 	}
-
-	out = cli.DockerCmd(t, "diff", name).Combined()
-	if strings.Trim(out, "\r\n") != "" && !eqToBaseDiff(out, t) {
-		t.Fatal("diff should be empty")
-	}
-}
-
-func eqToBaseDiff(out string, t *testing.T) bool {
-	name := "eqToBaseDiff" + testutil.RandomAlpha(32)
-	cli.DockerCmd(t, "run", "--name", name, "busybox", "echo", "hello")
-	cID := getIDByName(t, name)
-	baseDiff := cli.DockerCmd(t, "diff", cID).Combined()
-	baseArr := strings.Split(baseDiff, "\n")
-	sort.Strings(baseArr)
-	outArr := strings.Split(out, "\n")
-	sort.Strings(outArr)
-	return sliceEq(baseArr, outArr)
-}
-
-func sliceEq(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-
-	return true
 }
 
 func (s *DockerCLIRunSuite) TestRunWithBadDevice(c *testing.T) {

--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -13,6 +13,7 @@ import (
 	swarmtypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/swarm"
+	"github.com/moby/moby/v2/internal/sliceutil"
 	"github.com/moby/moby/v2/internal/testutil"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -61,7 +62,6 @@ func TestConfigList(t *testing.T) {
 	testName0 := "test0-" + t.Name()
 	testName1 := "test1-" + t.Name()
 	testNames := []string{testName0, testName1}
-	sort.Strings(testNames)
 
 	// create config test0
 	createConfig(ctx, t, c, testName0, []byte("TESTINGDATA0"), map[string]string{"type": "test"})
@@ -392,14 +392,13 @@ func TestConfigCreateResolve(t *testing.T) {
 	assert.NilError(t, err)
 	res, err = c.ConfigList(ctx, client.ConfigListOptions{})
 	assert.NilError(t, err)
-	assert.Assert(t, is.Equal(0, len(res.Items)))
+	assert.Assert(t, is.Len(res.Items, 0))
 }
 
 func configNamesFromList(entries []swarmtypes.Config) []string {
-	var values []string
-	for _, entry := range entries {
-		values = append(values, entry.Spec.Name)
-	}
-	sort.Strings(values)
+	values := sliceutil.Map(entries, func(entry swarmtypes.Config) string {
+		return entry.Spec.Name
+	})
+	slices.Sort(values)
 	return values
 }

--- a/integration/container/checkpoint_test.go
+++ b/integration/container/checkpoint_test.go
@@ -1,14 +1,16 @@
 package container
 
 import (
+	"cmp"
 	"encoding/json"
 	"net/http"
 	"net/url"
 	"os/exec"
 	"regexp"
-	"sort"
+	"slices"
 	"testing"
 
+	"github.com/moby/moby/api/types/checkpoint"
 	"github.com/moby/moby/api/types/common"
 
 	containertypes "github.com/moby/moby/api/types/container"
@@ -124,13 +126,11 @@ func TestCheckpoint(t *testing.T) {
 	res, err = apiClient.CheckpointList(ctx, cID, client.CheckpointListOptions{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(res.Items), 2)
-	cptNames := make([]string, 2)
-	for i, c := range res.Items {
-		cptNames[i] = c.Name
-	}
-	sort.Strings(cptNames)
-	assert.Equal(t, cptNames[0], "test")
-	assert.Equal(t, cptNames[1], "test2")
+	slices.SortFunc(res.Items, func(a, b checkpoint.Summary) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+	assert.Equal(t, res.Items[0].Name, "test")
+	assert.Equal(t, res.Items[1].Name, "test2")
 
 	// Restore the container from a second checkpoint.
 	t.Log("Restore the container")

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -8,12 +8,12 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/cpuguy83/tar2go"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/go-archive/compression"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/versions"
@@ -470,9 +470,9 @@ func TestSaveRepoWithMultipleImages(t *testing.T) {
 			assert.Check(t, err)
 		}
 	} else {
-		sort.Strings(actual)
-		sort.Strings(expected)
-		assert.Assert(t, is.DeepEqual(actual, expected), "archive does not contains the right layers: got %v, expected %v", actual, expected)
+		assert.Assert(t, is.DeepEqual(actual, expected, cmpopts.SortSlices(func(a, b string) bool {
+			return a < b
+		})), "archive does not contain the right layers")
 	}
 }
 

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -61,7 +61,7 @@ func WithNetworkMode(mode string) func(*TestContainerConfig) {
 // WithDNS sets external DNS servers for the container
 func WithDNS(dns []netip.Addr) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {
-		c.HostConfig.DNS = append([]netip.Addr(nil), dns...)
+		c.HostConfig.DNS = slices.Clone(dns)
 	}
 }
 

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -13,6 +13,7 @@ import (
 	swarmtypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/swarm"
+	"github.com/moby/moby/v2/internal/sliceutil"
 	"github.com/moby/moby/v2/internal/testutil"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -58,7 +59,6 @@ func TestSecretList(t *testing.T) {
 	testName0 := "test0-" + t.Name()
 	testName1 := "test1-" + t.Name()
 	testNames := []string{testName0, testName1}
-	sort.Strings(testNames)
 
 	// create secret test0
 	createSecret(ctx, t, c, testName0, []byte("TESTINGDATA0"), map[string]string{"type": "test"})
@@ -412,14 +412,13 @@ func TestSecretCreateResolve(t *testing.T) {
 	assert.NilError(t, err)
 	res, err = c.SecretList(ctx, client.SecretListOptions{})
 	assert.NilError(t, err)
-	assert.Assert(t, is.Equal(0, len(res.Items)))
+	assert.Assert(t, is.Len(res.Items, 0))
 }
 
 func namesFromList(entries []swarmtypes.Secret) []string {
-	var values []string
-	for _, entry := range entries {
-		values = append(values, entry.Spec.Name)
-	}
-	sort.Strings(values)
+	values := sliceutil.Map(entries, func(entry swarmtypes.Secret) string {
+		return entry.Spec.Name
+	})
+	slices.Sort(values)
 	return values
 }

--- a/integration/system/info_test.go
+++ b/integration/system/info_test.go
@@ -2,7 +2,7 @@ package system
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/moby/moby/api/types/registry"
@@ -140,6 +140,6 @@ func TestInfoRegistryMirrors(t *testing.T) {
 	defer d.Stop(t)
 
 	info := d.Info(t)
-	sort.Strings(info.RegistryConfig.Mirrors)
+	slices.Sort(info.RegistryConfig.Mirrors)
 	assert.DeepEqual(t, info.RegistryConfig.Mirrors, []string{registryMirror2 + "/", registryMirror1 + "/"})
 }


### PR DESCRIPTION

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
