### PR TITLE
daemon/pkg/registry: replace cloneRequest for request.Clone

### DIFF
--- a/daemon/pkg/registry/search_session.go
+++ b/daemon/pkg/registry/search_session.go
@@ -51,21 +51,6 @@ func newAuthTransport(base http.RoundTripper, authConfig *registry.AuthConfig, a
 	}
 }
 
-// cloneRequest returns a clone of the provided *http.Request.
-// The clone is a shallow copy of the struct and its Header map.
-func cloneRequest(r *http.Request) *http.Request {
-	// shallow copy of the struct
-	r2 := new(http.Request)
-	*r2 = *r
-	// deep copy of the Header
-	r2.Header = make(http.Header, len(r.Header))
-	for k, s := range r.Header {
-		r2.Header[k] = append([]string(nil), s...)
-	}
-
-	return r2
-}
-
 // onEOFReader wraps an io.ReadCloser and a function
 // the function will run at the end of file or close the file.
 type onEOFReader struct {
@@ -107,7 +92,7 @@ func (tr *authTransport) RoundTrip(orig *http.Request) (*http.Response, error) {
 		return tr.base.RoundTrip(orig)
 	}
 
-	req := cloneRequest(orig)
+	req := orig.Clone(orig.Context())
 	tr.mu.Lock()
 	tr.modReq[orig] = req
 	tr.mu.Unlock()


### PR DESCRIPTION
- updates https://github.com/moby/moby/pull/13265

This utility was originally added in 73823e5e56446b23ce01bb8e44a9670ab2552b0a, and looks to be a hand-crafted equivalent for request.Clone (which may not have been available yet at the time).


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
