### PR TITLE
daemon/internal/usergroup: fix subordinate ID range overlap detection

### DIFF
--- a/daemon/internal/usergroup/add_linux.go
+++ b/daemon/internal/usergroup/add_linux.go
@@ -147,6 +147,8 @@ func findNextGIDRange() (int, error) {
 	return findNextRangeStart(ranges), nil
 }
 
+// findNextRangeStart returns the first available subordinate ID range start.
+// The input ranges are sorted in-place by their starting ID.
 func findNextRangeStart(rangeList []user.SubID) int {
 	slices.SortFunc(rangeList, func(a, b user.SubID) int {
 		return cmp.Compare(a.SubID, b.SubID)
@@ -154,9 +156,7 @@ func findNextRangeStart(rangeList []user.SubID) int {
 
 	var startID int64 = defaultRangeStart
 	for _, arange := range rangeList {
-		high := startID + defaultRangeLen
-		if (startID >= arange.SubID && startID <= arange.SubID+arange.Count) ||
-			(high <= arange.SubID+arange.Count && high >= arange.SubID) {
+		if startID < arange.SubID+arange.Count && arange.SubID < startID+defaultRangeLen {
 			startID = arange.SubID + arange.Count
 		}
 	}

--- a/daemon/internal/usergroup/add_linux.go
+++ b/daemon/internal/usergroup/add_linux.go
@@ -1,10 +1,11 @@
 package usergroup
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"os/exec"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -135,8 +136,7 @@ func findNextUIDRange() (int, error) {
 	if err != nil {
 		return -1, fmt.Errorf("couldn't parse all ranges in /etc/subuid file: %v", err)
 	}
-	sortRanges(ranges)
-	return findNextRangeStart(ranges)
+	return findNextRangeStart(ranges), nil
 }
 
 func findNextGIDRange() (int, error) {
@@ -144,32 +144,21 @@ func findNextGIDRange() (int, error) {
 	if err != nil {
 		return -1, fmt.Errorf("couldn't parse all ranges in /etc/subgid file: %v", err)
 	}
-	sortRanges(ranges)
-	return findNextRangeStart(ranges)
+	return findNextRangeStart(ranges), nil
 }
 
-func sortRanges(ranges []user.SubID) {
-	sort.Slice(ranges, func(i, j int) bool {
-		return ranges[i].SubID < ranges[j].SubID
+func findNextRangeStart(rangeList []user.SubID) int {
+	slices.SortFunc(rangeList, func(a, b user.SubID) int {
+		return cmp.Compare(a.SubID, b.SubID)
 	})
-}
 
-func findNextRangeStart(rangeList []user.SubID) (int, error) {
 	var startID int64 = defaultRangeStart
 	for _, arange := range rangeList {
-		if wouldOverlap(arange, startID) {
+		high := startID + defaultRangeLen
+		if (startID >= arange.SubID && startID <= arange.SubID+arange.Count) ||
+			(high <= arange.SubID+arange.Count && high >= arange.SubID) {
 			startID = arange.SubID + arange.Count
 		}
 	}
-	return int(startID), nil
-}
-
-func wouldOverlap(arange user.SubID, ID int64) bool {
-	low := ID
-	high := low + defaultRangeLen
-	if (low >= arange.SubID && low <= arange.SubID+arange.Count) ||
-		(high <= arange.SubID+arange.Count && high >= arange.SubID) {
-		return true
-	}
-	return false
+	return int(startID)
 }

--- a/daemon/internal/usergroup/add_linux_test.go
+++ b/daemon/internal/usergroup/add_linux_test.go
@@ -66,6 +66,57 @@ func TestLookupUserAndGroup(t *testing.T) {
 	assert.Check(t, is.DeepEqual(fetchedGroupByID, fetchedGroup))
 }
 
+// TestFindNextRangeStart verifies that findNextRangeStart selects the first
+// available range, including when existing ranges are unsorted or fully
+// contained within the candidate range.
+func TestFindNextRangeStart(t *testing.T) {
+	tests := []struct {
+		name   string
+		ranges []mobyuser.SubID
+		want   int
+	}{
+		{
+			name: "empty",
+			want: defaultRangeStart,
+		},
+		{
+			name: "range at start",
+			ranges: []mobyuser.SubID{
+				{SubID: defaultRangeStart, Count: 100},
+			},
+			want: defaultRangeStart + 100,
+		},
+		{
+			name: "range contained within candidate",
+			ranges: []mobyuser.SubID{
+				{SubID: defaultRangeStart + 100, Count: 100},
+			},
+			want: defaultRangeStart + 200,
+		},
+		{
+			name: "range immediately after candidate",
+			ranges: []mobyuser.SubID{
+				{SubID: defaultRangeStart + defaultRangeLen, Count: 100},
+			},
+			want: defaultRangeStart,
+		},
+		{
+			name: "unsorted ranges",
+			ranges: []mobyuser.SubID{
+				{SubID: defaultRangeStart + 200, Count: 100},
+				{SubID: defaultRangeStart, Count: 100},
+			},
+			want: defaultRangeStart + 300,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, findNextRangeStart(tc.ranges), tc.want)
+		})
+	}
+}
+
 func delUser(t *testing.T, name string) {
 	t.Helper()
 	out, err := exec.Command("userdel", name).CombinedOutput()

--- a/daemon/internal/usergroup/add_linux_test.go
+++ b/daemon/internal/usergroup/add_linux_test.go
@@ -23,10 +23,10 @@ func TestNewIDMappings(t *testing.T) {
 	assert.Check(t, err)
 	defer delUser(t, tempUser)
 
-	tempUser, err := user.Lookup(tempUser)
+	tmpUser, err := user.Lookup(tempUser)
 	assert.Check(t, err)
 
-	idMapping, err := LoadIdentityMapping(tempUser.Username)
+	idMapping, err := LoadIdentityMapping(tmpUser.Username)
 	assert.Check(t, err)
 
 	rootUID, rootGID := idMapping.RootPair()
@@ -67,6 +67,7 @@ func TestLookupUserAndGroup(t *testing.T) {
 }
 
 func delUser(t *testing.T, name string) {
+	t.Helper()
 	out, err := exec.Command("userdel", name).CombinedOutput()
 	assert.Check(t, err, out)
 }


### PR DESCRIPTION
### daemon/internal/usergroup: simplify subordinate ID range selection

Sort subordinate ID ranges in findNextRangeStart using slices.SortFunc,
instead of sorting them separately at each call site.

Inline the range-overlap check, which is only used while selecting the next
range, and remove the unused error result from findNextRangeStart.


### daemon/internal/usergroup: fix subordinate ID range overlap detection

Treat subordinate ID ranges as half-open intervals when checking for
overlap with the next candidate range.

The previous check only detected overlap when either endpoint of the
candidate range fell inside an existing range. As a result, it missed
existing ranges that were fully contained within the candidate range.

Add unit coverage for contained, adjacent, empty, and unsorted ranges.



## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
