### PR TITLE
daemon: remove integrated gRPC stream cap

### DIFF
--- a/daemon/server/router/grpc/grpc.go
+++ b/daemon/server/router/grpc/grpc.go
@@ -9,6 +9,7 @@ package grpc
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 
@@ -45,7 +46,7 @@ func NewRouter(backends ...Backend) router.Router {
 	}
 
 	r := &grpcRouter{
-		h2Server:   &http2.Server{},
+		h2Server:   &http2.Server{MaxConcurrentStreams: math.MaxUint32},
 		grpcServer: grpc.NewServer(opts...),
 	}
 	for _, b := range backends {


### PR DESCRIPTION
Related to: https://github.com/docker/buildx/issues/3810
Related to: https://github.com/docker/buildx/issues/3486

## Summary

The integrated BuildKit `/grpc` adapter constructs an `http2.Server` without setting `MaxConcurrentStreams`, causing x/net to advertise and enforce its default limit of 250 streams. Buildx Bake multiplexes each target's Control and gateway RPCs over this connection, with every concurrent target opening at least three streams for Solve, Status, and Ping. Docker Compose delegates builds to Bake, which has no target-concurrency limit, so large projects can quickly exhaust the 250-stream cap. Once saturated, these new RPCs stall until BuildKit's 3 second gateway lookup expires, causing builds to fail with `rpc error: code = NotFound desc = no such job`.

This change sets `MaxConcurrentStreams` to `math.MaxUint32`, the maximum HTTP/2 value, effectively removing the adapter's stream limit and matching native grpc-go buildkitd behavior. 

Buildx issue #3810 reports intermittent failures around 120 targets. In our testing, the unpatched version consistently failed 150 target runs, while the patched adapter successfully handled 300 build targets at once.

## Release notes (optional)

```markdown changelog

Fix high-fanout integrated BuildKit builds that fail with `rpc error: code = NotFound desc = no such job`.

```
