### PR TITLE
Implement dynamic cgroup detection

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1622,14 +1622,14 @@ func (daemon *Daemon) setupSeccompProfile(cfg *config.Config) error {
 	return nil
 }
 
+var newSysInfo = sysinfo.New
+
 func getSysInfo(cfg *config.Config) *sysinfo.SysInfo {
-	var siOpts []sysinfo.Opt
-	if cgroupDriver(cfg) == cgroupSystemdDriver {
-		if euid := os.Getenv("ROOTLESSKIT_PARENT_EUID"); euid != "" {
-			siOpts = append(siOpts, sysinfo.WithCgroup2GroupPath("/user.slice/user-"+euid+".slice"))
-		}
+	siOpts, cgroupDiscoveryErr := rootlessSystemdSysInfoOptions(cfg)
+	si := newSysInfo(siOpts...)
+	if cgroupDiscoveryErr != nil {
+		si.Warnings = append(si.Warnings, cgroupDiscoveryErr.Error())
 	}
-	si := sysinfo.New(siOpts...)
 
 	// The "time-namespaces" feature-flag is a (temporary) escape-hatch to disable
 	// the use of time-namespaces for containers. This allows users to return to the

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 
-	cdcgroups "github.com/containerd/cgroups/v3"
 	"github.com/containerd/containerd/v2/core/containers"
 	coci "github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/log"
@@ -64,23 +63,11 @@ func withRootless(_ *Daemon, daemonCfg *dconfig.Config) coci.SpecOpts {
 	return func(_ context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
 		var v2Controllers []string
 		if cgroupDriver(daemonCfg) == cgroupSystemdDriver {
-			if cdcgroups.Mode() != cdcgroups.Unified {
-				return errors.New("rootless systemd driver doesn't support cgroup v1")
-			}
-			rootlesskitParentEUID := os.Getenv("ROOTLESSKIT_PARENT_EUID")
-			if rootlesskitParentEUID == "" {
-				return errors.New("$ROOTLESSKIT_PARENT_EUID is not set (requires RootlessKit v0.8.0)")
-			}
-			euid, err := strconv.Atoi(rootlesskitParentEUID)
-			if err != nil {
-				return errors.Wrap(err, "invalid $ROOTLESSKIT_PARENT_EUID: must be a numeric value")
-			}
-			controllersPath := fmt.Sprintf("/sys/fs/cgroup/user.slice/user-%d.slice/cgroup.controllers", euid)
-			controllersFile, err := os.ReadFile(controllersPath)
+			info, err := rootlessSystemdCgroupControllerInfo()
 			if err != nil {
 				return err
 			}
-			v2Controllers = strings.Fields(string(controllersFile))
+			v2Controllers = info.controllers
 		}
 		return specconv.ToRootless(s, v2Controllers)
 	}

--- a/daemon/rootless_cgroup_freebsd.go
+++ b/daemon/rootless_cgroup_freebsd.go
@@ -1,0 +1,23 @@
+package daemon
+
+import (
+	"github.com/moby/moby/v2/daemon/config"
+	"github.com/moby/moby/v2/pkg/sysinfo"
+	"github.com/pkg/errors"
+)
+
+type rootlessSystemdCgroupInfo struct {
+	groupPath   string
+	controllers []string
+}
+
+func rootlessSystemdCgroupControllerInfo() (rootlessSystemdCgroupInfo, error) {
+	return rootlessSystemdCgroupInfo{}, errors.New("rootless systemd cgroups are not supported on FreeBSD")
+}
+
+func rootlessSystemdSysInfoOptions(cfg *config.Config) ([]sysinfo.Opt, error) {
+	if cfg.Rootless && cgroupDriver(cfg) == cgroupSystemdDriver {
+		return nil, errors.New("rootless systemd cgroups are not supported on FreeBSD")
+	}
+	return nil, nil
+}

--- a/daemon/rootless_cgroup_linux.go
+++ b/daemon/rootless_cgroup_linux.go
@@ -1,0 +1,134 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	cdcgroups "github.com/containerd/cgroups/v3"
+	"github.com/containerd/cgroups/v3/cgroup2"
+	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/moby/moby/v2/daemon/config"
+	"github.com/moby/moby/v2/pkg/sysinfo"
+	ocicgroups "github.com/opencontainers/cgroups"
+	"github.com/pkg/errors"
+)
+
+const defaultCgroup2Root = "/sys/fs/cgroup"
+
+type rootlessSystemdCgroupInfo struct {
+	groupPath   string
+	controllers []string
+}
+
+type rootlessSystemdCgroupFiles struct {
+	userManagerControlGroup func() (string, error)
+	cgroup2Root             string
+	readCgroupFile          func(dir, file string) (string, error)
+}
+
+var (
+	rootlessSystemdCgroupMode         = cdcgroups.Mode
+	withCgroup2ControllersSysInfo     = sysinfo.WithCgroup2Controllers
+	discoverRootlessSystemdCgroupInfo = func() (rootlessSystemdCgroupInfo, error) {
+		return rootlessSystemdCgroupFiles{
+			userManagerControlGroup: systemdUserManagerControlGroup,
+			cgroup2Root:             defaultCgroup2Root,
+			readCgroupFile:          ocicgroups.ReadFile,
+		}.discover()
+	}
+)
+
+func systemdUserManagerControlGroup() (string, error) {
+	ctx := context.Background()
+	conn, err := systemdDbus.NewUserConnectionContext(ctx)
+	if err != nil {
+		return "", errors.Wrap(err, "connecting to systemd user manager")
+	}
+	defer conn.Close()
+
+	property, err := conn.GetManagerProperty("ControlGroup")
+	if err != nil {
+		return "", errors.Wrap(err, "getting systemd user manager control group")
+	}
+	groupPath, err := strconv.Unquote(property)
+	if err != nil {
+		return "", errors.Wrapf(err, "decoding systemd user manager ControlGroup property %q", property)
+	}
+	return groupPath, nil
+}
+
+func rootlessSystemdSysInfoOptions(cfg *config.Config) ([]sysinfo.Opt, error) {
+	if !cfg.Rootless || cgroupDriver(cfg) != cgroupSystemdDriver {
+		return nil, nil
+	}
+
+	info, err := rootlessSystemdCgroupControllerInfo()
+	if err != nil {
+		// Passing no option would make sysinfo.New inspect the cgroup mount root,
+		// which can expose controllers that are unavailable to a rootless daemon.
+		// Pass an explicit empty set so capability detection remains conservative.
+		return []sysinfo.Opt{withCgroup2ControllersSysInfo("/", nil)}, errors.Wrap(err, "detecting rootless systemd cgroup controllers")
+	}
+	return []sysinfo.Opt{withCgroup2ControllersSysInfo(info.groupPath, info.controllers)}, nil
+}
+
+// rootlessSystemdCgroupControllerInfo returns the cgroup and controllers that
+// systemd made available to the user manager. runc asks that manager to create
+// rootless container scopes, so its ControlGroup is the authoritative root for
+// both the hierarchy prefix and the controllers available to those scopes.
+//
+// Querying systemd also works when dockerd was not launched as a user service,
+// and preserves any outer cgroup prefix without assuming a user-slice layout.
+func rootlessSystemdCgroupControllerInfo() (rootlessSystemdCgroupInfo, error) {
+	if rootlessSystemdCgroupMode() != cdcgroups.Unified {
+		return rootlessSystemdCgroupInfo{}, errors.New("rootless systemd driver doesn't support cgroup v1")
+	}
+
+	rootlesskitParentEUID := os.Getenv("ROOTLESSKIT_PARENT_EUID")
+	if rootlesskitParentEUID == "" {
+		return rootlessSystemdCgroupInfo{}, errors.New("$ROOTLESSKIT_PARENT_EUID is not set (requires RootlessKit v0.8.0)")
+	}
+	if _, err := strconv.ParseUint(rootlesskitParentEUID, 10, 32); err != nil {
+		return rootlessSystemdCgroupInfo{}, errors.Wrap(err, "invalid $ROOTLESSKIT_PARENT_EUID: must be a numeric value")
+	}
+
+	return discoverRootlessSystemdCgroupInfo()
+}
+
+func (f rootlessSystemdCgroupFiles) discover() (rootlessSystemdCgroupInfo, error) {
+	if f.userManagerControlGroup == nil {
+		return rootlessSystemdCgroupInfo{}, errors.New("systemd user manager control-group lookup is not configured")
+	}
+	groupPath, err := f.userManagerControlGroup()
+	if err != nil {
+		return rootlessSystemdCgroupInfo{}, errors.Wrap(err, "resolving systemd user manager cgroup")
+	}
+	if groupPath == "" {
+		return rootlessSystemdCgroupInfo{}, errors.New("systemd user manager returned an empty control-group path")
+	}
+	if strings.HasSuffix(groupPath, " (deleted)") {
+		return rootlessSystemdCgroupInfo{}, fmt.Errorf("systemd user manager cgroup %q has been deleted", groupPath)
+	}
+	if err := cgroup2.VerifyGroupPath(groupPath); err != nil {
+		return rootlessSystemdCgroupInfo{}, errors.Wrapf(err, "invalid systemd user manager cgroup path %q", groupPath)
+	}
+
+	if f.readCgroupFile == nil {
+		return rootlessSystemdCgroupInfo{}, errors.New("rootless systemd cgroup file reader is not configured")
+	}
+
+	groupDir := filepath.Join(f.cgroup2Root, strings.TrimPrefix(groupPath, "/"))
+	controllersFile, err := f.readCgroupFile(groupDir, "cgroup.controllers")
+	if err != nil {
+		return rootlessSystemdCgroupInfo{}, errors.Wrapf(err, "reading controllers for rootless systemd cgroup %q at %s", groupPath, filepath.Join(groupDir, "cgroup.controllers"))
+	}
+
+	return rootlessSystemdCgroupInfo{
+		groupPath:   groupPath,
+		controllers: strings.Fields(controllersFile),
+	}, nil
+}

--- a/daemon/rootless_cgroup_linux_test.go
+++ b/daemon/rootless_cgroup_linux_test.go
@@ -1,0 +1,355 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cdcgroups "github.com/containerd/cgroups/v3"
+	"github.com/moby/moby/v2/daemon/config"
+	"github.com/moby/moby/v2/pkg/sysinfo"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestRootlessSystemdCgroupDiscovery(t *testing.T) {
+	tests := []struct {
+		name        string
+		processPath string
+		managerPath string
+	}{
+		{
+			name:        "conventional",
+			processPath: "/user.slice/user-1000.slice/user@1000.service/app.slice/docker.service",
+			managerPath: "/user.slice/user-1000.slice/user@1000.service",
+		},
+		{
+			name:        "prefixed",
+			processPath: "/outer/prefix/user.slice/user-1000.slice/user@1000.service/app.slice/docker.service",
+			managerPath: "/outer/prefix/user.slice/user-1000.slice/user@1000.service",
+		},
+		{
+			name:        "generic WSL-shaped prefix",
+			processPath: "/wsl-user/distro-280/systemd/user.slice/user-1000.slice/user@1000.service/app.slice/docker.service",
+			managerPath: "/wsl-user/distro-280/systemd/user.slice/user-1000.slice/user@1000.service",
+		},
+		{
+			name:        "daemon outside user manager",
+			processPath: "/system.slice/docker-entrypoint.service",
+			managerPath: "/user.slice/user-1000.slice/user@1000.service",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cgroupRoot := t.TempDir()
+			groupDir := filepath.Join(cgroupRoot, strings.TrimPrefix(tc.managerPath, "/"))
+			assert.NilError(t, os.MkdirAll(groupDir, 0o755))
+			assert.NilError(t, os.WriteFile(filepath.Join(groupDir, "cgroup.controllers"), []byte("cpu memory pids\n"), 0o600))
+			processDir := filepath.Join(cgroupRoot, strings.TrimPrefix(tc.processPath, "/"))
+			assert.NilError(t, os.MkdirAll(processDir, 0o755))
+			assert.NilError(t, os.WriteFile(filepath.Join(processDir, "cgroup.controllers"), []byte("io\n"), 0o600))
+
+			info, err := newRootlessSystemdCgroupFixture(tc.managerPath, nil, cgroupRoot).discover()
+			assert.NilError(t, err)
+			assert.Equal(t, info.groupPath, tc.managerPath)
+			assert.DeepEqual(t, info.controllers, []string{"cpu", "memory", "pids"})
+		})
+	}
+}
+
+func TestRootlessSystemdCgroupDiscoveryErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		managerPath string
+		lookupErr   error
+		expected    string
+	}{
+		{
+			name:      "manager lookup error",
+			lookupErr: errors.New("test D-Bus failure"),
+			expected:  "resolving systemd user manager cgroup",
+		},
+		{
+			name:        "empty path",
+			managerPath: "",
+			expected:    "empty control-group path",
+		},
+		{
+			name:        "unclean path",
+			managerPath: "/outer/../user.slice",
+			expected:    "invalid systemd user manager cgroup path",
+		},
+		{
+			name:        "relative path",
+			managerPath: "user.slice/user-1000.slice",
+			expected:    "invalid systemd user manager cgroup path",
+		},
+		{
+			name:        "deleted cgroup",
+			managerPath: "/user.slice/user@1000.service (deleted)",
+			expected:    "has been deleted",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cgroupRoot := t.TempDir()
+			_, err := newRootlessSystemdCgroupFixture(tc.managerPath, tc.lookupErr, cgroupRoot).discover()
+			assert.ErrorContains(t, err, tc.expected)
+		})
+	}
+
+	t.Run("missing controllers does not use conventional fallback", func(t *testing.T) {
+		groupPath := "/outer/prefix/user.slice/user-1000.slice/user@1000.service"
+		cgroupRoot := t.TempDir()
+		_, err := newRootlessSystemdCgroupFixture(groupPath, nil, cgroupRoot).discover()
+		assert.ErrorContains(t, err, groupPath)
+		assert.ErrorContains(t, err, "cgroup.controllers")
+	})
+
+	t.Run("symlink cannot escape cgroup mount", func(t *testing.T) {
+		base := t.TempDir()
+		cgroupRoot := filepath.Join(base, "cgroup")
+		outside := filepath.Join(base, "outside")
+		assert.NilError(t, os.Mkdir(cgroupRoot, 0o755))
+		assert.NilError(t, os.Mkdir(outside, 0o755))
+		assert.NilError(t, os.WriteFile(filepath.Join(outside, "cgroup.controllers"), []byte("cpu\n"), 0o600))
+		assert.NilError(t, os.Symlink(outside, filepath.Join(cgroupRoot, "escape")))
+
+		_, err := newRootlessSystemdCgroupFixture("/escape", nil, cgroupRoot).discover()
+		assert.ErrorContains(t, err, "reading controllers")
+	})
+}
+
+func TestRootlessSystemdCgroupCallSites(t *testing.T) {
+	t.Setenv("ROOTLESSKIT_PARENT_EUID", "1000")
+
+	originalMode := rootlessSystemdCgroupMode
+	originalDiscover := discoverRootlessSystemdCgroupInfo
+	originalNewSysInfo := newSysInfo
+	originalSysInfoOpt := withCgroup2ControllersSysInfo
+	t.Cleanup(func() {
+		rootlessSystemdCgroupMode = originalMode
+		discoverRootlessSystemdCgroupInfo = originalDiscover
+		newSysInfo = originalNewSysInfo
+		withCgroup2ControllersSysInfo = originalSysInfoOpt
+	})
+	rootlessSystemdCgroupMode = func() cdcgroups.CGMode { return cdcgroups.Unified }
+
+	const groupPath = "/outer/prefix/user.slice/user-1000.slice/user@1000.service"
+	discoveryCalls := 0
+	discoverRootlessSystemdCgroupInfo = func() (rootlessSystemdCgroupInfo, error) {
+		discoveryCalls++
+		return rootlessSystemdCgroupInfo{
+			groupPath:   groupPath,
+			controllers: []string{"cpu", "memory", "pids"},
+		}, nil
+	}
+	var sysInfoGroupPath string
+	var sysInfoControllers []string
+	withCgroup2ControllersSysInfo = func(groupPath string, controllers []string) sysinfo.Opt {
+		sysInfoGroupPath = groupPath
+		sysInfoControllers = append([]string(nil), controllers...)
+		return func(*sysinfo.SysInfo) {}
+	}
+	newSysInfo = func(opts ...sysinfo.Opt) *sysinfo.SysInfo {
+		assert.Equal(t, len(opts), 1)
+		return &sysinfo.SysInfo{}
+	}
+
+	cfg := rootlessSystemdConfig()
+	s := &specs.Spec{Linux: &specs.Linux{CgroupsPath: "user.slice:docker:test"}}
+	err := withRootless(nil, cfg)(context.Background(), nil, nil, s)
+	assert.NilError(t, err)
+	assert.Equal(t, s.Linux.CgroupsPath, "user.slice:docker:test")
+
+	_ = getSysInfo(cfg)
+	assert.Equal(t, discoveryCalls, 2, "OCI conversion and SysInfo must use the shared discovery helper")
+	assert.Equal(t, sysInfoGroupPath, groupPath)
+	assert.DeepEqual(t, sysInfoControllers, []string{"cpu", "memory", "pids"})
+}
+
+func TestRootlessSystemdCgroupDiscoveryErrorsAreConservativeInSysInfo(t *testing.T) {
+	t.Setenv("ROOTLESSKIT_PARENT_EUID", "1000")
+
+	originalMode := rootlessSystemdCgroupMode
+	originalDiscover := discoverRootlessSystemdCgroupInfo
+	originalNewSysInfo := newSysInfo
+	t.Cleanup(func() {
+		rootlessSystemdCgroupMode = originalMode
+		discoverRootlessSystemdCgroupInfo = originalDiscover
+		newSysInfo = originalNewSysInfo
+	})
+	rootlessSystemdCgroupMode = func() cdcgroups.CGMode { return cdcgroups.Unified }
+	discoverRootlessSystemdCgroupInfo = func() (rootlessSystemdCgroupInfo, error) {
+		return rootlessSystemdCgroupInfo{}, errors.New("test discovery failure")
+	}
+
+	cfg := rootlessSystemdConfig()
+	s := &specs.Spec{Linux: &specs.Linux{CgroupsPath: "user.slice:docker:test"}}
+	err := withRootless(nil, cfg)(context.Background(), nil, nil, s)
+	assert.ErrorContains(t, err, "test discovery failure")
+
+	newSysInfo = func(opts ...sysinfo.Opt) *sysinfo.SysInfo {
+		assert.Equal(t, len(opts), 1, "SysInfo must receive an explicit empty controller set instead of probing the cgroup mount root")
+		return &sysinfo.SysInfo{}
+	}
+	si := getSysInfo(cfg)
+	assert.Assert(t, is.Contains(strings.Join(si.Warnings, "\n"), "test discovery failure"))
+}
+
+func TestWithRootlessSystemdFiltersControllers(t *testing.T) {
+	t.Setenv("ROOTLESSKIT_PARENT_EUID", "1000")
+
+	originalMode := rootlessSystemdCgroupMode
+	originalDiscover := discoverRootlessSystemdCgroupInfo
+	t.Cleanup(func() {
+		rootlessSystemdCgroupMode = originalMode
+		discoverRootlessSystemdCgroupInfo = originalDiscover
+	})
+	rootlessSystemdCgroupMode = func() cdcgroups.CGMode { return cdcgroups.Unified }
+	discoverRootlessSystemdCgroupInfo = func() (rootlessSystemdCgroupInfo, error) {
+		return rootlessSystemdCgroupInfo{
+			groupPath:   "/user.slice/user-1000.slice/user@1000.service",
+			controllers: []string{"cpu", "memory", "pids"},
+		}, nil
+	}
+
+	memoryLimit := int64(64 * 1024 * 1024)
+	cpuQuota := int64(50_000)
+	pidsLimit := int64(100)
+	weight := uint16(500)
+	s := &specs.Spec{Linux: &specs.Linux{
+		CgroupsPath: "user.slice:docker:test",
+		Resources: &specs.LinuxResources{
+			Memory:  &specs.LinuxMemory{Limit: &memoryLimit},
+			CPU:     &specs.LinuxCPU{Quota: &cpuQuota, Cpus: "0"},
+			Pids:    &specs.LinuxPids{Limit: &pidsLimit},
+			BlockIO: &specs.LinuxBlockIO{Weight: &weight},
+		},
+	}}
+
+	err := withRootless(nil, rootlessSystemdConfig())(context.Background(), nil, nil, s)
+	assert.NilError(t, err)
+	assert.Assert(t, s.Linux.Resources.Memory != nil, "memory controller was removed")
+	assert.Assert(t, s.Linux.Resources.CPU != nil, "cpu controller was removed")
+	assert.Assert(t, s.Linux.Resources.Pids != nil, "pids controller was removed")
+	assert.Equal(t, s.Linux.Resources.CPU.Cpus, "", "cpuset settings must be removed when cpuset is unavailable")
+	assert.Check(t, is.Nil(s.Linux.Resources.BlockIO), "block I/O settings must be removed when io is unavailable")
+}
+
+func TestWithRootlessSystemdWithoutDelegatedControllers(t *testing.T) {
+	t.Setenv("ROOTLESSKIT_PARENT_EUID", "1000")
+
+	originalMode := rootlessSystemdCgroupMode
+	originalDiscover := discoverRootlessSystemdCgroupInfo
+	t.Cleanup(func() {
+		rootlessSystemdCgroupMode = originalMode
+		discoverRootlessSystemdCgroupInfo = originalDiscover
+	})
+	rootlessSystemdCgroupMode = func() cdcgroups.CGMode { return cdcgroups.Unified }
+	discoverRootlessSystemdCgroupInfo = func() (rootlessSystemdCgroupInfo, error) {
+		return rootlessSystemdCgroupInfo{
+			groupPath:   "/user.slice/user-1000.slice/user@1000.service",
+			controllers: []string{},
+		}, nil
+	}
+
+	s := &specs.Spec{Linux: &specs.Linux{
+		CgroupsPath: "user.slice:docker:test",
+		Resources:   &specs.LinuxResources{},
+	}}
+	err := withRootless(nil, rootlessSystemdConfig())(context.Background(), nil, nil, s)
+	assert.NilError(t, err)
+	assert.Equal(t, s.Linux.CgroupsPath, "")
+	assert.Check(t, is.Nil(s.Linux.Resources))
+}
+
+func TestRootlessSystemdEnvironmentValidation(t *testing.T) {
+	originalMode := rootlessSystemdCgroupMode
+	originalDiscover := discoverRootlessSystemdCgroupInfo
+	t.Cleanup(func() {
+		rootlessSystemdCgroupMode = originalMode
+		discoverRootlessSystemdCgroupInfo = originalDiscover
+	})
+	rootlessSystemdCgroupMode = func() cdcgroups.CGMode { return cdcgroups.Unified }
+	discoverRootlessSystemdCgroupInfo = func() (rootlessSystemdCgroupInfo, error) {
+		t.Fatal("discovery must not run with an invalid RootlessKit environment")
+		return rootlessSystemdCgroupInfo{}, nil
+	}
+
+	t.Run("missing", func(t *testing.T) {
+		t.Setenv("ROOTLESSKIT_PARENT_EUID", "")
+		_, err := rootlessSystemdCgroupControllerInfo()
+		assert.ErrorContains(t, err, "ROOTLESSKIT_PARENT_EUID is not set")
+	})
+	t.Run("malformed", func(t *testing.T) {
+		t.Setenv("ROOTLESSKIT_PARENT_EUID", "not-a-uid")
+		_, err := rootlessSystemdCgroupControllerInfo()
+		assert.ErrorContains(t, err, "invalid $ROOTLESSKIT_PARENT_EUID")
+
+		si := getSysInfo(rootlessSystemdConfig())
+		assert.Assert(t, is.Contains(strings.Join(si.Warnings, "\n"), "invalid $ROOTLESSKIT_PARENT_EUID"))
+	})
+}
+
+func TestRootfulAndCgroupfsSkipRootlessSystemdDiscovery(t *testing.T) {
+	originalDiscover := discoverRootlessSystemdCgroupInfo
+	originalNewSysInfo := newSysInfo
+	t.Cleanup(func() {
+		discoverRootlessSystemdCgroupInfo = originalDiscover
+		newSysInfo = originalNewSysInfo
+	})
+	discoverRootlessSystemdCgroupInfo = func() (rootlessSystemdCgroupInfo, error) {
+		t.Fatal("rootless systemd discovery must not run")
+		return rootlessSystemdCgroupInfo{}, nil
+	}
+	newSysInfo = func(...sysinfo.Opt) *sysinfo.SysInfo {
+		return &sysinfo.SysInfo{}
+	}
+
+	rootful := &config.Config{
+		CommonConfig: config.CommonConfig{ExecOptions: []string{"native.cgroupdriver=systemd"}},
+	}
+	_ = getSysInfo(rootful)
+
+	rootlessCgroupfs := &config.Config{
+		CommonConfig: config.CommonConfig{ExecOptions: []string{"native.cgroupdriver=cgroupfs"}},
+		Rootless:     true,
+	}
+	_ = getSysInfo(rootlessCgroupfs)
+}
+
+func newRootlessSystemdCgroupFixture(managerPath string, lookupErr error, cgroupRoot string) rootlessSystemdCgroupFiles {
+	return rootlessSystemdCgroupFiles{
+		userManagerControlGroup: func() (string, error) {
+			return managerPath, lookupErr
+		},
+		cgroup2Root: cgroupRoot,
+		readCgroupFile: func(dir, file string) (string, error) {
+			relDir, err := filepath.Rel(cgroupRoot, dir)
+			if err != nil {
+				return "", err
+			}
+			root, err := os.OpenRoot(cgroupRoot)
+			if err != nil {
+				return "", err
+			}
+			defer root.Close()
+			contents, err := root.ReadFile(filepath.Join(relDir, file))
+			return string(contents), err
+		},
+	}
+}
+
+func rootlessSystemdConfig() *config.Config {
+	return &config.Config{
+		CommonConfig: config.CommonConfig{ExecOptions: []string{"native.cgroupdriver=systemd"}},
+		Rootless:     true,
+	}
+}

--- a/pkg/sysinfo/cgroup2_linux.go
+++ b/pkg/sysinfo/cgroup2_linux.go
@@ -29,18 +29,22 @@ func newV2(options ...Opt) *SysInfo {
 		applyTimeNsInfo,
 	}
 
-	m, err := cgroupsV2.Load(sysInfo.cg2GroupPath)
-	if err != nil {
-		log.G(context.TODO()).Warn(err)
-	} else {
-		sysInfo.cg2Controllers = make(map[string]struct{})
-		controllers, err := m.Controllers()
+	if sysInfo.cg2Controllers == nil {
+		m, err := cgroupsV2.Load(sysInfo.cg2GroupPath)
 		if err != nil {
 			log.G(context.TODO()).Warn(err)
+		} else {
+			sysInfo.cg2Controllers = make(map[string]struct{})
+			controllers, err := m.Controllers()
+			if err != nil {
+				log.G(context.TODO()).Warn(err)
+			}
+			for _, c := range controllers {
+				sysInfo.cg2Controllers[c] = struct{}{}
+			}
 		}
-		for _, c := range controllers {
-			sysInfo.cg2Controllers[c] = struct{}{}
-		}
+	}
+	if sysInfo.cg2Controllers != nil {
 		ops = append(ops,
 			applyMemoryCgroupInfoV2,
 			applyCPUCgroupInfoV2,

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -85,6 +85,21 @@ func WithCgroup2GroupPath(g string) Opt {
 	}
 }
 
+// WithCgroup2Controllers specifies both the cgroup v2 group path and the
+// controllers known to be available to it. An empty controller list explicitly
+// means that no controllers are available.
+func WithCgroup2Controllers(g string, controllers []string) Opt {
+	return func(o *SysInfo) {
+		if p := path.Clean(g); p != "" {
+			o.cg2GroupPath = p
+		}
+		o.cg2Controllers = make(map[string]struct{}, len(controllers))
+		for _, controller := range controllers {
+			o.cg2Controllers[controller] = struct{}{}
+		}
+	}
+}
+
 // New returns a new SysInfo, using the filesystem to detect which features
 // the kernel supports.
 func New(options ...Opt) *SysInfo {

--- a/pkg/sysinfo/sysinfo_linux_test.go
+++ b/pkg/sysinfo/sysinfo_linux_test.go
@@ -69,6 +69,31 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestNewV2WithCgroup2Controllers(t *testing.T) {
+	t.Run("delegated controllers", func(t *testing.T) {
+		si := newV2(WithCgroup2Controllers("/delegated/docker.service", []string{"cpu", "memory", "pids"}))
+		if !si.CPUCfs || !si.CPUShares {
+			t.Fatal("expected CPU CFS and shares support when cpu is delegated")
+		}
+		if !si.MemoryLimit {
+			t.Fatal("expected memory limit support when memory is delegated")
+		}
+		if !si.PidsLimit {
+			t.Fatal("expected pids limit support when pids is delegated")
+		}
+		if si.BlkioWeight {
+			t.Fatal("did not expect I/O support when io is not delegated")
+		}
+	})
+
+	t.Run("explicitly empty", func(t *testing.T) {
+		si := newV2(WithCgroup2Controllers("/delegated/docker.service", []string{}))
+		if si.CPUCfs || si.MemoryLimit || si.PidsLimit {
+			t.Fatal("did not expect resource support without delegated controllers")
+		}
+	})
+}
+
 func TestIsCpusetListAvailable(t *testing.T) {
 	cases := []struct {
 		provided  string


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

Fixes: https://github.com/moby/moby/issues/53531

Rootless Docker assumed the systemd user cgroup was at a fixed location, causing container creation and resource detection to fail when systemd runs under a delegated cgroup prefix.

This PR discovers the daemon’s actual cgroup and delegated controllers, then uses them consistently for container specs and capability detection.

**Note**
I do not have the expertise in go nor the Moby project. The changes are AI-generated. I tried to manually review those. But I could not provide many meaningful insights. Please feel free to modify or rewrite this if needed.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Fix rootless container creation and resource detection with the systemd cgroup driver when the user cgroup hierarchy has an outer prefix.
```

## Tests

### Testcases
1. If no-limit rootless container works.
2. If cpu limit works for a rootless container.
3. If memory limit works for a rootless container.
4. If pid limit works for a rootless container.
5. If rootless container's cgroup hierarchy is correct.

### Test environments:
The three non-WSL environments are VMs.
| name | distro | kernel | docker | systemd |
| --- | --- | --- | --- | --- |
| WSL |  Ubuntu 26.04 LTS (Resolute Raccoon) | 6.18.40.1-microsoft-standard-WSL2 | docker 29.1.3 build  29.1.3-0ubuntu4.1 | 259.5-0ubuntu3.4 |
| Ubuntu | Ubuntu 24.04.4 LTS (Noble Numbat) | 6.8.0-110-generic | docker 29.7.2 build `6a43e3d` | 255.4-1ubuntu8.15 |
| Fedora | Fedora Linux 44 (Server Edition) | 6.19.10-300.fc44.x86_64 |  docker 29.7.2 build 1.fc44 | 259.5-1.fc44 |
| Arch | Arch Linux rolling release | 7.2.2-arch1-1 | docker 29.7.2 build `6a43e3d5af` | 261.2-1-arch |

### Test results:
**Before the change**
Tested with docker from the package manager.
| Testcase | basic | cpu limit | memory limit | pid limit | cgroup hierarchy |
| --- | --- | --- | --- | --- | --- |
| WSL | fail | fail | fail | fail | fail |
| Ubuntu | pass | pass | pass | pass | pass |
| Fedora | pass | pass | pass | pass | pass |
| Arch | pass | pass | pass | pass | pass |

**After the change**
| Testcase | basic | cpu limit | memory limit | pid limit | cgroup hierarchy |
| --- | --- | --- | --- | --- | --- |
| WSL | pass | pass | pass | pass | pass |
| Ubuntu | pass | pass | pass | pass | pass |
| Fedora | pass | pass | pass | pass | pass |
| Arch | pass | pass | pass | pass | pass |

### Test script
```bash
#!/usr/bin/env bash
#
# End-to-end test for rootless Docker with the systemd cgroup driver.
#
# This script starts a temporary, isolated rootless daemon. It does not replace,
# stop, reconfigure, or use the data directory of an existing Docker daemon.
#
# Usage:
#   ./rootless-cgroup-systemd.sh                 # test the installed dockerd
#   ./rootless-cgroup-systemd.sh ./dockerd       # test a copied dockerd binary
#   ./rootless-cgroup-systemd.sh --build         # build and test this checkout
#
# TEST_IMAGE may name a different image, but it must provide /bin/sh, cat, and
# sleep. The default is busybox:latest. The script first tries to copy the image
# from the existing Docker daemon, then tries to pull it with the test daemon.
#
set -Eeuo pipefail

if [[ -t 1 && ${TERM:-dumb} != dumb ]]; then
	CYAN=$'\033[36m'
	GREEN=$'\033[32m'
	YELLOW=$'\033[33m'
	RESET=$'\033[0m'
else
	CYAN=
	GREEN=
	YELLOW=
	RESET=
fi
if [[ -t 2 && ${TERM:-dumb} != dumb ]]; then
	RED=$'\033[31m'
	ERROR_RESET=$'\033[0m'
else
	RED=
	ERROR_RESET=
fi

info() { printf '%sINFO:%s %s\n' "$CYAN" "$RESET" "$*"; }
pass() { printf '%sPASS:%s %s\n' "$GREEN" "$RESET" "$*"; }
skip() { printf '%sSKIP:%s %s\n' "$YELLOW" "$RESET" "$*"; }
fail() {
	FAIL_REPORTED=1
	printf '%sFAIL: %s%s\n' "$RED" "$*" "$ERROR_RESET" >&2
	exit 1
}
test_fail() {
	((TEST_FAILURES += 1))
	printf '%sFAIL: %s%s\n' "$RED" "$*" "$ERROR_RESET" >&2
}

require_command() {
	command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
}

has_controller() {
	[[ " $CONTROLLERS " == *" $1 "* ]]
}

usage() {
	cat <<'EOF'
Usage:
  rootless-cgroup-systemd.sh [DOCKERD]
  rootless-cgroup-systemd.sh --build

With no argument, test the dockerd found in PATH.
With a path, test that dockerd binary.
With --build, build ./cmd/dockerd from the current Moby checkout and test it.
EOF
}

case "${1:-}" in
	-h|--help)
		usage
		exit 0
		;;
	--build)
		BUILD_FROM_CHECKOUT=1
		;;
	"")
		BUILD_FROM_CHECKOUT=0
		DOCKERD_SOURCE=$(command -v dockerd || true)
		;;
	*)
		BUILD_FROM_CHECKOUT=0
		DOCKERD_SOURCE=$1
		;;
esac

[[ $(id -u) -ne 0 ]] || fail "run this test as a non-root user"

for command in docker systemctl systemd-run rootlesskit dockerd-rootless.sh tar sha256sum; do
	require_command "$command"
done

if command -v slirp4netns >/dev/null 2>&1; then
	ROOTLESS_NETWORK=slirp4netns
elif command -v pasta >/dev/null 2>&1; then
	ROOTLESS_NETWORK=pasta
else
	fail "install slirp4netns or pasta before running this test"
fi

[[ -f /sys/fs/cgroup/cgroup.controllers ]] ||
	fail "this test requires cgroup v2 mounted at /sys/fs/cgroup"
systemctl --user show-environment >/dev/null 2>&1 ||
	fail "a working systemd user session is required"

RUNTIME_DIR=${XDG_RUNTIME_DIR:-"/run/user/$(id -u)"}
[[ -d "$RUNTIME_DIR" && -w "$RUNTIME_DIR" ]] ||
	fail "runtime directory is not writable: $RUNTIME_DIR"

TEST_ID="$$"
UNIT="moby-rootless-cgroup-test-${TEST_ID}.service"
WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/moby-rootless-cgroup-test.XXXXXX")
DOCKERD_UNDER_TEST="$WORK_DIR/dockerd"
STATE_DIR="$RUNTIME_DIR/moby-rootlesskit-test-${TEST_ID}"
SOCKET="$RUNTIME_DIR/moby-docker-test-${TEST_ID}.sock"
DATA_ROOT="$WORK_DIR/data"
EXEC_ROOT="$WORK_DIR/exec"
PID_FILE="$WORK_DIR/dockerd.pid"
DAEMON_CONFIG="$WORK_DIR/daemon.json"
IMAGE=${TEST_IMAGE:-busybox:latest}
UNIT_STARTED=0
CONTAINER_ID=""
FAIL_REPORTED=0
TEST_FAILURES=0

# This always addresses the temporary daemon, never the existing installation.
test_docker() {
	docker --host="unix://$SOCKET" "$@"
}

daemon_error_summary() {
	journalctl --user-unit="$UNIT" --no-pager -o cat -n 50 2>/dev/null |
		grep -Ei '(^|[[:space:]])(error|failed|failure)([=:[:space:]]|$)' |
		tail -n 10 || true
}

cleanup() {
	status=$?
	trap - EXIT
	set +e

	if [[ -n "$CONTAINER_ID" && -S "$SOCKET" ]]; then
		test_docker rm -f "$CONTAINER_ID" >/dev/null 2>&1 || true
	fi
	if [[ $UNIT_STARTED -eq 1 ]]; then
		systemctl --user stop "$UNIT" >/dev/null 2>&1 || true
		systemctl --user reset-failed "$UNIT" >/dev/null 2>&1 || true
	fi
	rm -f "$SOCKET"
	rm -rf "$STATE_DIR"

	# Files in data-root can be owned by subordinate UIDs. Remove them from a
	# matching user namespace, then fall back to a normal removal.
	if [[ -e "$WORK_DIR" ]]; then
		rootlesskit --net=host --disable-host-loopback=false \
			/bin/rm -rf "$WORK_DIR" >/dev/null 2>&1 ||
			rm -rf "$WORK_DIR" >/dev/null 2>&1 || true
	fi

	if ((TEST_FAILURES > 0)); then
		printf '%sFAIL: %d behavioral test(s) failed; temporary resources were removed%s\n' "$RED" "$TEST_FAILURES" "$ERROR_RESET" >&2
	elif [[ $status -eq 0 ]]; then
		printf '%sPASS:%s all applicable tests passed; temporary resources were removed\n' "$GREEN" "$RESET"
	elif [[ $FAIL_REPORTED -eq 0 ]]; then
		printf '%sFAIL: unexpected command failure (exit status %d)%s\n' "$RED" "$status" "$ERROR_RESET" >&2
	fi
	exit "$status"
}
trap cleanup EXIT

if [[ $BUILD_FROM_CHECKOUT -eq 1 ]]; then
	require_command go
	[[ -f go.mod ]] || fail "--build must be run from a Moby Git checkout"
	grep -q '^module github.com/moby/moby/v2$' go.mod ||
		fail "--build must be run from the root of a Moby Git checkout"
	CGO_ENABLED=0 go build -o "$DOCKERD_UNDER_TEST" ./cmd/dockerd
else
	[[ -n "${DOCKERD_SOURCE:-}" ]] || fail "dockerd was not found in PATH"
	[[ -x "$DOCKERD_SOURCE" ]] || fail "dockerd is not executable: $DOCKERD_SOURCE"
	DOCKERD_SOURCE=$(readlink -f "$DOCKERD_SOURCE")
	cp "$DOCKERD_SOURCE" "$DOCKERD_UNDER_TEST"
	chmod 0755 "$DOCKERD_UNDER_TEST"
fi

DOCKERD_VERSION=$("$DOCKERD_UNDER_TEST" --version)
DOCKERD_SHA256=$(sha256sum "$DOCKERD_UNDER_TEST" | awk '{print $1}')
info "dockerd under test: $DOCKERD_VERSION (SHA-256: $DOCKERD_SHA256)"

MANAGER_CGROUP=$(SYSTEMD_PAGER=cat systemctl --user show --value --property=ControlGroup)
[[ "$MANAGER_CGROUP" == /* ]] || fail "invalid systemd user-manager cgroup: $MANAGER_CGROUP"
OLD_FIXED_PATH="/sys/fs/cgroup/user.slice/user-$(id -u).slice/cgroup.controllers"
[[ -e "$OLD_FIXED_PATH" ]] && OLD_FIXED_PATH_STATE=present || OLD_FIXED_PATH_STATE=absent

printf '{}\n' >"$DAEMON_CONFIG"

if ! SYSTEMD_PAGER=cat systemd-run \
	--user \
	--collect \
	--unit="$UNIT" \
	--description="Temporary Moby rootless cgroup test" \
	--property=Delegate=yes \
	/usr/bin/env \
	DOCKERD="$DOCKERD_UNDER_TEST" \
	DOCKERD_ROOTLESS_ROOTLESSKIT_STATE_DIR="$STATE_DIR" \
	DOCKERD_ROOTLESS_ROOTLESSKIT_NET="$ROOTLESS_NETWORK" \
	XDG_RUNTIME_DIR="$RUNTIME_DIR" \
	DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=$RUNTIME_DIR/bus}" \
	PATH="$PATH" \
	"$(command -v dockerd-rootless.sh)" \
	--config-file="$DAEMON_CONFIG" \
	--host="unix://$SOCKET" \
	--data-root="$DATA_ROOT" \
	--exec-root="$EXEC_ROOT" \
	--pidfile="$PID_FILE" \
	--storage-driver=vfs \
	--iptables=false \
	--ip6tables=false \
	--bridge=none \
	--containerd-namespace="moby-test-$TEST_ID" \
	--containerd-plugins-namespace="moby-test-plugins-$TEST_ID" \
	--log-level=error >"$WORK_DIR/systemd-run.log" 2>&1; then
	fail "could not start the temporary systemd service:"$'\n'"$(tail -n 10 "$WORK_DIR/systemd-run.log")"
fi
UNIT_STARTED=1

DAEMON_READY=0
for _ in $(seq 1 200); do
	if test_docker info >/dev/null 2>&1; then
		DAEMON_READY=1
		break
	fi
	sleep 0.1
done
if [[ $DAEMON_READY -ne 1 ]]; then
	DAEMON_ERRORS=$(daemon_error_summary)
	if [[ -n "$DAEMON_ERRORS" ]]; then
		fail "the temporary rootless daemon did not become ready:"$'\n'"$DAEMON_ERRORS"
	fi
	fail "the temporary rootless daemon did not become ready"
fi
info "temporary isolated daemon started"

[[ -s "$PID_FILE" ]] || fail "dockerd did not create its PID file"
DAEMON_PID=$(<"$PID_FILE")
[[ "$DAEMON_PID" =~ ^[0-9]+$ && -r "/proc/$DAEMON_PID/cgroup" ]] ||
	fail "invalid or missing dockerd process: $DAEMON_PID"
DAEMON_CGROUP=$(cut -d: -f3 "/proc/$DAEMON_PID/cgroup")
[[ "$DAEMON_CGROUP" == /* ]] || fail "invalid dockerd cgroup: $DAEMON_CGROUP"
CONTROLLER_FILE="/sys/fs/cgroup${DAEMON_CGROUP}/cgroup.controllers"
[[ -r "$CONTROLLER_FILE" ]] || fail "controller file is missing: $CONTROLLER_FILE"
CONTROLLERS=$(<"$CONTROLLER_FILE")

DRIVER=$(test_docker info --format '{{.CgroupDriver}}')
CGROUP_VERSION=$(test_docker info --format '{{.CgroupVersion}}')
SECURITY_OPTIONS=$(test_docker info --format '{{json .SecurityOptions}}')
WARNINGS=$(test_docker info --format '{{json .Warnings}}')

[[ "$DRIVER" == systemd ]] || fail "expected systemd cgroup driver, got $DRIVER"
[[ "$CGROUP_VERSION" == 2 ]] || fail "expected cgroup v2, got $CGROUP_VERSION"
[[ "$SECURITY_OPTIONS" == *rootless* ]] || fail "daemon does not report rootless mode"
[[ "$DAEMON_CGROUP" == "$MANAGER_CGROUP/"* ]] ||
	fail "dockerd is not below the systemd user-manager cgroup"
info "daemon cgroup: $DAEMON_CGROUP"
info "delegated controllers: ${CONTROLLERS:-none}; old fixed path: $OLD_FIXED_PATH_STATE"

if docker image inspect "$IMAGE" >/dev/null 2>&1; then
	docker image save "$IMAGE" | test_docker image load >/dev/null
elif [[ "$IMAGE" == busybox:latest && -x /bin/busybox ]] &&
	ldd /bin/busybox 2>&1 | grep -Eq 'not a dynamic executable|statically linked'; then
	OFFLINE_ROOTFS="$WORK_DIR/offline-rootfs"
	mkdir -p "$OFFLINE_ROOTFS/bin"
	cp /bin/busybox "$OFFLINE_ROOTFS/bin/busybox"
	ln -s busybox "$OFFLINE_ROOTFS/bin/sh"
	ln -s busybox "$OFFLINE_ROOTFS/bin/cat"
	ln -s busybox "$OFFLINE_ROOTFS/bin/sleep"
	IMAGE="moby-rootless-cgroup-test:$TEST_ID"
	tar -C "$OFFLINE_ROOTFS" -c . | test_docker image import - "$IMAGE" >/dev/null
else
	if ! test_docker pull "$IMAGE" >"$WORK_DIR/image-pull.log" 2>&1; then
		fail "could not obtain $IMAGE; run 'docker pull $IMAGE' with the existing daemon and retry:"$'\n'"$(tail -n 10 "$WORK_DIR/image-pull.log")"
	fi
fi
info "test image is available in the temporary daemon"

set +e
NO_LIMIT_OUTPUT=$(test_docker run --rm --network=none "$IMAGE" /bin/sh -c 'echo no-limit-container-succeeded' 2>&1)
NO_LIMIT_STATUS=$?
set -e
if [[ $NO_LIMIT_STATUS -ne 0 ]]; then
	test_fail "no-limit rootless container:"$'\n'"$NO_LIMIT_OUTPUT"
elif [[ "$NO_LIMIT_OUTPUT" != *no-limit-container-succeeded* ]]; then
	test_fail "no-limit rootless container returned unexpected output:"$'\n'"$NO_LIMIT_OUTPUT"
else
	pass "no-limit rootless container"
fi

if has_controller cpu; then
	set +e
	CPU_OUTPUT=$(test_docker run --rm --network=none --cpus=1 "$IMAGE" /bin/sh -c 'cat /sys/fs/cgroup/cpu.max' 2>&1)
	CPU_STATUS=$?
	set -e
	if [[ $CPU_STATUS -ne 0 ]]; then
		test_fail "CPU-limited container:"$'\n'"$CPU_OUTPUT"
	elif [[ -z "$CPU_OUTPUT" || "$CPU_OUTPUT" == max* ]]; then
		test_fail "CPU quota was not applied: $CPU_OUTPUT"
	else
		pass "CPU limit applied"
	fi
else
	set +e
	CPU_ERROR=$(test_docker run --rm --network=none --cpus=1 "$IMAGE" /bin/sh -c true 2>&1)
	CPU_STATUS=$?
	set -e
	if [[ $CPU_STATUS -eq 0 ]]; then
		test_fail "--cpus succeeded even though cpu is not delegated"
	elif [[ "$CPU_ERROR" != *"NanoCPUs can not be set"* && "$CPU_ERROR" != *"CPU CFS"* ]]; then
		test_fail "--cpus was rejected for an unexpected reason:"$'\n'"$CPU_ERROR"
	else
		pass "CPU limit correctly rejected because cpu is not delegated"
	fi
fi

if has_controller memory; then
	set +e
	MEMORY_OUTPUT=$(test_docker run --rm --network=none --memory=16m "$IMAGE" /bin/sh -c 'cat /sys/fs/cgroup/memory.max' 2>&1)
	MEMORY_STATUS=$?
	set -e
	if [[ $MEMORY_STATUS -ne 0 ]]; then
		test_fail "memory-limited container:"$'\n'"$MEMORY_OUTPUT"
	elif [[ "$MEMORY_OUTPUT" != 16777216 ]]; then
		test_fail "memory limit was not applied: expected 16777216, got $MEMORY_OUTPUT"
	else
		pass "memory limit applied"
	fi
else
	skip "memory is not delegated"
fi

if has_controller pids; then
	set +e
	PIDS_OUTPUT=$(test_docker run --rm --network=none --pids-limit=16 "$IMAGE" /bin/sh -c 'cat /sys/fs/cgroup/pids.max' 2>&1)
	PIDS_STATUS=$?
	set -e
	if [[ $PIDS_STATUS -ne 0 ]]; then
		test_fail "PIDs-limited container:"$'\n'"$PIDS_OUTPUT"
	elif [[ "$PIDS_OUTPUT" != 16 ]]; then
		test_fail "PIDs limit was not applied: expected 16, got $PIDS_OUTPUT"
	else
		pass "PIDs limit applied"
	fi
else
	skip "pids is not delegated"
fi

set +e
CONTAINER_OUTPUT=$(test_docker run -d --network=none "$IMAGE" /bin/sh -c 'sleep 300' 2>&1)
CONTAINER_STATUS=$?
set -e
if [[ $CONTAINER_STATUS -ne 0 ]]; then
	test_fail "container systemd scope:"$'\n'"$CONTAINER_OUTPUT"
else
	CONTAINER_ID=$CONTAINER_OUTPUT
	set +e
	CONTAINER_PID=$(test_docker inspect --format '{{.State.Pid}}' "$CONTAINER_ID" 2>/dev/null)
	INSPECT_STATUS=$?
	set -e
	if [[ $INSPECT_STATUS -ne 0 || ! "$CONTAINER_PID" =~ ^[0-9]+$ || ! -r "/proc/$CONTAINER_PID/cgroup" ]]; then
		test_fail "container systemd scope: invalid or missing container process: ${CONTAINER_PID:-unknown}"
	else
		CONTAINER_CGROUP=$(cut -d: -f3 "/proc/$CONTAINER_PID/cgroup")
		if [[ -z "$CONTROLLERS" ]]; then
			skip "no controllers are delegated, so no container cgroup is expected"
		elif [[ "$CONTAINER_CGROUP" != "$MANAGER_CGROUP/"* ]]; then
			test_fail "container scope did not retain the user-manager cgroup prefix: $CONTAINER_CGROUP"
		elif [[ "$(basename "$CONTAINER_CGROUP")" != docker-*.scope ]]; then
			test_fail "container was not placed in a docker systemd scope: $CONTAINER_CGROUP"
		else
			pass "container systemd scope: $CONTAINER_CGROUP"
		fi
	fi

	test_docker rm -f "$CONTAINER_ID" >/dev/null 2>&1 || true
	CONTAINER_ID=""
fi

if ((TEST_FAILURES > 0)); then
	exit 1
fi


```
