### PR TITLE
container inspect: make Mounts order deterministic

### DIFF
--- a/daemon/container/container_unix.go
+++ b/daemon/container/container_unix.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"syscall"
 
 	"github.com/containerd/continuity/fs"
@@ -440,6 +441,9 @@ func (container *Container) GetMountPoints() []containertypes.MountPoint {
 			Propagation: m.Propagation,
 		})
 	}
+	slices.SortStableFunc(mountPoints, func(a, b containertypes.MountPoint) int {
+		return compareMountPaths(a.Destination, b.Destination)
+	})
 	return mountPoints
 }
 

--- a/daemon/container/container_windows.go
+++ b/daemon/container/container_windows.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/events"
@@ -192,6 +193,9 @@ func (container *Container) GetMountPoints() []containertypes.MountPoint {
 			RW:          m.RW,
 		})
 	}
+	slices.SortStableFunc(mountPoints, func(a, b containertypes.MountPoint) int {
+		return compareMountPaths(a.Destination, b.Destination)
+	})
 	return mountPoints
 }
 

--- a/daemon/container/mounts.go
+++ b/daemon/container/mounts.go
@@ -1,0 +1,34 @@
+package container
+
+import (
+	"cmp"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// compareMountPaths compares mount paths by depth so that parent paths sort
+// before paths beneath them.
+func compareMountPaths(a, b string) int {
+	a = filepath.Clean(a)
+	b = filepath.Clean(b)
+
+	aParts := strings.Count(a, string(os.PathSeparator))
+	bParts := strings.Count(b, string(os.PathSeparator))
+	if c := cmp.Compare(aParts, bParts); c != 0 {
+		return c
+	}
+	return cmp.Compare(a, b)
+}
+
+// SortMounts sorts mounts by destination depth so that parent mounts are
+// applied before mounts beneath them. Mounts at the same depth are sorted
+// by destination to produce a deterministic order.
+//
+// For example, /etc must be mounted before /etc/resolv.conf.
+func SortMounts(m []Mount) {
+	slices.SortStableFunc(m, func(a, b Mount) int {
+		return compareMountPaths(a.Destination, b.Destination)
+	})
+}

--- a/daemon/container/mounts_test.go
+++ b/daemon/container/mounts_test.go
@@ -1,4 +1,4 @@
-package daemon
+package container_test
 
 import (
 	"testing"
@@ -81,7 +81,7 @@ func TestSortMounts(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			sortMounts(tc.mounts)
+			container.SortMounts(tc.mounts)
 			assert.DeepEqual(t, tc.expected, tc.mounts)
 		})
 	}

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -479,7 +479,7 @@ var (
 // withMounts sets the container's mounts
 func withMounts(daemon *Daemon, daemonCfg *configStore, c *container.Container, mounts []container.Mount) coci.SpecOpts {
 	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
-		sortMounts(mounts)
+		container.SortMounts(mounts)
 
 		userMounts := make(map[string]struct{})
 		for _, m := range mounts {

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -42,11 +42,10 @@ func compareMountPaths(a, b string) int {
 // sortMounts sorts mounts by destination depth so that parent mounts are
 // applied before mounts beneath them. For example, /etc must be mounted
 // before /etc/resolv.conf.
-func sortMounts(m []container.Mount) []container.Mount {
+func sortMounts(m []container.Mount) {
 	slices.SortStableFunc(m, func(a, b container.Mount) int {
 		return compareMountPaths(a.Destination, b.Destination)
 	})
-	return m
 }
 
 // registerMountPoints initializes the container mount points with the configured volumes and bind mounts.

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -36,12 +36,17 @@ func compareMountPaths(a, b string) int {
 
 	aParts := strings.Count(a, string(os.PathSeparator))
 	bParts := strings.Count(b, string(os.PathSeparator))
-	return cmp.Compare(aParts, bParts)
+	if c := cmp.Compare(aParts, bParts); c != 0 {
+		return c
+	}
+	return cmp.Compare(a, b)
 }
 
 // sortMounts sorts mounts by destination depth so that parent mounts are
-// applied before mounts beneath them. For example, /etc must be mounted
-// before /etc/resolv.conf.
+// applied before mounts beneath them. Mounts at the same depth are sorted
+// by destination to produce a deterministic order.
+//
+// For example, /etc must be mounted before /etc/resolv.conf.
 func sortMounts(m []container.Mount) {
 	slices.SortStableFunc(m, func(a, b container.Mount) int {
 		return compareMountPaths(a.Destination, b.Destination)

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -1,13 +1,14 @@
 package daemon
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"maps"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -27,37 +28,24 @@ import (
 
 var _ volume.LiveRestorer = (*volumeWrapper)(nil)
 
-// mountSort implements [sort.Interface] to sort an array of mounts in
-// lexicographic order.
-type mountSort []container.Mount
+// compareMountPaths compares mount paths by depth so that parent paths sort
+// before paths beneath them.
+func compareMountPaths(a, b string) int {
+	a = filepath.Clean(a)
+	b = filepath.Clean(b)
 
-// Len returns the number of mounts. Used in sorting.
-func (m mountSort) Len() int {
-	return len(m)
+	aParts := strings.Count(a, string(os.PathSeparator))
+	bParts := strings.Count(b, string(os.PathSeparator))
+	return cmp.Compare(aParts, bParts)
 }
 
-// Less returns true if the number of parts (a/b/c would be 3 parts) in the
-// mount indexed by parameter 1 is less than that of the mount indexed by
-// parameter 2. Used in sorting.
-func (m mountSort) Less(i, j int) bool {
-	return m.parts(i) < m.parts(j)
-}
-
-// Swap swaps two items in an array of mounts. Used in sorting
-func (m mountSort) Swap(i, j int) {
-	m[i], m[j] = m[j], m[i]
-}
-
-// parts returns the number of parts in the destination of a mount. Used in sorting.
-func (m mountSort) parts(i int) int {
-	return strings.Count(filepath.Clean(m[i].Destination), string(os.PathSeparator))
-}
-
-// sortMounts sorts an array of mounts in lexicographic order. This ensure that
-// when mounting, the mounts don't shadow other mounts. For example, if mounting
-// /etc and /etc/resolv.conf, /etc/resolv.conf must not be mounted first.
+// sortMounts sorts mounts by destination depth so that parent mounts are
+// applied before mounts beneath them. For example, /etc must be mounted
+// before /etc/resolv.conf.
 func sortMounts(m []container.Mount) []container.Mount {
-	sort.Sort(mountSort(m))
+	slices.SortStableFunc(m, func(a, b container.Mount) int {
+		return compareMountPaths(a.Destination, b.Destination)
+	})
 	return m
 }
 

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -1,15 +1,10 @@
 package daemon
 
 import (
-	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"maps"
-	"os"
-	"path/filepath"
-	"slices"
-	"strings"
 	"time"
 
 	"github.com/containerd/log"
@@ -27,31 +22,6 @@ import (
 )
 
 var _ volume.LiveRestorer = (*volumeWrapper)(nil)
-
-// compareMountPaths compares mount paths by depth so that parent paths sort
-// before paths beneath them.
-func compareMountPaths(a, b string) int {
-	a = filepath.Clean(a)
-	b = filepath.Clean(b)
-
-	aParts := strings.Count(a, string(os.PathSeparator))
-	bParts := strings.Count(b, string(os.PathSeparator))
-	if c := cmp.Compare(aParts, bParts); c != 0 {
-		return c
-	}
-	return cmp.Compare(a, b)
-}
-
-// sortMounts sorts mounts by destination depth so that parent mounts are
-// applied before mounts beneath them. Mounts at the same depth are sorted
-// by destination to produce a deterministic order.
-//
-// For example, /etc must be mounted before /etc/resolv.conf.
-func sortMounts(m []container.Mount) {
-	slices.SortStableFunc(m, func(a, b container.Mount) int {
-		return compareMountPaths(a.Destination, b.Destination)
-	})
-}
 
 // registerMountPoints initializes the container mount points with the configured volumes and bind mounts.
 // It follows the next sequence to decide what to mount in each final destination:

--- a/daemon/volumes_test.go
+++ b/daemon/volumes_test.go
@@ -1,0 +1,88 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/moby/moby/v2/daemon/container"
+	"gotest.tools/v3/assert"
+)
+
+// TestSortMounts verifies that mounts are sorted by destination depth and
+// deterministically by destination when they have the same depth.
+func TestSortMounts(t *testing.T) {
+	tests := []struct {
+		name     string
+		mounts   []container.Mount
+		expected []container.Mount
+	}{
+		{
+			name: "nested",
+			mounts: []container.Mount{
+				{Destination: "/etc/resolv.conf"},
+				{Destination: "/etc"},
+			},
+			expected: []container.Mount{
+				{Destination: "/etc"},
+				{Destination: "/etc/resolv.conf"},
+			},
+		},
+		{
+			name: "same depth",
+			mounts: []container.Mount{
+				{Destination: "/var"},
+				{Destination: "/etc"},
+				{Destination: "/usr"},
+			},
+			expected: []container.Mount{
+				{Destination: "/etc"},
+				{Destination: "/usr"},
+				{Destination: "/var"},
+			},
+		},
+		{
+			name: "nested and same depth",
+			mounts: []container.Mount{
+				{Destination: "/var/lib/foo"},
+				{Destination: "/etc/resolv.conf"},
+				{Destination: "/var"},
+				{Destination: "/etc"},
+				{Destination: "/opt/data"},
+			},
+			expected: []container.Mount{
+				{Destination: "/etc"},
+				{Destination: "/var"},
+				{Destination: "/etc/resolv.conf"},
+				{Destination: "/opt/data"},
+				{Destination: "/var/lib/foo"},
+			},
+		},
+		{
+			name: "duplicate destinations preserve order",
+			mounts: []container.Mount{
+				{Source: "/source-1", Destination: "/var"},
+				{Source: "/source-c", Destination: "/etc"},
+				{Source: "/source-2", Destination: "/opt"},
+				{Source: "/source-a", Destination: "/etc"},
+				{Source: "/source-3", Destination: "/usr"},
+				{Source: "/source-b", Destination: "/etc"},
+				{Source: "/source-4", Destination: "/home"},
+			},
+			expected: []container.Mount{
+				{Source: "/source-c", Destination: "/etc"},
+				{Source: "/source-a", Destination: "/etc"},
+				{Source: "/source-b", Destination: "/etc"},
+				{Source: "/source-4", Destination: "/home"},
+				{Source: "/source-2", Destination: "/opt"},
+				{Source: "/source-3", Destination: "/usr"},
+				{Source: "/source-1", Destination: "/var"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sortMounts(tc.mounts)
+			assert.DeepEqual(t, tc.expected, tc.mounts)
+		})
+	}
+}

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -103,7 +103,7 @@ func (daemon *Daemon) setupMounts(ctx context.Context, c *container.Container) (
 		}
 	}
 
-	sortMounts(mounts)
+	container.SortMounts(mounts)
 	netMounts := c.NetworkMounts()
 	// if we are going to mount any of the network files from container
 	// metadata, the ownership must be set properly for potential container

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -103,7 +103,7 @@ func (daemon *Daemon) setupMounts(ctx context.Context, c *container.Container) (
 		}
 	}
 
-	mounts = sortMounts(mounts)
+	sortMounts(mounts)
 	netMounts := c.NetworkMounts()
 	// if we are going to mount any of the network files from container
 	// metadata, the ownership must be set properly for potential container

--- a/daemon/volumes_windows.go
+++ b/daemon/volumes_windows.go
@@ -48,7 +48,8 @@ func (daemon *Daemon) setupMounts(ctx context.Context, c *container.Container) (
 		})
 	}
 
-	return sortMounts(mnts), mntCleanups.Release(), nil
+	sortMounts(mnts)
+	return mnts, mntCleanups.Release(), nil
 }
 
 // setBindModeIfNull is platform specific processing which is a no-op on

--- a/daemon/volumes_windows.go
+++ b/daemon/volumes_windows.go
@@ -48,7 +48,7 @@ func (daemon *Daemon) setupMounts(ctx context.Context, c *container.Container) (
 		})
 	}
 
-	sortMounts(mnts)
+	container.SortMounts(mnts)
 	return mnts, mntCleanups.Release(), nil
 }
 


### PR DESCRIPTION
### daemon: sortMounts: rewrite with slices package

### daemon: sortMounts: remove return value

sortMounts sorts the input in-place; the return value was added as part of
its initial implementation in 81fa9feb0cdc0773eff99d7393c16271e84aac08 (https://github.com/moby/moby/pull/13161), and
from the looks of it was just for convenience.

Remove the return value to make it clear it sorts in-place and to not give
the impression that it returns a clone.

### daemon: make mount sorting deterministic

Use the mount destination as a tie-breaker when mounts have the same
depth. This preserves the existing parent-before-child ordering while
ensuring that the same set of mounts always produces the same order.

### daemon: sortMounts: move to container.SortMounts

Move the utility to the container package, which is where the Mount
type is defined, and to allow re-use of the utility both inside the
container package and the daemon package.

### daemon/container: GetMountPoints: sort mount-points

Container mount-points are stored in a map, so GetMountPoints could return
them in arbitrary order.

Sort the result using the common mount-path ordering to provide deterministic
container inspect output.

Before this patch, order of mounts would be randomized in container inspect;

    docker inspect mycontainer | jq .[].Mounts.[].Destination
    "/hello"
    "/hello/world"

    docker inspect mycontainer | jq .[].Mounts.[].Destination
    "/hello/world"
    "/hello"

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Fix inconsistent mount ordering in `docker inspect` output (`GET /containers/{id}/json`) and container listings (`docker ps`, `GET /containers/json`).
```

## A picture of a cute animal (not mandatory but encouraged)
