### PR TITLE
api: remove gotest.tools from tests

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -7,8 +7,5 @@ require (
 	github.com/moby/docker-image-spec v1.3.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
-	gotest.tools/v3 v3.5.2
 	pgregory.net/rapid v1.2.0
 )
-
-require github.com/google/go-cmp v0.7.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,14 +1,10 @@
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
-github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
-gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=
 pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
 pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=

--- a/api/pkg/authconfig/authconfig_test.go
+++ b/api/pkg/authconfig/authconfig_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/moby/moby/api/pkg/authconfig"
 	"github.com/moby/moby/api/types/registry"
-	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestDecodeAuthConfig(t *testing.T) {
@@ -107,19 +105,30 @@ func TestDecodeAuthConfig(t *testing.T) {
 				if !strings.HasSuffix(tc.inputBase64, "=") {
 					b64 = strings.TrimRight(b64, "=")
 				}
-				assert.Check(t, is.Equal(b64, tc.inputBase64))
+				if b64 != tc.inputBase64 {
+					t.Errorf("base64 fixture = %q, want %q", b64, tc.inputBase64)
+				}
 			}
 
 			out, err := authconfig.Decode(tc.inputBase64)
 			if tc.expectedErr != "" {
-				assert.Check(t, is.ErrorType(err, func(err error) bool {
-					_, ok := err.(interface{ InvalidParameter() })
-					return ok
-				}))
-				assert.Check(t, is.Error(err, tc.expectedErr))
-			} else {
-				assert.NilError(t, err)
-				assert.Equal(t, *out, tc.expected)
+				if err == nil {
+					t.Errorf("Decode(%q) error = nil, want %q", tc.inputBase64, tc.expectedErr)
+				} else {
+					if _, ok := err.(interface{ InvalidParameter() }); !ok {
+						t.Errorf("Decode(%q) error = %T, want invalid-parameter error", tc.inputBase64, err)
+					}
+					if err.Error() != tc.expectedErr {
+						t.Errorf("Decode(%q) error = %q, want %q", tc.inputBase64, err, tc.expectedErr)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Decode(%q) error = %v", tc.inputBase64, err)
+			}
+			if *out != tc.expected {
+				t.Errorf("Decode(%q) = %+v, want %+v", tc.inputBase64, *out, tc.expected)
 			}
 		})
 	}
@@ -156,16 +165,26 @@ func TestEncodeAuthConfig(t *testing.T) {
 	for _, tc := range tests {
 		// Sanity check to make sure our fixtures are correct.
 		b64 := base64.URLEncoding.EncodeToString([]byte(tc.outPlain))
-		assert.Check(t, is.Equal(b64, tc.outBase64))
+		if b64 != tc.outBase64 {
+			t.Errorf("base64 fixture = %q, want %q", b64, tc.outBase64)
+		}
 
 		t.Run(tc.doc, func(t *testing.T) {
 			out, err := authconfig.Encode(tc.input)
-			assert.NilError(t, err)
-			assert.Equal(t, out, tc.outBase64)
+			if err != nil {
+				t.Fatalf("Encode(%+v) error = %v", tc.input, err)
+			}
+			if out != tc.outBase64 {
+				t.Errorf("Encode(%+v) = %q, want %q", tc.input, out, tc.outBase64)
+			}
 
 			authJSON, err := base64.URLEncoding.DecodeString(out)
-			assert.NilError(t, err)
-			assert.Equal(t, string(authJSON), tc.outPlain)
+			if err != nil {
+				t.Fatalf("DecodeString(%q) error = %v", out, err)
+			}
+			if got := string(authJSON); got != tc.outPlain {
+				t.Errorf("decoded auth JSON = %q, want %q", got, tc.outPlain)
+			}
 		})
 	}
 }

--- a/api/types/container/assert_test.go
+++ b/api/types/container/assert_test.go
@@ -1,0 +1,28 @@
+package container_test
+
+import (
+	"testing"
+)
+
+func checkEqual[T comparable](t *testing.T, got, want T) {
+	t.Helper()
+	if got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func checkNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func checkError(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Errorf("expected error %q, got nil", want)
+	} else if err.Error() != want {
+		t.Errorf("error = %q, want %q", err, want)
+	}
+}

--- a/api/types/container/config_test.go
+++ b/api/types/container/config_test.go
@@ -5,21 +5,20 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/types/container"
-	"gotest.tools/v3/assert"
 )
 
 func TestMarshalConfig(t *testing.T) {
 	omitted := []byte(`{"Hostname":"","Domainname":"","User":"","AttachStdin":false,"AttachStdout":false,"AttachStderr":false,"Tty":false,"OpenStdin":false,"StdinOnce":false,"Env":null,"Cmd":null,"Image":"","Volumes":null,"WorkingDir":"","Entrypoint":null,"Labels":null}`)
 
 	bytes, err := json.Marshal(container.Config{})
-	assert.NilError(t, err)
-	assert.Equal(t, string(bytes), string(omitted))
+	checkNoError(t, err)
+	checkEqual(t, string(bytes), string(omitted))
 
 	empty := container.Config{
 		OnBuild: []string{},
 	}
 
 	bytes, err = json.Marshal(empty)
-	assert.NilError(t, err)
-	assert.Equal(t, string(bytes), string(omitted))
+	checkNoError(t, err)
+	checkEqual(t, string(bytes), string(omitted))
 }

--- a/api/types/container/health_test.go
+++ b/api/types/container/health_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/types/container"
-	"gotest.tools/v3/assert"
 )
 
 func TestValidateHealthStatus(t *testing.T) {
@@ -23,9 +22,9 @@ func TestValidateHealthStatus(t *testing.T) {
 		t.Run(string(tc.health), func(t *testing.T) {
 			err := container.ValidateHealthStatus(tc.health)
 			if tc.expectedErr == "" {
-				assert.NilError(t, err)
+				checkNoError(t, err)
 			} else {
-				assert.Error(t, err, tc.expectedErr)
+				checkError(t, err, tc.expectedErr)
 			}
 		})
 	}

--- a/api/types/container/hostconfig_test.go
+++ b/api/types/container/hostconfig_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/types/container"
-	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestValidateRestartPolicy(t *testing.T) {
@@ -94,21 +92,18 @@ func TestValidateRestartPolicy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := container.ValidateRestartPolicy(tc.input)
 			if tc.expectedErr == "" {
-				assert.Check(t, err)
-			} else {
-				assert.Check(t, is.ErrorType(err, isInvalidParameter))
-				assert.Check(t, is.Error(err, tc.expectedErr))
+				checkNoError(t, err)
+				return
 			}
+
+			if err == nil {
+				t.Errorf("ValidateRestartPolicy(%+v) error = nil, want %q", tc.input, tc.expectedErr)
+				return
+			}
+			if _, ok := err.(interface{ InvalidParameter() }); !ok {
+				t.Errorf("ValidateRestartPolicy(%+v) error = %T, want invalid-parameter error", tc.input, err)
+			}
+			checkError(t, err, tc.expectedErr)
 		})
 	}
-}
-
-// isInvalidParameter is a minimal implementation of [github.com/containerd/errdefs.IsInvalidArgument],
-// because this was the only import of that package in api/types, which is the
-// package imported by external users.
-func isInvalidParameter(err error) bool {
-	_, ok := err.(interface {
-		InvalidParameter()
-	})
-	return ok
 }

--- a/api/types/container/hostconfig_unix_test.go
+++ b/api/types/container/hostconfig_unix_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/types/container"
-	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestCgroupnsMode(t *testing.T) {
@@ -26,10 +24,10 @@ func TestCgroupnsMode(t *testing.T) {
 	}
 	for mode, expected := range modes {
 		t.Run("mode="+string(mode), func(t *testing.T) {
-			assert.Check(t, is.Equal(mode.IsPrivate(), expected.private))
-			assert.Check(t, is.Equal(mode.IsHost(), expected.host))
-			assert.Check(t, is.Equal(mode.IsEmpty(), expected.empty))
-			assert.Check(t, is.Equal(mode.Valid(), expected.valid))
+			checkEqual(t, mode.IsPrivate(), expected.private)
+			checkEqual(t, mode.IsHost(), expected.host)
+			checkEqual(t, mode.IsEmpty(), expected.empty)
+			checkEqual(t, mode.Valid(), expected.valid)
 		})
 	}
 }
@@ -57,9 +55,9 @@ func TestCgroupSpec(t *testing.T) {
 
 	for mode, expected := range modes {
 		t.Run("mode="+string(mode), func(t *testing.T) {
-			assert.Check(t, is.Equal(mode.Valid(), expected.valid))
-			assert.Check(t, is.Equal(mode.IsContainer(), expected.container))
-			assert.Check(t, is.Equal(mode.Container(), expected.ctrName))
+			checkEqual(t, mode.Valid(), expected.valid)
+			checkEqual(t, mode.IsContainer(), expected.container)
+			checkEqual(t, mode.Container(), expected.ctrName)
 		})
 	}
 }
@@ -88,14 +86,14 @@ func TestNetworkMode(t *testing.T) {
 	}
 	for mode, expected := range modes {
 		t.Run("mode="+string(mode), func(t *testing.T) {
-			assert.Check(t, is.Equal(mode.IsPrivate(), expected.private))
-			assert.Check(t, is.Equal(mode.IsBridge(), expected.bridge))
-			assert.Check(t, is.Equal(mode.IsHost(), expected.host))
-			assert.Check(t, is.Equal(mode.IsContainer(), expected.container))
-			assert.Check(t, is.Equal(mode.IsNone(), expected.none))
-			assert.Check(t, is.Equal(mode.IsDefault(), expected.isDefault))
-			assert.Check(t, is.Equal(mode.NetworkName(), expected.name))
-			assert.Check(t, is.Equal(mode.ConnectedContainer(), expected.ctrName))
+			checkEqual(t, mode.IsPrivate(), expected.private)
+			checkEqual(t, mode.IsBridge(), expected.bridge)
+			checkEqual(t, mode.IsHost(), expected.host)
+			checkEqual(t, mode.IsContainer(), expected.container)
+			checkEqual(t, mode.IsNone(), expected.none)
+			checkEqual(t, mode.IsDefault(), expected.isDefault)
+			checkEqual(t, mode.NetworkName(), expected.name)
+			checkEqual(t, mode.ConnectedContainer(), expected.ctrName)
 		})
 	}
 }
@@ -128,12 +126,12 @@ func TestIpcMode(t *testing.T) {
 
 	for mode, expected := range ipcModes {
 		t.Run("mode="+string(mode), func(t *testing.T) {
-			assert.Check(t, is.Equal(mode.Valid(), expected.valid))
-			assert.Check(t, is.Equal(mode.IsPrivate(), expected.private))
-			assert.Check(t, is.Equal(mode.IsHost(), expected.host))
-			assert.Check(t, is.Equal(mode.IsContainer(), expected.container))
-			assert.Check(t, is.Equal(mode.IsShareable(), expected.shareable))
-			assert.Check(t, is.Equal(mode.Container(), expected.ctrName))
+			checkEqual(t, mode.Valid(), expected.valid)
+			checkEqual(t, mode.IsPrivate(), expected.private)
+			checkEqual(t, mode.IsHost(), expected.host)
+			checkEqual(t, mode.IsContainer(), expected.container)
+			checkEqual(t, mode.IsShareable(), expected.shareable)
+			checkEqual(t, mode.Container(), expected.ctrName)
 		})
 	}
 }
@@ -152,9 +150,9 @@ func TestUTSMode(t *testing.T) {
 	}
 	for mode, expected := range modes {
 		t.Run("mode="+string(mode), func(t *testing.T) {
-			assert.Check(t, is.Equal(mode.IsPrivate(), expected.private))
-			assert.Check(t, is.Equal(mode.IsHost(), expected.host))
-			assert.Check(t, is.Equal(mode.Valid(), expected.valid))
+			checkEqual(t, mode.IsPrivate(), expected.private)
+			checkEqual(t, mode.IsHost(), expected.host)
+			checkEqual(t, mode.Valid(), expected.valid)
 		})
 	}
 }
@@ -173,9 +171,9 @@ func TestUsernsMode(t *testing.T) {
 	}
 	for mode, expected := range modes {
 		t.Run("mode="+string(mode), func(t *testing.T) {
-			assert.Check(t, is.Equal(mode.Valid(), expected.valid))
-			assert.Check(t, is.Equal(mode.IsPrivate(), expected.private))
-			assert.Check(t, is.Equal(mode.IsHost(), expected.host))
+			checkEqual(t, mode.Valid(), expected.valid)
+			checkEqual(t, mode.IsPrivate(), expected.private)
+			checkEqual(t, mode.IsHost(), expected.host)
 		})
 	}
 }
@@ -204,11 +202,11 @@ func TestPidMode(t *testing.T) {
 	}
 	for mode, expected := range modes {
 		t.Run("mode="+string(mode), func(t *testing.T) {
-			assert.Check(t, is.Equal(mode.Valid(), expected.valid))
-			assert.Check(t, is.Equal(mode.IsPrivate(), expected.private))
-			assert.Check(t, is.Equal(mode.IsHost(), expected.host))
-			assert.Check(t, is.Equal(mode.IsContainer(), expected.container))
-			assert.Check(t, is.Equal(mode.Container(), expected.ctrName))
+			checkEqual(t, mode.Valid(), expected.valid)
+			checkEqual(t, mode.IsPrivate(), expected.private)
+			checkEqual(t, mode.IsHost(), expected.host)
+			checkEqual(t, mode.IsContainer(), expected.container)
+			checkEqual(t, mode.Container(), expected.ctrName)
 		})
 	}
 }
@@ -223,9 +221,9 @@ func TestRestartPolicy(t *testing.T) {
 	}
 	for policy, expected := range policies {
 		t.Run("policy="+string(policy.Name), func(t *testing.T) {
-			assert.Check(t, is.Equal(policy.IsNone(), expected.none))
-			assert.Check(t, is.Equal(policy.IsAlways(), expected.always))
-			assert.Check(t, is.Equal(policy.IsOnFailure(), expected.onFailure))
+			checkEqual(t, policy.IsNone(), expected.none)
+			checkEqual(t, policy.IsAlways(), expected.always)
+			checkEqual(t, policy.IsOnFailure(), expected.onFailure)
 		})
 	}
 }

--- a/api/types/container/state_test.go
+++ b/api/types/container/state_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/types/container"
-	"gotest.tools/v3/assert"
 )
 
 func TestValidateContainerState(t *testing.T) {
@@ -25,9 +24,9 @@ func TestValidateContainerState(t *testing.T) {
 		t.Run(string(tc.state), func(t *testing.T) {
 			err := container.ValidateContainerState(tc.state)
 			if tc.expectedErr == "" {
-				assert.NilError(t, err)
+				checkNoError(t, err)
 			} else {
-				assert.Error(t, err, tc.expectedErr)
+				checkError(t, err, tc.expectedErr)
 			}
 		})
 	}

--- a/api/types/jsonstream/json_error_test.go
+++ b/api/types/jsonstream/json_error_test.go
@@ -4,16 +4,18 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/types/jsonstream"
-	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestError(t *testing.T) {
 	je := jsonstream.Error{Code: 404, Message: "Not found"}
-	assert.Assert(t, is.Error(&je, "Not found"))
+	if got := je.Error(); got != "Not found" {
+		t.Errorf("Error() = %q, want %q", got, "Not found")
+	}
 }
 
 func TestNilError(t *testing.T) {
 	var je *jsonstream.Error
-	assert.Assert(t, is.Error(je, "<nil>"))
+	if got := je.Error(); got != "<nil>" {
+		t.Errorf("Error() = %q, want %q", got, "<nil>")
+	}
 }

--- a/api/types/jsonstream/message_test.go
+++ b/api/types/jsonstream/message_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/types/jsonstream"
-	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
 // TestMessageMarshal is a sanity-check to make sure the struct is
@@ -29,8 +27,12 @@ func TestMessageMarshal(t *testing.T) {
 		Error: &jsonstream.Error{Code: http.StatusBadRequest, Message: "error message"},
 		Aux:   &auxM,
 	})
-	assert.NilError(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	const expected = `{"stream":"stream","status":"status","progressDetail":{"current":1,"total":2,"start":94777200,"hidecounts":true,"units":"lightyear"},"id":"id","errorDetail":{"code":400,"message":"error message"},"aux":{"aux":"aux"}}`
-	assert.Assert(t, is.Equal(string(b), expected))
+	if got := string(b); got != expected {
+		t.Errorf("json.Marshal() = %q, want %q", got, expected)
+	}
 }

--- a/api/types/network/hwaddr_test.go
+++ b/api/types/network/hwaddr_test.go
@@ -2,12 +2,15 @@ package network_test
 
 import (
 	"encoding/json"
+	"slices"
 	"testing"
 
 	"github.com/moby/moby/api/types/network"
-	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
+
+func equalHardwareAddr(a, b network.HardwareAddr) bool {
+	return (a == nil) == (b == nil) && slices.Equal(a, b)
+}
 
 func TestHardwareAddr_UnmarshalText(t *testing.T) {
 	cases := []struct {
@@ -22,10 +25,14 @@ func TestHardwareAddr_UnmarshalText(t *testing.T) {
 	for _, c := range cases {
 		a := network.HardwareAddr{0xde, 0xad, 0xbe, 0xef}
 		err := a.UnmarshalText([]byte(c.in))
-		if (c.err == "") != (err == nil) {
-			t.Errorf("UnmarshalText(%q) error = %v, want %v", c.in, err, c.err)
+		if c.err != "" {
+			assertErrorContains(t, err, c.err)
+		} else {
+			assertNoError(t, err)
 		}
-		assert.Check(t, is.DeepEqual(a, c.out), "UnmarshalText(%q)", c.in)
+		if !equalHardwareAddr(a, c.out) {
+			t.Errorf("UnmarshalText(%q) = %v, want %v", c.in, a, c.out)
+		}
 	}
 }
 
@@ -40,8 +47,8 @@ func TestHardwareAddr_MarshalText(t *testing.T) {
 	}
 	for _, c := range cases {
 		out, err := c.in.MarshalText()
-		assert.Check(t, err, "MarshalText(%v)", c.in)
-		assert.Check(t, is.Equal(string(out), c.out), "MarshalText(%v)", c.in)
+		assertNoError(t, err)
+		assertEqual(t, string(out), c.out)
 	}
 }
 
@@ -59,8 +66,8 @@ func TestHardwareAddr_MarshalJSON(t *testing.T) {
 			Mac network.HardwareAddr `json:"mac"`
 		}{c.in}
 		got, err := json.Marshal(s)
-		assert.Check(t, err, "json.Marshal(network.HardwareAddr(%v))", c.in)
-		assert.Check(t, is.Equal(string(got), c.out), "json.Marshal(network.HardwareAddr(%v))", c.in)
+		assertNoError(t, err)
+		assertEqual(t, string(got), c.out)
 	}
 }
 
@@ -79,9 +86,13 @@ func TestHardwareAddr_UnmarshalJSON(t *testing.T) {
 			Mac network.HardwareAddr `json:"mac"`
 		}{network.HardwareAddr{0xde, 0xad, 0xbe, 0xef}}
 		err := json.Unmarshal([]byte(c.in), &s)
-		if (c.err == "") != (err == nil) {
-			t.Errorf("json.Unmarshal(%q) error = %v, want %v", c.in, err, c.err)
+		if c.err != "" {
+			assertErrorContains(t, err, c.err)
+		} else {
+			assertNoError(t, err)
 		}
-		assert.Check(t, is.DeepEqual(s.Mac, c.out), "json.Unmarshal(%q)", c.in)
+		if !equalHardwareAddr(s.Mac, c.out) {
+			t.Errorf("json.Unmarshal(%q) = %v, want %v", c.in, s.Mac, c.out)
+		}
 	}
 }

--- a/api/types/network/port_test.go
+++ b/api/types/network/port_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"gotest.tools/v3/assert"
-
 	"github.com/moby/moby/api/types/network"
 )
 
@@ -25,34 +23,34 @@ var (
 func TestPort(t *testing.T) {
 	t.Run("Zero Value", func(t *testing.T) {
 		var p network.Port
-		assert.Check(t, p.IsZero())
-		assert.Check(t, !p.IsValid())
-		assert.Equal(t, p.String(), "invalid port")
-		assert.Equal(t, p.Proto(), network.IPProtocol(""))
-		assert.Equal(t, p.Num(), uint16(0))
-		assert.Equal(t, p.Port(), "")
-		assert.Equal(t, p.Range(), network.PortRange{})
+		assertEqual(t, p.IsZero(), true)
+		assertEqual(t, p.IsValid(), false)
+		assertEqual(t, p.String(), "invalid port")
+		assertEqual(t, p.Proto(), network.IPProtocol(""))
+		assertEqual(t, p.Num(), uint16(0))
+		assertEqual(t, p.Port(), "")
+		assertEqual(t, p.Range(), network.PortRange{})
 
 		t.Run("Marshal Unmarshal", func(t *testing.T) {
 			var p network.Port
 			bytes, err := p.MarshalText()
-			assert.NilError(t, err)
-			assert.Check(t, len(bytes) == 0)
+			assertNoError(t, err)
+			assertEqual(t, len(bytes), 0)
 
 			err = p.UnmarshalText([]byte(""))
-			assert.NilError(t, err)
-			assert.Equal(t, p, network.Port{})
+			assertNoError(t, err)
+			assertEqual(t, p, network.Port{})
 		})
 
 		t.Run("JSON Marshal Unmarshal", func(t *testing.T) {
 			var p network.Port
 			bytes, err := json.Marshal(p)
-			assert.NilError(t, err)
-			assert.Equal(t, string(bytes), `""`)
+			assertNoError(t, err)
+			assertEqual(t, string(bytes), `""`)
 
 			err = json.Unmarshal([]byte(`""`), &p)
-			assert.NilError(t, err)
-			assert.Equal(t, p, network.Port{})
+			assertNoError(t, err)
+			assertEqual(t, p, network.Port{})
 		})
 	})
 
@@ -72,10 +70,10 @@ func TestPort(t *testing.T) {
 		for _, tc := range tests {
 			t.Run(fmt.Sprintf("%d_%s", tc.num, tc.proto), func(t *testing.T) {
 				p, ok := network.PortFrom(tc.num, tc.proto)
-				assert.Check(t, ok)
-				assert.Equal(t, p.Num(), tc.num)
-				assert.Equal(t, p.Port(), strconv.Itoa(int(tc.num)))
-				assert.Equal(t, p.Proto(), tc.proto)
+				assertEqual(t, ok, true)
+				assertEqual(t, p.Num(), tc.num)
+				assertEqual(t, p.Port(), strconv.Itoa(int(tc.num)))
+				assertEqual(t, p.Proto(), tc.proto)
 			})
 		}
 
@@ -83,8 +81,8 @@ func TestPort(t *testing.T) {
 			pr1 := portFrom(1234, "tcp")
 			pr2 := portFrom(1234, "TCP")
 			pr3 := portFrom(1234, "tCp")
-			assert.Equal(t, pr1, pr2)
-			assert.Equal(t, pr2, pr3)
+			assertEqual(t, pr1, pr2)
+			assertEqual(t, pr2, pr3)
 		})
 
 		negativeTests := []struct {
@@ -97,10 +95,10 @@ func TestPort(t *testing.T) {
 		for _, tc := range negativeTests {
 			t.Run(fmt.Sprintf("%d_%s", tc.num, tc.proto), func(t *testing.T) {
 				p, ok := network.PortFrom(tc.num, tc.proto)
-				assert.Check(t, !ok)
-				assert.Check(t, p.IsZero())
-				assert.Check(t, !p.IsValid())
-				assert.Equal(t, p.String(), "invalid port")
+				assertEqual(t, ok, false)
+				assertEqual(t, p.IsZero(), true)
+				assertEqual(t, p.IsValid(), false)
+				assertEqual(t, p.String(), "invalid port")
 			})
 		}
 	})
@@ -170,23 +168,23 @@ func TestPort(t *testing.T) {
 		for _, tc := range tests {
 			t.Run(strings.ReplaceAll(tc.in, "/", "_"), func(t *testing.T) {
 				got, err := network.ParsePort(tc.in)
-				assert.NilError(t, err)
-				assert.Equal(t, got, tc.port)
+				assertNoError(t, err)
+				assertEqual(t, got, tc.port)
 
 				network.MustParsePort(tc.in) // should not panic
 
-				assert.Check(t, !got.IsZero())
-				assert.Check(t, got.IsValid())
+				assertEqual(t, got.IsZero(), false)
+				assertEqual(t, got.IsValid(), true)
 
 				// Check that ParsePort is a pure function.
 				got2, err := network.ParsePort(tc.in)
-				assert.NilError(t, err)
-				assert.Equal(t, got2, got)
+				assertNoError(t, err)
+				assertEqual(t, got2, got)
 
 				// Check that ParsePort(port.String()) is the identity function.
 				got3, err := network.ParsePort(got.String())
-				assert.NilError(t, err)
-				assert.Equal(t, got3, got)
+				assertNoError(t, err)
+				assertEqual(t, got3, got)
 
 				// Check String() output
 				s := got.String()
@@ -194,23 +192,23 @@ func TestPort(t *testing.T) {
 				if wants == "" {
 					wants = tc.in
 				}
-				assert.Equal(t, s, wants)
+				assertEqual(t, s, wants)
 
 				js := `"` + tc.in + `"`
 				var jsgot network.Port
 				err = json.Unmarshal([]byte(js), &jsgot)
-				assert.NilError(t, err)
-				assert.Equal(t, jsgot, got)
+				assertNoError(t, err)
+				assertEqual(t, jsgot, got)
 
 				jsb, err := json.Marshal(jsgot)
-				assert.NilError(t, err)
+				assertNoError(t, err)
 
 				jswant := `"` + wants + `"`
-				assert.Equal(t, string(jsb), jswant)
+				assertEqual(t, string(jsb), jswant)
 
 				// Check Range() output
 				r := got.Range()
-				assert.Equal(t, r, tc.portRange)
+				assertEqual(t, r, tc.portRange)
 			})
 		}
 
@@ -218,8 +216,8 @@ func TestPort(t *testing.T) {
 			p1 := network.MustParsePort("1234/tcp")
 			p2 := network.MustParsePort("1234/TCP")
 			p3 := network.MustParsePort("1234/tCp")
-			assert.Equal(t, p1, p2)
-			assert.Equal(t, p2, p3)
+			assertEqual(t, p1, p2)
+			assertEqual(t, p2, p3)
 		})
 
 		negativeTests := []string{
@@ -248,9 +246,9 @@ func TestPort(t *testing.T) {
 		for _, s := range negativeTests {
 			t.Run(strings.ReplaceAll(s, "/", "_"), func(t *testing.T) {
 				got, err := network.ParsePort(s)
-				assert.ErrorContains(t, err, "invalid port")
-				assert.Check(t, got.IsZero())
-				assert.Check(t, !got.IsValid())
+				assertErrorContains(t, err, "invalid port")
+				assertEqual(t, got.IsZero(), true)
+				assertEqual(t, got.IsValid(), false)
 
 				// Skip JSON unmarshalling test for empty string as that should succeed.
 				// See test "Zero Value" above.
@@ -261,8 +259,8 @@ func TestPort(t *testing.T) {
 				var jsGot network.Port
 				js := []byte(`"` + s + `"`)
 				err = json.Unmarshal(js, &jsGot)
-				assert.ErrorContains(t, err, "invalid port")
-				assert.Equal(t, jsGot, network.Port{})
+				assertErrorContains(t, err, "invalid port")
+				assertEqual(t, jsGot, network.Port{})
 			})
 		}
 	})
@@ -271,36 +269,38 @@ func TestPort(t *testing.T) {
 func TestPortRange(t *testing.T) {
 	t.Run("Zero Value", func(t *testing.T) {
 		var pr network.PortRange
-		assert.Check(t, pr.IsZero())
-		assert.Check(t, !pr.IsValid())
-		assert.Equal(t, pr.String(), "invalid port range")
-		assert.Equal(t, pr.Start(), uint16(0))
-		assert.Equal(t, pr.End(), uint16(0))
-		assert.Equal(t, pr.Proto(), network.IPProtocol(""))
-		assert.Equal(t, pr.Range(), pr)
+		assertEqual(t, pr.IsZero(), true)
+		assertEqual(t, pr.IsValid(), false)
+		assertEqual(t, pr.String(), "invalid port range")
+		assertEqual(t, pr.Start(), uint16(0))
+		assertEqual(t, pr.End(), uint16(0))
+		assertEqual(t, pr.Proto(), network.IPProtocol(""))
+		assertEqual(t, pr.Range(), pr)
 		var ephemeralPort network.Port
-		assert.Check(t, slices.Equal(slices.Collect(pr.All()), []network.Port{ephemeralPort}))
+		if got := slices.Collect(pr.All()); !slices.Equal(got, []network.Port{ephemeralPort}) {
+			t.Errorf("PortRange.All() = %#v, want %#v", got, []network.Port{ephemeralPort})
+		}
 
 		t.Run("Marshal Unmarshal", func(t *testing.T) {
 			var pr network.PortRange
 			bytes, err := pr.MarshalText()
-			assert.NilError(t, err)
-			assert.Check(t, len(bytes) == 0)
+			assertNoError(t, err)
+			assertEqual(t, len(bytes), 0)
 
 			err = pr.UnmarshalText([]byte(""))
-			assert.NilError(t, err)
-			assert.Equal(t, pr, network.PortRange{})
+			assertNoError(t, err)
+			assertEqual(t, pr, network.PortRange{})
 		})
 
 		t.Run("JSON Marshal Unmarshal", func(t *testing.T) {
 			var pr network.PortRange
 			bytes, err := json.Marshal(pr)
-			assert.NilError(t, err)
-			assert.Equal(t, string(bytes), `""`)
+			assertNoError(t, err)
+			assertEqual(t, string(bytes), `""`)
 
 			err = json.Unmarshal([]byte(`""`), &pr)
-			assert.NilError(t, err)
-			assert.Equal(t, pr, network.PortRange{})
+			assertNoError(t, err)
+			assertEqual(t, pr, network.PortRange{})
 		})
 	})
 
@@ -322,10 +322,10 @@ func TestPortRange(t *testing.T) {
 		for _, tc := range tests {
 			t.Run(fmt.Sprintf("%d_%d_%s", tc.start, tc.end, tc.proto), func(t *testing.T) {
 				pr, ok := network.PortRangeFrom(tc.start, tc.end, tc.proto)
-				assert.Check(t, ok)
-				assert.Equal(t, pr.Start(), tc.start)
-				assert.Equal(t, pr.End(), tc.end)
-				assert.Equal(t, pr.Proto(), tc.proto)
+				assertEqual(t, ok, true)
+				assertEqual(t, pr.Start(), tc.start)
+				assertEqual(t, pr.End(), tc.end)
+				assertEqual(t, pr.Proto(), tc.proto)
 			})
 		}
 
@@ -333,8 +333,8 @@ func TestPortRange(t *testing.T) {
 			pr1, _ := network.PortRangeFrom(1234, 5678, "tcp")
 			pr2, _ := network.PortRangeFrom(1234, 5678, "TCP")
 			pr3, _ := network.PortRangeFrom(1234, 5678, "tCp")
-			assert.Equal(t, pr1, pr2)
-			assert.Equal(t, pr2, pr3)
+			assertEqual(t, pr1, pr2)
+			assertEqual(t, pr2, pr3)
 		})
 
 		negativeTests := []struct {
@@ -348,9 +348,9 @@ func TestPortRange(t *testing.T) {
 		for _, tc := range negativeTests {
 			t.Run(fmt.Sprintf("%d_%d_%s", tc.start, tc.end, tc.proto), func(t *testing.T) {
 				pr, ok := network.PortRangeFrom(tc.start, tc.end, tc.proto)
-				assert.Check(t, !ok)
-				assert.Check(t, pr.IsZero())
-				assert.Check(t, !pr.IsValid())
+				assertEqual(t, ok, false)
+				assertEqual(t, pr.IsZero(), true)
+				assertEqual(t, pr.IsValid(), false)
 			})
 		}
 	})
@@ -416,22 +416,22 @@ func TestPortRange(t *testing.T) {
 		for _, tc := range tests {
 			t.Run(strings.ReplaceAll(tc.in, "/", "_"), func(t *testing.T) {
 				got, err := network.ParsePortRange(tc.in)
-				assert.NilError(t, err)
-				assert.Equal(t, got, tc.portRange)
-				assert.Check(t, !got.IsZero())
-				assert.Check(t, got.IsValid())
+				assertNoError(t, err)
+				assertEqual(t, got, tc.portRange)
+				assertEqual(t, got.IsZero(), false)
+				assertEqual(t, got.IsValid(), true)
 
 				network.MustParsePortRange(tc.in) // should not panic
 
 				// Check that ParsePortRange is a pure function.
 				got2, err := network.ParsePortRange(tc.in)
-				assert.NilError(t, err)
-				assert.Equal(t, got2, got)
+				assertNoError(t, err)
+				assertEqual(t, got2, got)
 
 				// Check that ParsePortRange(port.String()) is the identity function.
 				got3, err := network.ParsePortRange(got.String())
-				assert.NilError(t, err)
-				assert.Equal(t, got3, got)
+				assertNoError(t, err)
+				assertEqual(t, got3, got)
 
 				// Check String() output
 				s := got.String()
@@ -439,30 +439,30 @@ func TestPortRange(t *testing.T) {
 				if wants == "" {
 					wants = tc.in
 				}
-				assert.Equal(t, s, wants)
+				assertEqual(t, s, wants)
 
 				js := `"` + tc.in + `"`
 				var jsgot network.PortRange
 				err = json.Unmarshal([]byte(js), &jsgot)
-				assert.NilError(t, err)
-				assert.Equal(t, jsgot, got)
+				assertNoError(t, err)
+				assertEqual(t, jsgot, got)
 
 				jsb, err := json.Marshal(jsgot)
-				assert.NilError(t, err)
+				assertNoError(t, err)
 				jswant := `"` + wants + `"`
-				assert.Equal(t, string(jsb), jswant)
+				assertEqual(t, string(jsb), jswant)
 
 				// Check Range() output
 				r := got.Range()
-				assert.Equal(t, r, tc.portRange)
+				assertEqual(t, r, tc.portRange)
 			})
 
 			t.Run("Normalize Protocol", func(t *testing.T) {
 				pr1 := network.MustParsePortRange("1234-5678/tcp")
 				pr2 := network.MustParsePortRange("1234-5678/TCP")
 				pr3 := network.MustParsePortRange("1234-5678/tCp")
-				assert.Equal(t, pr1, pr2)
-				assert.Equal(t, pr2, pr3)
+				assertEqual(t, pr1, pr2)
+				assertEqual(t, pr2, pr3)
 			})
 
 			negativeTests := []string{
@@ -495,9 +495,11 @@ func TestPortRange(t *testing.T) {
 			for _, s := range negativeTests {
 				t.Run(strings.ReplaceAll(s, "/", "_"), func(t *testing.T) {
 					got, err := network.ParsePortRange(s)
-					assert.Check(t, err != nil)
-					assert.Check(t, got.IsZero())
-					assert.Check(t, !got.IsValid())
+					if err == nil {
+						t.Error("expected error")
+					}
+					assertEqual(t, got.IsZero(), true)
+					assertEqual(t, got.IsValid(), false)
 
 					// Skip JSON unmarshalling test for empty string as that should succeed.
 					// See test "Zero Value" above.
@@ -508,8 +510,10 @@ func TestPortRange(t *testing.T) {
 					var jsgot network.PortRange
 					js := []byte(`"` + s + `"`)
 					err = json.Unmarshal(js, &jsgot)
-					assert.Check(t, err != nil)
-					assert.Equal(t, jsgot, network.PortRange{})
+					if err == nil {
+						t.Error("expected error")
+					}
+					assertEqual(t, jsgot, network.PortRange{})
 				})
 			}
 		}
@@ -595,6 +599,29 @@ func BenchmarkPortRangeAll(b *testing.B) {
 			}
 		}
 	})
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertErrorContains(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error containing %q, got nil", want)
+	} else if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %q, want error containing %q", err, want)
+	}
+}
+
+func assertEqual[T comparable](t *testing.T, got, want T) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("got %v, want %v", got, want)
+	}
 }
 
 func portFrom(num uint16, proto network.IPProtocol) network.Port {

--- a/api/types/plugin/capability_test.go
+++ b/api/types/plugin/capability_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/types/plugin"
-	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 	"pgregory.net/rapid"
 )
 
@@ -56,16 +54,25 @@ func TestCapabilityID_MarshalUnmarshal(t *testing.T) {
 		t.Logf("InterfaceType(%q)", b)
 
 		var roundtrip plugin.CapabilityID
-		err = roundtrip.UnmarshalText(b)
-		assert.Assert(t, err)
-		assert.Assert(t, is.DeepEqual(typ, roundtrip))
+		if err := roundtrip.UnmarshalText(b); err != nil {
+			t.Fatal(err)
+		}
+		if typ != roundtrip {
+			t.Errorf("roundtrip = %+v, want %+v", roundtrip, typ)
+		}
 
 		jb, err := json.Marshal(string(b))
-		assert.Assert(t, err)
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		var oldparser pluginCapabilityID
-		err = oldparser.unmarshalJSON(jb)
-		assert.Assert(t, err)
-		assert.Assert(t, is.DeepEqual(typ, plugin.CapabilityID(oldparser)), "new parser does not match the old parser")
+		if err := oldparser.unmarshalJSON(jb); err != nil {
+			t.Fatal(err)
+		}
+		if typ != plugin.CapabilityID(oldparser) {
+			t.Errorf("new parser = %+v, old parser = %+v", typ, oldparser)
+		}
 	})
 }
 
@@ -81,11 +88,16 @@ func TestCapabilityID_JSONMarshalUnmarshal(t *testing.T) {
 		},
 	}
 	b, err := json.Marshal(a)
-	assert.Assert(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Logf("JSON: %s", b)
 
 	var roundtrip rt
-	err = json.Unmarshal(b, &roundtrip)
-	assert.Assert(t, err)
-	assert.Assert(t, is.DeepEqual(a, roundtrip))
+	if err := json.Unmarshal(b, &roundtrip); err != nil {
+		t.Fatal(err)
+	}
+	if a != roundtrip {
+		t.Errorf("roundtrip = %+v, want %+v", roundtrip, a)
+	}
 }

--- a/api/types/swarm/network_test.go
+++ b/api/types/swarm/network_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/api/types/swarm"
-	"gotest.tools/v3/assert"
 )
 
 func TestPortConfigCompareSort(t *testing.T) {
@@ -88,7 +87,9 @@ func TestPortConfigCompareSort(t *testing.T) {
 		t.Run(tc.doc, func(t *testing.T) {
 			got := slices.Clone(tc.ports)
 			slices.SortFunc(got, swarm.PortConfig.Compare)
-			assert.DeepEqual(t, tc.expected, got)
+			if !slices.Equal(got, tc.expected) {
+				t.Errorf("sorted ports = %#v, want %#v", got, tc.expected)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Most tests only did minimal assertions, which could be replaced with stdlib.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
