### PR TITLE
libnetwork: handle duplicate interface name suffixes

### DIFF
--- a/daemon/libnetwork/osl/interface_linux.go
+++ b/daemon/libnetwork/osl/interface_linux.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -406,7 +405,8 @@ func (n *Namespace) generateIfaceName(prefix string) string {
 		}
 	}
 
-	sort.Ints(suffixes)
+	slices.Sort(suffixes)
+	suffixes = slices.Compact(suffixes)
 
 	// There are gaps in the numbering; find the first unused number.
 	//
@@ -415,8 +415,8 @@ func (n *Namespace) generateIfaceName(prefix string) string {
 	// name overflow the IFNAMSIZ limit (= 16 chars), the kernel would reject
 	// that interface name while there are other unused numbers. So, instead
 	// use the lowest suffix available.
-	for i := 0; i < len(suffixes); i++ {
-		if i != suffixes[i] {
+	for i, suffix := range suffixes {
+		if i != suffix {
 			return prefix + strconv.Itoa(i)
 		}
 	}

--- a/daemon/libnetwork/osl/interface_linux_test.go
+++ b/daemon/libnetwork/osl/interface_linux_test.go
@@ -26,7 +26,8 @@ func TestGenerateIfaceName(t *testing.T) {
 		{names: []string{"test0", "test2"}, want: "test1"},
 		{names: []string{"test2"}, want: "test0"},
 		{names: []string{"test-0", "test-1"}, want: "test0"},
-		{names: []string{}, want: "test0"},
+		{names: []string{"test0", "test0", "test1"}, want: "test2"},
+		{names: nil, want: "test0"},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
Deduplicate interface name suffixes before looking for the first unused number.

Previously, duplicate suffixes shifted the slice index used to detect gaps and could cause generateIfaceName to return a name that was already in use.

Also use slices.Sort for sorting the suffixes.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
