### PR TITLE
daemon: add annotation filter for container list

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -15,6 +15,10 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 ## v1.56 API changes
 
+* `GET /containers/json` now supports an `annotation` filter to filter
+  containers by annotation, either by key (`annotation=key`) or by key and
+  value (`annotation="key=value"`), similar to the existing `label` filter.
+
 ## v1.55 API changes
 
 * `GET /images/{name}/attestations` is a new endpoint that returns the in-toto

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8365,6 +8365,7 @@ paths:
             Available filters:
 
             - `ancestor`=(`<image-name>[:<tag>]`, `<image id>`, or `<image@digest>`)
+            - `annotation=key` or `annotation="key=value"` of a container annotation
             - `before`=(`<container id>` or `<container name>`)
             - `expose`=(`<port>[/<proto>]`|`<startport-endport>/[<proto>]`)
             - `exited=<int>` containers with exit code of `<int>`

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -24,21 +24,22 @@ import (
 )
 
 var acceptedPsFilterTags = map[string]bool{
-	"ancestor":  true,
-	"before":    true,
-	"exited":    true,
-	"id":        true,
-	"isolation": true,
-	"label":     true,
-	"name":      true,
-	"status":    true,
-	"health":    true,
-	"since":     true,
-	"volume":    true,
-	"network":   true,
-	"is-task":   true,
-	"publish":   true,
-	"expose":    true,
+	"ancestor":   true,
+	"annotation": true,
+	"before":     true,
+	"exited":     true,
+	"id":         true,
+	"isolation":  true,
+	"label":      true,
+	"name":       true,
+	"status":     true,
+	"health":     true,
+	"since":      true,
+	"volume":     true,
+	"network":    true,
+	"is-task":    true,
+	"publish":    true,
+	"expose":     true,
 }
 
 // iterationAction represents possible outcomes happening during the container iteration.
@@ -455,6 +456,11 @@ func includeContainerInList(container *container.Snapshot, filter *listContext) 
 
 	// Do not include container if any of the labels don't match
 	if !filter.filters.MatchKVList("label", container.Labels) {
+		return excludeContainer
+	}
+
+	// Do not include container if any of the annotations don't match
+	if !filter.filters.MatchKVList("annotation", container.Summary.HostConfig.Annotations) {
 		return excludeContainer
 	}
 

--- a/daemon/list_test.go
+++ b/daemon/list_test.go
@@ -184,6 +184,70 @@ func TestContainerList_NameFilter(t *testing.T) {
 	assert.Assert(t, containerListContainsName(containerListWithPrefix, three.Name))
 }
 
+func TestContainerList_AnnotationFilter(t *testing.T) {
+	db, err := container.NewViewDB()
+	assert.NilError(t, err)
+	d := &Daemon{
+		containersReplica: db,
+	}
+
+	one := setupContainerWithName(t, "a1", d)
+	one.HostConfig.Annotations = map[string]string{"annotation1": "value1"}
+	assert.NilError(t, db.Save(one))
+
+	two := setupContainerWithName(t, "a2", d)
+	two.HostConfig.Annotations = map[string]string{"annotation1": "value2", "annotation2": "value1"}
+	assert.NilError(t, db.Save(two))
+
+	// no annotations
+	three := setupContainerWithName(t, "b1", d)
+
+	tests := []struct {
+		doc      string
+		filters  []filters.KeyValuePair
+		expected []string
+	}{
+		{
+			doc:      "by key",
+			filters:  []filters.KeyValuePair{filters.Arg("annotation", "annotation1")},
+			expected: []string{one.Name, two.Name},
+		},
+		{
+			doc:      "by key and value",
+			filters:  []filters.KeyValuePair{filters.Arg("annotation", "annotation1=value1")},
+			expected: []string{one.Name},
+		},
+		{
+			doc: "multiple annotations",
+			filters: []filters.KeyValuePair{
+				filters.Arg("annotation", "annotation1"),
+				filters.Arg("annotation", "annotation2=value1"),
+			},
+			expected: []string{two.Name},
+		},
+		{
+			doc:      "no match",
+			filters:  []filters.KeyValuePair{filters.Arg("annotation", "annotation1=other")},
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			containerList, err := d.Containers(context.Background(), &backend.ContainerListOptions{
+				All:     true,
+				Filters: filters.NewArgs(tc.filters...),
+			})
+			assert.NilError(t, err)
+			assert.Assert(t, is.Len(containerList, len(tc.expected)))
+			for _, name := range tc.expected {
+				assert.Assert(t, containerListContainsName(containerList, name))
+			}
+			assert.Assert(t, !containerListContainsName(containerList, three.Name))
+		})
+	}
+}
+
 func TestContainerList_LimitFilter(t *testing.T) {
 	db, err := container.NewViewDB()
 	assert.NilError(t, err)

--- a/integration/container/list_test.go
+++ b/integration/container/list_test.go
@@ -81,6 +81,53 @@ func TestContainerList_Annotations(t *testing.T) {
 	}
 }
 
+func TestContainerList_AnnotationFilter(t *testing.T) {
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	annotated := container.Create(ctx, t, apiClient, container.WithAnnotations(map[string]string{"com.example.key": "value"}))
+	defer container.Remove(ctx, t, apiClient, annotated, client.ContainerRemoveOptions{Force: true})
+	plain := container.Create(ctx, t, apiClient)
+	defer container.Remove(ctx, t, apiClient, plain, client.ContainerRemoveOptions{Force: true})
+
+	tests := []struct {
+		doc      string
+		filter   string
+		expected []string
+	}{
+		{
+			doc:      "by key",
+			filter:   "com.example.key",
+			expected: []string{annotated},
+		},
+		{
+			doc:      "by key and value",
+			filter:   "com.example.key=value",
+			expected: []string{annotated},
+		},
+		{
+			doc:      "no match",
+			filter:   "com.example.key=other",
+			expected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			ctx := testutil.StartSpan(ctx, t)
+			list, err := apiClient.ContainerList(ctx, client.ContainerListOptions{
+				All:     true,
+				Filters: make(client.Filters).Add("annotation", tc.filter),
+			})
+			assert.NilError(t, err)
+			assert.Assert(t, is.Len(list.Items, len(tc.expected)))
+			for i, id := range tc.expected {
+				assert.Check(t, is.Equal(list.Items[i].ID, id))
+			}
+		})
+	}
+}
+
 func TestContainerList_Filter(t *testing.T) {
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()


### PR DESCRIPTION
## Summary

Add an `annotation` filter to `GET /containers/json` (`docker ps --filter`), matching the semantics of the existing `label` filter: `annotation=key` matches containers carrying the annotation key, and `annotation="key=value"` also matches its value.

## Release notes (optional)

```markdown changelog
Add `annotation` filter to container listings (`docker ps`, `GET /containers/json`) allowing to filter containers by their annotations.
```

Created with: Claude Code
