### PR TITLE
daemon/graphdriver: rewrite asserts with slices and cmpopts

### DIFF
--- a/daemon/graphdriver/graphtest/graphtest_unix.go
+++ b/daemon/graphdriver/graphtest/graphtest_unix.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/docker/go-units"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/moby/go-archive"
 	"github.com/moby/moby/v2/daemon/graphdriver"
 	"github.com/moby/moby/v2/daemon/internal/quota"
 	"github.com/moby/moby/v2/daemon/internal/stringid"
@@ -293,9 +295,12 @@ func DriverTestChanges(t testing.TB, drivername string, driverOptions ...string)
 		t.Fatal(err)
 	}
 
-	if err = checkChanges(expectedChanges, changes); err != nil {
-		t.Fatal(err)
-	}
+	assert.DeepEqual(t, changes, expectedChanges, cmpopts.SortSlices(func(a, b archive.Change) bool {
+		if a.Path != b.Path {
+			return a.Path < b.Path
+		}
+		return a.Kind < b.Kind
+	}))
 }
 
 func writeRandomFile(path string, size uint64) error {

--- a/daemon/graphdriver/graphtest/testutil.go
+++ b/daemon/graphdriver/graphtest/testutil.go
@@ -7,7 +7,6 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"sort"
 
 	"github.com/moby/go-archive"
 	"github.com/moby/moby/v2/daemon/graphdriver"
@@ -214,33 +213,6 @@ func checkManyFiles(drv graphdriver.Driver, layer string, count int, seed int64)
 			if !bytes.Equal(fileContent, content) {
 				return fmt.Errorf("mismatched file content %v, expecting %v", fileContent, content)
 			}
-		}
-	}
-
-	return nil
-}
-
-type changeList []archive.Change
-
-func (c changeList) Less(i, j int) bool {
-	if c[i].Path == c[j].Path {
-		return c[i].Kind < c[j].Kind
-	}
-	return c[i].Path < c[j].Path
-}
-func (c changeList) Len() int      { return len(c) }
-func (c changeList) Swap(i, j int) { c[j], c[i] = c[i], c[j] }
-
-func checkChanges(expected, actual []archive.Change) error {
-	if len(expected) != len(actual) {
-		return fmt.Errorf("unexpected number of changes, expected %d, got %d", len(expected), len(actual))
-	}
-	sort.Sort(changeList(expected))
-	sort.Sort(changeList(actual))
-
-	for i := range expected {
-		if expected[i] != actual[i] {
-			return fmt.Errorf("unexpected change, expecting %v, got %v", expected[i], actual[i])
 		}
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
