### PR TITLE
daemon/libnetwork: remove dnsnames migration code

### DIFF
--- a/daemon/libnetwork/endpoint.go
+++ b/daemon/libnetwork/endpoint.go
@@ -21,7 +21,6 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork/netlabel"
 	"github.com/moby/moby/v2/daemon/libnetwork/scope"
 	"github.com/moby/moby/v2/daemon/libnetwork/types"
-	"github.com/moby/moby/v2/internal/sliceutil"
 	"go.opentelemetry.io/otel"
 )
 
@@ -208,10 +207,6 @@ func (ep *Endpoint) UnmarshalJSON(b []byte) (err error) {
 		}
 	}
 
-	var anonymous bool
-	if v, ok := epMap["anonymous"]; ok {
-		anonymous = v.(bool)
-	}
 	if v, ok := epMap["disableResolution"]; ok {
 		ep.disableResolution = v.(bool)
 	}
@@ -249,21 +244,10 @@ func (ep *Endpoint) UnmarshalJSON(b []byte) (err error) {
 	var myAliases []string
 	_ = json.Unmarshal(ma, &myAliases) //nolint:errcheck
 
-	_, hasDNSNames := epMap["dnsNames"]
 	dn, _ := json.Marshal(epMap["dnsNames"]) //nolint:errchkjson // FIXME: handle json (Un)Marshal errors (see above)
 	var dnsNames []string
 	_ = json.Unmarshal(dn, &dnsNames) //nolint:errcheck
 	ep.dnsNames = dnsNames
-
-	// TODO(aker): remove this migration code in v27
-	if !hasDNSNames {
-		// The field dnsNames was introduced in v25.0. If we don't have it, the on-disk state was written by an older
-		// daemon, thus we need to populate dnsNames based off of myAliases and anonymous values.
-		if !anonymous {
-			myAliases = append([]string{ep.name}, myAliases...)
-		}
-		ep.dnsNames = sliceutil.Dedup(myAliases)
-	}
 
 	return nil
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46853

This code was added in f5cc497eac4cdacbb806978cc2de018244c06e98 to address upgrades with live-restore enabled, and marked for removal in Docker v27.0.

> libnet: populate Endpoint.dnsNames on UnmarshalJSON
>
> This new property will be empty if the daemon was upgraded with
> live-restore enabled. To not break DNS resolutions for restored
> containers, we need to populate dnsNames based on endpoint's myAliases &
> anonymous properties.

This reverts f5cc497eac4cdacbb806978cc2de018244c06e98

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
