### PR TITLE
daemon/logger: use stdlib errors

### DIFF
--- a/daemon/logger/adapter.go
+++ b/daemon/logger/adapter.go
@@ -2,6 +2,8 @@ package logger
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,7 +13,6 @@ import (
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/logger/internal/logdriver"
 	"github.com/moby/moby/v2/pkg/plugingetter"
-	"github.com/pkg/errors"
 )
 
 // pluginAdapter takes a plugin and implements the Logger interface for logger
@@ -82,7 +83,7 @@ func (a *pluginAdapter) Close() error {
 
 	// may be nil, especially for unit tests
 	if pluginGetter != nil {
-		pluginGetter.Get(a.Name(), extName, plugingetter.Release)
+		_, _ = pluginGetter.Get(a.Name(), extName, plugingetter.Release)
 	}
 	return nil
 }
@@ -98,10 +99,10 @@ func (a *pluginAdapterWithRead) ReadLogs(ctx context.Context, config ReadConfig)
 		defer close(watcher.Msg)
 		stream, err := a.plugin.ReadLogs(a.logInfo, config)
 		if err != nil {
-			watcher.Err <- errors.Wrap(err, "error getting log reader")
+			watcher.Err <- fmt.Errorf("error getting log reader: %w", err)
 			return
 		}
-		defer stream.Close()
+		defer func() { _ = stream.Close() }()
 
 		dec := logdriver.NewLogEntryDecoder(stream)
 		for {
@@ -114,7 +115,7 @@ func (a *pluginAdapterWithRead) ReadLogs(ctx context.Context, config ReadConfig)
 				if errors.Is(err, io.EOF) {
 					return
 				}
-				watcher.Err <- errors.Wrap(err, "error decoding log message")
+				watcher.Err <- fmt.Errorf("error decoding log message: %w", err)
 				return
 			}
 

--- a/daemon/logger/factory.go
+++ b/daemon/logger/factory.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/go-units"
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/v2/pkg/plugingetter"
-	"github.com/pkg/errors"
 )
 
 // Creator builds a logging driver instance with given context.
@@ -94,7 +93,7 @@ func (lf *logdriverFactory) get(name string) (Creator, error) {
 	}
 
 	c, err := getPlugin(name, plugingetter.Acquire)
-	return c, errors.Wrapf(err, "logger: no log driver named '%s' is registered", name)
+	return c, fmt.Errorf("logger: no log driver named '%s' is registered: %w", name, err)
 }
 
 func (lf *logdriverFactory) getLogOptValidator(name string) LogOptValidator {
@@ -147,7 +146,7 @@ func ValidateLogOpts(name string, cfg map[string]string) error {
 			return fmt.Errorf("logger: max-buffer-size option is only supported with 'mode=%s'", containertypes.LogModeNonBlock)
 		}
 		if _, err := units.RAMInBytes(s); err != nil {
-			return errors.Wrap(err, "error parsing option max-buffer-size")
+			return fmt.Errorf("error parsing option max-buffer-size: %w", err)
 		}
 	}
 

--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -4,6 +4,8 @@ package fluentd
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"maps"
 	"math"
 	"net/url"
@@ -17,7 +19,6 @@ import (
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/logger/loggerutils"
 	"github.com/moby/moby/v2/errdefs"
-	"github.com/pkg/errors"
 )
 
 type fluentd struct {
@@ -160,7 +161,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case readTimeoutKey:
 			// Accepted
 		default:
-			return errors.Errorf("unknown log opt '%s' for fluentd log driver", key)
+			return fmt.Errorf("unknown log opt '%s' for fluentd log driver", key)
 		}
 	}
 
@@ -173,7 +174,7 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 
 	loc, err := parseAddress(cfg[addressKey])
 	if err != nil {
-		return config, errors.Wrapf(err, "invalid fluentd-address (%s)", cfg[addressKey])
+		return config, fmt.Errorf("invalid fluentd-address (%s): %w", cfg[addressKey], err)
 	}
 
 	bufferLimit := defaultBufferLimit
@@ -220,11 +221,11 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 	if cfg[asyncReconnectIntervalKey] != "" {
 		interval, err := time.ParseDuration(cfg[asyncReconnectIntervalKey])
 		if err != nil {
-			return config, errors.Wrapf(err, "invalid value for %s", asyncReconnectIntervalKey)
+			return config, fmt.Errorf("invalid value for %s: %w", asyncReconnectIntervalKey, err)
 		}
 		if interval != 0 {
 			if interval < minReconnectInterval || interval > maxReconnectInterval {
-				return config, errors.Errorf("invalid value for %s: value (%q) must be between %s and %s",
+				return config, fmt.Errorf("invalid value for %s: value (%q) must be between %s and %s",
 					asyncReconnectIntervalKey, interval, minReconnectInterval, maxReconnectInterval)
 			}
 			asyncReconnectInterval = int(interval.Milliseconds())
@@ -248,9 +249,9 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 	writeTimeout := time.Duration(0)
 	if cfg[writeTimeoutKey] != "" {
 		if d, err := time.ParseDuration(cfg[writeTimeoutKey]); err != nil {
-			return config, errors.Wrapf(err, "invalid value for %s: value must be a duration", writeTimeoutKey)
+			return config, fmt.Errorf("invalid value for %s: value must be a duration: %w", writeTimeoutKey, err)
 		} else if d < 0 {
-			return config, errors.Errorf("invalid value for %s: value must be a duration that is non-negative", writeTimeoutKey)
+			return config, fmt.Errorf("invalid value for %s: value must be a duration that is non-negative", writeTimeoutKey)
 		} else {
 			writeTimeout = d
 		}
@@ -259,9 +260,9 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 	readTimeout := time.Duration(0)
 	if cfg[readTimeoutKey] != "" {
 		if d, err := time.ParseDuration(cfg[readTimeoutKey]); err != nil {
-			return config, errors.Wrapf(err, "invalid value for %s: value must be a duration", readTimeoutKey)
+			return config, fmt.Errorf("invalid value for %s: value must be a duration: %w", readTimeoutKey, err)
 		} else if d < 0 {
-			return config, errors.Errorf("invalid value for %s: value must be a duration that is non-negative", readTimeoutKey)
+			return config, fmt.Errorf("invalid value for %s: value must be a duration that is non-negative", readTimeoutKey)
 		} else {
 			readTimeout = d
 		}
@@ -315,7 +316,7 @@ func parseAddress(address string) (*location, error) {
 	case "tcp", "tls":
 		// continue processing below
 	default:
-		return nil, errors.Errorf("unsupported scheme: '%s'", addr.Scheme)
+		return nil, fmt.Errorf("unsupported scheme: '%s'", addr.Scheme)
 	}
 
 	if addr.Path != "" {
@@ -332,7 +333,7 @@ func parseAddress(address string) (*location, error) {
 		// Port numbers are 16 bit: https://www.ietf.org/rfc/rfc793.html#section-3.1
 		portNum, err := strconv.ParseUint(p, 10, 16)
 		if err != nil {
-			return nil, errors.Wrap(err, "invalid port")
+			return nil, fmt.Errorf("invalid port: %w", err)
 		}
 		port = int(portNum)
 	}

--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -6,6 +6,7 @@ package jsonfilelog
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -14,13 +15,12 @@ import (
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/logger/jsonfilelog/jsonlog"
 	"github.com/moby/moby/v2/daemon/logger/loggerutils"
-	"github.com/pkg/errors"
 )
 
 // Name is the name of the file that the jsonlogger logs to.
 const Name = "json-file"
 
-// Every buffer will have to store the same constant json structure with the message
+// Every buffer will have to store the same constant JSON structure with the message
 // len(`{"log":"","stream:"stdout","time":"2000-01-01T00:00:00.000000000Z"}\n`) = 68.
 // So let's start with a buffer bigger than this.
 const initialBufSize = 256
@@ -136,13 +136,13 @@ func marshalMessage(msg *logger.Message, extra json.RawMessage, buf *bytes.Buffe
 		RawAttrs: extra,
 	}).MarshalJSONBuf(buf)
 	if err != nil {
-		return errors.Wrap(err, "error writing log message to buffer")
+		return fmt.Errorf("error writing log message to buffer: %w", err)
 	}
 	err = buf.WriteByte('\n')
-	return errors.Wrap(err, "error finalizing log buffer")
+	return fmt.Errorf("error finalizing log buffer: %w", err)
 }
 
-// ValidateLogOpt looks for json specific log options max-file & max-size.
+// ValidateLogOpt looks for JSON-specific log options max-file & max-size.
 func ValidateLogOpt(cfg map[string]string) error {
 	for key := range cfg {
 		switch key {

--- a/daemon/logger/jsonfilelog/jsonlog/time_marshalling.go
+++ b/daemon/logger/jsonfilelog/jsonlog/time_marshalling.go
@@ -1,9 +1,8 @@
 package jsonlog
 
 import (
+	"errors"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 const jsonFormat = `"` + time.RFC3339Nano + `"`

--- a/daemon/logger/local/config.go
+++ b/daemon/logger/local/config.go
@@ -1,11 +1,11 @@
 package local
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
 	"github.com/docker/go-units"
-	"github.com/pkg/errors"
 )
 
 // CreateConfig is used to configure new instances of driver

--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -3,6 +3,8 @@ package local
 import (
 	"cmp"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
 	"math/bits"
 	"slices"
@@ -14,7 +16,6 @@ import (
 	"github.com/moby/moby/v2/daemon/logger/loggerutils"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/errdefs"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -53,7 +54,7 @@ var LogOptKeys = map[string]bool{
 func ValidateLogOpt(cfg map[string]string) error {
 	for key := range cfg {
 		if !LogOptKeys[key] {
-			return errors.Errorf("unknown log opt '%s' for log driver %s", key, Name)
+			return fmt.Errorf("unknown log opt '%s' for log driver %s", key, Name)
 		}
 	}
 	return nil
@@ -137,7 +138,7 @@ func marshal(m *logger.Message, attrs []*logdriver.LogAttr, buffer *[]byte) erro
 	binary.BigEndian.PutUint32(buf[:encodeBinaryLen], uint32(protoSize))
 	n, err := proto.MarshalTo(buf[encodeBinaryLen:writeLen])
 	if err != nil {
-		return errors.Wrap(err, "error marshaling log entry")
+		return fmt.Errorf("error marshaling log entry: %w", err)
 	}
 	if n+(encodeBinaryLen*2) != writeLen {
 		return io.ErrShortWrite
@@ -161,7 +162,7 @@ func (d *driver) Log(msg *logger.Message) (err error) {
 	defer buffersPool.Put(buf)
 
 	if err := marshal(msg, d.extra, buf); err != nil {
-		return errors.Wrap(err, "error marshalling logger.Message")
+		return fmt.Errorf("error marshalling logger.Message: %w", err)
 	}
 	return d.logfile.WriteLogEntry(msg.Timestamp, *buf)
 }

--- a/daemon/logger/local/read.go
+++ b/daemon/logger/local/read.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/moby/moby/v2/daemon/logger/internal/logdriver"
 	"github.com/moby/moby/v2/daemon/logger/loggerutils"
 	"github.com/moby/moby/v2/errdefs"
-	"github.com/pkg/errors"
 )
 
 // maxMsgLen is the maximum size of the logger.Message after serialization.
@@ -25,7 +25,7 @@ func (d *driver) ReadLogs(ctx context.Context, config logger.ReadConfig) *logger
 func getTailReader(ctx context.Context, r loggerutils.SizeReaderAt, req int) (loggerutils.SizeReaderAt, int, error) {
 	size := r.Size()
 	if req < 0 {
-		return nil, 0, errdefs.InvalidParameter(errors.Errorf("invalid number of lines to tail: %d", req))
+		return nil, 0, errdefs.InvalidParameter(fmt.Errorf("invalid number of lines to tail: %d", req))
 	}
 
 	if size < (encodeBinaryLen*2)+1 {
@@ -47,7 +47,7 @@ func getTailReader(ctx context.Context, r loggerutils.SizeReaderAt, req int) (lo
 
 		n, err := r.ReadAt(buf, offset-encodeBinaryLen64)
 		if err != nil && !errors.Is(err, io.EOF) {
-			return nil, 0, errors.Wrap(err, "error reading log message footer")
+			return nil, 0, fmt.Errorf("error reading log message footer: %w", err)
 		}
 
 		if n != encodeBinaryLen {
@@ -58,7 +58,7 @@ func getTailReader(ctx context.Context, r loggerutils.SizeReaderAt, req int) (lo
 
 		n, err = r.ReadAt(buf, offset-encodeBinaryLen64-encodeBinaryLen64-int64(msgLen))
 		if err != nil && !errors.Is(err, io.EOF) {
-			return nil, 0, errors.Wrap(err, "error reading log message header")
+			return nil, 0, fmt.Errorf("error reading log message header: %w", err)
 		}
 
 		if n != encodeBinaryLen {
@@ -182,7 +182,7 @@ func decodeFunc(rdr io.Reader) loggerutils.Decoder {
 func (d *decoder) decodeSizeHeader() (int, error) {
 	err := d.readRecord(encodeBinaryLen)
 	if err != nil {
-		return 0, errors.Wrap(err, "could not read a size header")
+		return 0, fmt.Errorf("could not read a size header: %w", err)
 	}
 
 	msgLen := int(binary.BigEndian.Uint32(d.buf[:encodeBinaryLen]))
@@ -193,12 +193,12 @@ func (d *decoder) decodeLogEntry() (*logger.Message, error) {
 	msgLen := d.nextMsgLen
 	err := d.readRecord(msgLen + encodeBinaryLen)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not read a log entry (size=%d+%d)", msgLen, encodeBinaryLen)
+		return nil, fmt.Errorf("could not read a log entry (size=%d+%d): %w", msgLen, encodeBinaryLen, err)
 	}
 	d.nextMsgLen = 0
 
 	if err := d.proto.Unmarshal(d.buf[:msgLen]); err != nil {
-		return nil, errors.Wrapf(err, "error unmarshalling log entry (size=%d)", msgLen)
+		return nil, fmt.Errorf("error unmarshalling log entry (size=%d): %w", msgLen, err)
 	}
 
 	msg := protoToMessage(d.proto)

--- a/daemon/logger/loggerutils/cache/local_cache.go
+++ b/daemon/logger/loggerutils/cache/local_cache.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/containerd/log"
@@ -9,7 +10,6 @@ import (
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/logger/local"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -36,7 +36,7 @@ func WithLocalCache(l logger.Logger, info logger.Info) (logger.Logger, error) {
 
 	cacher, err := initLogger(info)
 	if err != nil {
-		return nil, errors.Wrap(err, "error initializing local log cache driver")
+		return nil, fmt.Errorf("error initializing local log cache driver: %w", err)
 	}
 
 	if container.LogMode(info.Config["mode"]) == container.LogModeUnset || container.LogMode(info.Config["mode"]) == container.LogModeNonBlock {
@@ -109,7 +109,7 @@ func ShouldUseCache(cfg map[string]string) bool {
 	}
 	b, err := strconv.ParseBool(cfg[cacheDisabledKey])
 	if err != nil {
-		// This shouldn't happen since the values are validated before hand.
+		// This shouldn't happen since the values are validated beforehand.
 		return false
 	}
 	return !b

--- a/daemon/logger/loggerutils/cache/validate.go
+++ b/daemon/logger/loggerutils/cache/validate.go
@@ -1,11 +1,11 @@
 package cache
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/logger/local"
-	"github.com/pkg/errors"
 )
 
 func init() {
@@ -20,7 +20,7 @@ func validateLogCacheOpts(cfg map[string]string) error {
 	if v := cfg[cacheDisabledKey]; v != "" {
 		_, err := strconv.ParseBool(v)
 		if err != nil {
-			return errors.Errorf("invalid value for option %s: %s", cacheDisabledKey, cfg[cacheDisabledKey])
+			return fmt.Errorf("invalid value for option %s: %s", cacheDisabledKey, cfg[cacheDisabledKey])
 		}
 	}
 	return nil

--- a/daemon/logger/loggerutils/follow.go
+++ b/daemon/logger/loggerutils/follow.go
@@ -2,13 +2,13 @@ package loggerutils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/logger"
-	"github.com/pkg/errors"
 )
 
 type follow struct {

--- a/daemon/logger/loggerutils/logfile.go
+++ b/daemon/logger/loggerutils/logfile.go
@@ -4,6 +4,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -18,7 +19,6 @@ import (
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/pkg/pools"
-	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -166,13 +166,13 @@ func (w *LogFile) WriteLogEntry(timestamp time.Time, marshalled []byte) error {
 	// Are we due for a rotation?
 	if w.capacity != -1 && w.pos.size >= w.capacity {
 		if err := w.rotate(); err != nil {
-			return errors.Wrap(err, "error rotating log file")
+			return fmt.Errorf("error rotating log file: %w", err)
 		}
 	}
 
 	n, err := w.f.Write(marshalled)
 	if err != nil {
-		return errors.Wrap(err, "error writing log entry")
+		return fmt.Errorf("error writing log entry: %w", err)
 	}
 	w.pos.size += int64(n)
 	w.lastTimestamp = timestamp
@@ -208,7 +208,7 @@ func (w *LogFile) rotate() (retErr error) {
 	if err := w.f.Close(); err != nil {
 		// if there was an error during a prior rotate, the file could already be closed
 		if !errors.Is(err, fs.ErrClosed) {
-			return errors.Wrap(err, "error closing file")
+			return fmt.Errorf("error closing file: %w", err)
 		}
 	}
 
@@ -280,7 +280,7 @@ func rotate(name string, maxFiles int, compress bool) error {
 	lastFile := fmt.Sprintf("%s.%d%s", name, maxFiles-1, extension)
 	err := unlink(lastFile)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return errors.Wrap(err, "error removing oldest log file")
+		return fmt.Errorf("error removing oldest log file: %w", err)
 	}
 
 	for i := maxFiles - 1; i > 1; i-- {
@@ -303,21 +303,21 @@ func compressFile(fileName string, lastTimestamp time.Time) (retErr error) {
 			log.G(context.TODO()).WithField("file", fileName).WithError(err).Debug("Could not open log file to compress")
 			return nil
 		}
-		return errors.Wrap(err, "failed to open log file")
+		return fmt.Errorf("failed to open log file: %w", err)
 	}
 	defer func() {
 		file.Close()
 		if retErr == nil {
 			err := unlink(fileName)
 			if err != nil && !errors.Is(err, fs.ErrNotExist) {
-				retErr = errors.Wrap(err, "failed to remove source log file")
+				retErr = fmt.Errorf("failed to remove source log file: %w", err)
 			}
 		}
 	}()
 
 	outFile, err := openFile(fileName+".gz", os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o640)
 	if err != nil {
-		return errors.Wrap(err, "failed to open or create gzip log file")
+		return fmt.Errorf("failed to open or create gzip log file: %w", err)
 	}
 	defer func() {
 		outFile.Close()
@@ -342,7 +342,7 @@ func compressFile(fileName string, lastTimestamp time.Time) (retErr error) {
 
 	_, err = pools.Copy(compressWriter, file)
 	if err != nil {
-		return errors.Wrapf(err, "error compressing log file %s", fileName)
+		return fmt.Errorf("error compressing log file %s: %w", fileName, err)
 	}
 
 	return nil
@@ -415,7 +415,7 @@ func (w *LogFile) tailFiles(ctx context.Context, config logger.ReadConfig, watch
 
 	if err != nil {
 		// TODO: Should we allow this to continue (as in set `cont=true`) and not error out the log stream?
-		err = errors.Wrap(err, "error opening rotated log files")
+		err = fmt.Errorf("error opening rotated log files: %w", err)
 		span.SetStatus(err)
 		watcher.Err <- err
 		return false
@@ -540,7 +540,7 @@ func (o *simpleFileOpener) ReaderAt(context.Context) (sizeReaderAtCloser, error)
 	if o.sz == 0 {
 		stat, err := o.f.Stat()
 		if err != nil {
-			return nil, errors.Wrap(err, "error stating file")
+			return nil, fmt.Errorf("error stating file: %w", err)
 		}
 		o.sz = stat.Size()
 	}
@@ -676,13 +676,13 @@ func (w *LogFile) openRotatedFile(ctx context.Context, i int, config logger.Read
 	}
 
 	if !errors.Is(err, fs.ErrNotExist) {
-		return nil, errors.Wrap(err, "error opening rotated log file")
+		return nil, fmt.Errorf("error opening rotated log file: %w", err)
 	}
 
 	f, err = open(fmt.Sprintf("%s.%d.gz", w.f.Name(), i))
 	if err != nil {
 		if !errors.Is(err, fs.ErrNotExist) {
-			return nil, errors.Wrap(err, "error opening file for decompression")
+			return nil, fmt.Errorf("error opening file for decompression: %w", err)
 		}
 		return &emptyFileOpener{}, nil
 	}
@@ -741,7 +741,7 @@ func getTailFiles(ctx context.Context, files []fileOpener, nLines int, getTailRe
 
 	for i := len(files) - 1; i >= 0 && nLines > 0; i-- {
 		if err := ctx.Err(); err != nil {
-			return nil, errors.Wrap(err, "stopping parsing files to tail due to error")
+			return nil, fmt.Errorf("stopping parsing files to tail due to error: %w", err)
 		}
 
 		fo := files[i]

--- a/daemon/logger/loggerutils/queue.go
+++ b/daemon/logger/loggerutils/queue.go
@@ -2,10 +2,10 @@ package loggerutils
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/moby/moby/v2/daemon/logger"
-	"github.com/pkg/errors"
 )
 
 // MessageQueue is a queue for log messages.

--- a/daemon/logger/loggerutils/sharedtemp_test.go
+++ b/daemon/logger/loggerutils/sharedtemp_test.go
@@ -1,6 +1,7 @@
 package loggerutils
 
 import (
+	"errors"
 	"io"
 	"io/fs"
 	"os"
@@ -12,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -155,7 +155,7 @@ func TestSharedTempFileConverter(t *testing.T) {
 		createFile(t, name, "hi there")
 		src, err := open(name)
 		assert.NilError(t, err)
-		defer src.Close()
+		defer func() { _ = src.Close() }()
 
 		fakeErr := errors.New("fake error")
 		var start sync.WaitGroup

--- a/daemon/logger/plugin.go
+++ b/daemon/logger/plugin.go
@@ -11,7 +11,6 @@ import (
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/moby/v2/pkg/plugingetter"
 	"github.com/moby/moby/v2/pkg/plugins"
-	"github.com/pkg/errors"
 )
 
 var pluginGetter plugingetter.PluginGetter
@@ -52,17 +51,17 @@ func makePluginClient(p plugingetter.CompatPlugin) (logPlugin, error) {
 	}
 	pa, ok := p.(plugingetter.PluginAddr)
 	if !ok {
-		return nil, errdefs.System(errors.Errorf("got unknown plugin type %T", p))
+		return nil, errdefs.System(fmt.Errorf("got unknown plugin type %T", p))
 	}
 
 	if pa.Protocol() != plugins.ProtocolSchemeHTTPV1 {
-		return nil, errors.Errorf("plugin protocol not supported: %s", p)
+		return nil, fmt.Errorf("plugin protocol not supported: %s", p)
 	}
 
 	addr := pa.Addr()
 	c, err := plugins.NewClientWithTimeout(addr.Network()+"://"+addr.String(), nil, pa.Timeout())
 	if err != nil {
-		return nil, errors.Wrap(err, "error making plugin client")
+		return nil, fmt.Errorf("error making plugin client: %w", err)
 	}
 	return &logPluginProxy{c}, nil
 }
@@ -104,7 +103,7 @@ func makePluginCreator(name string, l logPlugin, scopePath func(s string) string
 		a.enc = logdriver.NewLogEntryEncoder(a.stream)
 
 		if err := l.StartLogging(filepath.Join(unscopedPath, id), logCtx); err != nil {
-			return nil, errors.Wrapf(err, "error creating logger")
+			return nil, fmt.Errorf("error creating logger: %w", err)
 		}
 
 		if caps.ReadLogs {

--- a/daemon/logger/plugin_unix.go
+++ b/daemon/logger/plugin_unix.go
@@ -4,10 +4,10 @@ package logger
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/containerd/fifo"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -17,7 +17,7 @@ func openPluginStream(a *pluginAdapter) (io.WriteCloser, error) {
 	// If the plugin doesn't open for reads, then the container will block once the pipe is full.
 	f, err := fifo.OpenFifo(context.Background(), a.fifoPath, unix.O_RDWR|unix.O_CREAT|unix.O_NONBLOCK, 0o700)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error creating i/o pipe for log plugin: %s", a.Name())
+		return nil, fmt.Errorf("error creating i/o pipe for log plugin %q: %w", a.Name(), err)
 	}
 	return f, nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
