### PR TITLE
Add named container profiles

### DIFF
--- a/api/types/container/create_request.go
+++ b/api/types/container/create_request.go
@@ -10,4 +10,5 @@ type CreateRequest struct {
 	*Config
 	HostConfig       *HostConfig               `json:"HostConfig,omitempty"`
 	NetworkingConfig *network.NetworkingConfig `json:"NetworkingConfig,omitempty"`
+	Profile          string                    `json:"Profile,omitempty"`
 }

--- a/client/container_create.go
+++ b/client/container_create.go
@@ -50,6 +50,7 @@ func (cli *Client) ContainerCreate(ctx context.Context, options ContainerCreateO
 		Config:           cfg,
 		HostConfig:       normalizeHostConfig(options.HostConfig),
 		NetworkingConfig: options.NetworkingConfig,
+		Profile:          options.Profile,
 	})
 	defer ensureReaderClosed(resp)
 	if err != nil {

--- a/client/container_create_opts.go
+++ b/client/container_create_opts.go
@@ -13,6 +13,7 @@ type ContainerCreateOptions struct {
 	NetworkingConfig *network.NetworkingConfig
 	Platform         *ocispec.Platform
 	Name             string
+	Profile          string
 
 	// Image is a shortcut for Config.Image - only one of Image or Config.Image should be set.
 	Image string

--- a/daemon/command/config.go
+++ b/daemon/command/config.go
@@ -65,6 +65,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.IntVar(&conf.MaxDownloadAttempts, "max-download-attempts", conf.MaxDownloadAttempts, "Set the max download attempts for each pull")
 	flags.IntVar(&conf.ShutdownTimeout, "shutdown-timeout", conf.ShutdownTimeout, "Set the default shutdown timeout")
 	flags.IntVar(&conf.DefaultStopTimeout, "default-stop-timeout", conf.DefaultStopTimeout, "Set the default container stop timeout in seconds (0 to terminate immediately)")
+	flags.StringVar(&conf.DefaultContainerProfile, "default-container-profile", conf.DefaultContainerProfile, "Default container profile")
 
 	flags.StringVar(&conf.SwarmDefaultAdvertiseAddr, "swarm-default-advertise-addr", "", "Set default address or interface for swarm advertised address")
 	flags.BoolVar(&conf.Experimental, "experimental", false, "Enable experimental features")

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -195,6 +195,8 @@ type ContainerDefaults struct {
 	// DefaultStopTimeout is the timeout, in seconds, used for containers that
 	// do not have a container-specific timeout set.
 	DefaultStopTimeout int `json:"default-stop-timeout,omitempty"`
+	// DefaultContainerProfile is applied when a container does not select a profile.
+	DefaultContainerProfile string `json:"default-container-profile,omitempty"`
 }
 
 // CommonConfig defines the configuration of a docker daemon which is

--- a/daemon/containerprofile/profile.go
+++ b/daemon/containerprofile/profile.go
@@ -1,0 +1,176 @@
+// Package containerprofile loads named, daemon-managed container defaults.
+package containerprofile
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/moby/moby/api/types/container"
+)
+
+// DefaultDir is the standard directory containing daemon-managed profiles.
+const DefaultDir = "/etc/docker/container-profiles"
+
+var (
+	// ErrInvalidName indicates that a profile name is not a valid profile name.
+	ErrInvalidName = errors.New("invalid container profile name")
+	// ErrLoad indicates that a profile could not be read from disk.
+	ErrLoad = errors.New("could not load container profile")
+	// ErrInvalid indicates that a profile is not valid JSON or contains unsupported fields.
+	ErrInvalid = errors.New("invalid container profile")
+)
+
+// Profile contains the container settings that may be supplied by a named
+// daemon-managed profile. Pointer fields preserve explicitly configured zero
+// values while loading the profile.
+type Profile struct {
+	// ReadOnly makes the root filesystem read-only.
+	ReadOnly *bool `json:"read-only,omitempty"`
+	// CapAdd adds Linux capabilities.
+	CapAdd []string `json:"cap-add,omitempty"`
+	// CapDrop removes Linux capabilities.
+	CapDrop []string `json:"cap-drop,omitempty"`
+	// SecurityOpt sets container security options.
+	SecurityOpt []string `json:"security-opt,omitempty"`
+	// PidsLimit limits the number of processes.
+	PidsLimit *int64 `json:"pids-limit,omitempty"`
+	// Init enables Docker's init process.
+	Init *bool `json:"init,omitempty"`
+	// Tty allocates a pseudo-terminal.
+	Tty *bool `json:"tty,omitempty"`
+	// User sets the user or user:group for the process.
+	User *string `json:"user,omitempty"`
+	// WorkingDir sets the process working directory.
+	WorkingDir *string `json:"working-dir,omitempty"`
+	// StopTimeout sets the graceful stop timeout in seconds.
+	StopTimeout *int `json:"stop-timeout,omitempty"`
+	// Memory sets the memory limit in bytes.
+	Memory *int64 `json:"memory,omitempty"`
+	// NanoCPUs sets the CPU limit in 10^-9 CPUs.
+	NanoCPUs *int64 `json:"cpus,omitempty"`
+	// CPUQuota sets the CFS CPU quota in microseconds.
+	CPUQuota *int64 `json:"cpu-quota,omitempty"`
+	// CPUPeriod sets the CFS CPU period in microseconds.
+	CPUPeriod *int64 `json:"cpu-period,omitempty"`
+	// ShmSize sets /dev/shm size in bytes.
+	ShmSize *int64 `json:"shm-size,omitempty"`
+	// Tmpfs adds tmpfs mounts keyed by container path.
+	Tmpfs map[string]string `json:"tmpfs,omitempty"`
+	// Sysctls sets namespaced kernel parameters.
+	Sysctls map[string]string `json:"sysctls,omitempty"`
+	// Ulimits sets process resource limits.
+	Ulimits []*container.Ulimit `json:"ulimits,omitempty"`
+	// DNS sets the container DNS servers.
+	DNS []netip.Addr `json:"dns,omitempty"`
+	// DNSSearch sets DNS search domains.
+	DNSSearch []string `json:"dns-search,omitempty"`
+	// DNSOptions sets resolver options.
+	DNSOptions []string `json:"dns-options,omitempty"`
+}
+
+// Load reads and validates the named profile from dir.
+func Load(dir, name string) (Profile, error) {
+	// An empty name means that no profile was selected.
+	if name == "" {
+		return Profile{}, nil
+	}
+	if filepath.Base(name) != name || strings.ContainsAny(name, `/\\`) {
+		return Profile{}, fmt.Errorf("%w %q", ErrInvalidName, name)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, name+".json"))
+	if err != nil {
+		return Profile{}, fmt.Errorf("%w %q: %w", ErrLoad, name, err)
+	}
+	var p Profile
+	dec := json.NewDecoder(strings.NewReader(string(b)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&p); err != nil {
+		return Profile{}, fmt.Errorf("%w %q: %w", ErrInvalid, name, err)
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return Profile{}, fmt.Errorf("%w %q: multiple JSON values", ErrInvalid, name)
+		}
+		return Profile{}, fmt.Errorf("%w %q: %w", ErrInvalid, name, err)
+	}
+	return p, nil
+}
+
+// Apply fills unset container settings from p.
+func Apply(p Profile, cfg *container.Config, host *container.HostConfig) {
+	// Apply only fills fields that were not already supplied by the caller.
+	if host == nil {
+		return
+	}
+	if p.Init != nil && host.Init == nil {
+		host.Init = p.Init
+	}
+	if p.Tty != nil && cfg != nil && !cfg.Tty {
+		cfg.Tty = *p.Tty
+	}
+	if p.User != nil && cfg != nil && cfg.User == "" {
+		cfg.User = *p.User
+	}
+	if p.WorkingDir != nil && cfg != nil && cfg.WorkingDir == "" {
+		cfg.WorkingDir = *p.WorkingDir
+	}
+	if p.StopTimeout != nil && cfg != nil && cfg.StopTimeout == nil {
+		cfg.StopTimeout = p.StopTimeout
+	}
+	if p.ReadOnly != nil && !host.ReadonlyRootfs {
+		host.ReadonlyRootfs = *p.ReadOnly
+	}
+	if p.CapAdd != nil && len(host.CapAdd) == 0 {
+		host.CapAdd = append([]string(nil), p.CapAdd...)
+	}
+	if p.CapDrop != nil && len(host.CapDrop) == 0 {
+		host.CapDrop = append([]string(nil), p.CapDrop...)
+	}
+	if p.SecurityOpt != nil && len(host.SecurityOpt) == 0 {
+		host.SecurityOpt = append([]string(nil), p.SecurityOpt...)
+	}
+	if p.PidsLimit != nil && host.PidsLimit == nil {
+		host.PidsLimit = p.PidsLimit
+	}
+	if p.Memory != nil && host.Memory == 0 {
+		host.Memory = *p.Memory
+	}
+	if p.NanoCPUs != nil && host.NanoCPUs == 0 {
+		host.NanoCPUs = *p.NanoCPUs
+	}
+	if p.CPUQuota != nil && host.CPUQuota == 0 {
+		host.CPUQuota = *p.CPUQuota
+	}
+	if p.CPUPeriod != nil && host.CPUPeriod == 0 {
+		host.CPUPeriod = *p.CPUPeriod
+	}
+	if p.ShmSize != nil && host.ShmSize == 0 {
+		host.ShmSize = *p.ShmSize
+	}
+	if p.Tmpfs != nil && len(host.Tmpfs) == 0 {
+		host.Tmpfs = maps.Clone(p.Tmpfs)
+	}
+	if p.Sysctls != nil && len(host.Sysctls) == 0 {
+		host.Sysctls = maps.Clone(p.Sysctls)
+	}
+	if p.Ulimits != nil && len(host.Ulimits) == 0 {
+		host.Ulimits = slices.Clone(p.Ulimits)
+	}
+	if p.DNS != nil && len(host.DNS) == 0 {
+		host.DNS = slices.Clone(p.DNS)
+	}
+	if p.DNSSearch != nil && len(host.DNSSearch) == 0 {
+		host.DNSSearch = slices.Clone(p.DNSSearch)
+	}
+	if p.DNSOptions != nil && len(host.DNSOptions) == 0 {
+		host.DNSOptions = slices.Clone(p.DNSOptions)
+	}
+}

--- a/daemon/containerprofile/profile_test.go
+++ b/daemon/containerprofile/profile_test.go
@@ -1,0 +1,172 @@
+package containerprofile
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/moby/moby/api/types/container"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestLoad(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		invalid  bool
+	}{
+		{
+			name: "valid profile",
+			contents: `{
+				"read-only": true,
+				"cap-add": ["NET_ADMIN"],
+				"cap-drop": ["ALL"],
+				"security-opt": ["no-new-privileges"],
+				"pids-limit": 256,
+				"init": true,
+				"tty": true,
+				"user": "1000:1000",
+				"working-dir": "/work",
+				"stop-timeout": 30,
+				"memory": 536870912,
+				"cpus": 2000000000,
+				"cpu-quota": 100000,
+				"cpu-period": 1000000,
+				"shm-size": 67108864,
+				"tmpfs": {"/tmp": "rw,noexec"},
+				"sysctls": {"net.ipv4.ip_forward": "1"},
+				"ulimits": [{"Name": "nofile", "Soft": 1024, "Hard": 2048}],
+				"dns": ["1.1.1.1"],
+				"dns-search": ["example.com"],
+				"dns-options": ["ndots:1"]
+			}`,
+		},
+		{
+			name:     "unknown field",
+			contents: `{"privileged": true}`,
+			invalid:  true,
+		},
+		{
+			name:     "malformed JSON",
+			contents: `{`,
+			invalid:  true,
+		},
+		{
+			name:     "multiple JSON values",
+			contents: `{} {}`,
+			invalid:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			assert.NilError(t, os.WriteFile(
+				filepath.Join(dir, "profile.json"), []byte(tc.contents), 0o644,
+			))
+
+			profile, err := Load(dir, "profile")
+			if tc.invalid {
+				assert.Assert(t, errors.Is(err, ErrInvalid))
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.Assert(t, cmp.Equal(*profile.ReadOnly, true))
+			assert.DeepEqual(t, profile.CapAdd, []string{"NET_ADMIN"})
+			assert.DeepEqual(t, profile.CapDrop, []string{"ALL"})
+			assert.DeepEqual(t, profile.SecurityOpt, []string{"no-new-privileges"})
+			assert.Equal(t, *profile.PidsLimit, int64(256))
+			assert.Equal(t, *profile.Init, true)
+			assert.Equal(t, *profile.Tty, true)
+			assert.Equal(t, *profile.User, "1000:1000")
+			assert.Equal(t, *profile.WorkingDir, "/work")
+			assert.Equal(t, *profile.StopTimeout, 30)
+			assert.Equal(t, *profile.Memory, int64(536870912))
+			assert.Equal(t, *profile.NanoCPUs, int64(2000000000))
+			assert.Equal(t, *profile.CPUQuota, int64(100000))
+			assert.Equal(t, *profile.CPUPeriod, int64(1000000))
+			assert.Equal(t, *profile.ShmSize, int64(67108864))
+			assert.DeepEqual(t, profile.Tmpfs, map[string]string{"/tmp": "rw,noexec"})
+			assert.DeepEqual(t, profile.Sysctls, map[string]string{"net.ipv4.ip_forward": "1"})
+			assert.Equal(t, profile.Ulimits[0].Name, "nofile")
+			assert.Equal(t, profile.DNS[0].String(), "1.1.1.1")
+			assert.DeepEqual(t, profile.DNSSearch, []string{"example.com"})
+			assert.DeepEqual(t, profile.DNSOptions, []string{"ndots:1"})
+		})
+	}
+}
+
+func TestApply(t *testing.T) {
+	readOnly := true
+	init := true
+	tty := true
+	user := "1000:1000"
+	workingDir := "/work"
+	stopTimeout := 30
+	pidsLimit := int64(256)
+	memory := int64(512 * 1024 * 1024)
+
+	tests := []struct {
+		name    string
+		profile Profile
+		config  *container.Config
+		host    *container.HostConfig
+		check   func(*testing.T, *container.Config, *container.HostConfig)
+	}{
+		{
+			name: "applies all configured fields",
+			profile: Profile{
+				ReadOnly: &readOnly, Init: &init, Tty: &tty, User: &user,
+				WorkingDir: &workingDir, StopTimeout: &stopTimeout, PidsLimit: &pidsLimit,
+				Memory: &memory, CapDrop: []string{"ALL"},
+			},
+			config: &container.Config{}, host: &container.HostConfig{},
+			check: func(t *testing.T, config *container.Config, host *container.HostConfig) {
+				assert.Assert(t, config.Tty)
+				assert.Equal(t, config.User, user)
+				assert.Equal(t, config.WorkingDir, workingDir)
+				assert.Equal(t, *config.StopTimeout, stopTimeout)
+				assert.Assert(t, host.ReadonlyRootfs)
+				assert.Equal(t, *host.Init, init)
+				assert.Equal(t, *host.PidsLimit, pidsLimit)
+				assert.Equal(t, host.Memory, memory)
+				assert.DeepEqual(t, host.CapDrop, []string{"ALL"})
+			},
+		},
+		{
+			name:    "leaves omitted fields unchanged",
+			profile: Profile{},
+			config:  &container.Config{User: "docker", Tty: true},
+			host: &container.HostConfig{
+				ReadonlyRootfs: true,
+				Resources:      container.Resources{PidsLimit: &pidsLimit},
+			},
+			check: func(t *testing.T, config *container.Config, host *container.HostConfig) {
+				assert.Equal(t, config.User, "docker")
+				assert.Assert(t, config.Tty)
+				assert.Assert(t, host.ReadonlyRootfs)
+				assert.Equal(t, *host.PidsLimit, pidsLimit)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			Apply(tc.profile, tc.config, tc.host)
+			tc.check(t, tc.config, tc.host)
+		})
+	}
+}
+
+func TestLoadRejectsInvalidName(t *testing.T) {
+	_, err := Load(t.TempDir(), "../profile")
+	assert.Assert(t, errors.Is(err, ErrInvalidName))
+}
+
+func TestLoadMissingProfile(t *testing.T) {
+	_, err := Load(t.TempDir(), "missing")
+	assert.Assert(t, errors.Is(err, ErrLoad))
+}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -17,6 +17,7 @@ import (
 	networktypes "github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/daemon/container"
+	"github.com/moby/moby/v2/daemon/containerprofile"
 	"github.com/moby/moby/v2/daemon/images"
 	"github.com/moby/moby/v2/daemon/internal/image"
 	"github.com/moby/moby/v2/daemon/internal/metrics"
@@ -76,6 +77,20 @@ func (daemon *Daemon) containerCreate(ctx context.Context, daemonCfg *configStor
 	start := time.Now()
 	if opts.params.Config == nil {
 		return containertypes.CreateResponse{}, errdefs.InvalidParameter(errors.New("config cannot be empty in order to create a container"))
+	}
+	profileName := opts.params.Profile
+	if profileName == "" {
+		profileName = daemonCfg.Config.ContainerDefaults.DefaultContainerProfile
+	}
+	if profileName != "" {
+		p, err := containerprofile.Load(
+			containerprofile.DefaultDir,
+			profileName,
+		)
+		if err != nil {
+			return containertypes.CreateResponse{}, errdefs.InvalidParameter(err)
+		}
+		containerprofile.Apply(p, opts.params.Config, opts.params.HostConfig)
 	}
 
 	// Normalize some defaults. Doing this "ad-hoc" here for now, as there's

--- a/daemon/server/backend/backend.go
+++ b/daemon/server/backend/backend.go
@@ -20,6 +20,7 @@ type ContainerCreateConfig struct {
 	NetworkingConfig            *network.NetworkingConfig
 	Platform                    *ocispec.Platform
 	DefaultReadOnlyNonRecursive bool
+	Profile                     string
 }
 
 // ContainerRmConfig holds arguments for the container remove

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -784,6 +784,7 @@ func (c *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 		NetworkingConfig:            networkingConfig,
 		Platform:                    platform,
 		DefaultReadOnlyNonRecursive: defaultReadOnlyNonRecursive,
+		Profile:                     req.Profile,
 	})
 
 	// Log warnings for debugging, regardless if the request was successful or not.

--- a/integration/daemon/container_profiles_test.go
+++ b/integration/daemon/container_profiles_test.go
@@ -1,0 +1,139 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	containertypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
+	"github.com/moby/moby/v2/daemon/containerprofile"
+	"github.com/moby/moby/v2/internal/testutil"
+	"github.com/moby/moby/v2/internal/testutil/daemon"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/skip"
+)
+
+func TestContainerProfiles(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	ctx := testutil.StartSpan(baseContext, t)
+
+	profilesDir := containerprofile.DefaultDir
+	profileName := fmt.Sprintf("moby-test-%d", os.Getpid())
+	if err := os.MkdirAll(profilesDir, 0o755); err != nil {
+		t.Skipf("cannot create container profile directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Remove(filepath.Join(profilesDir, profileName+".json"))
+	})
+	secureProfile := map[string]any{
+		"read-only":  true,
+		"pids-limit": 256,
+		"init":       true,
+	}
+	profileJSON, err := json.Marshal(secureProfile)
+	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(
+		filepath.Join(profilesDir, profileName+".json"), profileJSON, 0o644,
+	))
+
+	configFile := filepath.Join(t.TempDir(), "daemon.json")
+	config := map[string]string{"default-container-profile": profileName}
+	configJSON, err := json.Marshal(config)
+	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(configFile, configJSON, 0o644))
+
+	d := daemon.New(t)
+	t.Cleanup(func() { d.Stop(t) })
+	d.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false", "--config-file", configFile)
+	c := d.NewClientT(t)
+
+	tests := []struct {
+		name             string
+		profile          string
+		pidsLimit        *int64
+		expectedPids     int64
+		expectedReadOnly bool
+		expectedInit     *bool
+	}{
+		{
+			name:             "daemon default profile",
+			expectedPids:     256,
+			expectedReadOnly: true,
+			expectedInit:     boolPtr(true),
+		},
+		{
+			name:             "explicit profile",
+			profile:          profileName,
+			expectedPids:     256,
+			expectedReadOnly: true,
+			expectedInit:     boolPtr(true),
+		},
+		{
+			name:             "container option overrides profile",
+			pidsLimit:        int64Ptr(1024),
+			expectedPids:     1024,
+			expectedReadOnly: true,
+			expectedInit:     boolPtr(true),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			options := client.ContainerCreateOptions{
+				Config: &containertypes.Config{
+					Image: "busybox:latest",
+				},
+				Profile: tc.profile,
+			}
+
+			if tc.pidsLimit != nil {
+				options.HostConfig = &containertypes.HostConfig{
+					Resources: containertypes.Resources{
+						PidsLimit: tc.pidsLimit,
+					},
+				}
+			}
+
+			created, err := c.ContainerCreate(ctx, options)
+			assert.NilError(t, err)
+			t.Cleanup(func() {
+				_, _ = c.ContainerRemove(ctx, created.ID, client.ContainerRemoveOptions{
+					Force: true,
+				})
+			})
+
+			inspect, err := c.ContainerInspect(ctx, created.ID, client.ContainerInspectOptions{})
+			assert.NilError(t, err)
+			assert.Equal(
+				t,
+				inspect.Container.HostConfig.ReadonlyRootfs,
+				tc.expectedReadOnly,
+			)
+			assert.Equal(
+				t,
+				*inspect.Container.HostConfig.PidsLimit,
+				tc.expectedPids,
+			)
+			if tc.expectedInit == nil {
+				assert.Assert(t, inspect.Container.HostConfig.Init == nil)
+			} else {
+				assert.Equal(
+					t,
+					*inspect.Container.HostConfig.Init,
+					*tc.expectedInit,
+				)
+			}
+		})
+	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}

--- a/vendor/github.com/moby/moby/api/types/container/create_request.go
+++ b/vendor/github.com/moby/moby/api/types/container/create_request.go
@@ -10,4 +10,5 @@ type CreateRequest struct {
 	*Config
 	HostConfig       *HostConfig               `json:"HostConfig,omitempty"`
 	NetworkingConfig *network.NetworkingConfig `json:"NetworkingConfig,omitempty"`
+	Profile          string                    `json:"Profile,omitempty"`
 }

--- a/vendor/github.com/moby/moby/client/container_create.go
+++ b/vendor/github.com/moby/moby/client/container_create.go
@@ -50,6 +50,7 @@ func (cli *Client) ContainerCreate(ctx context.Context, options ContainerCreateO
 		Config:           cfg,
 		HostConfig:       normalizeHostConfig(options.HostConfig),
 		NetworkingConfig: options.NetworkingConfig,
+		Profile:          options.Profile,
 	})
 	defer ensureReaderClosed(resp)
 	if err != nil {

--- a/vendor/github.com/moby/moby/client/container_create_opts.go
+++ b/vendor/github.com/moby/moby/client/container_create_opts.go
@@ -13,6 +13,7 @@ type ContainerCreateOptions struct {
 	NetworkingConfig *network.NetworkingConfig
 	Platform         *ocispec.Platform
 	Name             string
+	Profile          string
 
 	// Image is a shortcut for Config.Image - only one of Image or Config.Image should be set.
 	Image string


### PR DESCRIPTION
## Summary

Add named daemon-managed container profiles loaded from `/etc/docker/container-profiles/`.

Profiles can be selected through the container-create API or the Go client, and a daemon-wide default profile can be configured with `default-container-profile`.

The initial schema supports reusable security, resource, process, filesystem, DNS, tmpfs, sysctl, and ulimit defaults. Profile loading rejects unknown fields and invalid JSON.

## Release notes (optional)

```markdown changelog

- Add named container profiles for reusable container defaults.

```
