### PR TITLE
integration/container: skip socketcall AF_ALG test when kernel lacks it

### DIFF
--- a/integration/container/exec_afalg_linux_test.go
+++ b/integration/container/exec_afalg_linux_test.go
@@ -9,10 +9,25 @@ import (
 
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
+	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
 )
+
+// kernelSupportsAFALG reports whether the host kernel has the AF_ALG address
+// family registered. Starting with kernel 7.2, AF_ALG is deprecated and may
+// be built without CONFIG_CRYPTO_USER_API, so socket creation fails with
+// EAFNOSUPPORT before any LSM policy is consulted, which is indistinguishable
+// from a denied test result.
+func kernelSupportsAFALG() bool {
+	fd, err := unix.Socket(unix.AF_ALG, unix.SOCK_SEQPACKET, 0)
+	defer unix.Close(fd)
+	if err != nil {
+		return err != unix.EAFNOSUPPORT
+	}
+	return true
+}
 
 var (
 	//go:embed testdata/af_alg.c
@@ -119,6 +134,10 @@ func TestExecSocketDenied(t *testing.T) {
 		// which catches it at the security_socket_create hook even
 		// though seccomp cannot filter socketcall args.
 		t.Run("AF_ALG", func(t *testing.T) {
+			if testEnv.IsLocalDaemon() {
+				skip.If(t, !kernelSupportsAFALG(), "host kernel does not support AF_ALG")
+			}
+
 			binPath := "/tmp/socketcall_af_alg"
 			res := container.ExecT(ctx, t, apiClient, cID, append(gcc,
 				"-DSOCK_FAMILY=AF_ALG", "-DSOCK_TYPE=SOCK_SEQPACKET",


### PR DESCRIPTION
## Summary

Kernel 7.2 deprecated AF_ALG and may omit it entirely, so socket creation fails with EAFNOSUPPORT before any LSM gets to deny it.

Probe AF_ALG support on the local daemon's kernel and skip the subtest when it's unavailable.

Otherwise test fails on openSUSE Tumbleweed like this:

http://openqa-assets.opensuse.org/tests/6199435/file/docker_engine-integration-container.xml

```
Failed
=== RUN   TestExecSocketDenied/socketcall_int80/AF_ALG
    exec_afalg_linux_test.go:134: assertion failed: string "socket: address family not supported by protocol\n" does not contain "permission denied"
--- FAIL: TestExecSocketDenied/socketcall_int80/AF_ALG (0.11s)
```

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
