### PR TITLE
integration/container: only assert AF_ALG socketcall denial under Apparmor

### DIFF
--- a/integration/container/exec_afalg_linux_test.go
+++ b/integration/container/exec_afalg_linux_test.go
@@ -129,11 +129,17 @@ func TestExecSocketDenied(t *testing.T) {
 		})
 		res.AssertSuccess(t)
 
-		// AF_ALG (38) via socketcall must be denied by the LSM
-		// (AppArmor's "deny network alg" or SELinux's alg_socket deny),
-		// which catches it at the security_socket_create hook even
-		// though seccomp cannot filter socketcall args.
+		// AF_ALG (38) via socketcall must be denied by the LSM, which
+		// catches it at the security_socket_create hook even though
+		// seccomp cannot filter socketcall args. Docker ships and
+		// controls the "deny network alg" rule in its own AppArmor
+		// profile, so that backstop is verified here. SELinux
+		// enforcement of an equivalent alg_socket deny depends on the
+		// distro's container-selinux policy, which Docker does not
+		// ship, so it isn't asserted on SELinux-only hosts.
 		t.Run("AF_ALG", func(t *testing.T) {
+			skip.If(t, !hasAppArmor, "AF_ALG socketcall denial is only guaranteed by Docker's own AppArmor profile")
+
 			if testEnv.IsLocalDaemon() {
 				skip.If(t, !kernelSupportsAFALG(), "host kernel does not support AF_ALG")
 			}


### PR DESCRIPTION
## Summary

SELinux's alg_socket enforcement lives in the distro's container-selinux policy, not in anything Docker ships, so it can't be relied on in this test.

Otherwise test fails on openSUSE Tumbleweed:

http://openqa-assets.opensuse.org/tests/6199953/file/docker_engine-integration-container.xml

```
# Test messages # TestExecSocketDenied/socketcall_int80/AF_ALG
# failure: 

Failed
=== RUN   TestExecSocketDenied/socketcall_int80/AF_ALG
    exec_afalg_linux_test.go:152: assertion failed: 0 (res.ExitCode int) != 1 (int): expected AF_ALG socketcall to fail, got: socket(38, 5, 0) via socketcall succeeded
        
    exec_afalg_linux_test.go:153: assertion failed: string "socket(38, 5, 0) via socketcall succeeded\n" does not contain "permission denied"
--- FAIL: TestExecSocketDenied/socketcall_int80/AF_ALG (0.12s)
```

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
