### PR TITLE
Deny AF_VSOCK sockets via AppArmor and SELinux

### DIFF
--- a/contrib/selinux/docker-af-vsock-deny.cil
+++ b/contrib/selinux/docker-af-vsock-deny.cil
@@ -1,0 +1,12 @@
+;; Block AF_VSOCK sockets in container domains.
+;; AF_VSOCK could let a container connect to virtual machines running on the
+;; host.
+;;
+;; This rule targets container_domain (container_t, spc_t, etc.) and
+;; does not affect the container runtime (container_runtime_t) or host
+;; processes.
+;;
+;; Requires SELinux userspace >= 3.6 for CIL deny support.
+;; Requires container-selinux for the container_domain attribute.
+
+(deny container_domain self (vsock_socket (create)))

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/hashicorp/serf v0.10.4
 	github.com/in-toto/in-toto-golang v0.11.0
 	github.com/ishidawataru/sctp v0.0.0-20251114114122-19ddcbc6aae2
+	github.com/mdlayher/socket v0.6.0
 	github.com/miekg/dns v1.1.73
 	github.com/mistifyio/go-zfs/v4 v4.0.0
 	github.com/mitchellh/copystructure v1.2.0
@@ -234,7 +235,6 @@ require (
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/klauspost/compress v1.19.2 // indirect
 	github.com/knqyf263/go-plugin v0.9.0 // indirect
-	github.com/mdlayher/socket v0.6.0 // indirect
 	github.com/mdlayher/vsock v1.3.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/sys/capability v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/moby/moby/client v0.5.1
 	github.com/moby/patternmatcher v0.6.1
 	github.com/moby/policy-helpers v0.0.0-20260901142052-72f704e6cdb6
-	github.com/moby/profiles/apparmor v0.2.1
+	github.com/moby/profiles/apparmor v0.2.2-0.20260828104831-61eaf32614c7
 	github.com/moby/profiles/seccomp v0.2.3
 	github.com/moby/pubsub v1.0.0
 	github.com/moby/swarmkit/v2 v2.1.3-0.20260828175525-ad0357aedfca

--- a/go.sum
+++ b/go.sum
@@ -531,8 +531,8 @@ github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x
 github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/policy-helpers v0.0.0-20260901142052-72f704e6cdb6 h1:wxmKL9KLJGSNWvWZwkEmhN5RhGpmz+Jzp4Yu4scoM0I=
 github.com/moby/policy-helpers v0.0.0-20260901142052-72f704e6cdb6/go.mod h1:hNMdiq4WjSmuyvy8lWcflH6erzSg/MgZlFyM7vC7Z2c=
-github.com/moby/profiles/apparmor v0.2.1 h1:LAUrERjl2trYlInOppli35RQJPIfR3KMWQYeNFTd4+s=
-github.com/moby/profiles/apparmor v0.2.1/go.mod h1:DtaWKVB992B38PG5i6VZU6w71JQatA6qtkaQGiqUsoc=
+github.com/moby/profiles/apparmor v0.2.2-0.20260828104831-61eaf32614c7 h1:UT9OE6rPBJMkVCtWFGVWDMA9RjJqtHf7iQXz0zEO164=
+github.com/moby/profiles/apparmor v0.2.2-0.20260828104831-61eaf32614c7/go.mod h1:QatdynU8N2E+cQ5obf9JRwq05Wb7bPdyrAEUf6NDyK8=
 github.com/moby/profiles/seccomp v0.2.3 h1:nrHNSiECQQvq4WjgceCUgJXIXUJBIswVQ133k4Do2mA=
 github.com/moby/profiles/seccomp v0.2.3/go.mod h1:8m3qkkWZXrRsMqlUUN2zyccnYmBf3EAdQYPMVJ3NBhk=
 github.com/moby/pubsub v1.0.0 h1:jkp/imWsmJz2f6LyFsk7EkVeN2HxR/HTTOY8kHrsxfA=

--- a/integration/container/exec_afalg_linux_test.go
+++ b/integration/container/exec_afalg_linux_test.go
@@ -3,10 +3,15 @@ package container
 import (
 	"context"
 	_ "embed"
+	"fmt"
+	"io"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/mdlayher/socket"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"golang.org/x/sys/unix"
@@ -77,7 +82,9 @@ func compileAndExecSocketDenied(ctx context.Context, t *testing.T, apiClient cli
 // TestExecSocketDenied verifies that AF_ALG and AF_VSOCK sockets cannot be
 // created inside a container. AF_ALG is blocked by the default seccomp profile
 // (via socket arg filtering) and by the default AppArmor profile (via
-// "deny network alg"). AF_VSOCK is blocked by seccomp only.
+// "deny network alg"). Direct AF_VSOCK creation is blocked by seccomp. The
+// socketcall compatibility path must either be denied or unable to communicate
+// with the host.
 func TestExecSocketDenied(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 
@@ -117,11 +124,13 @@ func TestExecSocketDenied(t *testing.T) {
 		// is behind a userspace pointer). Only an LSM (AppArmor or
 		// SELinux) can deny AF_ALG via the security_socket_create hook.
 		hasAppArmor := slices.ContainsFunc(testEnv.DaemonInfo.SecurityOptions, func(option string) bool {
-			return strings.HasPrefix(option, "name=apparmor,")
+			name, _, _ := strings.Cut(option, ",")
+			return name == "name=apparmor"
 		})
-		hasLSM := hasAppArmor ||
-			slices.Contains(testEnv.DaemonInfo.SecurityOptions, "name=selinux")
-		skip.If(t, !hasLSM, "socketcall filtering requires AppArmor or SELinux")
+		hasSeLinux := slices.ContainsFunc(testEnv.DaemonInfo.SecurityOptions, func(option string) bool {
+			name, _, _ := strings.Cut(option, ",")
+			return name == "name=selinux"
+		})
 
 		srcPath := "/tmp/socketcall.c"
 		res := container.ExecT(ctx, t, apiClient, cID, []string{
@@ -129,6 +138,7 @@ func TestExecSocketDenied(t *testing.T) {
 		})
 		res.AssertSuccess(t)
 
+		hasLSM := hasAppArmor || hasSeLinux
 		// AF_ALG (38) via socketcall must be denied by the LSM
 		// (AppArmor's "deny network alg" or SELinux's alg_socket deny),
 		// which catches it at the security_socket_create hook even
@@ -137,6 +147,7 @@ func TestExecSocketDenied(t *testing.T) {
 			if testEnv.IsLocalDaemon() {
 				skip.If(t, !kernelSupportsAFALG(), "host kernel does not support AF_ALG")
 			}
+			skip.If(t, !hasLSM, "socketcall filtering requires AppArmor or SELinux")
 
 			binPath := "/tmp/socketcall_af_alg"
 			res := container.ExecT(ctx, t, apiClient, cID, append(gcc,
@@ -154,6 +165,153 @@ func TestExecSocketDenied(t *testing.T) {
 			assert.NilError(t, err)
 			assert.Check(t, is.Equal(res.ExitCode, 1), "expected AF_ALG socketcall to fail, got: %s", res.Combined())
 			assert.Check(t, is.Contains(strings.ToLower(res.Combined()), "permission denied"))
+		})
+
+		// A denied AF_VSOCK socket is sufficient. If socket creation is
+		// permitted, verify that the socket cannot communicate with the host.
+		t.Run("AF_VSOCK", func(t *testing.T) {
+			skip.If(t, !hasLSM, "socketcall filtering requires AppArmor or SELinux")
+			const probePath = "/tmp/socketcall_af_vsock_probe"
+			res := container.ExecT(ctx, t, apiClient, cID, append(gcc,
+				"-DSOCK_FAMILY=AF_VSOCK", "-DSOCK_TYPE=SOCK_STREAM",
+				"-include", "linux/vm_sockets.h",
+				srcPath, "-o", probePath,
+			))
+			res.AssertSuccess(t)
+
+			res, err := container.Exec(ctx, apiClient, cID, []string{probePath},
+				func(ec *client.ExecCreateOptions) {
+					ec.User = "1000"
+				},
+			)
+			assert.NilError(t, err)
+			probeOutput := res.Combined()
+			if res.ExitCode == 1 {
+				out := strings.ToLower(probeOutput)
+				denied := strings.Contains(out, "socket") &&
+					(strings.Contains(out, "not permitted") || strings.Contains(out, "permission denied"))
+				assert.Assert(t, denied, "unexpected AF_VSOCK creation failure: %s", probeOutput)
+				return
+			}
+			assert.Assert(t, res.ExitCode == 0, "unexpected AF_VSOCK creation probe exit code %d: %s", res.ExitCode, probeOutput)
+
+			skip.If(t, testEnv.IsRemoteDaemon, "communication check requires a local daemon")
+
+			const (
+				clientPayload         = "client-to-listener"
+				serverPayload         = "listener-to-client"
+				connectDeniedExitCode = 3
+			)
+
+			listener, err := socket.Socket(unix.AF_VSOCK, unix.SOCK_STREAM, 0, "vsock", nil)
+			if err != nil {
+				t.Skipf("AF_VSOCK listener unavailable: %v", err)
+			}
+			defer listener.Close()
+
+			if err := listener.Bind(&unix.SockaddrVM{
+				CID:  unix.VMADDR_CID_LOCAL,
+				Port: unix.VMADDR_PORT_ANY,
+			}); err != nil {
+				t.Skipf("AF_VSOCK listener unavailable: %v", err)
+			}
+			if err := listener.Listen(unix.SOMAXCONN); err != nil {
+				t.Skipf("AF_VSOCK listener unavailable: %v", err)
+			}
+
+			addr, err := listener.Getsockname()
+			if err != nil {
+				t.Skipf("AF_VSOCK listener unavailable: %v", err)
+			}
+			vmAddr, ok := addr.(*unix.SockaddrVM)
+			if !ok {
+				t.Fatalf("unexpected AF_VSOCK listener address type %T", addr)
+			}
+
+			binPath := "/tmp/socketcall_af_vsock_connect"
+			res = container.ExecT(ctx, t, apiClient, cID, append(gcc,
+				"-DSOCK_FAMILY=AF_VSOCK", "-DSOCK_TYPE=SOCK_STREAM",
+				"-DVSOCK_CONNECT", "-DPORT="+strconv.FormatUint(uint64(vmAddr.Port), 10),
+				"-DCONNECT_DENIED_EXIT_CODE="+strconv.Itoa(connectDeniedExitCode),
+				`-DCLIENT_PAYLOAD="`+clientPayload+`"`,
+				`-DEXPECTED_SERVER_PAYLOAD="`+serverPayload+`"`,
+				"-include", "linux/vm_sockets.h",
+				srcPath, "-o", binPath,
+			))
+			res.AssertSuccess(t)
+
+			type exchangeResult struct {
+				accepted bool
+				details  string
+				err      error
+			}
+
+			deadline := time.Now().Add(10 * time.Second)
+			if err := listener.SetDeadline(deadline); err != nil {
+				t.Skipf("cannot set AF_VSOCK listener deadline: %v", err)
+			}
+			serverResult := make(chan exchangeResult, 1)
+			go func() {
+				conn, _, err := listener.Accept(context.Background(), 0)
+				if err != nil {
+					serverResult <- exchangeResult{err: fmt.Errorf("accept AF_VSOCK connection: %w", err)}
+					return
+				}
+				defer conn.Close()
+
+				result := exchangeResult{accepted: true, details: "listener accepted AF_VSOCK connection"}
+				if err := conn.SetDeadline(deadline); err != nil {
+					result.err = fmt.Errorf("set AF_VSOCK connection deadline: %w", err)
+					serverResult <- result
+					return
+				}
+
+				payload := make([]byte, len(clientPayload))
+				n, err := io.ReadFull(conn, payload)
+				result.details += fmt.Sprintf("; client payload read %d/%d bytes: %q", n, len(clientPayload), payload[:n])
+				if err != nil {
+					result.err = fmt.Errorf("read client payload: %w", err)
+					serverResult <- result
+					return
+				}
+				if string(payload) != clientPayload {
+					result.err = fmt.Errorf("client payload mismatch: got %q, want %q", payload, clientPayload)
+					serverResult <- result
+					return
+				}
+
+				n64, err := io.Copy(conn, strings.NewReader(serverPayload))
+				result.details += fmt.Sprintf("; server payload wrote %d/%d bytes: %q", n64, len(serverPayload), serverPayload[:n64])
+				if err != nil {
+					result.err = fmt.Errorf("write server payload: %w", err)
+				} else if n64 != int64(len(serverPayload)) {
+					result.err = fmt.Errorf("short server payload write: wrote %d of %d bytes", n64, len(serverPayload))
+				}
+				serverResult <- result
+			}()
+
+			execCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+			res, execErr := container.Exec(execCtx, apiClient, cID, []string{binPath},
+				func(ec *client.ExecCreateOptions) {
+					ec.User = "1000"
+				},
+			)
+			cancel()
+			_ = listener.Close()
+			exchange := <-serverResult
+
+			clientOutput := ""
+			clientExitCode := -1
+			if execErr == nil {
+				clientOutput = res.Combined()
+				clientExitCode = res.ExitCode
+			}
+			if exchange.accepted {
+				t.Fatalf("AF_VSOCK communication reached the host listener\nexchange: %s\nexchange error: %v\nclient exit code: %d\nclient output: %s\nclient exec error: %v", exchange.details, exchange.err, clientExitCode, clientOutput, execErr)
+			}
+
+			assert.NilError(t, execErr, "listener result: %v; client output: %s", exchange.err, clientOutput)
+			assert.Assert(t, res.ExitCode == connectDeniedExitCode, "expected AF_VSOCK connect to fail with EPERM or EACCES; listener result: %v; client output: %s", exchange.err, clientOutput)
 		})
 
 		// AF_INET via socketcall must still work to ensure the deny

--- a/integration/container/testdata/socketcall.c
+++ b/integration/container/testdata/socketcall.c
@@ -1,11 +1,15 @@
 #include <stdio.h>
 #include <errno.h>
+#include <stdint.h>
+#include <signal.h>
+#include <string.h>
 #include <unistd.h>
 #include <sys/socket.h>
 #include <sys/mman.h>
 
 #define SYS_SOCKETCALL_I386 102
 #define SYS_SOCKET 1
+#define SYS_CONNECT 3
 
 #ifndef SOCK_FAMILY
 #error "define SOCK_FAMILY via -DSOCK_FAMILY=..."
@@ -14,19 +18,79 @@
 #error "define SOCK_TYPE via -DSOCK_TYPE=..."
 #endif
 
+#ifdef VSOCK_CONNECT
+#ifndef PORT
+#error "define PORT via -DPORT=..."
+#endif
+#ifndef CLIENT_PAYLOAD
+#error "define CLIENT_PAYLOAD via -DCLIENT_PAYLOAD=..."
+#endif
+#ifndef EXPECTED_SERVER_PAYLOAD
+#error "define EXPECTED_SERVER_PAYLOAD via -DEXPECTED_SERVER_PAYLOAD=..."
+#endif
+#ifndef CONNECT_DENIED_EXIT_CODE
+#error "define CONNECT_DENIED_EXIT_CODE via -DCONNECT_DENIED_EXIT_CODE=..."
+#endif
+
+static void timeout(int signal) {
+    (void)signal;
+    static const char message[] = "socketcall client timed out\n";
+    write(STDERR_FILENO, message, sizeof(message) - 1);
+    _exit(124);
+}
+
+static int write_full(int fd, const char *buf, size_t len) {
+    while (len > 0) {
+        ssize_t n = write(fd, buf, len);
+        if (n < 0 && errno == EINTR)
+            continue;
+        if (n <= 0) {
+            if (n == 0)
+                errno = EIO;
+            perror("write");
+            return -1;
+        }
+        buf += n;
+        len -= (size_t)n;
+    }
+    return 0;
+}
+
+static int read_full(int fd, char *buf, size_t len) {
+    while (len > 0) {
+        ssize_t n = read(fd, buf, len);
+        if (n < 0 && errno == EINTR)
+            continue;
+        if (n < 0) {
+            perror("read");
+            return -1;
+        }
+        if (n == 0) {
+            fprintf(stderr, "unexpected EOF while reading server payload\n");
+            return -1;
+        }
+        buf += n;
+        len -= (size_t)n;
+    }
+    return 0;
+}
+#endif
+
 int main() {
     /*
      * The int $0x80 ia32 compat path truncates all registers to 32 bits.
-     * The args pointer must live below 4 GB, so allocate it with MAP_32BIT.
+     * Every pointer used by socketcall must live below 4 GB, so keep its
+     * arguments and address in the MAP_32BIT allocation.
      */
-    unsigned int *args = mmap(NULL, 4096,
+    unsigned char *mapping = mmap(NULL, 4096,
         PROT_READ | PROT_WRITE,
         MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT,
         -1, 0);
-    if (args == MAP_FAILED) {
+    if (mapping == MAP_FAILED) {
         perror("mmap");
         return 2;
     }
+    unsigned int *args = (unsigned int *)mapping;
     args[0] = SOCK_FAMILY;
     args[1] = SOCK_TYPE;
     args[2] = 0;
@@ -45,7 +109,56 @@ int main() {
         return 1;
     }
 
+#ifdef VSOCK_CONNECT
+    signal(SIGALRM, timeout);
+    alarm(10);
+
+    int fd = ret;
+    struct sockaddr_vm *address = (struct sockaddr_vm *)(mapping + 64);
+    memset(address, 0, sizeof(*address));
+    address->svm_family = AF_VSOCK;
+    address->svm_cid = VMADDR_CID_LOCAL;
+    address->svm_port = PORT;
+
+    args[0] = (unsigned int)fd;
+    args[1] = (unsigned int)(uintptr_t)address;
+    args[2] = sizeof(*address);
+    asm volatile (
+        "int $0x80"
+        : "=a"(ret)
+        : "a"(SYS_SOCKETCALL_I386), "b"(SYS_CONNECT), "c"(args)
+        : "memory"
+    );
+    if (ret < 0) {
+        int error = -ret;
+        errno = error;
+        perror("connect");
+        close(fd);
+        if (error == EPERM || error == EACCES)
+            return CONNECT_DENIED_EXIT_CODE;
+        return 1;
+    }
+
+    static const char client_payload[] = CLIENT_PAYLOAD;
+    static const char server_payload[] = EXPECTED_SERVER_PAYLOAD;
+    char reply[sizeof(server_payload) - 1];
+    if (write_full(fd, client_payload, sizeof(client_payload) - 1) < 0 ||
+        read_full(fd, reply, sizeof(reply)) < 0) {
+        close(fd);
+        return 1;
+    }
+    if (memcmp(reply, server_payload, sizeof(reply)) != 0) {
+        fprintf(stderr, "server payload mismatch\n");
+        close(fd);
+        return 1;
+    }
+    alarm(0);
+    printf("AF_VSOCK connect via socketcall succeeded\n");
+    close(fd);
+    return 0;
+#else
     printf("socket(%d, %d, 0) via socketcall succeeded\n", SOCK_FAMILY, SOCK_TYPE);
     close(ret);
     return 0;
+#endif
 }

--- a/vendor/github.com/moby/profiles/apparmor/apparmor.go
+++ b/vendor/github.com/moby/profiles/apparmor/apparmor.go
@@ -1,4 +1,4 @@
-// Copyright The Moby Authors.
+// SPDX-FileCopyrightText: Copyright The Moby Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
@@ -80,16 +80,10 @@ func installDefault(ctx context.Context, name string) error {
 	// Figure out the daemon profile.
 	var daemonProfile string
 	if currentProfile, err := os.ReadFile("/proc/self/attr/current"); err == nil {
-		// /proc/self/attr/current returns the current label for the process.
-		// Unlike /sys/kernel/security/apparmor/profiles, this value may not
-		// include a " (<mode>)" suffix (e.g. it can be just "unconfined").
-		// If a suffix is present, it is of the form "<profile> (<mode>)".
-		// Profile names may contain spaces, so split on " (" rather than the
-		// first space. Trim whitespace first because the value includes a
-		// trailing newline.
-		if profile, _, _ := strings.Cut(strings.TrimSpace(string(currentProfile)), " ("); profile != "" {
-			daemonProfile = profile
-		}
+		// Profile may be either "<profile> (<mode>)", e.g. "foo (enforce)"
+		// or a bare profile (e.g. "unconfined"). Use cleanProfileName to
+		// only get the profile name.
+		daemonProfile = cleanProfileName(string(currentProfile))
 	}
 
 	p := profileData{
@@ -121,9 +115,10 @@ func isLoaded(name string, fileName string) (bool, error) {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		// Entries are of the form "<profile> (<mode>)", e.g. "foo (enforce)".
-		// Profile names may contain spaces (quoted names are supported in AppArmor),
-		// so split on " (" rather than the first space.
-		if prefix, _, ok := strings.Cut(scanner.Text(), " ("); ok && prefix == name {
+		// Profile names may contain spaces (quoted names are supported in AppArmor);
+		// use splitCon to correctly handle profile names containing spaces and/or parentheses.
+		label, _ := splitCon(scanner.Text())
+		if label == name {
 			return true, nil
 		}
 	}
@@ -144,4 +139,53 @@ func loadProfile(ctx context.Context, profile io.Reader) error {
 	}
 
 	return nil
+}
+
+// cleanProfileName returns the AppArmor profile name from a confinement
+// context as reported by /proc/self/attr/current.
+//
+// The value may be either a bare profile name, "unconfined", or a profile name
+// with a trailing mode suffix of the form " (<mode>)". If profile is empty,
+// cleanProfileName returns "unconfined".
+func cleanProfileName(profile string) string {
+	label, _ := splitCon(profile)
+	if label == "" {
+		return "unconfined"
+	}
+	return label
+}
+
+// splitCon splits an AppArmor confinement context into a label and mode,
+// similar to libapparmor [splitcon]. splitCon follows libapparmor's parsing
+// semantics and does not validate the returned mode.
+//
+// /proc/self/attr/current returns the current label for the process, but
+// unlike /sys/kernel/security/apparmor/profiles, this value may not include
+// a " (<mode>)" suffix.
+//
+// Supported forms:
+//
+//	<profile>
+//	<profile> (<mode>)
+//	unconfined
+//
+// splitCon strips one trailing newline before parsing.
+//
+// [splitcon]: https://gitlab.com/apparmor/apparmor/-/blob/v5.0.1/libraries/libapparmor/src/kernel.c#L562-615
+func splitCon(con string) (label, mode string) {
+	// Value includes a trailing newline.
+	con = strings.TrimSuffix(con, "\n")
+	if con == "" || con == "unconfined" {
+		return con, ""
+	}
+
+	if strings.HasSuffix(con, ")") {
+		// Profile names may contain spaces, so split on the last " (" before
+		// the trailing ")" rather than the first space.
+		if i := strings.LastIndex(con[:len(con)-1], " ("); i >= 0 {
+			return con[:i], con[i+2 : len(con)-1]
+		}
+	}
+
+	return con, ""
 }

--- a/vendor/github.com/moby/profiles/apparmor/template.go
+++ b/vendor/github.com/moby/profiles/apparmor/template.go
@@ -1,4 +1,4 @@
-// Copyright The Moby Authors.
+// SPDX-FileCopyrightText: Copyright The Moby Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
@@ -34,6 +34,8 @@ profile "{{.Name}}" flags=(attach_disconnected,mediate_deleted) {
   network,
   # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
   deny network alg,
+  # Disallow AF_VSOCK to prevent host/guest communication.
+  deny network vsock,
   capability,
   file,
   umount,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1335,7 +1335,7 @@ github.com/moby/policy-helpers/image
 github.com/moby/policy-helpers/roots
 github.com/moby/policy-helpers/roots/dhi
 github.com/moby/policy-helpers/types
-# github.com/moby/profiles/apparmor v0.2.1
+# github.com/moby/profiles/apparmor v0.2.2-0.20260828104831-61eaf32614c7
 ## explicit; go 1.23.0
 github.com/moby/profiles/apparmor
 # github.com/moby/profiles/seccomp v0.2.3


### PR DESCRIPTION
### contrib/selinux: Add CIL policy to deny AF_VSOCK sockets

  Moby's default seccomp profile denies direct AF_VSOCK socket creation so ordinary containers cannot connect to virtual machines on the host. On architectures with the 32-bit socketcall syscall, seccomp cannot inspect the address family because it is passed through a userspace pointer.

  Add a SELinux deny rule for vsock_socket creation. SELinux enforces this at the socket creation hook, so it covers both socket and socketcall.



### vendor: github.com/moby/profiles/apparmor v0.2.2-dev (61eaf32614c7)

  full diff: https://github.com/moby/profiles/compare/apparmor/v0.2.1...61eaf32614c7



### integration/container: Verify AF_VSOCK socketcall isolation

  AF_VSOCK must not provide host communication through the ia32 socketcall compatibility path. Accept EPERM or EACCES when socket creation is denied.

  If creation succeeds, connect to a CID-local host listener and exchange distinct payloads in both directions. Fail as soon as the host listener accepts the connection, and retain an AF_INET socketcall success case to ensure that the restriction is targeted.

  The AF_VSOCK case is expected to fail on amd64 until policy or namespace isolation closes the communication path.






```markdown changelog
Prevent containers from using the 32-bit `socketcall(2)` path to create `AF_VSOCK` sockets and communicate with host virtual machines by adding AppArmor and SELinux policy rules.
```