### PR TITLE
daemon: logstream: refactor and optimize

### DIFF
--- a/daemon/server/httputils/logstream/logstream.go
+++ b/daemon/server/httputils/logstream/logstream.go
@@ -1,12 +1,13 @@
 package logstream
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-	"sort"
+	"slices"
 
 	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/v2/daemon/internal/stdcopymux"
@@ -50,16 +51,33 @@ func Write(ctx context.Context, w http.ResponseWriter, msgs <-chan *backend.LogM
 			// check if the message contains an error. if so, write that error
 			// and exit
 			if msg.Err != nil {
-				fmt.Fprintf(sysErrStream, "Error grabbing logs: %v\n", msg.Err)
+				_, _ = fmt.Fprintf(sysErrStream, "Error grabbing logs: %v\n", msg.Err)
 				continue
 			}
-			logLine := msg.Line
-			if config.Details {
-				logLine = append(attrsByteSlice(msg.Attrs), ' ')
+			var logLine []byte
+			if !config.Timestamps && !config.Details {
+				// Fast path: avoid allocating and copying the message.
+				logLine = msg.Line
+			} else {
+				size := len(msg.Line)
+				if config.Timestamps {
+					size += len(rfc3339NanoFixed) + 1
+				}
+				if config.Details {
+					// Reserve some space for attributes to reduce reallocations.
+					size += len(msg.Attrs) * 16
+				}
+				logLine = make([]byte, 0, size)
+
+				if config.Timestamps {
+					logLine = append(logLine, msg.Timestamp.Format(rfc3339NanoFixed)...)
+					logLine = append(logLine, ' ')
+				}
+				if config.Details {
+					logLine = appendAttrs(logLine, msg.Attrs)
+					logLine = append(logLine, ' ')
+				}
 				logLine = append(logLine, msg.Line...)
-			}
-			if config.Timestamps {
-				logLine = append([]byte(msg.Timestamp.Format(rfc3339NanoFixed)+" "), logLine...)
 			}
 			switch msg.Source {
 			case "stdout":
@@ -80,26 +98,20 @@ func Write(ctx context.Context, w http.ResponseWriter, msgs <-chan *backend.LogM
 	}
 }
 
-type byKey []backend.LogAttr
-
-func (b byKey) Len() int           { return len(b) }
-func (b byKey) Less(i, j int) bool { return b[i].Key < b[j].Key }
-func (b byKey) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
-
-func attrsByteSlice(a []backend.LogAttr) []byte {
-	// Note this sorts "a" in-place. That is fine here - nothing else is
+func appendAttrs(dst []byte, attrs []backend.LogAttr) []byte {
+	// Note this sorts attrs in-place. That is fine here - nothing else is
 	// going to use Attrs or care about the order.
-	sort.Sort(byKey(a))
+	slices.SortFunc(attrs, func(a, b backend.LogAttr) int {
+		return cmp.Compare(a.Key, b.Key)
+	})
 
-	var ret []byte
-	for i, pair := range a {
-		k, v := url.QueryEscape(pair.Key), url.QueryEscape(pair.Value)
-		ret = append(ret, []byte(k)...)
-		ret = append(ret, '=')
-		ret = append(ret, []byte(v)...)
-		if i != len(a)-1 {
-			ret = append(ret, ',')
+	for i, pair := range attrs {
+		if i > 0 {
+			dst = append(dst, ',')
 		}
+		dst = append(dst, url.QueryEscape(pair.Key)...)
+		dst = append(dst, '=')
+		dst = append(dst, url.QueryEscape(pair.Value)...)
 	}
-	return ret
+	return dst
 }

--- a/daemon/server/httputils/logstream/logstream.go
+++ b/daemon/server/httputils/logstream/logstream.go
@@ -54,10 +54,26 @@ func Write(ctx context.Context, w http.ResponseWriter, msgs <-chan *backend.LogM
 				_, _ = fmt.Fprintf(sysErrStream, "Error grabbing logs: %v\n", msg.Err)
 				continue
 			}
-			var logLine []byte
+			var stream io.Writer
+			switch msg.Source {
+			case "stdout":
+				if !config.ShowStdout {
+					continue
+				}
+				stream = outStream
+			case "stderr":
+				if !config.ShowStderr {
+					continue
+				}
+				stream = errStream
+			default:
+				// unknown source
+				continue
+			}
+
 			if !config.Timestamps && !config.Details {
 				// Fast path: avoid allocating and copying the message.
-				logLine = msg.Line
+				_, _ = stream.Write(msg.Line)
 			} else {
 				size := len(msg.Line)
 				if config.Timestamps {
@@ -67,7 +83,7 @@ func Write(ctx context.Context, w http.ResponseWriter, msgs <-chan *backend.LogM
 					// Reserve some space for attributes to reduce reallocations.
 					size += len(msg.Attrs) * 16
 				}
-				logLine = make([]byte, 0, size)
+				logLine := make([]byte, 0, size)
 
 				if config.Timestamps {
 					logLine = append(logLine, msg.Timestamp.Format(rfc3339NanoFixed)...)
@@ -78,21 +94,7 @@ func Write(ctx context.Context, w http.ResponseWriter, msgs <-chan *backend.LogM
 					logLine = append(logLine, ' ')
 				}
 				logLine = append(logLine, msg.Line...)
-			}
-			switch msg.Source {
-			case "stdout":
-				if config.ShowStdout {
-					_, _ = outStream.Write(logLine)
-				}
-				continue
-			case "stderr":
-				if config.ShowStderr {
-					_, _ = errStream.Write(logLine)
-				}
-				continue
-			default:
-				// unknown source
-				continue
+				_, _ = stream.Write(logLine)
 			}
 		}
 	}

--- a/daemon/server/httputils/logstream/logstream_bench_test.go
+++ b/daemon/server/httputils/logstream/logstream_bench_test.go
@@ -1,0 +1,97 @@
+package logstream_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/moby/moby/v2/daemon/server/backend"
+	"github.com/moby/moby/v2/daemon/server/httputils/logstream"
+)
+
+type discardResponseWriter struct{}
+
+func (discardResponseWriter) Header() http.Header        { return nil }
+func (discardResponseWriter) WriteHeader(statusCode int) {}
+func (discardResponseWriter) Flush()                     {}
+func (discardResponseWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func BenchmarkWrite(b *testing.B) {
+	const line = "hello world\n"
+
+	for _, tc := range []struct {
+		name   string
+		config backend.ContainerLogsOptions
+	}{
+		{
+			name: "Plain",
+			config: backend.ContainerLogsOptions{
+				ShowStdout: true,
+			},
+		},
+		{
+			name: "Timestamps",
+			config: backend.ContainerLogsOptions{
+				ShowStdout: true,
+				Timestamps: true,
+			},
+		},
+		{
+			name: "Details",
+			config: backend.ContainerLogsOptions{
+				ShowStdout: true,
+				Details:    true,
+			},
+		},
+		{
+			name: "TimestampsAndDetails",
+			config: backend.ContainerLogsOptions{
+				ShowStdout: true,
+				Timestamps: true,
+				Details:    true,
+			},
+		},
+		{
+			name: "DiscardedWithTimestampsAndDetails",
+			config: backend.ContainerLogsOptions{
+				ShowStdout: false,
+				Timestamps: true,
+				Details:    true,
+			},
+		},
+		{
+			name: "Discarded",
+			config: backend.ContainerLogsOptions{
+				ShowStdout: false,
+			},
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			msg := &backend.LogMessage{
+				Source:    "stdout",
+				Line:      []byte(line),
+				Timestamp: time.Date(2026, 9, 2, 12, 34, 56, 123456789, time.UTC),
+				Attrs: []backend.LogAttr{
+					{Key: "container", Value: "example"},
+					{Key: "foo", Value: "bar"},
+				},
+			}
+
+			msgs := make(chan *backend.LogMessage)
+			go func() {
+				for range b.N {
+					msgs <- msg
+				}
+				close(msgs)
+			}()
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(line)))
+			b.ResetTimer()
+
+			logstream.Write(b.Context(), discardResponseWriter{}, msgs, &tc.config, false)
+		})
+	}
+}


### PR DESCRIPTION
### daemon: logstream: add benchmark

### daemon: logstream: simplify log message construction

Build log messages from left to right, appending optional timestamps and
attributes before the log payload.

Avoid allocating and copying the log payload when no additional formatting
is requested. When formatting is needed, preallocate the output buffer using
the known message and timestamp sizes, with a small per-attribute estimate
to reduce reallocations while appending details.

Replace the custom sort.Interface implementation for log attributes with
slices.SortFunc, and append encoded attributes directly to the log buffer
instead of constructing an intermediate byte slice.

This preserves the existing output format while simplifying message
construction and reducing unnecessary allocations.


### daemon: logstream: skip formatting discarded messages

Select the output stream before constructing the log message, and skip
messages for disabled or unknown streams immediately.

This avoids timestamp formatting, attribute sorting and escaping, and buffer
allocation for messages that would not be written.

For messages that don't require additional formatting, write the original
message payload directly to the selected stream.


Benchmark before/after:

```console
goos: darwin
goarch: arm64
pkg: github.com/moby/moby/v2/daemon/server/httputils/logstream
cpu: Apple M3 Pro
                                        │ before.txt  │              after.txt              │
                                        │   sec/op    │   sec/op     vs base                │
Write/Plain                               143.2n ± 8%   142.8n ± 8%        ~ (p=0.493 n=10)
Write/Timestamps                          303.0n ± 2%   290.8n ± 4%   -4.01% (p=0.002 n=10)
Write/Details                             238.4n ± 1%   193.6n ± 1%  -18.77% (p=0.000 n=10)
Write/TimestampsAndDetails                403.8n ± 1%   320.8n ± 1%  -20.56% (p=0.000 n=10)
Write/DiscardedWithTimestampsAndDetails   394.5n ± 1%   134.1n ± 4%  -66.02% (p=0.000 n=10)
Write/Discarded                           133.0n ± 0%   132.6n ± 4%        ~ (p=0.089 n=10)
geomean                                   245.5n        189.2n       -22.95%

                                        │  before.txt  │               after.txt               │
                                        │     B/s      │     B/s       vs base                 │
Write/Plain                               79.92Mi ± 8%   80.12Mi ± 8%         ~ (p=0.516 n=10)
Write/Timestamps                          37.78Mi ± 2%   39.36Mi ± 4%    +4.19% (p=0.002 n=10)
Write/Details                             48.01Mi ± 1%   59.10Mi ± 1%   +23.10% (p=0.000 n=10)
Write/TimestampsAndDetails                28.33Mi ± 1%   35.67Mi ± 1%   +25.90% (p=0.000 n=10)
Write/DiscardedWithTimestampsAndDetails   29.01Mi ± 1%   85.36Mi ± 4%  +194.25% (p=0.000 n=10)
Write/Discarded                           86.07Mi ± 0%   86.31Mi ± 4%         ~ (p=0.109 n=10)
geomean                                   46.61Mi        60.49Mi        +29.77%

                                        │  before.txt   │                after.txt                │
                                        │     B/op      │    B/op     vs base                     │
Write/Plain                                0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
Write/Timestamps                          128.00 ± 0%     80.00 ± 0%   -37.50% (p=0.000 n=10)
Write/Details                             136.00 ± 0%     48.00 ± 0%   -64.71% (p=0.000 n=10)
Write/TimestampsAndDetails                 280.0 ± 0%     112.0 ± 0%   -60.00% (p=0.000 n=10)
Write/DiscardedWithTimestampsAndDetails    280.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
Write/Discarded                            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
geomean                                               ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                                        │  before.txt  │                after.txt                │
                                        │  allocs/op   │ allocs/op   vs base                     │
Write/Plain                               0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
Write/Timestamps                          3.000 ± 0%     2.000 ± 0%   -33.33% (p=0.000 n=10)
Write/Details                             4.000 ± 0%     1.000 ± 0%   -75.00% (p=0.000 n=10)
Write/TimestampsAndDetails                7.000 ± 0%     2.000 ± 0%   -71.43% (p=0.000 n=10)
Write/DiscardedWithTimestampsAndDetails   7.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=10)
Write/Discarded                           0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
geomean                                              ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean
```



## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
