### PR TITLE
integration/service: Wait for initial tasks before updating

### DIFF
--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -111,6 +111,8 @@ func TestServiceUpdateSecrets(t *testing.T) {
 
 	serviceName := "TestService_" + t.Name()
 	serviceID := swarm.CreateService(ctx, t, d, swarm.ServiceWithName(serviceName))
+	// Avoid racing the update with the initial task startup.
+	poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, serviceID, 1), swarm.ServicePoll)
 	service := getService(ctx, t, apiClient, serviceID)
 
 	// add secret
@@ -181,6 +183,8 @@ func TestServiceUpdateConfigs(t *testing.T) {
 
 	serviceName := "TestService_" + t.Name()
 	serviceID := swarm.CreateService(ctx, t, d, swarm.ServiceWithName(serviceName))
+	// Avoid racing the update with the initial task startup.
+	poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, serviceID, 1), swarm.ServicePoll)
 	service := getService(ctx, t, apiClient, serviceID)
 
 	// add config


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/53446
- Fixes: https://github.com/moby/moby/issues/37547

## Summary

Wait for the initial service task to to start before updating configs or secrets. This avoids racing the with initial task startup and stale service versions.
