### PR TITLE
daemon/server/httputils: add contentencoding package

### DIFF
--- a/daemon/server/httputils/contentencoding/contentencoding.go
+++ b/daemon/server/httputils/contentencoding/contentencoding.go
@@ -1,0 +1,21 @@
+// Package contentencoding provides utilities for negotiating HTTP content
+// encodings.
+package contentencoding
+
+import (
+	"net/http"
+
+	"github.com/golang/gddo/httputil"
+)
+
+// Negotiate returns the best offered content encoding for the request's
+// Accept-Encoding header. If multiple offers match with equal weight, the
+// offer that appears earlier in the list is preferred.
+//
+// It returns "identity" if no content encoding is selected and an unencoded
+// response is acceptable, or an empty string if none of the offered encodings
+// and identity are acceptable.
+func Negotiate(requestHeaders http.Header, offers []string) string {
+	req := &http.Request{Header: requestHeaders}
+	return httputil.NegotiateContentEncoding(req, offers)
+}

--- a/daemon/server/httputils/contentencoding/contentencoding_test.go
+++ b/daemon/server/httputils/contentencoding/contentencoding_test.go
@@ -1,0 +1,128 @@
+package contentencoding_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/moby/moby/v2/daemon/server/httputils/contentencoding"
+)
+
+func TestNegotiate(t *testing.T) {
+	tests := []struct {
+		doc            string
+		acceptEncoding string
+		offers         []string
+		expected       string
+		skip           string
+	}{
+		{
+			doc:      "no Accept-Encoding header",
+			offers:   []string{"gzip", "deflate"},
+			expected: "identity",
+		},
+		{
+			doc:            "gzip selected",
+			acceptEncoding: "gzip",
+			offers:         []string{"gzip", "deflate"},
+			expected:       "gzip",
+		},
+		{
+			doc:            "deflate selected",
+			acceptEncoding: "deflate",
+			offers:         []string{"gzip", "deflate"},
+			expected:       "deflate",
+		},
+		{
+			doc:            "highest q wins",
+			acceptEncoding: "gzip;q=0.5, deflate;q=0.9",
+			offers:         []string{"gzip", "deflate"},
+			expected:       "deflate",
+		},
+		{
+			doc:            "tie q earlier offer wins",
+			acceptEncoding: "gzip;q=0.8, deflate;q=0.8",
+			offers:         []string{"deflate", "gzip"},
+			expected:       "deflate",
+		},
+		{
+			doc:            "wildcard selects first offer",
+			acceptEncoding: "*",
+			offers:         []string{"gzip", "deflate"},
+			expected:       "gzip",
+		},
+		{
+			// RFC 9110 section 12.5.3 specifies that identity is acceptable by
+			// default unless explicitly excluded.
+			doc:            "rejected offer falls back to identity",
+			acceptEncoding: "gzip;q=0",
+			offers:         []string{"gzip", "deflate"},
+			expected:       "identity",
+			skip:           "FIXME: gddo does not correctly negotiate identity",
+		},
+		{
+			doc:            "identity explicitly selected",
+			acceptEncoding: "identity",
+			offers:         []string{"gzip", "deflate"},
+			expected:       "identity",
+		},
+		{
+			doc:            "identity has higher quality",
+			acceptEncoding: "gzip;q=0.5, identity;q=0.8",
+			offers:         []string{"gzip"},
+			expected:       "identity",
+			skip:           "FIXME: gddo does not correctly negotiate identity",
+		},
+		{
+			doc:            "all encodings rejected",
+			acceptEncoding: "gzip;q=0, deflate;q=0, identity;q=0",
+			offers:         []string{"gzip", "deflate"},
+			expected:       "",
+		},
+		{
+			doc:            "unsupported encoding falls back to identity",
+			acceptEncoding: "unsupported",
+			offers:         []string{"gzip", "deflate"},
+			expected:       "identity",
+		},
+		{
+			doc:            "unsupported encoding with identity rejected",
+			acceptEncoding: "unsupported, identity;q=0",
+			offers:         []string{"gzip", "deflate"},
+			expected:       "",
+			skip:           "FIXME: gddo does not correctly negotiate identity",
+		},
+		{
+			// Content-coding names are case-insensitive per RFC 9110.
+			doc:            "encoding is case-insensitive",
+			acceptEncoding: "GZip",
+			offers:         []string{"gzip", "deflate"},
+			expected:       "gzip",
+			skip:           "FIXME: gddo matches content-coding names case-sensitively",
+		},
+		{
+			doc:            "offer is case-insensitive",
+			acceptEncoding: "gzip",
+			offers:         []string{"GZip", "deflate"},
+			expected:       "GZip",
+			skip:           "FIXME: gddo matches content-coding names case-sensitively",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			t.Parallel()
+			if tc.skip != "" {
+				t.Skip(tc.skip)
+			}
+			h := make(http.Header)
+			if tc.acceptEncoding != "" {
+				h.Set("Accept-Encoding", tc.acceptEncoding)
+			}
+
+			got := contentencoding.Negotiate(h, tc.offers)
+			if got != tc.expected {
+				t.Fatalf("got %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}

--- a/daemon/server/router/container/copy.go
+++ b/daemon/server/router/container/copy.go
@@ -9,9 +9,9 @@ import (
 	"io"
 	"net/http"
 
-	gddohttputil "github.com/golang/gddo/httputil"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/v2/daemon/server/httputils"
+	"github.com/moby/moby/v2/daemon/server/httputils/contentencoding"
 )
 
 // setContainerPathStatHeader encodes the stat to JSON, base64 encode, and place in a header.
@@ -45,7 +45,7 @@ func (c *containerRouter) headContainersArchive(ctx context.Context, w http.Resp
 
 func writeCompressedResponse(w http.ResponseWriter, r *http.Request, body io.Reader) error {
 	var cw io.Writer
-	switch gddohttputil.NegotiateContentEncoding(r, []string{"gzip", "deflate"}) {
+	switch contentencoding.Negotiate(r.Header, []string{"gzip", "deflate"}) {
 	case "gzip":
 		gw := gzip.NewWriter(w)
 		defer gw.Close()
@@ -59,8 +59,15 @@ func writeCompressedResponse(w http.ResponseWriter, r *http.Request, body io.Rea
 		defer fw.Close()
 		cw = fw
 		w.Header().Set("Content-Encoding", "deflate")
-	default:
+	case "identity":
 		cw = w
+	case "":
+		// No acceptable encoding.
+
+		// TODO(thaJeztah): Decide whether to return 406 or preserve the current behavior.
+		cw = w
+	default:
+		panic("unexpected content encoding")
 	}
 	_, err := io.Copy(cw, body)
 	return err


### PR DESCRIPTION
Add a small wrapper around gddo's NegotiateContentEncoding utility with a signature tailored to our use, accepting just the request headers instead of the whole request.

This keeps content-encoding negotiation behind an internal API, similar to the existing contenttype package, and prepares for internalising the gddo implementation without changing callers.

Add tests covering explicit encodings, wildcard matching, quality values, identity encoding, and the case where no encoding is acceptable.


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
