### PR TITLE
libnetwork/cnmallocator: release task addresses after a network is removed

### DIFF
--- a/daemon/libnetwork/cnmallocator/networkallocator.go
+++ b/daemon/libnetwork/cnmallocator/networkallocator.go
@@ -327,10 +327,18 @@ func (na *cnmNetworkAllocator) IsTaskAllocated(t *api.Task) bool {
 
 	// Find the first global scope network
 	for _, nAttach := range t.Networks {
-		// If the network is not allocated, the task cannot be allocated.
 		localNet, ok := na.networks[nAttach.Network.ID]
 		if !ok {
-			return false
+			// The network has been deallocated while the task was still
+			// referencing it: a network can be removed as soon as its tasks
+			// are marked for removal, before they actually terminate. The
+			// task no longer holds anything on that network, but it still
+			// holds its addresses on the remaining networks (typically the
+			// ingress network), so skip this attachment rather than
+			// declaring the whole task unallocated. Doing the latter would
+			// prevent the task from ever being deallocated and leak those
+			// addresses.
+			continue
 		}
 
 		// Nothing else to check for local scope network
@@ -516,7 +524,13 @@ func (na *cnmNetworkAllocator) releaseEndpoints(networks []*api.NetworkAttachmen
 	for _, nAttach := range networks {
 		localNet := na.getNetwork(nAttach.Network.ID)
 		if localNet == nil {
-			return fmt.Errorf("could not find network allocator state for network %s", nAttach.Network.ID)
+			// The network has already been deallocated together with its
+			// address pools, so there is nothing left to release for this
+			// attachment. Keep going: the addresses held on the other
+			// networks still have to be released.
+			log.G(context.TODO()).Debugf("network %s is already deallocated, skipping its endpoints while releasing", nAttach.Network.ID)
+			nAttach.Addresses = nil
+			continue
 		}
 
 		if localNet.isNodeLocal {

--- a/daemon/libnetwork/cnmallocator/networkallocator_test.go
+++ b/daemon/libnetwork/cnmallocator/networkallocator_test.go
@@ -789,3 +789,75 @@ func TestCorrectlyPassIPAMOptions(t *testing.T) {
 	assert.Check(t, is.DeepEqual(expectedIpamOptions, ipamDriver.actualIpamOptions))
 	assert.Check(t, err)
 }
+
+// TestDeallocateTaskAfterNetworkRemoval covers the sequence produced by
+// `docker stack rm`: the overlay network of a stack is removed as soon as its
+// tasks are marked for removal, i.e. before they have actually terminated.
+// When such a task finally terminates, the allocator must still recognise it
+// as allocated (otherwise the swarmkit allocator never calls DeallocateTask)
+// and DeallocateTask must release the addresses the task holds on its
+// remaining networks, notably the ingress network, which outlives every stack.
+func TestDeallocateTaskAfterNetworkRemoval(t *testing.T) {
+	na := newNetworkAllocator(t)
+
+	ingress := &api.Network{
+		ID: "ingressID",
+		Spec: api.NetworkSpec{
+			Annotations: api.Annotations{
+				Name: "ingress",
+			},
+			Ingress: true,
+			IPAM: &api.IPAMOptions{
+				Driver: &api.Driver{},
+				Configs: []*api.IPAMConfig{
+					{
+						Subnet:  "10.0.0.0/29",
+						Gateway: "10.0.0.1",
+					},
+				},
+			},
+		},
+	}
+	overlay := &api.Network{
+		ID: "overlayID",
+		Spec: api.NetworkSpec{
+			Annotations: api.Annotations{
+				Name: "overlay",
+			},
+		},
+	}
+	assert.NilError(t, na.Allocate(ingress))
+	assert.NilError(t, na.Allocate(overlay))
+
+	task := &api.Task{
+		ID: "taskID",
+		Networks: []*api.NetworkAttachment{
+			{Network: ingress},
+			{Network: overlay},
+		},
+	}
+	assert.NilError(t, na.AllocateTask(task))
+	assert.Check(t, na.IsTaskAllocated(task))
+	assert.Check(t, is.Len(task.Networks[0].Addresses, 1))
+	ingressAddr := task.Networks[0].Addresses[0]
+
+	// The overlay network is removed while the task is still shutting down.
+	assert.NilError(t, na.Deallocate(overlay))
+
+	// The task still holds an address on the ingress network, so it is
+	// still allocated, and deallocating it must release that address.
+	assert.Check(t, na.IsTaskAllocated(task))
+	assert.NilError(t, na.DeallocateTask(task))
+	assert.Check(t, is.Len(task.Networks[0].Addresses, 0))
+	assert.Check(t, !na.IsTaskAllocated(task))
+
+	// The ingress address must be available again.
+	task2 := &api.Task{
+		ID: "taskID2",
+		Networks: []*api.NetworkAttachment{
+			{Network: ingress, Addresses: []string{ingressAddr}},
+		},
+	}
+	assert.NilError(t, na.AllocateTask(task2))
+	assert.Check(t, is.Equal(task2.Networks[0].Addresses[0], ingressAddr))
+}


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/37338

## Summary

### Motivation

#37338 has been open since 2018: on a swarm that redeploys stacks regularly, new tasks publishing ports eventually get stuck in the `New` state with `could not find an available IP while allocating VIP`, although `docker network inspect` shows only a handful of endpoints on the network, and only restarting the manager (or recreating the network) helps. We hit it in production on Docker 28.5.2: a single-manager swarm with ~16 services publishing ports and `docker stack rm` + `docker stack deploy` a few times a week exhausted the `/24` ingress pool in about a month, while `docker network inspect ingress` listed two endpoints. Tracing where the addresses went led to one concrete, deterministically reproducible leak path in the network allocator; this PR fixes that path. Other sequences that remove a network while its tasks are still shutting down (draining a node, a node going away) go through the same code, which may explain further reports in that issue.

### Root cause

`controlapi.removeNetwork` allows a network to be removed as soon as every task referencing it is marked for removal (`DesiredState > RUNNING`), i.e. before the tasks actually terminate. `docker stack rm` does exactly that: it removes the services and immediately afterwards the networks, while the containers are still being stopped (up to `stop_grace_period`).

When such a task later reaches a terminal state, the swarmkit allocator only calls `DeallocateTask()` if `IsTaskAllocated()` is true (`manager/allocator/network.go`, `doTaskAlloc`). `cnmNetworkAllocator.IsTaskAllocated()` returned `false` as soon as one of the task's networks was unknown to the allocator, so `DeallocateTask()` was never called; `releaseEndpoints()` would also have aborted on the first unknown network. The task's entry in `na.tasks` and its addresses on the surviving networks were therefore never released. The `ingress` network outlives every stack, so every task of a service publishing ports leaked one ingress address per `docker stack rm`. A manager restart rebuilds the IPAM state from the store and hides the problem for a while, which is the "restart the leader" workaround reported in the issue.

### Fix

Confined to `daemon/libnetwork/cnmallocator/networkallocator.go`:

- `IsTaskAllocated()` skips attachments whose network has been deallocated instead of declaring the whole task unallocated;
- `releaseEndpoints()` skips such attachments (nothing is left to release there, the pools are gone) instead of returning an error, so the addresses on the remaining networks are released.

The allocation path keeps its semantics: a task gets its `na.tasks` entry only after every attachment has been allocated, and a network disappears from the allocator only after `removeNetwork` has verified that every task referencing it is on its way out. No change to the `NetworkAllocator` interface or to swarmkit is needed.

### Verification

Unit test `TestDeallocateTaskAfterNetworkRemoval` fails before the fix at both assertions (`IsTaskAllocated` returns `false`; `DeallocateTask` returns `could not find network allocator state`) and passes after; the rest of the package, including the swarmkit allocator test suite, passes.

Daemon-level reproduction on a single-node swarm, with the `ingress` network shrunk to `/28` (12 usable addresses) so that the exhaustion shows up quickly:

```sh
docker network rm ingress
docker network create --driver overlay --ingress --subnet 10.250.0.0/28 --gateway 10.250.0.1 ingress
for i in $(seq 1 12); do
  docker network create -d overlay leak_net
  docker service create -d --name leak_svc --network leak_net --publish 18090:80 alpine:3.19 sleep 300
  # wait until the task is Running, then mimic `docker stack rm`:
  docker service rm leak_svc
  docker network rm leak_net          # succeeds while the container is still being stopped
  sleep 14
done
docker service create -d --name probe --publish 18080:80 alpine:3.19 sleep 300
docker service ps probe
```

- Docker 28.5.2 as released: every iteration leaks the task's ingress address; on the 12th iteration the task itself no longer starts, and the probe stays in `New` (still after a further 30 s), the daemon logging `could not find an available IP while allocating VIP`.
- Same sequence, but `docker network rm` only after the container is gone (control run): no leak.
- Daemon built with this fix: all 12 iterations pass and the probe gets its address, immediately and after a further 30 s.

## Release notes (optional)

Fix a leak of swarm task IP addresses (typically on the `ingress` network) when a network is removed while tasks attached to it are still shutting down, for example by `docker stack rm`. Over time the leak exhausted the network's address pool and left new tasks stuck in the `New` state with "could not find an available IP while allocating VIP".
