### PR TITLE
daemon/c8d-supervised: Disable CRI plugins in containerd v2

### DIFF
--- a/daemon/internal/containerd/server/supervisor/remote_daemon_options.go
+++ b/daemon/internal/containerd/server/supervisor/remote_daemon_options.go
@@ -30,10 +30,17 @@ func WithLogFormat(format log.OutputFormat) DaemonOpt {
 	}
 }
 
-// WithCRIDisabled disables the CRI plugin.
+// WithCRIDisabled disables the CRI plugins.
+//
+// Containerd v1 uses the single io.containerd.grpc.v1.cri plugin, while
+// containerd v2 splits CRI into io.containerd.cri.v1.images and io.containerd.cri.v1.runtime.
 func WithCRIDisabled() DaemonOpt {
 	return func(r *Daemon) error {
-		r.config.DisabledPlugins = append(r.config.DisabledPlugins, "io.containerd.grpc.v1.cri")
+		r.config.DisabledPlugins = append(r.config.DisabledPlugins,
+			"io.containerd.grpc.v1.cri",
+			"io.containerd.cri.v1.images",
+			"io.containerd.cri.v1.runtime",
+		)
 		return nil
 	}
 }


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

- related to: https://github.com/containerd/containerd/pull/9681

Managed containerd disabled only the containerd v1 monolithic CRI plugin.

After containerd v2, that plugin was split into two separate:
- io.containerd.cri.v1.images
- io.containerd.cri.v1.runtime


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Prevent containerd's v2 CRI plugins from loading when CRI is disabled.
```

## A picture of a cute animal (not mandatory but encouraged)
