### PR TITLE
integration/container: Fix LSM name detection

### DIFF
--- a/integration/container/exec_afalg_linux_test.go
+++ b/integration/container/exec_afalg_linux_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mdlayher/socket"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/pkg/security"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
@@ -123,13 +124,12 @@ func TestExecSocketDenied(t *testing.T) {
 		// Seccomp cannot filter socketcall arguments (the address family
 		// is behind a userspace pointer). Only an LSM (AppArmor or
 		// SELinux) can deny AF_ALG via the security_socket_create hook.
-		hasAppArmor := slices.ContainsFunc(testEnv.DaemonInfo.SecurityOptions, func(option string) bool {
-			name, _, _ := strings.Cut(option, ",")
-			return name == "name=apparmor"
+		securityOptions := security.DecodeOptions(testEnv.DaemonInfo.SecurityOptions)
+		hasAppArmor := slices.ContainsFunc(securityOptions, func(option security.Option) bool {
+			return option.Name == "apparmor"
 		})
-		hasSeLinux := slices.ContainsFunc(testEnv.DaemonInfo.SecurityOptions, func(option string) bool {
-			name, _, _ := strings.Cut(option, ",")
-			return name == "name=selinux"
+		hasSeLinux := slices.ContainsFunc(securityOptions, func(option security.Option) bool {
+			return option.Name == "selinux"
 		})
 
 		srcPath := "/tmp/socketcall.c"

--- a/vendor/github.com/moby/moby/client/pkg/security/security_opts.go
+++ b/vendor/github.com/moby/moby/client/pkg/security/security_opts.go
@@ -1,0 +1,40 @@
+package security
+
+import (
+	"strings"
+)
+
+// Option contains the name and options of a security option
+type Option struct {
+	Name    string
+	Options []KeyValue
+}
+
+// KeyValue holds a key/value pair.
+type KeyValue struct {
+	Key, Value string
+}
+
+// DecodeOptions decodes a security options string slice to a
+// type-safe [Option].
+func DecodeOptions(opts []string) []Option {
+	so := make([]Option, 0, len(opts))
+	for _, opt := range opts {
+		secopt := Option{}
+		for s := range strings.SplitSeq(opt, ",") {
+			k, v, _ := strings.Cut(s, "=")
+			if k == "" {
+				continue
+			}
+			if k == "name" {
+				secopt.Name = v
+				continue
+			}
+			secopt.Options = append(secopt.Options, KeyValue{Key: k, Value: v})
+		}
+		if secopt.Name != "" {
+			so = append(so, secopt)
+		}
+	}
+	return so
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1322,6 +1322,7 @@ github.com/moby/moby/client/internal
 github.com/moby/moby/client/internal/mod
 github.com/moby/moby/client/internal/timestamp
 github.com/moby/moby/client/pkg/jsonmessage
+github.com/moby/moby/client/pkg/security
 github.com/moby/moby/client/pkg/stringid
 github.com/moby/moby/client/pkg/versions
 # github.com/moby/patternmatcher v0.6.1


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

Security option fields are comma-separated, but the LSM name is not required to be first. Decode them with the shared client security parser so the socketcall test does not skip when AppArmor or SELinux is active.


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
