### PR TITLE
daemon/libnetwork: Skip flaky NetworkDB islands test

### DIFF
--- a/daemon/libnetwork/networkdb/networkdb_test.go
+++ b/daemon/libnetwork/networkdb/networkdb_test.go
@@ -1038,6 +1038,8 @@ func TestParallelDelete(t *testing.T) {
 }
 
 func TestNetworkDBIslands(t *testing.T) {
+	t.Skip("FIXME: flaky test; see https://github.com/moby/moby/issues/42459")
+
 	pollTimeout := func() time.Duration {
 		const defaultTimeout = 120 * time.Second
 		dl, ok := t.Deadline()


### PR DESCRIPTION
- address: https://github.com/moby/moby/issues/42459"