### PR TITLE
extpoints: Remove unused mobyextgen service directives

### DIFF
--- a/extpoints/containernamegenerator/v0/containernamegenerator.go
+++ b/extpoints/containernamegenerator/v0/containernamegenerator.go
@@ -36,8 +36,6 @@ type GenerateContainerNameReply struct {
 }
 
 // Point is the single-provider container name-generator point.
-//
-//mobyextgen:service=ContainerNameGenerator
 var Point = extensions.DefineSinglePoint[ContainerNameGenerator]("org.mobyproject.extension.containernamegenerator.v0")
 
 // GenerateContainerName calls the effective container name provider.

--- a/extpoints/servicenamegenerator/v0/servicenamegenerator.go
+++ b/extpoints/servicenamegenerator/v0/servicenamegenerator.go
@@ -35,8 +35,6 @@ type GenerateServiceNameReply struct {
 }
 
 // Point is the single-provider service name-generator point.
-//
-//mobyextgen:service=ServiceNameGenerator
 var Point = extensions.DefineSinglePoint[ServiceNameGenerator]("org.mobyproject.extension.servicenamegenerator.v0")
 
 // GenerateServiceName calls the effective service name provider.


### PR DESCRIPTION
mobyextgen infers each ordinary point's service interface from the generic type argument to DefinePoint or DefineSinglePoint.

These comments were leftovers from the initial version which I forgot to remove.