### PR TITLE
daemon/c8d-supervised: Disable CRI pod sandbox plugin

### DIFF
--- a/daemon/internal/containerd/server/supervisor/remote_daemon_options.go
+++ b/daemon/internal/containerd/server/supervisor/remote_daemon_options.go
@@ -33,13 +33,14 @@ func WithLogFormat(format log.OutputFormat) DaemonOpt {
 // WithCRIDisabled disables the CRI plugins.
 //
 // Containerd v1 uses the single io.containerd.grpc.v1.cri plugin, while
-// containerd v2 splits CRI into io.containerd.cri.v1.images and io.containerd.cri.v1.runtime.
+// containerd v2 splits CRI across multiple plugins.
 func WithCRIDisabled() DaemonOpt {
 	return func(r *Daemon) error {
 		r.config.DisabledPlugins = append(r.config.DisabledPlugins,
 			"io.containerd.grpc.v1.cri",
 			"io.containerd.cri.v1.images",
 			"io.containerd.cri.v1.runtime",
+			"io.containerd.podsandbox.controller.v1.podsandbox",
 		)
 		return nil
 	}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

Managed containerd disabled the containerd v2 CRI runtime plugin but still attempted to initialize its pod-sandbox controller:

```
failed to load plugin error="unable to load CRI runtime service plugin dependency: no plugins registered for io.containerd.cri.v1.runtime: plugin: not found" id=io.containerd.podsandbox.controller.v1.podsandbox type=io.containerd.podsandbox.controller.v1
```

Disable the pod-sandbox controller with the other CRI plugins.


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Fix managed containerd logging a CRI pod-sandbox plugin dependency warning during startup.
```

## A picture of a cute animal (not mandatory but encouraged)
