### PR TITLE
daemon: simplify healthcheck tests

### DIFF
--- a/daemon/health_test.go
+++ b/daemon/health_test.go
@@ -1,8 +1,6 @@
 package daemon
 
 import (
-	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -10,15 +8,10 @@ import (
 	eventtypes "github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/events"
+	"gotest.tools/v3/assert"
 )
 
-func reset(c *container.Container) {
-	c.State = &container.State{}
-	c.State.Health = &container.Health{}
-	c.State.Health.SetStatus(containertypes.Starting)
-}
-
-func TestNoneHealthcheck(t *testing.T) {
+func TestHealthcheckNone(t *testing.T) {
 	c := &container.Container{
 		ID:   "container_id",
 		Name: "container_name",
@@ -31,131 +24,136 @@ func TestNoneHealthcheck(t *testing.T) {
 		State: &container.State{},
 	}
 	store, err := container.NewViewDB()
-	if err != nil {
-		t.Fatal(err)
-	}
-	daemon := &Daemon{
-		containersReplica: store,
-	}
-
+	assert.NilError(t, err)
+	daemon := &Daemon{containersReplica: store}
 	daemon.initHealthMonitor(c)
-	if c.State.Health != nil {
-		t.Error("Expecting Health to be nil, but was not")
-	}
+	assert.Assert(t, c.State.Health == nil)
 }
 
-// FIXME(vdemeester) This takes around 3s… This is *way* too long
 func TestHealthStates(t *testing.T) {
-	e := events.New()
-	_, l, cancel := e.Subscribe()
-	defer cancel()
+	tests := []struct {
+		name        string
+		retries     int
+		startPeriod time.Duration
+		test        func(t *testing.T, c *container.Container, handleResult func(time.Duration, int), expectEvent func(eventtypes.Action))
+	}{
+		{
+			name:    "status transitions",
+			retries: 1,
+			test: func(t *testing.T, c *container.Container, handleResult func(time.Duration, int), expectEvent func(eventtypes.Action)) {
+				handleResult(time.Second, 1)
+				expectEvent(eventtypes.ActionHealthStatusUnhealthy)
 
-	expect := func(expected eventtypes.Action) {
-		select {
-		case event := <-l:
-			ev := event.(eventtypes.Message)
-			if ev.Action != expected {
-				t.Errorf("Expecting event %#v, but got %#v\n", expected, ev.Action)
-			}
-		case <-time.After(1 * time.Second):
-			t.Errorf("Expecting event %#v, but got nothing\n", expected)
-		}
-	}
+				handleResult(2*time.Second, 0)
+				expectEvent(eventtypes.ActionHealthStatusHealthy)
 
-	c := &container.Container{
-		ID:   "container_id",
-		Name: "container_name",
-		Config: &containertypes.Config{
-			Image: "image_name",
+				handleResult(3*time.Second, 1)
+				expectEvent(eventtypes.ActionHealthStatusUnhealthy)
+			},
+		},
+		{
+			name:    "retries",
+			retries: 3,
+			test: func(t *testing.T, c *container.Container, handleResult func(time.Duration, int), expectEvent func(eventtypes.Action)) {
+				handleResult(20*time.Second, 1)
+				handleResult(40*time.Second, 1)
+
+				assert.Equal(t, c.State.Health.Status(), containertypes.Starting)
+				assert.Equal(t, c.State.Health.FailingStreak, 2)
+
+				handleResult(60*time.Second, 1)
+				expectEvent(eventtypes.ActionHealthStatusUnhealthy)
+
+				handleResult(80*time.Second, 0)
+				expectEvent(eventtypes.ActionHealthStatusHealthy)
+
+				assert.Equal(t, c.State.Health.FailingStreak, 0)
+			},
+		},
+		{
+			name:        "start period",
+			retries:     2,
+			startPeriod: 30 * time.Second,
+			test: func(t *testing.T, c *container.Container, handleResult func(time.Duration, int), expectEvent func(eventtypes.Action)) {
+				handleResult(20*time.Second, 1)
+
+				assert.Equal(t, c.State.Health.Status(), containertypes.Starting)
+				assert.Equal(t, c.State.Health.FailingStreak, 0)
+
+				handleResult(50*time.Second, 1)
+
+				assert.Equal(t, c.State.Health.Status(), containertypes.Starting)
+				assert.Equal(t, c.State.Health.FailingStreak, 1)
+
+				handleResult(80*time.Second, 0)
+				expectEvent(eventtypes.ActionHealthStatusHealthy)
+
+				assert.Equal(t, c.State.Health.FailingStreak, 0)
+			},
 		},
 	}
 
-	store, err := container.NewViewDB()
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := events.New()
+			_, listener, cancel := e.Subscribe()
+			t.Cleanup(cancel)
 
-	daemon := &Daemon{
-		EventsService:     e,
-		containersReplica: store,
-	}
-	muteLogs(t)
+			store, err := container.NewViewDB()
+			assert.NilError(t, err)
 
-	c.Config.Healthcheck = &containertypes.HealthConfig{
-		Retries: 1,
-	}
+			c := &container.Container{
+				ID:   "container_id",
+				Name: "container_name",
+				Config: &containertypes.Config{
+					Image: "image_name",
+					Healthcheck: &containertypes.HealthConfig{
+						Retries:     tc.retries,
+						StartPeriod: tc.startPeriod,
+					},
+				},
+				State: &container.State{
+					Health: &container.Health{
+						Health: containertypes.Health{
+							Status: containertypes.Starting,
+						},
+					},
+				},
+			}
 
-	reset(c)
+			daemon := &Daemon{
+				EventsService:     e,
+				containersReplica: store,
+			}
 
-	handleResult := func(startTime time.Time, exitCode int) {
-		handleProbeResult(daemon, c, &containertypes.HealthcheckResult{
-			Start:    startTime,
-			End:      startTime,
-			ExitCode: exitCode,
-		}, nil)
-	}
+			handleResult := func(sinceStart time.Duration, exitCode int) {
+				start := c.State.StartedAt.Add(sinceStart)
+				handleProbeResult(daemon, c, &containertypes.HealthcheckResult{
+					Start:    start,
+					End:      start,
+					ExitCode: exitCode,
+				}, nil)
+			}
 
-	// starting -> failed -> success -> failed
+			// expectEvent verifies that the next emitted event has the expected action.
+			expectEvent := func(expected eventtypes.Action) {
+				t.Helper()
 
-	handleResult(c.State.StartedAt.Add(1*time.Second), 1)
-	expect(eventtypes.ActionHealthStatusUnhealthy)
-
-	handleResult(c.State.StartedAt.Add(2*time.Second), 0)
-	expect(eventtypes.ActionHealthStatusHealthy)
-
-	handleResult(c.State.StartedAt.Add(3*time.Second), 1)
-	expect(eventtypes.ActionHealthStatusUnhealthy)
-
-	// Test retries
-
-	reset(c)
-	c.Config.Healthcheck.Retries = 3
-
-	handleResult(c.State.StartedAt.Add(20*time.Second), 1)
-	handleResult(c.State.StartedAt.Add(40*time.Second), 1)
-	if status := c.State.Health.Status(); status != containertypes.Starting {
-		t.Errorf("Expecting starting, but got %#v\n", status)
-	}
-	if c.State.Health.Health.FailingStreak != 2 {
-		t.Errorf("Expecting FailingStreak=2, but got %d\n", c.State.Health.Health.FailingStreak)
-	}
-	handleResult(c.State.StartedAt.Add(60*time.Second), 1)
-	expect(eventtypes.ActionHealthStatusUnhealthy)
-
-	handleResult(c.State.StartedAt.Add(80*time.Second), 0)
-	expect(eventtypes.ActionHealthStatusHealthy)
-	if c.State.Health.FailingStreak != 0 {
-		t.Errorf("Expecting FailingStreak=0, but got %d\n", c.State.Health.Health.FailingStreak)
-	}
-
-	// Test start period
-
-	reset(c)
-	c.Config.Healthcheck.Retries = 2
-	c.Config.Healthcheck.StartPeriod = 30 * time.Second
-
-	handleResult(c.State.StartedAt.Add(20*time.Second), 1)
-	if status := c.State.Health.Status(); status != containertypes.Starting {
-		t.Errorf("Expecting starting, but got %#v\n", status)
-	}
-	if c.State.Health.Health.FailingStreak != 0 {
-		t.Errorf("Expecting FailingStreak=0, but got %d\n", c.State.Health.FailingStreak)
-	}
-	handleResult(c.State.StartedAt.Add(50*time.Second), 1)
-	if status := c.State.Health.Status(); status != containertypes.Starting {
-		t.Errorf("Expecting starting, but got %#v\n", status)
-	}
-	if c.State.Health.Health.FailingStreak != 1 {
-		t.Errorf("Expecting FailingStreak=1, but got %d\n", c.State.Health.Health.FailingStreak)
-	}
-	handleResult(c.State.StartedAt.Add(80*time.Second), 0)
-	expect(eventtypes.ActionHealthStatusHealthy)
-	if c.State.Health.Health.FailingStreak != 0 {
-		t.Errorf("Expecting FailingStreak=0, but got %d\n", c.State.Health.Health.FailingStreak)
+				select {
+				case event := <-listener:
+					ev, ok := event.(eventtypes.Message)
+					assert.Assert(t, ok)
+					assert.Equal(t, ev.Action, expected)
+				default:
+					t.Fatalf("expected event %v, got none", expected)
+				}
+			}
+			tc.test(t, c, handleResult, expectEvent)
+		})
 	}
 }
 
-func TestCmdProbeEmptyCommand(t *testing.T) {
+func TestHealthcheckEmptyCommand(t *testing.T) {
 	c := &container.Container{
 		ID: "container_id",
 		Config: &containertypes.Config{
@@ -164,12 +162,8 @@ func TestCmdProbeEmptyCommand(t *testing.T) {
 			},
 		},
 	}
-	p := &cmdProbe{shell: false}
-	_, err := p.run(context.Background(), nil, c)
-	if err == nil {
-		t.Fatal("expected error for empty healthcheck command, got nil")
-	}
-	if !strings.Contains(err.Error(), "has no command") {
-		t.Fatalf("expected 'has no command' error, got: %v", err)
-	}
+
+	p := &cmdProbe{}
+	_, err := p.run(t.Context(), nil, c)
+	assert.ErrorContains(t, err, "has no command")
 }


### PR DESCRIPTION
Split TestHealthcheckStates into isolated subtests and clean up the related healthcheck tests using gotest.tools assertions.

Remove the timeout used when checking emitted health events, as event publication completes before handleProbeResult returns. This also removes the stale FIXME about the test taking several seconds.

Rename the healthcheck tests to use a common prefix for consistency.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
