### PR TITLE
daemon: check for error-type for "removal already in progress"

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -37,8 +37,11 @@ func (daemon *Daemon) containerRm(cfg *config.Config, name string, opts *backend
 
 	// Container state RemovalInProgress should be used to avoid races.
 	if inProgress := ctr.State.SetRemovalInProgress(); inProgress {
-		err := fmt.Errorf("removal of container %s is already in progress", name)
-		return errdefs.Conflict(err)
+		// TODO(thaJeztah): Consider waiting for an in-progress removal instead of returning a conflict.
+		// Concurrent removal is not itself a conflicting operation, and using Conflict makes it
+		// indistinguishable from actual state conflicts, such as attempting to remove a running
+		// or paused container without force.
+		return errdefs.Conflict(fmt.Errorf("removal of container %s is already in progress", name))
 	}
 	defer ctr.State.ResetRemovalInProgress()
 

--- a/daemon/delete_test.go
+++ b/daemon/delete_test.go
@@ -80,11 +80,12 @@ func TestContainerDelete(t *testing.T) {
 	}
 }
 
-func TestContainerDoubleDelete(t *testing.T) {
-	c := newContainerWithState(&container.State{})
-
-	// Mark the container as having a delete in progress
-	c.State.SetRemovalInProgress()
+// TestContainerDeleteRemovalInProgress verifies that removing a container
+// that is already being removed returns a conflict, even when forced.
+func TestContainerDeleteRemovalInProgress(t *testing.T) {
+	c := newContainerWithState(&container.State{
+		RemovalInProgress: true,
+	})
 
 	d, cleanup := newDaemonWithTmpRoot(t)
 	defer cleanup()
@@ -93,5 +94,6 @@ func TestContainerDoubleDelete(t *testing.T) {
 	// Try to remove the container when its state is removalInProgress.
 	// It should return an error indicating it is under removal progress.
 	err := d.ContainerRm(c.ID, &backend.ContainerRmConfig{ForceRemove: true})
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsConflict))
 	assert.Check(t, is.ErrorContains(err, fmt.Sprintf("removal of container %s is already in progress", c.ID)))
 }

--- a/internal/testutil/environment/clean.go
+++ b/internal/testutil/environment/clean.go
@@ -76,7 +76,7 @@ func deleteAllContainers(ctx context.Context, t testing.TB, apiclient client.Con
 		})
 
 		// Ignore if container is already gone, or removal of container is already in progress.
-		if err == nil || cerrdefs.IsNotFound(err) || strings.Contains(err.Error(), "is already in progress") {
+		if err == nil || cerrdefs.IsNotFound(err) || (cerrdefs.IsConflict(err) && strings.Contains(err.Error(), "is already in progress")) {
 			continue
 		}
 		assert.Check(t, err, "failed to remove %s", ctr.ID)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
