### PR TITLE
integration/networking: make TestNslookupWindows less flaky

### DIFF
--- a/integration/networking/resolvconf_test.go
+++ b/integration/networking/resolvconf_test.go
@@ -198,17 +198,32 @@ func TestNslookupWindows(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "windows")
 
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
 	attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	res := container.RunAttach(attachCtx, t, c,
-		container.WithCmd("nslookup", "docker.com"),
+	res := container.RunAttach(attachCtx, t, apiClient,
+		container.WithCmd("nslookup", "example.com"),
 	)
-	defer c.ContainerRemove(ctx, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+	t.Cleanup(func() {
+		container.Remove(ctx, t, apiClient, res.ContainerID, client.ContainerRemoveOptions{Force: true})
+	})
 
 	assert.Check(t, is.Equal(res.ExitCode, 0))
 	// Current default is to forward requests to external servers, which
 	// can only be changed in daemon.json using feature flag "windows-dns-proxy".
-	assert.Check(t, is.Contains(res.Stdout.String(), "Addresses:"))
+	output := res.Stdout.String()
+	_, answer, ok := strings.Cut(output, "Name:")
+	assert.Check(t, ok, "nslookup output does not contain an answer: %q", output)
+	if !ok {
+		return
+	}
+
+	name, answer, _ := strings.Cut(answer, "\n")
+	assert.Check(t, is.Equal(strings.TrimSpace(name), "example.com"))
+
+	assert.Check(t, strings.Contains(answer, "Address:") ||
+		strings.Contains(answer, "Addresses:"),
+		"nslookup output does not contain an address: %q", output,
+	)
 }


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/53600
- updates https://github.com/moby/moby/pull/47584
- updates https://github.com/moby/moby/pull/52477


Accept both the singular and plural address output from nslookup, as it uses "Address:" when only one address is returned and "Addresses:" when multiple addresses are returned.

Also use example.com for the external DNS lookup, as the test only needs to verify resolution of an external name.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
