### PR TITLE
pkg/tailfile: Handle truncation during tail scans

### DIFF
--- a/pkg/tailfile/tailfile.go
+++ b/pkg/tailfile/tailfile.go
@@ -40,8 +40,12 @@ func TailFile(f *os.File, n int) ([][]byte, error) {
 	return buf, nil
 }
 
-// SizeReaderAt is an interface used to get a ReaderAt as well as the size of the underlying reader.
-// Note that the size of the underlying reader should not change when using this interface.
+// SizeReaderAt provides a ReaderAt and the size of its underlying data.
+// The reported size may be stale if the underlying data is truncated.
+// If truncation is detected while locating the tail, scanning restarts at the
+// shortened end.
+// Other concurrent mutations are not supported.
+// The returned tail reader is not a snapshot of the underlying data.
 type SizeReaderAt interface {
 	io.ReaderAt
 	Size() int64
@@ -63,42 +67,46 @@ func NewTailReaderWithDelimiter(ctx context.Context, r SizeReaderAt, reqLines in
 	if len(delimiter) == 0 {
 		return nil, 0, errors.New("must provide a delimiter")
 	}
-	var (
-		size      = r.Size()
-		tailStart int64
-		tailEnd   = size
-		found     int
-	)
-
-	if int64(len(delimiter)) >= size {
+	if int64(len(delimiter)) >= r.Size() {
 		return io.NewSectionReader(bytes.NewReader(nil), 0, 0), 0, nil
 	}
 
 	s := newScanner(r, delimiter)
-	for s.Scan(ctx) {
-		if err := s.Err(); err != nil {
-			return nil, 0, s.Err()
+	for {
+		size := s.end
+		s.pos = size
+		s.idx = 0
+		var (
+			tailEnd int64
+			found   int
+		)
+		for s.Scan(ctx) {
+			found++
+			if found == 1 {
+				tailEnd = s.End()
+			}
+			if found == reqLines {
+				break
+			}
 		}
-
-		found++
-		if found == 1 {
-			tailEnd = s.End()
-		}
+		var tailStart int64
 		if found == reqLines {
-			break
+			tailStart = s.Start(ctx)
 		}
-	}
+		if err := s.Err(); err != nil {
+			return nil, 0, err
+		}
+		// Truncation invalidates the recorded delimiters. Each retry starts
+		// at a strictly smaller end, so a stale Size cannot prevent progress.
+		if s.end < size {
+			continue
+		}
+		if found == 0 {
+			return io.NewSectionReader(bytes.NewReader(nil), 0, 0), 0, nil
+		}
 
-	tailStart = s.Start(ctx)
-
-	if found == 0 {
-		return io.NewSectionReader(bytes.NewReader(nil), 0, 0), 0, nil
+		return io.NewSectionReader(r, tailStart, tailEnd-tailStart), found, nil
 	}
-
-	if found < reqLines && tailStart != 0 {
-		tailStart = 0
-	}
-	return io.NewSectionReader(r, tailStart, tailEnd-tailStart), found, nil
 }
 
 func newScanner(r SizeReaderAt, delim []byte) *scanner {
@@ -112,6 +120,7 @@ func newScanner(r SizeReaderAt, delim []byte) *scanner {
 	return &scanner{
 		r:     r,
 		pos:   size,
+		end:   size,
 		buf:   make([]byte, readSize),
 		delim: delim,
 	}
@@ -120,12 +129,14 @@ func newScanner(r SizeReaderAt, delim []byte) *scanner {
 type scanner struct {
 	r     SizeReaderAt
 	pos   int64
+	end   int64
 	buf   []byte
 	delim []byte
 	err   error
 	idx   int
 }
 
+// Start locates the start of the current record, advancing the scanner if needed.
 func (s *scanner) Start(ctx context.Context) int64 {
 	if s.idx > 0 {
 		idx := bytes.LastIndex(s.buf[:s.idx], s.delim)
@@ -134,22 +145,10 @@ func (s *scanner) Start(ctx context.Context) int64 {
 		}
 	}
 
-	// slow path
-	buf := make([]byte, len(s.buf))
-	copy(buf, s.buf)
-
-	readAhead := &scanner{
-		r:     s.r,
-		pos:   s.pos,
-		delim: s.delim,
-		idx:   s.idx,
-		buf:   buf,
-	}
-
-	if !readAhead.Scan(ctx) {
+	if !s.Scan(ctx) {
 		return 0
 	}
-	return readAhead.End()
+	return s.End()
 }
 
 func (s *scanner) End() int64 {
@@ -187,8 +186,21 @@ func (s *scanner) Scan(ctx context.Context) bool {
 				s.err = err
 				return false
 			}
+			if n < readSize {
+				end := offset + int64(n)
+				if n == 0 && offset > 0 {
+					// Probe for the new end instead of stepping one empty block at a time.
+					end, err = s.findEnd(ctx, offset)
+					if err != nil {
+						s.err = err
+						return false
+					}
+				}
+				s.end = end
+				return false
+			}
 
-			s.pos -= int64(n)
+			s.pos = offset
 			idx = n
 		}
 
@@ -211,4 +223,30 @@ func (s *scanner) Scan(ctx context.Context) bool {
 			s.pos += int64(len(s.delim)) - 1
 		}
 	}
+}
+
+// findEnd returns the current end of the data, given that a read at hi
+// returned nothing. It binary searches for the last readable byte, so a large
+// truncation costs O(log n) reads rather than one read per block.
+func (s *scanner) findEnd(ctx context.Context, hi int64) (int64, error) {
+	var (
+		lo int64
+		b  [1]byte
+	)
+	for lo < hi {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		mid := lo + (hi-lo)/2
+		n, err := s.r.ReadAt(b[:], mid)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return 0, err
+		}
+		if n == 0 {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	return lo, nil
 }

--- a/pkg/tailfile/tailfile_test.go
+++ b/pkg/tailfile/tailfile_test.go
@@ -139,6 +139,227 @@ truncated line`)
 	}
 }
 
+func TestNewTailReaderWithDelimiterAfterTruncation(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		data        string
+		sectionSize int64
+		delimiter   string
+		reqLines    int
+		want        string
+		wantLines   int
+	}{
+		{
+			name:        "empty backing",
+			sectionSize: blockSize + 7,
+			delimiter:   "\n",
+			reqLines:    3,
+		},
+		{
+			name:        "large truncation",
+			data:        "one\ntwo\npartial",
+			sectionSize: 1000 * blockSize,
+			delimiter:   "\n",
+			reqLines:    10,
+			want:        "one\ntwo\n",
+			wantLines:   2,
+		},
+		{
+			name:        "partial read limited records",
+			data:        "a\nbb\nccc\npartial",
+			sectionSize: int64(len("a\nbb\nccc\npartial") + 4),
+			delimiter:   "\n",
+			reqLines:    2,
+			want:        "bb\nccc\n",
+			wantLines:   2,
+		},
+		{
+			name:        "short read matching overlap length",
+			data:        "###",
+			sectionSize: 20,
+			delimiter:   "####",
+			reqLines:    2,
+		},
+		{
+			name:        "boundary spanning delimiter",
+			data:        "aaaa####",
+			sectionSize: blockSize + 6,
+			delimiter:   "####",
+			reqLines:    3,
+			want:        "aaaa####",
+			wantLines:   1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			section := io.NewSectionReader(strings.NewReader(tc.data), 0, tc.sectionSize)
+			r := &boundedSizeReaderAt{t: t, SectionReader: section}
+
+			tail, lines, err := NewTailReaderWithDelimiter(context.Background(), r, tc.reqLines, []byte(tc.delimiter))
+			assert.NilError(t, err)
+			assert.Equal(t, lines, tc.wantLines)
+			assert.Equal(t, tail.Size(), int64(len(tc.want)))
+
+			got, err := io.ReadAll(tail)
+			assert.NilError(t, err)
+			assert.Equal(t, string(got), tc.want)
+		})
+	}
+}
+
+func TestNewTailReaderReadError(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		data        string
+		sectionSize int64
+		failRead    int
+	}{
+		{name: "scan", sectionSize: 2 * blockSize, failRead: 1},
+		{name: "end probe", sectionSize: 2 * blockSize, failRead: 2},
+		{
+			name:     "read ahead",
+			data:     "one\n" + strings.Repeat("a", 2*blockSize) + "\n",
+			failRead: 2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			wantErr := errors.New("read failed")
+			data := strings.NewReader(tc.data)
+			var reads int
+			r := io.NewSectionReader(readerAtFunc(func(p []byte, off int64) (int, error) {
+				reads++
+				if reads >= tc.failRead {
+					return 0, wantErr
+				}
+				return data.ReadAt(p, off)
+			}), 0, max(tc.sectionSize, data.Size()))
+
+			_, _, err := NewTailReader(context.Background(), r, 1)
+			assert.ErrorIs(t, err, wantErr)
+		})
+	}
+}
+
+func TestNewTailReaderCancelEndSearch(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := io.NewSectionReader(readerAtFunc(func(p []byte, off int64) (int, error) {
+		if ctx.Err() != nil {
+			t.Fatal("read after cancellation")
+		}
+		if len(p) == 1 {
+			cancel()
+		}
+		return 0, io.EOF
+	}), 0, 1<<30)
+
+	_, _, err := NewTailReader(ctx, r, 1)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestNewTailReaderTruncateDuringScan(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name      string
+		delimiter string
+		surviving string
+		suffix    string
+		wantLast  string
+		wantAll   string
+		wantLines int
+	}{
+		{
+			name: "before counting records", delimiter: "\n",
+			surviving: "one\ntwo\npartial", suffix: strings.Repeat("x", 4*blockSize),
+			wantLast: "two\n", wantAll: "one\ntwo\n", wantLines: 2,
+		},
+		{
+			name: "zero read after counting records", delimiter: "\n",
+			surviving: "one\ntwo\npartial", suffix: strings.Repeat("x", 4*blockSize) + "\n",
+			wantLast: "two\n", wantAll: "one\ntwo\n", wantLines: 2,
+		},
+		{
+			name: "partial read after counting records", delimiter: "\n",
+			surviving: "one\ntwo\npartial", suffix: strings.Repeat("x", blockSize) + "\n",
+			wantLast: "two\n", wantAll: "one\ntwo\n", wantLines: 2,
+		},
+		{
+			name: "empty after counting records", delimiter: "\n",
+			suffix: strings.Repeat("x", 4*blockSize) + "\n",
+		},
+		{
+			name: "no complete records remain", delimiter: "\n",
+			surviving: "partial", suffix: strings.Repeat("x", 4*blockSize) + "\n",
+		},
+		{
+			name: "multibyte delimiter", delimiter: "####",
+			surviving: "first####second####partial", suffix: strings.Repeat("x", 4*blockSize) + "####",
+			wantLast: "second####", wantAll: "first####second####", wantLines: 2,
+		},
+	} {
+		for _, reqLines := range []int{1, 10} {
+			t.Run(fmt.Sprintf("%s/%d", tc.name, reqLines), func(t *testing.T) {
+				t.Parallel()
+				data := strings.NewReader(tc.surviving + tc.suffix)
+				size := data.Size()
+				var truncated bool
+				r := &boundedSizeReaderAt{
+					t: t,
+					SectionReader: io.NewSectionReader(readerAtFunc(func(p []byte, off int64) (int, error) {
+						n, err := data.ReadAt(p, off)
+						if !truncated {
+							assert.NilError(t, err)
+							assert.Equal(t, n, len(p))
+							data = strings.NewReader(tc.surviving)
+							truncated = true
+						}
+						return n, err
+					}), 0, size),
+				}
+
+				tail, lines, err := NewTailReaderWithDelimiter(context.Background(), r, reqLines, []byte(tc.delimiter))
+				assert.NilError(t, err)
+				assert.Equal(t, lines, min(reqLines, tc.wantLines))
+				want := tc.wantAll
+				if reqLines == 1 {
+					want = tc.wantLast
+				}
+				assert.Equal(t, tail.Size(), int64(len(want)))
+				got, err := io.ReadAll(tail)
+				assert.NilError(t, err)
+				assert.Equal(t, string(got), want)
+			})
+		}
+	}
+}
+
+type readerAtFunc func([]byte, int64) (int, error)
+
+func (f readerAtFunc) ReadAt(p []byte, off int64) (int, error) {
+	return f(p, off)
+}
+
+type boundedSizeReaderAt struct {
+	t *testing.T
+	*io.SectionReader
+	reads int
+}
+
+func (r *boundedSizeReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	r.t.Helper()
+	r.reads++
+	if r.reads > 100 {
+		r.t.Fatal("tail reader did not terminate after source truncation")
+	}
+	return r.SectionReader.ReadAt(p, off)
+}
+
 func BenchmarkTail(b *testing.B) {
 	f, err := os.CreateTemp("", "tail-test")
 	if err != nil {


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

- fix: https://github.com/moby/moby/issues/53591

Restart at the shortened end after a short read, discarding stale record counts and offsets.
Binary-search the end after empty reads to avoid hangs and excessive reads when Size is stale.


## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
