### PR TITLE
fix: invalid swagger YAML indentation

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,7 +3,7 @@
 ARG GO_VERSION=1.26.8
 
 FROM golang:${GO_VERSION}-alpine AS base
-RUN apk add --no-cache bash make yamllint
+RUN apk add --no-cache bash libfyaml make yamllint
 CMD ["/bin/bash"]
 
 # go-swagger

--- a/api/scripts/validate-swagger.sh
+++ b/api/scripts/validate-swagger.sh
@@ -6,6 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 echo "Validating swagger.yaml..."
 
+fy-tool --yaml-1.2 --null-output swagger.yaml
 yamllint -f parsable -c validate/yamllint.yaml swagger.yaml
 
 if out=$(swagger validate swagger.yaml); then

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1382,10 +1382,9 @@ definitions:
           enum:
             - {}
           default: {}
-        example: {
-          "80/tcp": {},
+        example:
+          "80/tcp": {}
           "443/tcp": {}
-        }
       Tty:
         description: |
           Attach standard streams to a TTY, including `stdin` if it is not closed.
@@ -1518,10 +1517,9 @@ definitions:
           enum:
             - {}
           default: {}
-        example: {
-          "80/tcp": {},
+        example:
+          "80/tcp": {}
           "443/tcp": {}
-        }
       Env:
         description: |
           A list of environment variables to set inside the container in the
@@ -1748,11 +1746,10 @@ definitions:
         x-nullable: false
         additionalProperties:
           type: "string"
-        example: {
-          "MergedDir": "/var/lib/docker/overlay2/ef749362d13333e65fc95c572eb525abbe0052e16e086cb64bc3b98ae9aa6d74/merged",
-          "UpperDir": "/var/lib/docker/overlay2/ef749362d13333e65fc95c572eb525abbe0052e16e086cb64bc3b98ae9aa6d74/diff",
+        example:
+          "MergedDir": "/var/lib/docker/overlay2/ef749362d13333e65fc95c572eb525abbe0052e16e086cb64bc3b98ae9aa6d74/merged"
+          "UpperDir": "/var/lib/docker/overlay2/ef749362d13333e65fc95c572eb525abbe0052e16e086cb64bc3b98ae9aa6d74/diff"
           "WorkDir": "/var/lib/docker/overlay2/ef749362d13333e65fc95c572eb525abbe0052e16e086cb64bc3b98ae9aa6d74/work"
-        }
 
   Storage:
     description: |
@@ -6353,10 +6350,9 @@ definitions:
         items:
           $ref: "#/definitions/ContainerBlkioStatEntry"
     example:
-      io_service_bytes_recursive: [
-        {"major": 254, "minor": 0, "op": "read", "value": 7593984},
-        {"major": 254, "minor": 0, "op": "write", "value": 100}
-      ]
+      io_service_bytes_recursive:
+        - {"major": 254, "minor": 0, "op": "read", "value": 7593984}
+        - {"major": 254, "minor": 0, "op": "write", "value": 100}
       io_serviced_recursive: null
       io_queue_recursive: null
       io_service_time_recursive: null


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

`swagger.yaml` contained invalid indentation that caused parsers like js-yaml and libfyaml to fail.

[YAML 1.2.2](https://yaml.org/spec/1.2.2/#823-block-nodes) requires flow nodes to be indented further than their parent block collection. four examples had closing braces or brackets aligned with the parent key.

yamllint accepts this and rejects the corrected indentation: https://github.com/adrienverge/yamllint/issues/833

this converts those examples from flow style to block style without changing their values, so both yamllint and stricter parsers accept the YAML.

also adds libfyaml validation to catch invalid syntax going forward, while keeping yamllint for the existing style rules.

<!--
## Release notes (optional)

One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top


```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
-->