### PR TITLE
Dockerfile: update crun to v1.29.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -364,7 +364,7 @@ FROM rootlesskit-${TARGETOS} AS rootlesskit
 
 FROM base AS crun
 # CRUN_VERSION is the version of crun to install in the dev-container.
-ARG CRUN_VERSION=1.21
+ARG CRUN_VERSION=1.29.1
 RUN --mount=type=cache,sharing=locked,id=moby-crun-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-crun-aptcache,target=/var/cache/apt \
         apt-get update && apt-get install -y --no-install-recommends \
@@ -372,11 +372,12 @@ RUN --mount=type=cache,sharing=locked,id=moby-crun-aptlib,target=/var/lib/apt \
             automake \
             build-essential \
             libcap-dev \
+            libjson-c-dev \
             libprotobuf-c-dev \
             libseccomp-dev \
             libsystemd-dev \
             libtool \
-            libyajl-dev \
+            pkgconf \
             python3 \
             ;
 WORKDIR /tmp/crun-build


### PR DESCRIPTION
Updates the crun version used in integration tests to the latest release.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

## Summary

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
