### PR TITLE
daemon/server/router/grpc: fix linting for deprecated http2 code

### DIFF
--- a/daemon/server/router/grpc/grpc.go
+++ b/daemon/server/router/grpc/grpc.go
@@ -27,7 +27,7 @@ import (
 type grpcRouter struct {
 	routes     []router.Route
 	grpcServer *grpc.Server
-	h2Server   *http2.Server
+	h2Server   *http2.Server //nolint:staticcheck // http2.Server is deprecated; kept for backward compatibility.
 }
 
 // NewRouter initializes a new grpc http router
@@ -45,7 +45,7 @@ func NewRouter(backends ...Backend) router.Router {
 	}
 
 	r := &grpcRouter{
-		h2Server:   &http2.Server{},
+		h2Server:   &http2.Server{}, //nolint:staticcheck // http2.Server is deprecated; kept for backward compatibility.
 		grpcServer: grpc.NewServer(opts...),
 	}
 	for _, b := range backends {

--- a/daemon/server/router/grpc/grpc_routes.go
+++ b/daemon/server/router/grpc/grpc_routes.go
@@ -38,8 +38,19 @@ func (gr *grpcRouter) serveGRPC(ctx context.Context, w http.ResponseWriter, r *h
 	conn.Write([]byte{})
 	resp.Write(conn)
 
-	// https://godoc.org/golang.org/x/net/http2#Server.ServeConn
-	// TODO: is it a problem that conn has already been written to?
-	gr.h2Server.ServeConn(conn, &http2.ServeConnOpts{Handler: gr.grpcServer})
+	// Keep using the deprecated http2.Server for compatibility with clients
+	// using the legacy /grpc endpoint, which performs an HTTP/1.1 Upgrade: h2c
+	// handshake. net/http's unencrypted HTTP/2 support uses HTTP/2 with prior
+	// knowledge and does not support Upgrade: h2c.
+	//
+	// New clients should use native gRPC over the Docker socket instead. See:
+	// - https://github.com/moby/moby/pull/50744
+	// - https://github.com/docker/buildx/pull/3369
+	// - https://github.com/docker/buildx/pull/3780
+	//
+	// TODO: Remove this together with the deprecated /grpc endpoint.
+	gr.h2Server.ServeConn(conn, &http2.ServeConnOpts{ //nolint:staticcheck // http2.ServeConn and http2.ServeConnOpts are deprecated.
+		Handler: gr.grpcServer,
+	})
 	return nil
 }


### PR DESCRIPTION
relates to;

- https://github.com/moby/moby/pull/50744
- https://github.com/docker/buildx/pull/3369
- https://github.com/docker/buildx/pull/3780




## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog

```

## A picture of a cute animal (not mandatory but encouraged)
