### PR TITLE
daemon/listeners: preserve configured TLS ALPN protocols

### DIFF
--- a/daemon/listeners/listeners_linux.go
+++ b/daemon/listeners/listeners_linux.go
@@ -27,9 +27,12 @@ func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) ([]net.Listene
 		}
 		ls = append(ls, fds...)
 	case "tcp":
-		l, err := sockets.NewTCPSocket(addr, tlsConfig)
+		l, err := net.Listen("tcp", addr)
 		if err != nil {
 			return nil, err
+		}
+		if tlsConfig != nil {
+			l = tls.NewListener(l, tlsConfig)
 		}
 		ls = append(ls, l)
 	case "unix":

--- a/daemon/listeners/listeners_test.go
+++ b/daemon/listeners/listeners_test.go
@@ -1,0 +1,62 @@
+package listeners
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestTCPListenerALPN(t *testing.T) {
+	certServer := httptest.NewTLSServer(nil)
+	defer certServer.Close()
+	roots := x509.NewCertPool()
+	roots.AddCert(certServer.Certificate())
+
+	for _, proto := range []string{"h2", "http/1.1", ""} {
+		name := proto
+		if name == "" {
+			name = "no_alpn"
+		}
+		t.Run(name, func(t *testing.T) {
+			config := &tls.Config{
+				Certificates: certServer.TLS.Certificates,
+				NextProtos:   []string{"h2", "http/1.1"},
+				MinVersion:   tls.VersionTLS12,
+			}
+			listeners, err := Init("tcp", "127.0.0.1:0", "", config)
+			assert.NilError(t, err)
+			listener := listeners[0]
+			defer listener.Close()
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+
+			handshake := make(chan error, 1)
+			go func() {
+				conn, err := listener.Accept()
+				if err != nil {
+					handshake <- err
+					return
+				}
+				defer conn.Close()
+				handshake <- conn.(*tls.Conn).HandshakeContext(ctx)
+			}()
+
+			clientConfig := &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12}
+			if proto != "" {
+				clientConfig.NextProtos = []string{proto}
+			}
+			dialer := tls.Dialer{Config: clientConfig}
+			conn, err := dialer.DialContext(ctx, "tcp", listener.Addr().String())
+			assert.NilError(t, err)
+			defer conn.Close()
+			assert.NilError(t, <-handshake)
+			assert.Equal(t, conn.(*tls.Conn).ConnectionState().NegotiatedProtocol, proto)
+			assert.DeepEqual(t, config.NextProtos, []string{"h2", "http/1.1"})
+		})
+	}
+}

--- a/daemon/listeners/listeners_windows.go
+++ b/daemon/listeners/listeners_windows.go
@@ -22,12 +22,14 @@ func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) ([]net.Listene
 
 	switch proto {
 	case "tcp":
-		l, err := sockets.NewTCPSocket(addr, tlsConfig)
+		l, err := net.Listen("tcp", addr)
 		if err != nil {
 			return nil, err
 		}
+		if tlsConfig != nil {
+			l = tls.NewListener(l, tlsConfig)
+		}
 		ls = append(ls, l)
-
 	case "npipe":
 		sddl, err := getSecurityDescriptor(additionalUsersAndGroups)
 		if err != nil {
@@ -43,7 +45,6 @@ func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) ([]net.Listene
 			return nil, err
 		}
 		ls = append(ls, l)
-
 	case "unix":
 		l, err := sockets.NewUnixSocket(addr, additionalUsersAndGroups)
 		if err != nil {


### PR DESCRIPTION
follow-up:
- https://github.com/docker/buildx/pull/4069#discussion_r3968564400
- https://github.com/moby/moby/pull/50744

## Summary

Fix TLS protocol negotiation for native gRPC connections to the daemon. The daemon configures `h2` and `http/1.1`, but `sockets.NewTCPSocket` overwrites that configuration with only `http/1.1`. Clients requesting `h2` fail the TLS handshake with `tls: client requested unsupported application protocols (["h2"])`.

Create TCP listeners using `net.Listen` and `tls.NewListener` on Linux and Windows to preserve the supplied TLS configuration.

## Release notes (optional)

```markdown changelog
Fix TLS ALPN negotiation for native gRPC connections to the Docker daemon.
```