### PR TITLE
daemon: Migrate to github.com/containerd/log/otel

### DIFF
--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -16,8 +16,8 @@ import (
 	"time"
 
 	containerddefaults "github.com/containerd/containerd/v2/defaults"
-	"github.com/containerd/containerd/v2/pkg/tracing"
 	"github.com/containerd/log"
+	logotel "github.com/containerd/log/otel"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/tracing/detect"
@@ -274,7 +274,7 @@ func (cli *daemonCLI) start(ctx context.Context) (retErr error) {
 
 	tp, otelShutdown := otelutil.NewTracerProvider(ctx, true)
 	otel.SetTracerProvider(tp)
-	log.G(ctx).Logger.AddHook(tracing.NewLogrusHook())
+	log.G(ctx).Logger.AddHook(logotel.NewLogrusHook())
 
 	pluginStore := plugin.NewStore()
 

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/fifo v1.1.0
 	github.com/containerd/log v0.1.0
+	github.com/containerd/log/otel v0.1.0
 	github.com/containerd/nri v0.12.2
 	github.com/containerd/platforms v1.0.0-rc.5
 	github.com/containerd/plugin v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,8 @@ github.com/containerd/go-runc v1.2.1 h1:TAnah92bVA7dYDZ7Mm9FrOoFQvnLZdL3z3xT7BS1
 github.com/containerd/go-runc v1.2.1/go.mod h1:Azy6SkBcIFMSMYiYUuSQhZ25zD3zJEYYbbIVplhYD7M=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
+github.com/containerd/log/otel v0.1.0 h1:Az5rFFo0+c4v2yC8ROR63sWsZpKl/vhtUnUhqLSpE6U=
+github.com/containerd/log/otel v0.1.0/go.mod h1:65C5iYF2xIQByCyxzoO2KKKK1+/tGxD4XqhdlrTtvzE=
 github.com/containerd/nri v0.12.2 h1:piA7h2QUm0m3+e994qWFPYwnoXXwAphwDc1Ydx1eWi4=
 github.com/containerd/nri v0.12.2/go.mod h1:o6Pz0I/iks9g2KlH3WdgvFtc9rB7k0aeoZCAH01xOGk=
 github.com/containerd/nydus-snapshotter v0.15.15 h1:kVYbFpYA4K43qxGVoc/VBwRXLAVWn4X9mdwGrR+HsLk=

--- a/vendor/github.com/containerd/log/otel/LICENSE
+++ b/vendor/github.com/containerd/log/otel/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright The containerd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/containerd/log/otel/helpers.go
+++ b/vendor/github.com/containerd/log/otel/helpers.go
@@ -1,0 +1,87 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package otel
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func keyValue(k string, v any) attribute.KeyValue {
+	if v == nil {
+		return attribute.String(k, "<nil>")
+	}
+
+	switch typed := v.(type) {
+	case bool:
+		return attribute.Bool(k, typed)
+	case []bool:
+		return attribute.BoolSlice(k, typed)
+	case int:
+		return attribute.Int(k, typed)
+	case []int:
+		return attribute.IntSlice(k, typed)
+	case int8:
+		return attribute.Int(k, int(typed))
+	case []int8:
+		ls := make([]int, 0, len(typed))
+		for _, i := range typed {
+			ls = append(ls, int(i))
+		}
+		return attribute.IntSlice(k, ls)
+	case int16:
+		return attribute.Int(k, int(typed))
+	case []int16:
+		ls := make([]int, 0, len(typed))
+		for _, i := range typed {
+			ls = append(ls, int(i))
+		}
+		return attribute.IntSlice(k, ls)
+	case int32:
+		return attribute.Int64(k, int64(typed))
+	case []int32:
+		ls := make([]int64, 0, len(typed))
+		for _, i := range typed {
+			ls = append(ls, int64(i))
+		}
+		return attribute.Int64Slice(k, ls)
+	case int64:
+		return attribute.Int64(k, typed)
+	case []int64:
+		return attribute.Int64Slice(k, typed)
+	case float64:
+		return attribute.Float64(k, typed)
+	case []float64:
+		return attribute.Float64Slice(k, typed)
+	case string:
+		return attribute.String(k, typed)
+	case []string:
+		return attribute.StringSlice(k, typed)
+	case error:
+		return attribute.String(k, fmt.Sprint(typed))
+	}
+
+	if stringer, ok := v.(fmt.Stringer); ok {
+		return attribute.String(k, fmt.Sprint(stringer))
+	}
+	if b, err := json.Marshal(v); b != nil && err == nil {
+		return attribute.String(k, string(b))
+	}
+	return attribute.String(k, fmt.Sprint(v))
+}

--- a/vendor/github.com/containerd/log/otel/log.go
+++ b/vendor/github.com/containerd/log/otel/log.go
@@ -1,0 +1,148 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package otel provides integration between containerd/log and OpenTelemetry.
+//
+// In particular, it provides a hook that records log entries as events on
+// active OpenTelemetry spans.
+package otel
+
+import (
+	"slices"
+
+	"github.com/containerd/log"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// allLevels is the equivalent to [logrus.AllLevels].
+//
+// [logrus.AllLevels]: https://github.com/sirupsen/logrus/blob/v1.9.3/logrus.go#L80-L89
+var allLevels = []log.Level{
+	log.PanicLevel,
+	log.FatalLevel,
+	log.ErrorLevel,
+	log.WarnLevel,
+	log.InfoLevel,
+	log.DebugLevel,
+	log.TraceLevel,
+}
+
+type HookOpt func(*LogrusHook)
+
+// NewLogrusHook creates a new logrus hook
+func NewLogrusHook(opts ...HookOpt) *LogrusHook {
+	hook := &LogrusHook{}
+	for _, opt := range opts {
+		opt(hook)
+	}
+	if hook.levels == nil {
+		hook.levels = slices.Clone(allLevels)
+	}
+	return hook
+}
+
+func WithTraceIDField(enabled bool) HookOpt {
+	return func(h *LogrusHook) {
+		h.enableTraceIDField = enabled
+	}
+}
+
+// WithLevel configures the minimum log level handled by the hook.
+// Entries below this level are ignored.
+func WithLevel(level log.Level) HookOpt {
+	return func(h *LogrusHook) {
+		for i, l := range allLevels {
+			if l == level {
+				h.levels = slices.Clone(allLevels[:i+1])
+				return
+			}
+		}
+	}
+}
+
+// WithErrorStatusLevel configures the minimum log level that marks the
+// active span with an error status.
+func WithErrorStatusLevel(level log.Level) HookOpt {
+	return func(h *LogrusHook) {
+		h.errorStatusLevel = &level
+	}
+}
+
+// LogrusHook is a [logrus.Hook] which adds logrus events to active spans.
+// If the span is not recording or the span context is invalid, the hook
+// is a no-op.
+//
+// [logrus.Hook]: https://github.com/sirupsen/logrus/blob/v1.9.3/hooks.go#L3-L11
+type LogrusHook struct {
+	enableTraceIDField bool
+	errorStatusLevel   *log.Level
+	levels             []log.Level
+}
+
+// Levels returns the logrus levels that this hook is interested in.
+func (h *LogrusHook) Levels() []log.Level {
+	if h.levels == nil {
+		return allLevels
+	}
+	return h.levels
+}
+
+// Fire is called when a log event occurs.
+func (h *LogrusHook) Fire(entry *log.Entry) error {
+	if entry.Context == nil {
+		return nil
+	}
+
+	span := trace.SpanFromContext(entry.Context)
+	spanCtx := span.SpanContext()
+	if !spanCtx.IsValid() {
+		return nil
+	}
+
+	if h.enableTraceIDField {
+		entry.Data["trace_id"] = spanCtx.TraceID().String()
+	}
+
+	if !span.IsRecording() {
+		return nil
+	}
+
+	span.AddEvent(
+		entry.Message,
+		trace.WithAttributes(logrusDataToAttrs(entry.Data)...),
+		trace.WithAttributes(attribute.String("level", entry.Level.String())),
+		trace.WithTimestamp(entry.Time),
+	)
+
+	// Set the span status based on the log level, rather than the presence of
+	// an error field. Error values may be attached to lower-severity log entries
+	// without indicating that the operation represented by the span failed.
+	if h.errorStatusLevel != nil && entry.Level <= *h.errorStatusLevel {
+		span.SetStatus(codes.Error, entry.Message)
+	}
+
+	return nil
+}
+
+func logrusDataToAttrs(data map[string]any) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, len(data))
+	for k, v := range data {
+		attrs = append(attrs, keyValue(k, v))
+	}
+	return attrs
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -580,6 +580,9 @@ github.com/containerd/go-runc
 ## explicit; go 1.20
 github.com/containerd/log
 github.com/containerd/log/logtest
+# github.com/containerd/log/otel v0.1.0
+## explicit; go 1.23
+github.com/containerd/log/otel
 # github.com/containerd/nri v0.12.2
 ## explicit; go 1.24.0
 github.com/containerd/nri/pkg/adaptation


### PR DESCRIPTION
- extracted from: https://github.com/moby/moby/pull/53615

NewLogrusHook from containerd/pkg/tracing will be deprecated in 2.4