### PR TITLE
[25.0] vendor: golang.org/x/crypto v0.56.0

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -220,7 +220,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	google.golang.org/api v0.228.0 // indirect
 	google.golang.org/genproto v0.0.0-20250324211829-b45e905df463 // indirect

--- a/vendor.sum
+++ b/vendor.sum
@@ -4955,8 +4955,8 @@ golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtC
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/vendor/golang.org/x/crypto/ssh/certs.go
+++ b/vendor/golang.org/x/crypto/ssh/certs.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"slices"
 	"sort"
 	"time"
 )
@@ -305,8 +306,11 @@ const sourceAddressCriticalOption = "source-address"
 // minimally, the IsAuthority callback should be set.
 type CertChecker struct {
 	// SupportedCriticalOptions lists the CriticalOptions that the
-	// server application layer understands. These are only used
-	// for user certificates.
+	// application layer understands. A certificate carrying a critical
+	// option that is not listed here is rejected.
+	// CertChecker.Authenticate additionally accepts the source-address
+	// option, which the server enforces on the Permissions that
+	// Authenticate returns.
 	SupportedCriticalOptions []string
 
 	// IsUserAuthority should return true if the key is recognized as an
@@ -369,8 +373,9 @@ func (c *CertChecker) CheckHostKey(addr string, remote net.Addr, key PublicKey) 
 	return c.CheckCert(hostname, cert)
 }
 
-// Authenticate checks a user certificate. Authenticate can be used as
-// a value for ServerConfig.PublicKeyCallback.
+// Authenticate checks a user certificate. Authenticate can be used as a value
+// for ServerConfig.PublicKeyCallback. The source-address critical option is
+// allowed, as it will be enforced by the server.
 func (c *CertChecker) Authenticate(conn ConnMetadata, pubKey PublicKey) (*Permissions, error) {
 	cert, ok := pubKey.(*Certificate)
 	if !ok {
@@ -389,8 +394,11 @@ func (c *CertChecker) Authenticate(conn ConnMetadata, pubKey PublicKey) (*Permis
 	if !c.IsUserAuthority(cert.SignatureKey) {
 		return nil, fmt.Errorf("ssh: certificate signed by unrecognized authority")
 	}
-
-	if err := c.CheckCert(conn.User(), cert); err != nil {
+	// The source-address critical option is enforced by serverAuthenticate,
+	// so it is supported regardless of SupportedCriticalOptions
+	cc := *c
+	cc.SupportedCriticalOptions = append(slices.Clip(cc.SupportedCriticalOptions), sourceAddressCriticalOption)
+	if err := cc.CheckCert(conn.User(), cert); err != nil {
 		return nil, err
 	}
 
@@ -398,27 +406,15 @@ func (c *CertChecker) Authenticate(conn ConnMetadata, pubKey PublicKey) (*Permis
 }
 
 // CheckCert checks CriticalOptions, ValidPrincipals, revocation, timestamp and
-// the signature of the certificate.
+// the signature of the certificate. Critical options that are not listed in
+// SupportedCriticalOptions are rejected.
 func (c *CertChecker) CheckCert(principal string, cert *Certificate) error {
 	if c.IsRevoked != nil && c.IsRevoked(cert) {
 		return fmt.Errorf("ssh: certificate serial %d revoked", cert.Serial)
 	}
 
 	for opt := range cert.CriticalOptions {
-		// sourceAddressCriticalOption will be enforced by
-		// serverAuthenticate
-		if opt == sourceAddressCriticalOption {
-			continue
-		}
-
-		found := false
-		for _, supp := range c.SupportedCriticalOptions {
-			if supp == opt {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(c.SupportedCriticalOptions, opt) {
 			return fmt.Errorf("ssh: unsupported critical option %q in certificate", opt)
 		}
 	}

--- a/vendor/golang.org/x/crypto/ssh/channel.go
+++ b/vendor/golang.org/x/crypto/ssh/channel.go
@@ -173,6 +173,12 @@ type channel struct {
 	// (for outbound channels) or received (for inbound channels).
 	decided bool
 
+	// established is set to true once the channel is open and may carry normal
+	// channel traffic: for an outbound channel when the peer's open
+	// confirmation is received, for an inbound channel when the local side
+	// accepts it. It is set and read from different goroutines.
+	established atomic.Bool
+
 	// direction contains either channelOutbound, for channels created
 	// locally, or channelInbound, for channels created by the peer.
 	direction channelDirection
@@ -434,10 +440,20 @@ func (ch *channel) responseMessageReceived() error {
 		return errors.New("ssh: duplicate response received for channel")
 	}
 	ch.decided = true
+	ch.established.Store(true)
 	return nil
 }
 
 func (ch *channel) handlePacket(packet []byte) error {
+	// Only the open response is expected before the channel is established.
+	if !ch.established.Load() {
+		switch packet[0] {
+		case msgChannelOpenConfirm, msgChannelOpenFailure:
+		default:
+			return nil
+		}
+	}
+
 	switch packet[0] {
 	case msgChannelData, msgChannelExtendedData:
 		return ch.handleData(packet)
@@ -503,7 +519,8 @@ func (ch *channel) handlePacket(packet []byte) error {
 		default:
 		}
 	default:
-		ch.msg <- msg
+		// No other message type is expected on an established channel.
+		return fmt.Errorf("ssh: unexpected message type %d on channel %d", packet[0], ch.localId)
 	}
 	return nil
 }
@@ -554,6 +571,7 @@ func (ch *channel) Accept() (Channel, <-chan *Request, error) {
 		MaxPacketSize: ch.maxIncomingPayload,
 	}
 	ch.decided = true
+	ch.established.Store(true)
 	if err := ch.sendMessage(confirm); err != nil {
 		return nil, nil, err
 	}

--- a/vendor/golang.org/x/crypto/ssh/transport.go
+++ b/vendor/golang.org/x/crypto/ssh/transport.go
@@ -331,13 +331,19 @@ func exchangeVersions(rw io.ReadWriter, versionLine []byte) (them []byte, err er
 // chars
 const maxVersionStringBytes = 255
 
+// maxPreVersionLines is the maximum number of lines sent by the peer
+// before the version string. Each of these lines is limited to a maximum
+// of maxVersionStringBytes chars. Lines sent before the version string
+// are silently ignored.
+const maxPreVersionLines = 1024
+
 // Read version string as specified by RFC 4253, section 4.2.
 func readVersion(r io.Reader) ([]byte, error) {
 	versionString := make([]byte, 0, 64)
 	var ok bool
 	var buf [1]byte
 
-	for length := 0; length < maxVersionStringBytes; length++ {
+	for lines := 0; len(versionString) < maxVersionStringBytes && lines < maxPreVersionLines; {
 		_, err := io.ReadFull(r, buf[:])
 		if err != nil {
 			return nil, err
@@ -347,9 +353,9 @@ func readVersion(r io.Reader) ([]byte, error) {
 		if buf[0] == '\n' {
 			if !bytes.HasPrefix(versionString, []byte("SSH-")) {
 				// RFC 4253 says we need to ignore all version string lines
-				// except the one containing the SSH version (provided that
-				// all the lines do not exceed 255 bytes in total).
+				// except the one containing the SSH version.
 				versionString = versionString[:0]
+				lines++
 				continue
 			}
 			ok = true

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1323,8 +1323,8 @@ go.uber.org/zap/internal/bufferpool
 go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
 go.uber.org/zap/zapcore
-# golang.org/x/crypto v0.55.0
-## explicit; go 1.25.0
+# golang.org/x/crypto v0.56.0
+## explicit; go 1.26.0
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/chacha20
 golang.org/x/crypto/chacha20poly1305


### PR DESCRIPTION
- Related to: https://github.com/moby/moby/pull/53560 (master: x/crypto v0.56.0)
- Follow-up to: https://github.com/moby/moby/pull/53619 (this branch, which landed on v0.55.0)

## Summary

Bumps `golang.org/x/crypto` v0.55.0 -> v0.56.0 to fix two denial-of-service issues in
`golang.org/x/crypto/ssh`:

- [CVE-2026-56855](https://www.cve.org/CVERecord?id=CVE-2026-56855) / [GO-2026-6355](https://pkg.go.dev/vuln/GO-2026-6355) — after a channel has been established, a malicious peer could send crafted messages that deadlock the entire connection ([go.dev/issue/81317](https://go.dev/issue/81317))
- [CVE-2026-78662](https://www.cve.org/CVERecord?id=CVE-2026-78662) / [GO-2026-6354](https://pkg.go.dev/vuln/GO-2026-6354) — a channel registered in the mux's `chanList` is not usable until established, and a malicious peer could flood its `incomingRequests` to deadlock the connection ([go.dev/issue/81316](https://go.dev/issue/81316))

full diff: https://github.com/golang/crypto/compare/v0.55.0...v0.56.0

## Why this is a separate PR from #53619

#53619 took this branch from v0.52.0 to **v0.55.0**, which was the correct fix version
for the issue it was addressing (CVE-2026-56854 / GO-2026-6303, fixed in v0.55.0). The
two advisories above were published against v0.55.0 itself and are fixed only in
v0.56.0, so they were out of that PR's scope — it closed what it set out to close.

## Reachability

`x/crypto/ssh` is not imported by moby's own code; it arrives through
`github.com/moby/buildkit` and `github.com/secure-systems-lab/go-securesystemslib`. It
is nonetheless reachable:

```
govulncheck -mode=source ./cmd/dockerd/...

before:  CVE-2026-78662  golang.org/x/crypto  symbol-reachable via ssh.Dial
         CVE-2026-56855  golang.org/x/crypto  symbol-reachable via ssh.Dial
after:   neither reported
```

Both advisories are `REVIEWED` in the Go vulnerability database and declare their
affected symbols, so these are call-graph results rather than module-level version
matches.

## Cost

v0.56.0 declares the same requirements as v0.55.0 — `x/net` v0.57.0, `x/sys` v0.47.0,
`x/term` v0.45.0, `x/text` v0.41.0 — all of which this branch already satisfies. Nothing
else moves:

```
 vendor.mod                                  |  2 +-
 vendor.sum                                  |  4 +--
 vendor/golang.org/x/crypto/ssh/certs.go     | 38 +++++++++++++----------------
 vendor/golang.org/x/crypto/ssh/channel.go   | 20 ++++++++++++++-
 vendor/golang.org/x/crypto/ssh/transport.go | 12 ++++++---
 vendor/modules.txt                          |  4 +--
 6 files changed, 50 insertions(+), 30 deletions(-)
```

This is a native re-vendor rather than a cherry-pick of b8a620d256, because master
carries `go.mod` where this branch carries `vendor.mod`; the resulting vendored tree is
the same, and the commit message reproduces upstream's description of both issues.

`go build ./...` is clean and `go mod verify` passes.

## Release notes (optional)

```markdown changelog
- Update `golang.org/x/crypto` to v0.56.0 to fix two denial-of-service issues (CVE-2026-56855, CVE-2026-78662) in the SSH transport, where a malicious peer could deadlock a connection.
```

## A picture of a cute animal (not mandatory but encouraged)

🦫