### PR TITLE
windows: preserve hard links when committing a container

### DIFF
--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -630,6 +630,7 @@ func (d *Driver) GetMetadata(id string) (map[string]string, error) {
 }
 
 func writeTarFromLayer(r hcsshim.LayerReader, w io.Writer) error {
+	linkRecords := make(map[[16]byte]string)
 	t := tar.NewWriter(w)
 	for {
 		name, size, fileInfo, err := r.Next()
@@ -648,6 +649,21 @@ func writeTarFromLayer(r hcsshim.LayerReader, w io.Writer) error {
 				return err
 			}
 		} else {
+			// For files with multiple hardlinks, write the first occurrence normally
+			// and record its path. Subsequent occurrences are emitted as hardlinks to it.
+			if nlinks, id, err := r.LinkInfo(); err == nil && nlinks > 1 {
+				if prev, ok := linkRecords[id.FileID]; ok {
+					hdr := backuptar.BasicInfoHeader(name, 0, fileInfo)
+					hdr.Mode = 0o644
+					hdr.Typeflag = tar.TypeLink
+					hdr.Linkname = prev
+					if err := t.WriteHeader(hdr); err != nil {
+						return err
+					}
+					continue
+				}
+				linkRecords[id.FileID] = filepath.ToSlash(name)
+			}
 			err = backuptar.WriteTarFileFromBackupStream(t, r, name, size, fileInfo)
 			if err != nil {
 				return err

--- a/daemon/graphdriver/windows/windows_test.go
+++ b/daemon/graphdriver/windows/windows_test.go
@@ -1,0 +1,182 @@
+//go:build windows
+
+package windows
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/Microsoft/go-winio"
+	"golang.org/x/sys/windows"
+)
+
+// fakeEntry describes one file returned by fakeLayerReader.
+type fakeEntry struct {
+	name   string
+	data   []byte
+	nlinks uint32
+	fileID [16]byte
+}
+
+// fakeLayerReader implements hcsshim.LayerReader over a scripted set of files
+// so that writeTarFromLayer can be exercised without a real layer.
+type fakeLayerReader struct {
+	entries []fakeEntry
+	idx     int
+	stream  *bytes.Reader
+}
+
+func (r *fakeLayerReader) Next() (string, int64, *winio.FileBasicInfo, error) {
+	if r.idx >= len(r.entries) {
+		return "", 0, nil, io.EOF
+	}
+	e := r.entries[r.idx]
+	r.idx++
+
+	stream, err := backupStream(e.data)
+	if err != nil {
+		return "", 0, nil, err
+	}
+	r.stream = bytes.NewReader(stream)
+
+	fileInfo := &winio.FileBasicInfo{FileAttributes: windows.FILE_ATTRIBUTE_NORMAL}
+	return e.name, int64(len(e.data)), fileInfo, nil
+}
+
+func (r *fakeLayerReader) LinkInfo() (uint32, *winio.FileIDInfo, error) {
+	e := r.entries[r.idx-1]
+	return e.nlinks, &winio.FileIDInfo{VolumeSerialNumber: 1, FileID: e.fileID}, nil
+}
+
+func (r *fakeLayerReader) Read(b []byte) (int, error) {
+	if r.stream == nil {
+		return 0, io.EOF
+	}
+	return r.stream.Read(b)
+}
+
+func (r *fakeLayerReader) Close() error { return nil }
+
+// backupStream wraps raw file contents in a Win32 backup stream, which is what
+// WriteTarFileFromBackupStream expects to read.
+func backupStream(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	w := winio.NewBackupStreamWriter(&buf)
+	if err := w.WriteHeader(&winio.BackupHeader{Id: winio.BackupData, Size: int64(len(data))}); err != nil {
+		return nil, err
+	}
+	if _, err := w.Write(data); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+type tarEntry struct {
+	name     string
+	typeflag byte
+	linkname string
+	size     int64
+}
+
+func readTar(t *testing.T, b []byte) []tarEntry {
+	t.Helper()
+
+	var entries []tarEntry
+	tr := tar.NewReader(bytes.NewReader(b))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("reading tar: %v", err)
+		}
+		entries = append(entries, tarEntry{
+			name:     hdr.Name,
+			typeflag: hdr.Typeflag,
+			linkname: hdr.Linkname,
+			size:     hdr.Size,
+		})
+	}
+	return entries
+}
+
+func TestWriteTarFromLayerHardLinks(t *testing.T) {
+	fileIDA := [16]byte{1}
+	fileIDB := [16]byte{2}
+
+	for _, tc := range []struct {
+		name     string
+		entries  []fakeEntry
+		expected []tarEntry
+	}{
+		{
+			// Every later name for a file ID points at the first name, never at
+			// the name immediately before it, so links are never chained.
+			name: "repeated names link to the first name",
+			entries: []fakeEntry{
+				{name: "Files/a.txt", data: []byte("payload"), nlinks: 3, fileID: fileIDA},
+				{name: "Files/b.txt", data: []byte("payload"), nlinks: 3, fileID: fileIDA},
+				{name: "Files/c.txt", data: []byte("payload"), nlinks: 3, fileID: fileIDA},
+			},
+			expected: []tarEntry{
+				{name: "Files/a.txt", typeflag: tar.TypeReg, size: 7},
+				{name: "Files/b.txt", typeflag: tar.TypeLink, linkname: "Files/a.txt"},
+				{name: "Files/c.txt", typeflag: tar.TypeLink, linkname: "Files/a.txt"},
+			},
+		},
+		{
+			name: "distinct file IDs are never linked",
+			entries: []fakeEntry{
+				{name: "Files/a.txt", data: []byte("payload"), nlinks: 2, fileID: fileIDA},
+				{name: "Files/b.txt", data: []byte("payload"), nlinks: 2, fileID: fileIDB},
+			},
+			expected: []tarEntry{
+				{name: "Files/a.txt", typeflag: tar.TypeReg, size: 7},
+				{name: "Files/b.txt", typeflag: tar.TypeReg, size: 7},
+			},
+		},
+		{
+			name: "a single link count is never linked",
+			entries: []fakeEntry{
+				{name: "Files/a.txt", data: []byte("payload"), nlinks: 1, fileID: fileIDA},
+				{name: "Files/b.txt", data: []byte("payload"), nlinks: 1, fileID: fileIDA},
+			},
+			expected: []tarEntry{
+				{name: "Files/a.txt", typeflag: tar.TypeReg, size: 7},
+				{name: "Files/b.txt", typeflag: tar.TypeReg, size: 7},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			r := &fakeLayerReader{entries: tc.entries}
+			if err := writeTarFromLayer(r, &buf); err != nil {
+				t.Fatalf("writeTarFromLayer: %v", err)
+			}
+
+			got := readTar(t, buf.Bytes())
+			if len(got) != len(tc.expected) {
+				t.Fatalf("got %d tar entries, want %d: %+v", len(got), len(tc.expected), got)
+			}
+
+			for i, want := range tc.expected {
+				if got[i].name != want.name {
+					t.Errorf("entry %d: name = %q, want %q", i, got[i].name, want.name)
+				}
+				if got[i].typeflag != want.typeflag {
+					t.Errorf("entry %d (%s): typeflag = %q, want %q", i, want.name, got[i].typeflag, want.typeflag)
+				}
+				if got[i].linkname != want.linkname {
+					t.Errorf("entry %d (%s): linkname = %q, want %q", i, want.name, got[i].linkname, want.linkname)
+				}
+				// A hard link entry must not carry a second copy of the payload.
+				if want.typeflag == tar.TypeLink && got[i].size != 0 {
+					t.Errorf("entry %d (%s): size = %d, want 0 for a hard link", i, want.name, got[i].size)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**- What I did**

Preserve hard links when committing a Windows container.

`writeTarFromLayer` wrote a full copy for every name of a file, so files sharing a file ID in a layer became independent copies in the committed image. The link relationship was lost and the payload was stored once per name.

**- How I did it**

The layer reader already exposes `LinkInfo`, which returns the link count and file ID of the current file, so no new API was needed.

For a file reporting more than one link, the file ID of the first name seen is recorded. Any later name with the same file ID is written as a `tar.TypeLink` header pointing at that first name instead of streaming the contents again.

The import side already handles `tar.TypeLink` through `legacyLayerWriter.AddLink`, so no change was required there.

**- How to verify it**

Unit tests are included in `daemon/graphdriver/windows/windows_test.go`. They drive `writeTarFromLayer` through a scripted `LayerReader`, so the behaviour can be checked without a container or a particular Windows build:

```
go test ./daemon/graphdriver/windows/
```

They assert that a later name for a file ID becomes a `tar.TypeLink` entry carrying no payload, that later names point at the first name rather than chaining to the previous one, and that distinct file IDs and files with a single link are never linked. Reverting the change in `windows.go` makes them fail.

Please also read this part, because there is a dependency for the end to end behaviour.

`NewLayerReader` obtains its link count from the layer export produced by the Windows container storage layer. On current Windows builds that export writes an independent copy for every name, so `LinkInfo` always reports a link count of one, the new branch never runs, and this change is inert with no behaviour difference. A corresponding fix to the Windows container storage export is being made separately, and only with both changes present is the link preserved end to end.

Verified on a Windows Server build carrying that matching OS change:

1. Run a container and create a file with two additional hard linked names:

```
docker run --name src mcr.microsoft.com/windows/servercore:ltsc2025 cmd /c ^
  "mkdir C:\hltest && echo hello > C:\hltest\original.dat && ^
   mklink /H C:\hltest\link1.dat C:\hltest\original.dat && ^
   mklink /H C:\hltest\link2.dat C:\hltest\original.dat"
```

2. `docker commit src img:latest`

3. Inspect the resulting image layer on the host with `fsutil hardlink list` against `Files\hltest\original.dat`.

Before this change the layer reports one link, meaning three independent copies. With this change it reports three names sharing one file ID.

A `docker save`, `docker image rm`, `docker load` round trip was also run and the reloaded layer still reports three links with intact file contents.

Note that hard links in a read only layer are not observable from inside a running container, because the container filter presents layer files as separate per name objects. This is existing behaviour and is also true of hard links that ship in base images. Verification should be done against the image layer on the host.

**- Size impact**

Measured on the same source container, with a 200 MB payload and two additional hard linked names, so 600 MB of logical content:

| | Committed layer on disk |
| --- | --- |
| Before | 608.2 MB |
| After | 208.2 MB |

The saving scales with the number of names sharing the file ID.

**- Description for the changelog**

```markdown changelog
Windows: Preserve hard links when committing a container, so a file with multiple names is stored once in the resulting image layer instead of once per name.
```