### PR TITLE
builder: Default to BuildKit on Windows with containerd image store

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -10768,10 +10768,9 @@ paths:
               description: |
                 Default version of docker image builder
 
-                The default on Linux is version "2" (BuildKit), but the daemon
-                can be configured to recommend version "1" (classic Builder).
-                Windows does not yet support BuildKit for native Windows images,
-                and uses "1" (classic builder) as a default.
+                The default is version "2" (BuildKit), except on Windows when
+                not using the containerd image store, where it is version "1"
+                (classic builder).
 
                 This value is a recommendation as advertised by the daemon, and
                 it is up to the client to choose which builder to use.
@@ -10821,7 +10820,15 @@ paths:
               description: "Max API Version the server supports"
             Builder-Version:
               type: "string"
-              description: "Default version of docker image builder"
+              description: |
+                Default version of docker image builder
+
+                The default is version "2" (BuildKit), except on Windows when
+                not using the containerd image store, where it is version "1"
+                (classic builder).
+
+                This value is a recommendation as advertised by the daemon, and
+                it is up to the client to choose which builder to use.
             Docker-Experimental:
               type: "boolean"
               description: "If the server is running with experimental mode enabled"

--- a/daemon/build.go
+++ b/daemon/build.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 
 	"github.com/distribution/reference"
+	"github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/api/types/events"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -17,6 +18,27 @@ func (daemon *Daemon) validateBuildkitConfig(features map[string]bool) error {
 		return errors.New("features.buildkit=true requires the containerd image store on Windows")
 	}
 	return nil
+}
+
+// BuilderVersion returns the daemon's recommended builder version.
+// BuildKit is preferred except on Windows.
+// This is only a recommendation; clients choose which builder to use.
+//
+// Setting features.buildkit=false is an escape hatch to recommend the classic
+// builder instead.
+// CLI users can opt out per invocation with DOCKER_BUILDKIT=0.
+// On Windows, using BuildKit requires the containerd image store.
+func (daemon *Daemon) BuilderVersion() build.BuilderVersion {
+	if enabled, ok := daemon.config().Features["buildkit"]; ok {
+		if enabled {
+			return build.BuilderBuildKit
+		}
+		return build.BuilderV1
+	}
+	if runtime.GOOS == "windows" {
+		return build.BuilderV1
+	}
+	return build.BuilderBuildKit
 }
 
 // ImageExportedByBuildkit is a callback that is called when an image is exported by buildkit.

--- a/daemon/build.go
+++ b/daemon/build.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"runtime"
 
+	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	"github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/api/types/events"
@@ -12,11 +13,17 @@ import (
 )
 
 func (daemon *Daemon) validateBuildkitConfig(features map[string]bool) error {
+	if !features["buildkit"] {
+		return nil
+	}
+
 	// Check the actual image store, not the containerd-snapshotter feature flag:
 	// storage-driver selection, migration, or a reload can make them differ.
-	if runtime.GOOS == "windows" && features["buildkit"] && !daemon.usesSnapshotter {
+	if runtime.GOOS == "windows" && !daemon.usesSnapshotter {
 		return errors.New("features.buildkit=true requires the containerd image store on Windows")
 	}
+
+	log.G(context.TODO()).Warn("features.buildkit=true is unnecessary because BuildKit is already the default builder; remove this setting from the daemon configuration")
 	return nil
 }
 

--- a/daemon/build.go
+++ b/daemon/build.go
@@ -21,7 +21,7 @@ func (daemon *Daemon) validateBuildkitConfig(features map[string]bool) error {
 }
 
 // BuilderVersion returns the daemon's recommended builder version.
-// BuildKit is preferred except on Windows.
+// BuildKit is preferred except on Windows with the classic image store.
 // This is only a recommendation; clients choose which builder to use.
 //
 // Setting features.buildkit=false is an escape hatch to recommend the classic
@@ -35,7 +35,7 @@ func (daemon *Daemon) BuilderVersion() build.BuilderVersion {
 		}
 		return build.BuilderV1
 	}
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" && !daemon.usesSnapshotter {
 		return build.BuilderV1
 	}
 	return build.BuilderBuildKit

--- a/daemon/build.go
+++ b/daemon/build.go
@@ -2,11 +2,22 @@ package daemon
 
 import (
 	"context"
+	"errors"
+	"runtime"
 
 	"github.com/distribution/reference"
 	"github.com/moby/moby/api/types/events"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
+
+func (daemon *Daemon) validateBuildkitConfig(features map[string]bool) error {
+	// Check the actual image store, not the containerd-snapshotter feature flag:
+	// storage-driver selection, migration, or a reload can make them differ.
+	if runtime.GOOS == "windows" && features["buildkit"] && !daemon.usesSnapshotter {
+		return errors.New("features.buildkit=true requires the containerd image store on Windows")
+	}
+	return nil
+}
 
 // ImageExportedByBuildkit is a callback that is called when an image is exported by buildkit.
 // This is used to log the image creation event for untagged images.

--- a/daemon/build_test.go
+++ b/daemon/build_test.go
@@ -1,0 +1,81 @@
+package daemon
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/moby/moby/api/types/build"
+	"github.com/moby/moby/v2/daemon/config"
+	"gotest.tools/v3/assert"
+)
+
+func TestBuilderVersion(t *testing.T) {
+	t.Parallel()
+
+	defaultVersion := build.BuilderBuildKit
+	if runtime.GOOS == "windows" {
+		defaultVersion = build.BuilderV1
+	}
+
+	for _, tc := range []struct {
+		name           string
+		features       map[string]bool
+		useSnapshotter bool
+		expected       build.BuilderVersion
+	}{
+		{
+			name:     "classic image store default",
+			expected: defaultVersion,
+		},
+		{
+			name:           "containerd image store default",
+			useSnapshotter: true,
+			expected:       defaultVersion,
+		},
+		{
+			name:     "classic image store with buildkit enabled",
+			features: map[string]bool{"buildkit": true},
+			expected: build.BuilderBuildKit,
+		},
+		{
+			name:           "containerd image store with buildkit enabled",
+			features:       map[string]bool{"buildkit": true},
+			useSnapshotter: true,
+			expected:       build.BuilderBuildKit,
+		},
+		{
+			name:     "classic image store with buildkit disabled",
+			features: map[string]bool{"buildkit": false},
+			expected: build.BuilderV1,
+		},
+		{
+			name:           "containerd image store with buildkit disabled",
+			features:       map[string]bool{"buildkit": false},
+			useSnapshotter: true,
+			expected:       build.BuilderV1,
+		},
+		{
+			name:     "classic image store with mismatched feature flag",
+			features: map[string]bool{"containerd-snapshotter": true},
+			expected: defaultVersion,
+		},
+		{
+			name:           "containerd image store with mismatched feature flag",
+			features:       map[string]bool{"containerd-snapshotter": false},
+			useSnapshotter: true,
+			expected:       defaultVersion,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			daemon := &Daemon{usesSnapshotter: tc.useSnapshotter}
+			daemon.configStore.Store(&configStore{
+				Config: config.Config{
+					CommonConfig: config.CommonConfig{Features: tc.features},
+				},
+			})
+			assert.Equal(t, daemon.BuilderVersion(), tc.expected)
+		})
+	}
+}

--- a/daemon/build_test.go
+++ b/daemon/build_test.go
@@ -12,9 +12,9 @@ import (
 func TestBuilderVersion(t *testing.T) {
 	t.Parallel()
 
-	defaultVersion := build.BuilderBuildKit
+	classicStoreDefault := build.BuilderBuildKit
 	if runtime.GOOS == "windows" {
-		defaultVersion = build.BuilderV1
+		classicStoreDefault = build.BuilderV1
 	}
 
 	for _, tc := range []struct {
@@ -25,12 +25,12 @@ func TestBuilderVersion(t *testing.T) {
 	}{
 		{
 			name:     "classic image store default",
-			expected: defaultVersion,
+			expected: classicStoreDefault,
 		},
 		{
 			name:           "containerd image store default",
 			useSnapshotter: true,
-			expected:       defaultVersion,
+			expected:       build.BuilderBuildKit,
 		},
 		{
 			name:     "classic image store with buildkit enabled",
@@ -57,13 +57,13 @@ func TestBuilderVersion(t *testing.T) {
 		{
 			name:     "classic image store with mismatched feature flag",
 			features: map[string]bool{"containerd-snapshotter": true},
-			expected: defaultVersion,
+			expected: classicStoreDefault,
 		},
 		{
 			name:           "containerd image store with mismatched feature flag",
 			features:       map[string]bool{"containerd-snapshotter": false},
 			useSnapshotter: true,
-			expected:       defaultVersion,
+			expected:       build.BuilderBuildKit,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -844,7 +844,7 @@ func buildRouters(opts routerOptions) []router.Router {
 			opts.daemon.ImageService(),
 			opts.daemon.RegistryService(),
 		),
-		systemrouter.NewRouter(opts.daemon, opts.cluster, opts.builder.buildkit, opts.daemon.Features),
+		systemrouter.NewRouter(opts.daemon, opts.cluster, opts.builder.buildkit),
 		volume.NewRouter(opts.daemon.VolumesService(), opts.cluster),
 		build.NewRouter(opts.builder.backend, opts.daemon),
 		sessionrouter.NewRouter(opts.builder.sessionManager), //nolint:staticcheck // Deprecated endpoint kept for backward compatibility

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1377,6 +1377,12 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		}
 	}
 
+	// Validate after image-store selection and possible migration, but before
+	// restoring containers.
+	if err := d.validateBuildkitConfig(cfgStore.Features); err != nil {
+		return nil, err
+	}
+
 	go d.execCommandGC()
 
 	d.containerd, err = libcontainerd.NewClient(ctx, d.containerdClient, filepath.Join(config.ExecRoot, "containerd"), config.ContainerdNamespace, d)

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -300,6 +300,10 @@ func (daemon *Daemon) reloadNetworkDiagnosticPort(txn *reloadTxn, newCfg *config
 
 // reloadFeatures updates configuration with enabled/disabled features
 func (daemon *Daemon) reloadFeatures(_ *reloadTxn, newCfg *configStore, conf *config.Config, attributes map[string]string) error {
+	if err := daemon.validateBuildkitConfig(conf.Features); err != nil {
+		return err
+	}
+
 	// update corresponding configuration
 	// note that we allow features option to be entirely unset
 	newCfg.Features = conf.Features

--- a/daemon/server/router/build/build.go
+++ b/daemon/server/router/build/build.go
@@ -1,11 +1,6 @@
 package build
 
-import (
-	"runtime"
-
-	"github.com/moby/moby/api/types/build"
-	"github.com/moby/moby/v2/daemon/server/router"
-)
+import "github.com/moby/moby/v2/daemon/server/router"
 
 // buildRouter is a router to talk with the build controller
 type buildRouter struct {
@@ -35,33 +30,4 @@ func (br *buildRouter) initRoutes() {
 		router.NewPostRoute("/build/prune", br.postPrune, router.WithMinimumAPIVersion("1.31")),
 		router.NewPostRoute("/build/cancel", br.postCancel),
 	}
-}
-
-// BuilderVersion derives the default docker builder version from the config.
-//
-// The default on Linux is version "2" (BuildKit), but the daemon can be
-// configured to recommend version "1" (classic Builder). Windows does not
-// yet support BuildKit for native Windows images, and uses "1" (classic builder)
-// as a default.
-//
-// This value is only a recommendation as advertised by the daemon, and it is
-// up to the client to choose which builder to use.
-func BuilderVersion(features map[string]bool) build.BuilderVersion {
-	// TODO(thaJeztah) move the default to daemon/config
-	bv := build.BuilderBuildKit
-	if runtime.GOOS == "windows" {
-		// BuildKit is not yet the default on Windows.
-		bv = build.BuilderV1
-	}
-
-	// Allow the features field in the daemon config to override the
-	// default builder to advertise.
-	if enable, ok := features["buildkit"]; ok {
-		if enable {
-			bv = build.BuilderBuildKit
-		} else {
-			bv = build.BuilderV1
-		}
-	}
-	return bv
 }

--- a/daemon/server/router/system/backend.go
+++ b/daemon/server/router/system/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/api/types/swarm"
@@ -16,6 +17,7 @@ import (
 // Backend is the methods that need to be implemented to provide
 // system specific functionality.
 type Backend interface {
+	BuilderVersion() build.BuilderVersion
 	SystemInfo(context.Context) (*system.Info, error)
 	SystemVersion(context.Context) (system.VersionResponse, error)
 	SystemDiskUsage(ctx context.Context, opts backend.DiskUsageOptions) (*backend.DiskUsage, error)

--- a/daemon/server/router/system/system.go
+++ b/daemon/server/router/system/system.go
@@ -9,11 +9,10 @@ import (
 // systemRouter provides information about the Docker system overall.
 // It gathers information about host, daemon and container events.
 type systemRouter struct {
-	backend  Backend
-	cluster  ClusterBackend
-	routes   []router.Route
-	builder  BuildBackend
-	features func() map[string]bool
+	backend Backend
+	cluster ClusterBackend
+	routes  []router.Route
+	builder BuildBackend
 
 	// collectSystemInfo is a single-flight for the /info endpoint,
 	// unique per API version (as different API versions may return
@@ -22,12 +21,11 @@ type systemRouter struct {
 }
 
 // NewRouter initializes a new system router
-func NewRouter(b Backend, c ClusterBackend, builder BuildBackend, features func() map[string]bool) router.Router {
+func NewRouter(b Backend, c ClusterBackend, builder BuildBackend) router.Router {
 	r := &systemRouter{
-		backend:  b,
-		cluster:  c,
-		builder:  builder,
-		features: features,
+		backend: b,
+		cluster: c,
+		builder: builder,
 	}
 
 	r.routes = []router.Route{

--- a/daemon/server/router/system/system_routes.go
+++ b/daemon/server/router/system/system_routes.go
@@ -22,7 +22,6 @@ import (
 	"github.com/moby/moby/v2/daemon/server/buildbackend"
 	"github.com/moby/moby/v2/daemon/server/httputils"
 	"github.com/moby/moby/v2/daemon/server/httputils/contenttype"
-	"github.com/moby/moby/v2/daemon/server/router/build"
 	"github.com/moby/moby/v2/pkg/ioutils"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -37,8 +36,7 @@ func (s *systemRouter) pingHandler(ctx context.Context, w http.ResponseWriter, r
 	w.Header().Add("Cache-Control", "no-cache, no-store, must-revalidate")
 	w.Header().Add("Pragma", "no-cache")
 
-	builderVersion := build.BuilderVersion(s.features())
-	if bv := builderVersion; bv != "" {
+	if bv := s.backend.BuilderVersion(); bv != "" {
 		w.Header().Set("Builder-Version", string(bv))
 	}
 

--- a/daemon/server/router/system/system_routes_test.go
+++ b/daemon/server/router/system/system_routes_test.go
@@ -1,0 +1,50 @@
+package system
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/moby/moby/api/types/build"
+	"gotest.tools/v3/assert"
+)
+
+func TestPingBuilderVersion(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		version build.BuilderVersion
+	}{
+		{name: "classic builder", version: build.BuilderV1},
+		{name: "buildkit", version: build.BuilderBuildKit},
+		{name: "unspecified"},
+	} {
+		for _, method := range []string{http.MethodGet, http.MethodHead} {
+			t.Run(tc.name+"/"+method, func(t *testing.T) {
+				t.Parallel()
+
+				s := &systemRouter{
+					backend: &builderVersionBackend{version: tc.version},
+				}
+				req := httptest.NewRequestWithContext(t.Context(), method, "/_ping", nil)
+				rec := httptest.NewRecorder()
+
+				assert.NilError(t, s.pingHandler(t.Context(), rec, req, nil))
+				assert.Equal(t, rec.Code, http.StatusOK)
+				assert.Equal(t, rec.Header().Get("Builder-Version"), string(tc.version))
+				_, present := rec.Header()["Builder-Version"]
+				assert.Equal(t, present, tc.version != "")
+			})
+		}
+	}
+}
+
+type builderVersionBackend struct {
+	Backend
+	version build.BuilderVersion
+}
+
+func (b *builderVersionBackend) BuilderVersion() build.BuilderVersion {
+	return b.version
+}

--- a/integration/system/ping_test.go
+++ b/integration/system/ping_test.go
@@ -114,7 +114,7 @@ func TestPingBuilderHeader(t *testing.T) {
 		defer d.Stop(t)
 
 		expected := build.BuilderBuildKit
-		if runtime.GOOS == "windows" {
+		if runtime.GOOS == "windows" && !testEnv.UsingSnapshotter() {
 			expected = build.BuilderV1
 		}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Make sure commits are signed off (`git commit -s`) with your real name.

To explicitly stress-test specific integration tests for flakiness in CI,
add a /flaky-check directive anywhere in the PR body (outside of comments):
  /flaky-check=TestFoo,TestBar

If the PR relates to an existing issue or PR, mention it at the top:

- Fixes: https://github.com/moby/moby/issues/12345678
- Replaces: https://github.com/moby/moby/pull/12345678
- Follow up to: https://github.com/moby/moby/pull/12345678
- Related to: https://github.com/moby/moby/issues/12345678
-->

- related to: https://github.com/moby/moby/issues/51643


## Summary

Recommend BuildKit on Windows when the containerd image store is enabled.
Keep the classic builder default for the classic image store and honor explicit features.buildkit overrides.

## Release notes (optional)

<!--
One-sentence user-facing release note.
Leave empty if the change is not changelog-worthy.
Use present tense and imperative tone.

Good:
- Fix a panic when running `docker top` on a non-running Windows container.
- Don't print warnings in `docker info` for broken symlinks in CLI plugin directories.

Bad:
- Refactor test TestFooWithBar
- Fixed a panic when running docker top
-->

```markdown changelog
Windows: Default to BuildKit when using the containerd image store.
```

## A picture of a cute animal (not mandatory but encouraged)
