### PR TITLE
daemon: Reject BuildKit feature with Windows graphdrivers

### DIFF
--- a/daemon/build.go
+++ b/daemon/build.go
@@ -2,11 +2,22 @@ package daemon
 
 import (
 	"context"
+	"errors"
+	"runtime"
 
 	"github.com/distribution/reference"
 	"github.com/moby/moby/api/types/events"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
+
+func (daemon *Daemon) validateBuildkitConfig(features map[string]bool) error {
+	// Check the actual image store, not the containerd-snapshotter feature flag:
+	// storage-driver selection, migration, or a reload can make them differ.
+	if runtime.GOOS == "windows" && features["buildkit"] && !daemon.usesSnapshotter {
+		return errors.New("features.buildkit=true requires the containerd image store on Windows")
+	}
+	return nil
+}
 
 // ImageExportedByBuildkit is a callback that is called when an image is exported by buildkit.
 // This is used to log the image creation event for untagged images.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1377,6 +1377,12 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		}
 	}
 
+	// Validate after image-store selection and possible migration, but before
+	// restoring containers.
+	if err := d.validateBuildkitConfig(cfgStore.Features); err != nil {
+		return nil, err
+	}
+
 	go d.execCommandGC()
 
 	d.containerd, err = libcontainerd.NewClient(ctx, d.containerdClient, filepath.Join(config.ExecRoot, "containerd"), config.ContainerdNamespace, d)

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -300,6 +300,10 @@ func (daemon *Daemon) reloadNetworkDiagnosticPort(txn *reloadTxn, newCfg *config
 
 // reloadFeatures updates configuration with enabled/disabled features
 func (daemon *Daemon) reloadFeatures(_ *reloadTxn, newCfg *configStore, conf *config.Config, attributes map[string]string) error {
+	if err := daemon.validateBuildkitConfig(conf.Features); err != nil {
+		return err
+	}
+
 	// update corresponding configuration
 	// note that we allow features option to be entirely unset
 	newCfg.Features = conf.Features


### PR DESCRIPTION
It needs containerd image store and would error later anyway so let's just fail early.