### PR TITLE
api/scripts: Allow isolated model generation with an API directory

### DIFF
--- a/api/scripts/generate-swagger-api.sh
+++ b/api/scripts/generate-swagger-api.sh
@@ -3,7 +3,9 @@
 # -*- indent-tabs-mode: t -*-
 set -eu
 
-API_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Usage: generate-swagger-api.sh [api-directory]
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+API_DIR="${1:-${SCRIPT_DIR}/..}"
 
 generate_model() {
 	local package="$1"

--- a/api/scripts/validate-swagger-gen.sh
+++ b/api/scripts/validate-swagger-gen.sh
@@ -22,12 +22,16 @@ done
 
 cp "${API_DIR}/swagger.yaml" "${TMP_DIR}/"
 cp "${API_DIR}/swagger-gen.yaml" "${TMP_DIR}/"
+cp "${API_DIR}/go.mod" "${TMP_DIR}/"
 cp -r "${API_DIR}/templates" "${TMP_DIR}/" 2> /dev/null || true
 
 echo "Generating swagger types in temporary folder..."
 (
 	cd "${TMP_DIR}"
-	"${SCRIPT_DIR}/generate-swagger-api.sh" > /dev/null 2>&1
+	"${SCRIPT_DIR}/generate-swagger-api.sh" "${TMP_DIR}" > "${TMP_DIR}/generate.log" 2>&1 || {
+		cat "${TMP_DIR}/generate.log" >&2
+		exit 1
+	}
 )
 
 echo "Run diff for all generated files..."


### PR DESCRIPTION
The model validator changed into a temporary directory, but the generator derived its output directory from its script location and still wrote into the source tree.

Accept an optional API-directory argument and pass the temporary module directory during validation.