### PR TITLE
WIP: api: Move to OpenAPI 3.2 spec

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,7 +3,15 @@
 ARG GO_VERSION=1.26.8
 
 FROM golang:${GO_VERSION}-alpine AS base
-RUN apk add --no-cache bash make yamllint
+RUN apk add --no-cache bash make yamllint py3-pip
+# OpenAPI validation and YAML parsing for the Swagger compatibility specification.
+ARG OPENAPI_SPEC_VALIDATOR_VERSION=0.9.0
+ARG PYYAML_VERSION=6.0.2
+RUN python3 -m venv /opt/openapi && \
+    /opt/openapi/bin/pip install --no-cache-dir \
+        "openapi-spec-validator==${OPENAPI_SPEC_VALIDATOR_VERSION}" \
+        "PyYAML==${PYYAML_VERSION}"
+ENV PATH="/opt/openapi/bin:${PATH}"
 CMD ["/bin/bash"]
 
 # go-swagger

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -18,7 +18,7 @@ CMD ["/bin/bash"]
 FROM base AS swagger
 WORKDIR /go/src/github.com/go-swagger/go-swagger
 # GO_SWAGGER_VERSION specifies the version of the go-swagger binary to install.
-# Go-swagger is used in CI for generating types from swagger.yaml in
+# Go-swagger is used in CI for generating types from openapi.yaml in
 # api/scripts/generate-swagger-api.sh
 ARG GO_SWAGGER_VERSION=v0.33.1
 ARG TARGETPLATFORM

--- a/api/Makefile
+++ b/api/Makefile
@@ -38,7 +38,7 @@ build:
 		.
 
 .PHONY: swagger-gen
-swagger-gen: build ## generate swagger API types
+swagger-gen: build ## generate swagger.yaml and API types
 	$(DOCKER_RUN) ./scripts/generate-swagger-api.sh
 
 .PHONY: swagger-spec
@@ -51,9 +51,9 @@ swagger-docs: ## preview the API documentation
 	@docker run --rm \
 		-v ./:/usr/share/nginx/html/swagger/ \
 		-e 'REDOC_OPTIONS=hide-hostname="true" lazy-rendering' \
-		-e SPEC_URL="swagger/swagger.yaml" \
+		-e SPEC_URL="swagger/openapi.yaml" \
 		-p $(SWAGGER_DOCS_PORT):80 \
-		redocly/redoc:v2.5.1
+		redocly/redoc:v2.5.3
 
 .PHONY: validate-swagger
 validate-swagger: build ## validate OpenAPI and the generated Swagger specification

--- a/api/Makefile
+++ b/api/Makefile
@@ -41,6 +41,10 @@ build:
 swagger-gen: build ## generate swagger API types
 	$(DOCKER_RUN) ./scripts/generate-swagger-api.sh
 
+.PHONY: swagger-spec
+swagger-spec: build ## generate the Swagger 2.0 compatibility specification
+	$(DOCKER_RUN) ./scripts/generate-swagger-spec.sh
+
 .PHONY: swagger-docs
 swagger-docs: ## preview the API documentation
 	@echo "API docs preview will be running at http://localhost:$(SWAGGER_DOCS_PORT)"
@@ -52,7 +56,7 @@ swagger-docs: ## preview the API documentation
 		redocly/redoc:v2.5.1
 
 .PHONY: validate-swagger
-validate-swagger: build ## validate the swagger.yaml file
+validate-swagger: build ## validate OpenAPI and the generated Swagger specification
 	$(DOCKER_RUN) ./scripts/validate-swagger.sh
 
 .PHONY: validate-swagger-gen

--- a/api/README.md
+++ b/api/README.md
@@ -10,14 +10,15 @@ The Engine API is an HTTP API used by the command-line client to communicate wit
 
 It consists of various components in this repository:
 
-- `api/swagger.yaml` A Swagger definition of the API.
-- `api/types/` Types shared by both the client and server, representing various objects, options, responses, etc. Most are written manually, but some are automatically generated from the Swagger definition. See [#27919](https://github.com/moby/moby/issues/27919) for progress on this.
+- `api/openapi.yaml` An OpenAPI 3.2.0 definition of the API.
+- `api/swagger.yaml` The generated Swagger 2.0 compatibility definition of the same API.
+- `api/types/` Types shared by both the client and server, representing various objects, options, responses, etc. Most are written manually, but some are automatically generated from the API definition. See [#27919](https://github.com/moby/moby/issues/27919) for progress on this.
 - `client/` The Go client used by the command-line client. It can also be used by third-party Go programs.
 - `daemon/` The daemon, which serves the API.
 
-## Swagger definition
+## OpenAPI definition
 
-The API is defined by the [Swagger](http://swagger.io/specification/) definition in `api/swagger.yaml`. This definition can be used to:
+The API is defined by the [OpenAPI 3.2.0](https://spec.openapis.org/oas/v3.2.0) definition in `api/openapi.yaml`. This definition can be used to:
 
 1. Automatically generate documentation.
 2. Automatically generate the Go server and client. (A work-in-progress.)
@@ -25,24 +26,40 @@ The API is defined by the [Swagger](http://swagger.io/specification/) definition
 
 ## Updating the API documentation
 
-The API documentation is generated entirely from `api/swagger.yaml`. If you make updates to the API, edit this file to represent the change in the documentation.
+The API documentation is generated entirely from `api/openapi.yaml`. If you make updates to the API, edit this file to represent the change in the documentation.
 Documentation for each API version can be found in the [docs directory](docs/README.md), which also provides a [CHANGELOG.md](docs/CHANGELOG.md). 
 
 The file is split into two main sections:
 
-- `definitions`, which defines re-usable objects used in requests and responses
+- `components.schemas`, which defines re-usable objects used in requests and responses
 - `paths`, which defines the API endpoints (and some inline objects which don't need to be reusable)
 
-To make an edit, first look for the endpoint you want to edit under `paths`, then make the required edits. Endpoints may reference reusable objects with `$ref`, which can be found in the `definitions` section.
+To make an edit, first look for the endpoint you want to edit under `paths`, then make the required edits. Endpoints may reference reusable objects with `$ref: "#/components/schemas/Name"`.
 
-There is hopefully enough example material in the file for you to copy a similar pattern from elsewhere in the file (e.g. adding new fields or endpoints), but for the full reference, see the [Swagger specification](https://github.com/moby/moby/issues/27919).
+Request bodies are defined by `requestBody.content`, and response schemas and examples by `responses.<status>.content`, keyed by media type. Non-body parameters use `schema`. Array query parameters use `style: form` with `explode: true` for repeated keys and `explode: false` for comma-separated values; do not rely on the OpenAPI default, which differs from Swagger 2.0.
 
-`swagger.yaml` is validated by `hack/validate/swagger` to ensure it is a valid Swagger definition. This is useful when making edits to ensure you are doing the right thing.
+The relative server URL retains the version prefix without choosing a daemon hostname. `x-schemes` records the supported HTTP and HTTPS transports. The root `x-consumes` and `x-produces` retain the legacy Swagger defaults for compatibility generation; OpenAPI consumers use each operation's explicit `content` instead. Streaming media types and connection-upgrade descriptions are part of the contract; an empty media object means the response schema is unspecified, not that there is no stream. Explicit `consumes` declarations on operations without a request body are retained as `x-consumes`.
+
+Schemas use the default OpenAPI 3.1 schema dialect (JSON Schema 2020-12), declared by `jsonSchemaDialect`. Keep the document within what the Docker documentation pipeline and the Go model projection accept: do not use the removed OpenAPI 3.0 `nullable` keyword, `type` unions, `anyOf`, `oneOf`, or the 3.2-only `itemSchema` and tag hierarchy fields until the published documentation renders them. Whether a field may be JSON `null` on the wire is recorded only by the `x-nullable` generator extension; it reflects the Go representation and is not yet a reviewed statement about the API contract.
+
+Run `make -C api swagger-spec` from the repository root after editing `openapi.yaml`, and commit the generated `swagger.yaml` too. Do not edit `swagger.yaml` directly. `scripts/swagger_spec.py` converts the complete specification, including endpoints, parameters, bodies, headers, examples, and schemas. When the existing Swagger matches the projected content and schema property order, generation retains its text unchanged, including comments and formatting. Content or property-order changes produce fresh YAML; formatting may then change. Generation also works without an existing Swagger file.
+
+The generated Swagger follows the OpenAPI documentation, including repeated query parameters, bodyless HEAD responses, and omission of the invalid `RemoteManagers` null default. Swagger 2.0 cannot express different media types for individual responses, so each operation's `produces` lists their union. OpenAPI remains authoritative for which response uses which media type. No endpoint-specific compatibility overrides preserve the previous documentation errors.
+
+Run `make -C api validate-swagger` to check YAML style, validate OpenAPI 3.2 (including `default` values against their schemas), validate Swagger 2.0, and test the converter. This compares the checked-in Swagger with a fresh projection, including schema property order, and checks that regeneration leaves the file byte-for-byte unchanged. YAML response-key types and parameter placement do not affect the comparison. The pinned validators and YAML parser are installed by `api/Dockerfile`. Historical `api/docs/v*.yaml` specifications are not migrated.
+
+## Generating Go models
+
+Run `make swagger-gen` from the repository root, or `make swagger-gen` in this directory, as before. This first regenerates `api/swagger.yaml` from `api/openapi.yaml`, then feeds that full Swagger 2.0 file to go-swagger, pinned in `api/Dockerfile`. The converter preserves property order (including `--keep-spec-order`), custom formats, examples, and generator extensions.
+
+JSON Schema 2020-12 evaluates keywords placed beside `$ref`, so a referenced property carries its `description`, `x-nullable`, and `x-omitempty` directly, exactly as go-swagger reads them. The projection keeps original `allOf` compositions and Go pointer/omitempty behavior. Schema constructs that go-swagger cannot represent cause the projection to fail rather than silently lose information.
+
+Run `make -C api validate-swagger-gen` to regenerate into a temporary module and compare the results with the checked-in Go models. Do not change generated models just to accommodate a specification-format change.
 
 ## Viewing the API documentation
 
-When you make edits to `swagger.yaml`, you may want to check the generated API documentation to ensure it renders correctly.
+When you make edits to `openapi.yaml`, you may want to check the generated API documentation to ensure it renders correctly.
 
 Run `make swagger-docs` and a preview will be running at `http://localhost:9000`. Some of the styling may be incorrect, but you'll be able to ensure that it is generating the correct documentation.
 
-The production documentation is generated by vendoring `swagger.yaml` into [docker/docs](https://github.com/docker/docs).
+The production documentation is generated by vendoring the versioned `docs/v*.yaml` copies of `openapi.yaml` into [docker/docs](https://github.com/docker/docs).

--- a/api/docs/README.md
+++ b/api/docs/README.md
@@ -11,14 +11,22 @@ with some exceptions where features were deprecated. For an overview
 of changes for each version, refer to [CHANGELOG.md](CHANGELOG.md).
 
 The latest version of the API specification can be found [at the root directory
-of this module](../swagger.yaml) which may contain unreleased changes.
+of this module](../openapi.yaml) which may contain unreleased changes.
+It uses [OpenAPI 3.2.0](https://spec.openapis.org/oas/v3.2.0). This format
+migration does not change the Engine API contract or generated Go models.
+A generated [Swagger 2.0 compatibility specification](../swagger.yaml) is
+also available and is used by the Go model generator. Edit `openapi.yaml`
+and regenerate it rather than editing `swagger.yaml` directly.
+See the [module README](../README.md) for validation and model-generation
+instructions.
 
 For API version v1.24, documentation is only available in markdown
-format, for later versions [Swagger (OpenAPI) v2.0](https://swagger.io/specification/v2/)
-specifications can be found in this directory. The Moby project itself
-primarily uses these swagger files to produce the API documentation;
+format. Historical `v*.yaml` files in this directory retain their original
+[Swagger (OpenAPI) v2.0](https://swagger.io/specification/v2/) format; they
+are not converted along with the latest specification. The Moby project itself
+primarily uses these specification files to produce the API documentation;
 while we attempt to make these files match the actual implementation,
-the OpenAPI 2.0 specification has limitations that prevent us from
+the specification formats have limitations that prevent us from
 expressing all options provided. There may be discrepancies (for which
 we welcome contributions). If you find bugs, or discrepancies, please
 open a ticket (or pull request).

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,15286 @@
+# An OpenAPI 3.2.0 definition of the Engine API.
+#
+# This is used for generating API documentation and the types used by the
+# client/server. See api/README.md for more information.
+#
+# Some style notes:
+# - This file is used by ReDoc, which allows GitHub Flavored Markdown in
+#   descriptions.
+# - There is no maximum line length, for ease of editing and pretty diffs.
+# - operationIds are in the format "NounVerb", with a singular noun.
+
+openapi: "3.2.0"
+jsonSchemaDialect: "https://spec.openapis.org/oas/3.1/dialect/base"
+x-schemes:
+  - "http"
+  - "https"
+x-produces:
+  - "application/json"
+  - "text/plain"
+x-consumes:
+  - "application/json"
+  - "text/plain"
+servers:
+  - url: "/v1.56"
+info:
+  title: "Docker Engine API"
+  version: "1.56"
+  x-logo:
+    url: "https://docs.docker.com/assets/images/logo-docker-main.png"
+  description: |
+    The Engine API is an HTTP API served by Docker Engine. It is the API the
+    Docker client uses to communicate with the Engine, so everything the Docker
+    client can do can be done with the API.
+
+    Most of the client's commands map directly to API endpoints (e.g. `docker ps`
+    is `GET /containers/json`). The notable exception is running containers,
+    which consists of several API calls.
+
+    # Errors
+
+    The API uses standard HTTP status codes to indicate the success or failure
+    of the API call. The body of the response will be JSON in the following
+    format:
+
+    ```
+    {
+      "message": "page not found"
+    }
+    ```
+
+    # Versioning
+
+    The API is usually changed in each release, so API calls are versioned to
+    ensure that clients don't break. To lock to a specific version of the API,
+    you prefix the URL with its version, for example, call `/v1.30/info` to use
+    the v1.30 version of the `/info` endpoint. If the API version specified in
+    the URL is not supported by the daemon, a HTTP `400 Bad Request` error message
+    is returned.
+
+    If you omit the version-prefix, the current version of the API is used.
+    For example, calling `/info` is the same as calling `/v1.56/info`. Using the
+    API without a version-prefix is deprecated and will be removed in a future release.
+
+    Engine releases in the near future should support this version of the API,
+    so your client will continue to work even if it is talking to a newer Engine.
+
+    The API uses an open schema model, which means the server may add extra properties
+    to responses. Likewise, the server will ignore any extra query parameters and
+    request body properties. When you write clients, you need to ignore additional
+    properties in responses to ensure they do not break when talking to newer
+    daemons.
+
+
+    # Authentication
+
+    Authentication for registries is handled client side. The client has to send
+    authentication details to various endpoints that need to communicate with
+    registries, such as `POST /images/(name)/push`. These are sent as
+    `X-Registry-Auth` header as a [base64url encoded](https://tools.ietf.org/html/rfc4648#section-5)
+    (JSON) string with the following structure:
+
+    ```
+    {
+      "username": "string",
+      "password": "string",
+      "serveraddress": "string"
+    }
+    ```
+
+    The `serveraddress` is a domain/IP without a protocol. Throughout this
+    structure, double quotes are required.
+
+    If you have already got an identity token from the [`/auth` endpoint](#operation/SystemAuth),
+    you can just pass this instead of credentials:
+
+    ```
+    {
+      "identitytoken": "9cbaf023786cd7..."
+    }
+    ```
+
+# The tags on paths define the menu sections in the ReDoc documentation, so
+# the usage of tags must make sense for that:
+# - They should be singular, not plural.
+# - There should not be too many tags, or the menu becomes unwieldy. For
+#   example, it is preferable to add a path to the "System" tag instead of
+#   creating a tag with a single path in it.
+# - The order of tags in this list defines the order in the menu.
+tags:
+  # Primary objects
+  - name: "Container"
+    x-displayName: "Containers"
+    description: |
+      Create and manage containers.
+  - name: "Image"
+    x-displayName: "Images"
+  - name: "Network"
+    x-displayName: "Networks"
+    description: |
+      Networks are user-defined networks that containers can be attached to.
+      See the [networking documentation](https://docs.docker.com/network/)
+      for more information.
+  - name: "Volume"
+    x-displayName: "Volumes"
+    description: |
+      Create and manage persistent storage that can be attached to containers.
+  - name: "Exec"
+    x-displayName: "Exec"
+    description: |
+      Run new commands inside running containers. Refer to the
+      [command-line reference](https://docs.docker.com/engine/reference/commandline/exec/)
+      for more information.
+
+      To exec a command in a container, you first need to create an exec instance,
+      then start it. These two API endpoints are wrapped up in a single command-line
+      command, `docker exec`.
+
+  # Swarm things
+  - name: "Swarm"
+    x-displayName: "Swarm"
+    description: |
+      Engines can be clustered together in a swarm. Refer to the
+      [swarm mode documentation](https://docs.docker.com/engine/swarm/)
+      for more information.
+  - name: "Node"
+    x-displayName: "Nodes"
+    description: |
+      Nodes are instances of the Engine participating in a swarm. Swarm mode
+      must be enabled for these endpoints to work.
+  - name: "Service"
+    x-displayName: "Services"
+    description: |
+      Services are the definitions of tasks to run on a swarm. Swarm mode must
+      be enabled for these endpoints to work.
+  - name: "Task"
+    x-displayName: "Tasks"
+    description: |
+      A task is a container running on a swarm. It is the atomic scheduling unit
+      of swarm. Swarm mode must be enabled for these endpoints to work.
+  - name: "Secret"
+    x-displayName: "Secrets"
+    description: |
+      Secrets are sensitive data that can be used by services. Swarm mode must
+      be enabled for these endpoints to work.
+  - name: "Config"
+    x-displayName: "Configs"
+    description: |
+      Configs are application configurations that can be used by services. Swarm
+      mode must be enabled for these endpoints to work.
+  # System things
+  - name: "Plugin"
+    x-displayName: "Plugins"
+  - name: "System"
+    x-displayName: "System"
+
+components:
+  schemas:
+    ImageHistoryResponseItem:
+      type: "object"
+      x-go-name: HistoryResponseItem
+      title: "HistoryResponseItem"
+      description: "individual image layer information in response to ImageHistory operation"
+      required: [Id, Created, CreatedBy, Tags, Size, Comment]
+      properties:
+        Id:
+          type: "string"
+          x-nullable: false
+        Created:
+          type: "integer"
+          format: "int64"
+          x-nullable: false
+        CreatedBy:
+          type: "string"
+          x-nullable: false
+        Tags:
+          type: "array"
+          items:
+            type: "string"
+        Size:
+          type: "integer"
+          format: "int64"
+          x-nullable: false
+        Comment:
+          type: "string"
+          x-nullable: false
+    PortSummary:
+      type: "object"
+      description: |
+        Describes a port-mapping between the container and the host.
+      required: [PrivatePort, Type]
+      properties:
+        IP:
+          type: "string"
+          format: "ip-address"
+          description: "Host IP address that the container's port is mapped to"
+          x-go-type:
+            type: Addr
+            import:
+              package: net/netip
+        PrivatePort:
+          type: "integer"
+          format: "uint16"
+          x-nullable: false
+          description: "Port on the container"
+        PublicPort:
+          type: "integer"
+          format: "uint16"
+          description: "Port exposed on the host"
+        Type:
+          type: "string"
+          x-nullable: false
+          enum: ["tcp", "udp", "sctp"]
+      example:
+        PrivatePort: 8080
+        PublicPort: 80
+        Type: "tcp"
+
+    MountType:
+      description: |-
+        The mount type. Available types:
+
+        - `bind` a mount of a file or directory from the host into the container.
+        - `cluster` a Swarm cluster volume.
+        - `image` an OCI image.
+        - `npipe` a named pipe from the host into the container.
+        - `tmpfs` a `tmpfs`.
+        - `volume` a docker volume with the given `Name`.
+      type: "string"
+      enum:
+        - "bind"
+        - "cluster"
+        - "image"
+        - "npipe"
+        - "tmpfs"
+        - "volume"
+      example: "volume"
+
+    MountPoint:
+      type: "object"
+      description: |
+        MountPoint represents a mount point configuration inside the container.
+        This is used for reporting the mountpoints in use by a container.
+      properties:
+        Type:
+          description: |
+            The mount type:
+
+            - `bind` a mount of a file or directory from the host into the container.
+            - `cluster` a Swarm cluster volume.
+            - `image` an OCI image.
+            - `npipe` a named pipe from the host into the container.
+            - `tmpfs` a `tmpfs`.
+            - `volume` a docker volume with the given `Name`.
+          allOf:
+            - $ref: "#/components/schemas/MountType"
+          example: "volume"
+        Name:
+          description: |
+            Name is the name reference to the underlying data defined by `Source`
+            e.g., the volume name.
+          type: "string"
+          example: "myvolume"
+        Source:
+          description: |
+            Source location of the mount.
+
+            For volumes, this contains the storage location of the volume (within
+            `/var/lib/docker/volumes/`). For bind-mounts, and `npipe`, this contains
+            the source (host) part of the bind-mount. For `tmpfs` mount points, this
+            field is empty.
+          type: "string"
+          example: "/var/lib/docker/volumes/myvolume/_data"
+        Destination:
+          description: |
+            Destination is the path relative to the container root (`/`) where
+            the `Source` is mounted inside the container.
+          type: "string"
+          example: "/usr/share/nginx/html/"
+        Driver:
+          description: |
+            Driver is the volume driver used to create the volume (if it is a volume).
+          type: "string"
+          example: "local"
+        Mode:
+          description: |
+            Mode is a comma separated list of options supplied by the user when
+            creating the bind/volume mount.
+
+            The default is platform-specific (`"z"` on Linux, empty on Windows).
+          type: "string"
+          example: "z"
+        RW:
+          description: |
+            Whether the mount is mounted writable (read-write).
+          type: "boolean"
+          example: true
+        Propagation:
+          description: |
+            Propagation describes how mounts are propagated from the host into the
+            mount point, and vice-versa. Refer to the [Linux kernel documentation](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt)
+            for details. This field is not used on Windows.
+          type: "string"
+          example: ""
+
+    DeviceMapping:
+      type: "object"
+      description: "A device mapping between the host and container"
+      properties:
+        PathOnHost:
+          type: "string"
+        PathInContainer:
+          type: "string"
+        CgroupPermissions:
+          type: "string"
+      example:
+        PathOnHost: "/dev/deviceName"
+        PathInContainer: "/dev/deviceName"
+        CgroupPermissions: "mrw"
+
+    DeviceRequest:
+      type: "object"
+      description: "A request for devices to be sent to device drivers"
+      properties:
+        Driver:
+          description: |
+            The name of the device driver to use for this request.
+
+            Note that if this is specified the capabilities are ignored when
+            selecting a device driver.
+          type: "string"
+          example: "nvidia"
+        Count:
+          type: "integer"
+          example: -1
+        DeviceIDs:
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "0"
+            - "1"
+            - "GPU-fef8089b-4820-abfc-e83e-94318197576e"
+        Capabilities:
+          description: |
+            A list of capabilities; an OR list of AND lists of capabilities.
+
+            Note that if a driver is specified the capabilities have no effect on
+            selecting a driver as the driver name is used directly.
+
+            Note that if no driver is specified the capabilities are used to
+            select a driver with the required capabilities.
+          type: "array"
+          items:
+            type: "array"
+            items:
+              type: "string"
+          example:
+            # gpu AND nvidia AND compute
+            - ["gpu", "nvidia", "compute"]
+        Options:
+          description: |
+            Driver-specific options, specified as a key/value pairs. These options
+            are passed directly to the driver.
+          type: "object"
+          additionalProperties:
+            type: "string"
+
+    ThrottleDevice:
+      type: "object"
+      properties:
+        Path:
+          description: "Device path"
+          type: "string"
+        Rate:
+          description: "Rate"
+          type: "integer"
+          format: "int64"
+          minimum: 0
+
+    Mount:
+      type: "object"
+      properties:
+        Target:
+          description: "Container path."
+          type: "string"
+        Source:
+          description: |-
+            Mount source (e.g. a volume name, a host path). The source cannot be
+            specified when using `Type=tmpfs`. For `Type=bind`, the source path
+            must either exist, or the `CreateMountpoint` must be set to `true` to
+            create the source path on the host if missing.
+
+            For `Type=npipe`, the pipe must exist prior to creating the container.
+          type: "string"
+        Type:
+          description: |
+            The mount type. Available types:
+
+            - `bind` Mounts a file or directory from the host into the container. The `Source` must exist prior to creating the container.
+            - `cluster` a Swarm cluster volume
+            - `image` Mounts an image.
+            - `npipe` Mounts a named pipe from the host into the container. The `Source` must exist prior to creating the container.
+            - `tmpfs` Create a tmpfs with the given options. The mount `Source` cannot be specified for tmpfs.
+            - `volume` Creates a volume with the given name and options (or uses a pre-existing volume with the same name and options). These are **not** removed when the container is removed.
+          allOf:
+            - $ref: "#/components/schemas/MountType"
+        ReadOnly:
+          description: "Whether the mount should be read-only."
+          type: "boolean"
+        Consistency:
+          description: "The consistency requirement for the mount: `default`, `consistent`, `cached`, or `delegated`."
+          type: "string"
+        BindOptions:
+          description: "Optional configuration for the `bind` type."
+          type: "object"
+          properties:
+            Propagation:
+              description: "A propagation mode with the value `[r]private`, `[r]shared`, or `[r]slave`."
+              type: "string"
+              enum:
+                - "private"
+                - "rprivate"
+                - "shared"
+                - "rshared"
+                - "slave"
+                - "rslave"
+            NonRecursive:
+              description: "Disable recursive bind mount."
+              type: "boolean"
+              default: false
+            CreateMountpoint:
+              description: "Create mount point on host if missing"
+              type: "boolean"
+              default: false
+            ReadOnlyNonRecursive:
+              description: |
+                Make the mount non-recursively read-only, but still leave the mount recursive
+                (unless NonRecursive is set to `true` in conjunction).
+
+                Added in v1.44, before that version all read-only mounts were
+                non-recursive by default. To match the previous behaviour this
+                will default to `true` for clients on versions prior to v1.44.
+              type: "boolean"
+              default: false
+            ReadOnlyForceRecursive:
+              description: "Raise an error if the mount cannot be made recursively read-only."
+              type: "boolean"
+              default: false
+        VolumeOptions:
+          description: "Optional configuration for the `volume` type."
+          type: "object"
+          properties:
+            NoCopy:
+              description: "Populate volume with data from the target."
+              type: "boolean"
+              default: false
+            Labels:
+              description: "User-defined key/value metadata."
+              type: "object"
+              additionalProperties:
+                type: "string"
+            DriverConfig:
+              description: "Map of driver specific options"
+              type: "object"
+              properties:
+                Name:
+                  description: "Name of the driver to use to create the volume."
+                  type: "string"
+                Options:
+                  description: "key/value map of driver specific options."
+                  type: "object"
+                  additionalProperties:
+                    type: "string"
+            Subpath:
+              description: "Source path inside the volume. Must be relative without any back traversals."
+              type: "string"
+              example: "dir-inside-volume/subdirectory"
+        ImageOptions:
+          description: "Optional configuration for the `image` type."
+          type: "object"
+          properties:
+            Subpath:
+              description: "Source path inside the image. Must be relative without any back traversals."
+              type: "string"
+              example: "dir-inside-image/subdirectory"
+        TmpfsOptions:
+          description: "Optional configuration for the `tmpfs` type."
+          type: "object"
+          properties:
+            SizeBytes:
+              description: "The size for the tmpfs mount in bytes."
+              type: "integer"
+              format: "int64"
+            Mode:
+              description: |
+                The permission mode for the tmpfs mount in an integer.
+                The value must not be in octal format (e.g. 755) but rather
+                the decimal representation of the octal value (e.g. 493).
+              type: "integer"
+            Options:
+              description: |
+                The options to be passed to the tmpfs mount. An array of arrays.
+                Flag options should be provided as 1-length arrays. Other types
+                should be provided as as 2-length arrays, where the first item is
+                the key and the second the value.
+              type: "array"
+              items:
+                type: "array"
+                minItems: 1
+                maxItems: 2
+                items:
+                  type: "string"
+              example:
+                [["noexec"]]
+
+    RestartPolicy:
+      description: |
+        The behavior to apply when the container exits. The default is not to
+        restart.
+
+        An ever increasing delay (double the previous delay, starting at 100ms) is
+        added before each restart to prevent flooding the server.
+      type: "object"
+      properties:
+        Name:
+          type: "string"
+          description: |
+            - Empty string means not to restart
+            - `no` Do not automatically restart
+            - `always` Always restart
+            - `unless-stopped` Restart always except when the user has manually stopped the container
+            - `on-failure` Restart only when the container exit code is non-zero
+          enum:
+            - ""
+            - "no"
+            - "always"
+            - "unless-stopped"
+            - "on-failure"
+        MaximumRetryCount:
+          type: "integer"
+          description: |
+            If `on-failure` is used, the number of times to retry before giving up.
+
+    Resources:
+      description: "A container's resources (cgroups config, ulimits, etc)"
+      type: "object"
+      properties:
+        # Applicable to all platforms
+        CpuShares:
+          description: |
+            An integer value representing this container's relative CPU weight
+            versus other containers.
+          type: "integer"
+        Memory:
+          description: "Memory limit in bytes."
+          type: "integer"
+          format: "int64"
+          default: 0
+        # Applicable to UNIX platforms
+        CgroupParent:
+          description: |
+            Path to `cgroups` under which the container's `cgroup` is created. If
+            the path is not absolute, the path is considered to be relative to the
+            `cgroups` path of the init process. Cgroups are created if they do not
+            already exist.
+          type: "string"
+        BlkioWeight:
+          description: "Block IO weight (relative weight)."
+          type: "integer"
+          minimum: 0
+          maximum: 1000
+        BlkioWeightDevice:
+          description: |
+            Block IO weight (relative device weight) in the form:
+
+            ```
+            [{"Path": "device_path", "Weight": weight}]
+            ```
+          type: "array"
+          items:
+            type: "object"
+            properties:
+              Path:
+                type: "string"
+              Weight:
+                type: "integer"
+                minimum: 0
+        BlkioDeviceReadBps:
+          description: |
+            Limit read rate (bytes per second) from a device, in the form:
+
+            ```
+            [{"Path": "device_path", "Rate": rate}]
+            ```
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ThrottleDevice"
+        BlkioDeviceWriteBps:
+          description: |
+            Limit write rate (bytes per second) to a device, in the form:
+
+            ```
+            [{"Path": "device_path", "Rate": rate}]
+            ```
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ThrottleDevice"
+        BlkioDeviceReadIOps:
+          description: |
+            Limit read rate (IO per second) from a device, in the form:
+
+            ```
+            [{"Path": "device_path", "Rate": rate}]
+            ```
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ThrottleDevice"
+        BlkioDeviceWriteIOps:
+          description: |
+            Limit write rate (IO per second) to a device, in the form:
+
+            ```
+            [{"Path": "device_path", "Rate": rate}]
+            ```
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ThrottleDevice"
+        CpuPeriod:
+          description: "The length of a CPU period in microseconds."
+          type: "integer"
+          format: "int64"
+        CpuQuota:
+          description: |
+            Microseconds of CPU time that the container can get in a CPU period.
+          type: "integer"
+          format: "int64"
+        CpuRealtimePeriod:
+          description: |
+            The length of a CPU real-time period in microseconds. Set to 0 to
+            allocate no time allocated to real-time tasks.
+          type: "integer"
+          format: "int64"
+        CpuRealtimeRuntime:
+          description: |
+            The length of a CPU real-time runtime in microseconds. Set to 0 to
+            allocate no time allocated to real-time tasks.
+          type: "integer"
+          format: "int64"
+        CpusetCpus:
+          description: |
+            CPUs in which to allow execution (e.g., `0-3`, `0,1`).
+          type: "string"
+          example: "0-3"
+        CpusetMems:
+          description: |
+            Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only
+            effective on NUMA systems.
+          type: "string"
+        Devices:
+          description: "A list of devices to add to the container."
+          type: "array"
+          items:
+            $ref: "#/components/schemas/DeviceMapping"
+        DeviceCgroupRules:
+          description: "a list of cgroup rules to apply to the container"
+          type: "array"
+          items:
+            type: "string"
+            example: "c 13:* rwm"
+        DeviceRequests:
+          description: |
+            A list of requests for devices to be sent to device drivers.
+          type: "array"
+          items:
+            $ref: "#/components/schemas/DeviceRequest"
+        MemoryReservation:
+          description: "Memory soft limit in bytes."
+          type: "integer"
+          format: "int64"
+        MemorySwap:
+          description: |
+            Total memory limit (memory + swap). Set as `-1` to enable unlimited
+            swap.
+          type: "integer"
+          format: "int64"
+        MemorySwappiness:
+          description: |
+            Tune a container's memory swappiness behavior. Accepts an integer
+            between 0 and 100.
+          type: "integer"
+          format: "int64"
+          minimum: 0
+          maximum: 100
+        NanoCpus:
+          description: "CPU quota in units of 10<sup>-9</sup> CPUs."
+          type: "integer"
+          format: "int64"
+        OomKillDisable:
+          description: "Disable OOM Killer for the container."
+          type: "boolean"
+        Init:
+          description: |
+            Run an init inside the container that forwards signals and reaps
+            processes. This field is omitted if empty, and the default (as
+            configured on the daemon) is used.
+          type: "boolean"
+          x-nullable: true
+        PidsLimit:
+          description: |
+            Tune a container's PIDs limit. Set `0` or `-1` for unlimited, or `null`
+            to not change.
+          type: "integer"
+          format: "int64"
+          x-nullable: true
+        Ulimits:
+          description: |
+            A list of resource limits to set in the container. For example:
+
+            ```
+            {"Name": "nofile", "Soft": 1024, "Hard": 2048}
+            ```
+          type: "array"
+          items:
+            type: "object"
+            properties:
+              Name:
+                description: "Name of ulimit"
+                type: "string"
+              Soft:
+                description: "Soft limit"
+                type: "integer"
+              Hard:
+                description: "Hard limit"
+                type: "integer"
+        # Applicable to Windows
+        CpuCount:
+          description: |
+            The number of usable CPUs (Windows only).
+
+            On Windows Server containers, the processor resource controls are
+            mutually exclusive. The order of precedence is `CPUCount` first, then
+            `CPUShares`, and `CPUPercent` last.
+          type: "integer"
+          format: "int64"
+        CpuPercent:
+          description: |
+            The usable percentage of the available CPUs (Windows only).
+
+            On Windows Server containers, the processor resource controls are
+            mutually exclusive. The order of precedence is `CPUCount` first, then
+            `CPUShares`, and `CPUPercent` last.
+          type: "integer"
+          format: "int64"
+        IOMaximumIOps:
+          description: "Maximum IOps for the container system drive (Windows only)"
+          type: "integer"
+          format: "int64"
+        IOMaximumBandwidth:
+          description: |
+            Maximum IO in bytes per second for the container system drive
+            (Windows only).
+          type: "integer"
+          format: "int64"
+
+    Limit:
+      description: |
+        An object describing a limit on resources which can be requested by a task.
+      type: "object"
+      properties:
+        NanoCPUs:
+          type: "integer"
+          format: "int64"
+          example: 4000000000
+        MemoryBytes:
+          type: "integer"
+          format: "int64"
+          example: 8272408576
+        Pids:
+          description: |
+            Limits the maximum number of PIDs in the container. Set `0` for unlimited.
+          type: "integer"
+          format: "int64"
+          default: 0
+          example: 100
+
+    ResourceObject:
+      description: |
+        An object describing the resources which can be advertised by a node and
+        requested by a task.
+      type: "object"
+      properties:
+        NanoCPUs:
+          type: "integer"
+          format: "int64"
+          example: 4000000000
+        MemoryBytes:
+          type: "integer"
+          format: "int64"
+          example: 8272408576
+        GenericResources:
+          $ref: "#/components/schemas/GenericResources"
+
+    GenericResources:
+      description: |
+        User-defined resources can be either Integer resources (e.g, `SSD=3`) or
+        String resources (e.g, `GPU=UUID1`).
+      type: "array"
+      items:
+        type: "object"
+        properties:
+          NamedResourceSpec:
+            type: "object"
+            properties:
+              Kind:
+                type: "string"
+              Value:
+                type: "string"
+          DiscreteResourceSpec:
+            type: "object"
+            properties:
+              Kind:
+                type: "string"
+              Value:
+                type: "integer"
+                format: "int64"
+      example:
+        - DiscreteResourceSpec:
+            Kind: "SSD"
+            Value: 3
+        - NamedResourceSpec:
+            Kind: "GPU"
+            Value: "UUID1"
+        - NamedResourceSpec:
+            Kind: "GPU"
+            Value: "UUID2"
+
+    HealthConfig:
+      description: |
+        A test to perform to check that the container is healthy.
+        Healthcheck commands should be side-effect free.
+      type: "object"
+      properties:
+        Test:
+          description: |
+            The test to perform. Possible values are:
+
+            - `[]` inherit healthcheck from image or parent image
+            - `["NONE"]` disable healthcheck
+            - `["CMD", args...]` exec arguments directly
+            - `["CMD-SHELL", command]` run command with system's default shell
+
+            A non-zero exit code indicates a failed healthcheck:
+            - `0` healthy
+            - `1` unhealthy
+            - `2` reserved (treated as unhealthy)
+            - other values: error running probe
+          type: "array"
+          items:
+            type: "string"
+        Interval:
+          description: |
+            The time to wait between checks in nanoseconds. It should be 0 or at
+            least 1000000 (1 ms). 0 means inherit.
+          type: "integer"
+          format: "int64"
+        Timeout:
+          description: |
+            The time to wait before considering the check to have hung. It should
+            be 0 or at least 1000000 (1 ms). 0 means inherit.
+
+            If the health check command does not complete within this timeout,
+            the check is considered failed and the health check process is
+            forcibly terminated without a graceful shutdown.
+          type: "integer"
+          format: "int64"
+        Retries:
+          description: |
+            The number of consecutive failures needed to consider a container as
+            unhealthy. 0 means inherit.
+          type: "integer"
+        StartPeriod:
+          description: |
+            Start period for the container to initialize before starting
+            health-retries countdown in nanoseconds. It should be 0 or at least
+            1000000 (1 ms). 0 means inherit.
+          type: "integer"
+          format: "int64"
+        StartInterval:
+          description: |
+            The time to wait between checks in nanoseconds during the start period.
+            It should be 0 or at least 1000000 (1 ms). 0 means inherit.
+          type: "integer"
+          format: "int64"
+
+    Health:
+      description: |
+        Health stores information about the container's healthcheck results.
+      type: "object"
+      x-nullable: true
+      properties:
+        Status:
+          description: |
+            Status is one of `none`, `starting`, `healthy` or `unhealthy`
+
+            - "none"      Indicates there is no healthcheck
+            - "starting"  Starting indicates that the container is not yet ready
+            - "healthy"   Healthy indicates that the container is running correctly
+            - "unhealthy" Unhealthy indicates that the container has a problem
+          type: "string"
+          enum:
+            - "none"
+            - "starting"
+            - "healthy"
+            - "unhealthy"
+          example: "healthy"
+        FailingStreak:
+          description: "FailingStreak is the number of consecutive failures"
+          type: "integer"
+          example: 0
+        Log:
+          type: "array"
+          description: |
+            Log contains the last few results (oldest first)
+          items:
+            $ref: "#/components/schemas/HealthcheckResult"
+
+    HealthcheckResult:
+      description: |
+        HealthcheckResult stores information about a single run of a healthcheck probe
+      type: "object"
+      x-nullable: true
+      properties:
+        Start:
+          description: |
+            Date and time at which this check started in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "date-time"
+          example: "2020-01-04T10:44:24.496525531Z"
+        End:
+          description: |
+            Date and time at which this check ended in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "dateTime"
+          example: "2020-01-04T10:45:21.364524523Z"
+        ExitCode:
+          description: |
+            ExitCode meanings:
+
+            - `0` healthy
+            - `1` unhealthy
+            - `2` reserved (considered unhealthy)
+            - other values: error running probe
+          type: "integer"
+          example: 0
+        Output:
+          description: "Output from last check"
+          type: "string"
+
+    HostConfig:
+      description: "Container configuration that depends on the host we are running on"
+      allOf:
+        - $ref: "#/components/schemas/Resources"
+        - type: "object"
+          properties:
+            # Applicable to all platforms
+            Binds:
+              type: "array"
+              description: |
+                A list of volume bindings for this container. Each volume binding
+                is a string in one of these forms:
+
+                - `host-src:container-dest[:options]` to bind-mount a host path
+                  into the container. Both `host-src`, and `container-dest` must
+                  be an _absolute_ path.
+                - `volume-name:container-dest[:options]` to bind-mount a volume
+                  managed by a volume driver into the container. `container-dest`
+                  must be an _absolute_ path.
+
+                `options` is an optional, comma-delimited list of:
+
+                - `nocopy` disables automatic copying of data from the container
+                  path to the volume. The `nocopy` flag only applies to named volumes.
+                - `[ro|rw]` mounts a volume read-only or read-write, respectively.
+                  If omitted or set to `rw`, volumes are mounted read-write.
+                - `[z|Z]` applies SELinux labels to allow or deny multiple containers
+                  to read and write to the same volume.
+                    - `z`: a _shared_ content label is applied to the content. This
+                      label indicates that multiple containers can share the volume
+                      content, for both reading and writing.
+                    - `Z`: a _private unshared_ label is applied to the content.
+                      This label indicates that only the current container can use
+                      a private volume. Labeling systems such as SELinux require
+                      proper labels to be placed on volume content that is mounted
+                      into a container. Without a label, the security system can
+                      prevent a container's processes from using the content. By
+                      default, the labels set by the host operating system are not
+                      modified.
+                - `[[r]shared|[r]slave|[r]private]` specifies mount
+                  [propagation behavior](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt).
+                  This only applies to bind-mounted volumes, not internal volumes
+                  or named volumes. Mount propagation requires the source mount
+                  point (the location where the source directory is mounted in the
+                  host operating system) to have the correct propagation properties.
+                  For shared volumes, the source mount point must be set to `shared`.
+                  For slave volumes, the mount must be set to either `shared` or
+                  `slave`.
+              items:
+                type: "string"
+            ContainerIDFile:
+              type: "string"
+              description: "Path to a file where the container ID is written"
+              example: ""
+            LogConfig:
+              type: "object"
+              description: "The logging configuration for this container"
+              properties:
+                Type:
+                  description: |-
+                    Name of the logging driver used for the container or "none"
+                    if logging is disabled.
+                  type: "string"
+                  enum:
+                    - "local"
+                    - "json-file"
+                    - "syslog"
+                    - "journald"
+                    - "gelf"
+                    - "fluentd"
+                    - "awslogs"
+                    - "splunk"
+                    - "etwlogs"
+                    - "none"
+                Config:
+                  description: |-
+                    Driver-specific configuration options for the logging driver.
+                  type: "object"
+                  additionalProperties:
+                    type: "string"
+                  example:
+                    "max-file": "5"
+                    "max-size": "10m"
+            NetworkMode:
+              type: "string"
+              description: |
+                Network mode to use for this container. Supported standard values
+                are: `bridge`, `host`, `none`, and `container:<name|id>`. Any
+                other value is taken as a custom network's name to which this
+                container should connect to.
+            PortBindings:
+              $ref: "#/components/schemas/PortMap"
+            RestartPolicy:
+              $ref: "#/components/schemas/RestartPolicy"
+            AutoRemove:
+              type: "boolean"
+              description: |
+                Automatically remove the container when the container's process
+                exits. This has no effect if `RestartPolicy` is set.
+            VolumeDriver:
+              type: "string"
+              description: "Driver that this container uses to mount volumes."
+            VolumesFrom:
+              type: "array"
+              description: |
+                A list of volumes to inherit from another container, specified in
+                the form `<container name>[:<ro|rw>]`.
+              items:
+                type: "string"
+            Mounts:
+              description: |
+                Specification for mounts to be added to the container.
+              type: "array"
+              items:
+                $ref: "#/components/schemas/Mount"
+            ConsoleSize:
+              type: "array"
+              description: |
+                Initial console size, as an `[height, width]` array.
+              x-nullable: true
+              minItems: 2
+              maxItems: 2
+              items:
+                type: "integer"
+                minimum: 0
+              example: [80, 64]
+            Annotations:
+              type: "object"
+              description: |
+                Arbitrary non-identifying metadata attached to container and
+                provided to the runtime when the container is started.
+              additionalProperties:
+                type: "string"
+
+            # Applicable to UNIX platforms
+            CapAdd:
+              type: "array"
+              description: |
+                A list of kernel capabilities to add to the container. Conflicts
+                with option 'Capabilities'.
+              items:
+                type: "string"
+            CapDrop:
+              type: "array"
+              description: |
+                A list of kernel capabilities to drop from the container. Conflicts
+                with option 'Capabilities'.
+              items:
+                type: "string"
+            CgroupnsMode:
+              type: "string"
+              enum:
+                - "private"
+                - "host"
+              description: |
+                cgroup namespace mode for the container. Possible values are:
+
+                - `"private"`: the container runs in its own private cgroup namespace
+                - `"host"`: use the host system's cgroup namespace
+
+                If not specified, the daemon default is used, which can either be `"private"`
+                or `"host"`, depending on daemon version, kernel support and configuration.
+            Dns:
+              type: "array"
+              description: "A list of DNS servers for the container to use."
+              items:
+                type: "string"
+                format: "ip-address"
+                x-go-type:
+                  type: Addr
+                  import:
+                    package: net/netip
+            DnsOptions:
+              type: "array"
+              description: "A list of DNS options."
+              items:
+                type: "string"
+            DnsSearch:
+              type: "array"
+              description: "A list of DNS search domains."
+              items:
+                type: "string"
+            ExtraHosts:
+              type: "array"
+              description: |
+                A list of hostnames/IP mappings to add to the container's `/etc/hosts`
+                file. Specified in the form `["hostname:IP"]`.
+              items:
+                type: "string"
+            GroupAdd:
+              type: "array"
+              description: |
+                A list of additional groups that the container process will run as.
+              items:
+                type: "string"
+            IpcMode:
+              type: "string"
+              description: |
+                IPC sharing mode for the container. Possible values are:
+
+                - `"none"`: own private IPC namespace, with /dev/shm not mounted
+                - `"private"`: own private IPC namespace
+                - `"shareable"`: own private IPC namespace, with a possibility to share it with other containers
+                - `"container:<name|id>"`: join another (shareable) container's IPC namespace
+                - `"host"`: use the host system's IPC namespace
+
+                If not specified, daemon default is used, which can either be `"private"`
+                or `"shareable"`, depending on daemon version and configuration.
+            Cgroup:
+              type: "string"
+              description: "Cgroup to use for the container."
+            Links:
+              type: "array"
+              description: |
+                A list of links for the container in the form `container_name:alias`.
+              items:
+                type: "string"
+            OomScoreAdj:
+              type: "integer"
+              description: |
+                An integer value containing the score given to the container in
+                order to tune OOM killer preferences.
+              example: 500
+            PidMode:
+              type: "string"
+              description: |
+                Set the PID (Process) Namespace mode for the container. It can be
+                either:
+
+                - `"container:<name|id>"`: joins another container's PID namespace
+                - `"host"`: use the host's PID namespace inside the container
+            Privileged:
+              type: "boolean"
+              description: |-
+                Gives the container full access to the host.
+            PublishAllPorts:
+              type: "boolean"
+              description: |
+                Allocates an ephemeral host port for all of a container's
+                exposed ports.
+
+                Ports are de-allocated when the container stops and allocated when
+                the container starts. The allocated port might be changed when
+                restarting the container.
+
+                The port is selected from the ephemeral port range that depends on
+                the kernel. For example, on Linux the range is defined by
+                `/proc/sys/net/ipv4/ip_local_port_range`.
+            ReadonlyRootfs:
+              type: "boolean"
+              description: "Mount the container's root filesystem as read only."
+            SecurityOpt:
+              type: "array"
+              description: |
+                A list of string values to customize labels for MLS systems, such
+                as SELinux.
+              items:
+                type: "string"
+            StorageOpt:
+              type: "object"
+              description: |
+                Storage driver options for this container, in the form `{"size": "120G"}`.
+              additionalProperties:
+                type: "string"
+            Tmpfs:
+              type: "object"
+              description: |
+                A map of container directories which should be replaced by tmpfs
+                mounts, and their corresponding mount options. For example:
+
+                ```
+                { "/run": "rw,noexec,nosuid,size=65536k" }
+                ```
+              additionalProperties:
+                type: "string"
+            UTSMode:
+              type: "string"
+              description: "UTS namespace to use for the container."
+            UsernsMode:
+              type: "string"
+              description: |
+                Sets the usernamespace mode for the container when usernamespace
+                remapping option is enabled.
+            ShmSize:
+              type: "integer"
+              format: "int64"
+              description: |
+                Size of `/dev/shm` in bytes. If omitted, the system uses 64MB.
+              minimum: 0
+            Sysctls:
+              type: "object"
+              x-nullable: true
+              description: |-
+                A list of kernel parameters (sysctls) to set in the container.
+
+                This field is omitted if not set.
+              additionalProperties:
+                type: "string"
+              example:
+                "net.ipv4.ip_forward": "1"
+            Runtime:
+              type: "string"
+              x-nullable: true
+              description: |-
+                Runtime to use with this container.
+            Umask:
+              type: "integer"
+              format: "uint32"
+              x-nullable: true
+              description: |-
+                Set the initial umask for a Unix container.
+
+                If omitted, the daemon does not set a umask in the OCI process
+                specification, and the runtime's default behavior applies.
+
+                JSON integers are decimal. For example, use `18` for the octal
+                umask `0022`, and `511` for the octal umask `0777`.
+            # Applicable to Windows
+            Isolation:
+              type: "string"
+              description: |
+                Isolation technology of the container. (Windows only)
+              enum:
+                - "default"
+                - "process"
+                - "hyperv"
+                - ""
+            MaskedPaths:
+              type: "array"
+              description: |
+                The list of paths to be masked inside the container (this overrides
+                the default set of paths).
+              items:
+                type: "string"
+              example:
+                - "/proc/asound"
+                - "/proc/acpi"
+                - "/proc/kcore"
+                - "/proc/keys"
+                - "/proc/latency_stats"
+                - "/proc/timer_list"
+                - "/proc/timer_stats"
+                - "/proc/sched_debug"
+                - "/proc/scsi"
+                - "/sys/firmware"
+                - "/sys/devices/virtual/powercap"
+            ReadonlyPaths:
+              type: "array"
+              description: |
+                The list of paths to be set as read-only inside the container
+                (this overrides the default set of paths).
+              items:
+                type: "string"
+              example:
+                - "/proc/bus"
+                - "/proc/fs"
+                - "/proc/irq"
+                - "/proc/sys"
+                - "/proc/sysrq-trigger"
+
+    ContainerConfig:
+      description: |
+        Configuration for a container that is portable between hosts.
+      type: "object"
+      properties:
+        Hostname:
+          description: |
+            The hostname to use for the container, as a valid RFC 1123 hostname.
+          type: "string"
+          example: "439f4e91bd1d"
+        Domainname:
+          description: |
+            The domain name to use for the container.
+          type: "string"
+        User:
+          description: |-
+            Commands run as this user inside the container. If omitted, commands
+            run as the user specified in the image the container was started from.
+
+            Can be either user-name or UID, and optional group-name or GID,
+            separated by a colon (`<user-name|UID>[<:group-name|GID>]`).
+          type: "string"
+          example: "123:456"
+        AttachStdin:
+          description: "Whether to attach to `stdin`."
+          type: "boolean"
+          default: false
+        AttachStdout:
+          description: "Whether to attach to `stdout`."
+          type: "boolean"
+          default: true
+        AttachStderr:
+          description: "Whether to attach to `stderr`."
+          type: "boolean"
+          default: true
+        ExposedPorts:
+          description: |
+            An object mapping ports to an empty object in the form:
+
+            `{"<port>/<tcp|udp|sctp>": {}}`
+          type: "object"
+          x-nullable: true
+          additionalProperties:
+            type: "object"
+            enum:
+              - {}
+            default: {}
+          example: {
+            "80/tcp": {},
+            "443/tcp": {}
+          }
+        Tty:
+          description: |
+            Attach standard streams to a TTY, including `stdin` if it is not closed.
+          type: "boolean"
+          default: false
+        OpenStdin:
+          description: "Open `stdin`"
+          type: "boolean"
+          default: false
+        StdinOnce:
+          description: "Close `stdin` after one attached client disconnects"
+          type: "boolean"
+          default: false
+        Env:
+          description: |
+            A list of environment variables to set inside the container in the
+            form `["VAR=value", ...]`. A variable without `=` is removed from the
+            environment, rather than to have an empty value.
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        Cmd:
+          description: |
+            Command to run specified as a string or an array of strings.
+          type: "array"
+          items:
+            type: "string"
+          example: ["/bin/sh"]
+        Healthcheck:
+          $ref: "#/components/schemas/HealthConfig"
+        ArgsEscaped:
+          description: "Command is already escaped (Windows only)"
+          type: "boolean"
+          default: false
+          example: false
+          x-nullable: true
+        Image:
+          description: |
+            The name (or reference) of the image to use when creating the container,
+            or which was used when the container was created.
+          type: "string"
+          example: "example-image:1.0"
+        Volumes:
+          description: |
+            An object mapping mount point paths inside the container to empty
+            objects.
+          type: "object"
+          additionalProperties:
+            type: "object"
+            enum:
+              - {}
+            default: {}
+        WorkingDir:
+          description: "The working directory for commands to run in."
+          type: "string"
+          example: "/public/"
+        Entrypoint:
+          description: |
+            The entry point for the container as a string or an array of strings.
+
+            If the array consists of exactly one empty string (`[""]`) then the
+            entry point is reset to system default (i.e., the entry point used by
+            docker when there is no `ENTRYPOINT` instruction in the `Dockerfile`).
+          type: "array"
+          items:
+            type: "string"
+          example: []
+        NetworkDisabled:
+          description: "Disable networking for the container."
+          type: "boolean"
+          x-nullable: true
+        OnBuild:
+          description: |
+            `ONBUILD` metadata that were defined in the image's `Dockerfile`.
+          type: "array"
+          x-nullable: true
+          items:
+            type: "string"
+          example: []
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.some-label: "some-value"
+            com.example.some-other-label: "some-other-value"
+        StopSignal:
+          description: |
+            Signal to stop a container as a string or unsigned integer.
+          type: "string"
+          example: "SIGTERM"
+          x-nullable: true
+        StopTimeout:
+          description: |
+            Timeout to stop a container in seconds. If omitted, the daemon-wide
+            default (`default-stop-timeout`) is used.
+          type: "integer"
+          x-nullable: true
+        Shell:
+          description: |
+            Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell.
+          type: "array"
+          x-nullable: true
+          items:
+            type: "string"
+          example: ["/bin/sh", "-c"]
+
+    ImageConfig:
+      description: |
+        Configuration of the image. These fields are used as defaults
+        when starting a container from the image.
+      type: "object"
+      properties:
+        User:
+          description: "The user that commands are run as inside the container."
+          type: "string"
+          example: "web:web"
+        ExposedPorts:
+          description: |
+            An object mapping ports to an empty object in the form:
+
+            `{"<port>/<tcp|udp|sctp>": {}}`
+          type: "object"
+          x-nullable: true
+          additionalProperties:
+            type: "object"
+            enum:
+              - {}
+            default: {}
+          example: {
+            "80/tcp": {},
+            "443/tcp": {}
+          }
+        Env:
+          description: |
+            A list of environment variables to set inside the container in the
+            form `["VAR=value", ...]`. A variable without `=` is removed from the
+            environment, rather than to have an empty value.
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        Cmd:
+          description: |
+            Command to run specified as a string or an array of strings.
+          type: "array"
+          items:
+            type: "string"
+          example: ["/bin/sh"]
+        Healthcheck:
+          $ref: "#/components/schemas/HealthConfig"
+        ArgsEscaped:
+          description: "Command is already escaped (Windows only)"
+          type: "boolean"
+          default: false
+          example: false
+          x-nullable: true
+        Volumes:
+          description: |
+            An object mapping mount point paths inside the container to empty
+            objects.
+          type: "object"
+          additionalProperties:
+            type: "object"
+            enum:
+              - {}
+            default: {}
+          example:
+            "/app/data": {}
+            "/app/config": {}
+        WorkingDir:
+          description: "The working directory for commands to run in."
+          type: "string"
+          example: "/public/"
+        Entrypoint:
+          description: |
+            The entry point for the container as a string or an array of strings.
+
+            If the array consists of exactly one empty string (`[""]`) then the
+            entry point is reset to system default (i.e., the entry point used by
+            docker when there is no `ENTRYPOINT` instruction in the `Dockerfile`).
+          type: "array"
+          items:
+            type: "string"
+          example: []
+        OnBuild:
+          description: |
+            `ONBUILD` metadata that were defined in the image's `Dockerfile`.
+          type: "array"
+          x-nullable: true
+          items:
+            type: "string"
+          example: []
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.some-label: "some-value"
+            com.example.some-other-label: "some-other-value"
+        StopSignal:
+          description: |
+            Signal to stop a container as a string or unsigned integer.
+          type: "string"
+          example: "SIGTERM"
+          x-nullable: true
+        Shell:
+          description: |
+            Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell.
+          type: "array"
+          x-nullable: true
+          items:
+            type: "string"
+          example: ["/bin/sh", "-c"]
+
+    NetworkingConfig:
+      description: |
+        NetworkingConfig represents the container's networking configuration for
+        each of its interfaces.
+        It is used for the networking configs specified in the `docker create`
+        and `docker network connect` commands.
+      type: "object"
+      properties:
+        EndpointsConfig:
+          description: |
+            A mapping of network name to endpoint configuration for that network.
+            The endpoint configuration can be left empty to connect to that
+            network with no particular endpoint configuration.
+          type: "object"
+          additionalProperties:
+            $ref: "#/components/schemas/EndpointSettings"
+      example:
+        # putting an example here, instead of using the example values from
+        # /components/schemas/EndpointSettings, because EndpointSettings contains
+        # operational data returned when inspecting a container that we don't
+        # accept here.
+        EndpointsConfig:
+          isolated_nw:
+            IPAMConfig:
+              IPv4Address: "172.20.30.33"
+              IPv6Address: "2001:db8:abcd::3033"
+              LinkLocalIPs:
+                - "169.254.34.68"
+                - "fe80::3468"
+            MacAddress: "02:42:ac:12:05:02"
+            Links:
+              - "container_1"
+              - "container_2"
+            Aliases:
+              - "server_x"
+              - "server_y"
+          database_nw: {}
+
+    NetworkSettings:
+      description: "NetworkSettings exposes the network settings in the API"
+      type: "object"
+      properties:
+        SandboxID:
+          description: SandboxID uniquely represents a container's network stack.
+          type: "string"
+          example: "9d12daf2c33f5959c8bf90aa513e4f65b561738661003029ec84830cd503a0c3"
+        SandboxKey:
+          description: SandboxKey is the full path of the netns handle
+          type: "string"
+          example: "/var/run/docker/netns/8ab54b426c38"
+        Ports:
+          $ref: "#/components/schemas/PortMap"
+        Networks:
+          description: |
+            Information about all networks that the container is connected to.
+          type: "object"
+          additionalProperties:
+            $ref: "#/components/schemas/EndpointSettings"
+
+    Address:
+      description: Address represents an IPv4 or IPv6 IP address.
+      type: "object"
+      properties:
+        Addr:
+          description: IP address.
+          type: "string"
+        PrefixLen:
+          description: Mask length of the IP address.
+          type: "integer"
+
+    PortMap:
+      description: |
+        PortMap describes the mapping of container ports to host ports, using the
+        container's port-number and protocol as key in the format `<port>/<protocol>`,
+        for example, `80/udp`.
+
+        If a container's port is mapped for multiple protocols, separate entries
+        are added to the mapping table.
+      type: "object"
+      additionalProperties:
+        type: "array"
+        x-nullable: true
+        items:
+          $ref: "#/components/schemas/PortBinding"
+      example:
+        "443/tcp":
+          - HostIp: "127.0.0.1"
+            HostPort: "4443"
+        "80/tcp":
+          - HostIp: "0.0.0.0"
+            HostPort: "80"
+          - HostIp: "0.0.0.0"
+            HostPort: "8080"
+        "80/udp":
+          - HostIp: "0.0.0.0"
+            HostPort: "80"
+        "53/udp":
+          - HostIp: "0.0.0.0"
+            HostPort: "53"
+        "2377/tcp": null
+
+    PortBinding:
+      description: |
+        PortBinding represents a binding between a host IP address and a host
+        port.
+      type: "object"
+      properties:
+        HostIp:
+          description: "Host IP address that the container's port is mapped to."
+          type: "string"
+          example: "127.0.0.1"
+          x-go-type:
+            type: Addr
+            import:
+              package: net/netip
+        HostPort:
+          description: "Host port number that the container's port is mapped to."
+          type: "string"
+          example: "4443"
+
+    DriverData:
+      description: |
+        Information about the storage driver used to store the container's and
+        image's filesystem.
+      type: "object"
+      required: [Name, Data]
+      properties:
+        Name:
+          description: "Name of the storage driver."
+          type: "string"
+          x-nullable: false
+          example: "overlay2"
+        Data:
+          description: |
+            Low-level storage metadata, provided as key/value pairs.
+
+            This information is driver-specific, and depends on the storage-driver
+            in use, and should be used for informational purposes only.
+          type: "object"
+          x-nullable: false
+          additionalProperties:
+            type: "string"
+          example: {
+            "MergedDir": "/var/lib/docker/overlay2/ef749362d13333e65fc95c572eb525abbe0052e16e086cb64bc3b98ae9aa6d74/merged",
+            "UpperDir": "/var/lib/docker/overlay2/ef749362d13333e65fc95c572eb525abbe0052e16e086cb64bc3b98ae9aa6d74/diff",
+            "WorkDir": "/var/lib/docker/overlay2/ef749362d13333e65fc95c572eb525abbe0052e16e086cb64bc3b98ae9aa6d74/work"
+          }
+
+    Storage:
+      description: |
+        Information about the storage used by the container.
+      type: "object"
+      properties:
+        RootFS:
+          description: |
+            Information about the storage used for the container's root filesystem.
+          type: "object"
+          x-nullable: true
+          $ref: "#/components/schemas/RootFSStorage"
+
+    RootFSStorage:
+      description: |
+        Information about the storage used for the container's root filesystem.
+      type: "object"
+      x-go-name: RootFSStorage
+      properties:
+        Snapshot:
+          description: |
+            Information about the snapshot used for the container's root filesystem.
+          type: "object"
+          x-nullable: true
+          $ref: "#/components/schemas/RootFSStorageSnapshot"
+
+    RootFSStorageSnapshot:
+      description: |
+        Information about a snapshot backend of the container's root filesystem.
+      type: "object"
+      x-go-name: RootFSStorageSnapshot
+      properties:
+        Name:
+          description: "Name of the snapshotter."
+          type: "string"
+          x-nullable: false
+
+    FilesystemChange:
+      description: |
+        Change in the container's filesystem.
+      type: "object"
+      required: [Path, Kind]
+      properties:
+        Path:
+          description: |
+            Path to file or directory that has changed.
+          type: "string"
+          x-nullable: false
+        Kind:
+          $ref: "#/components/schemas/ChangeType"
+
+    ChangeType:
+      description: |
+        Kind of change
+
+        Can be one of:
+
+        - `0`: Modified ("C")
+        - `1`: Added ("A")
+        - `2`: Deleted ("D")
+      type: "integer"
+      format: "uint8"
+      enum: [0, 1, 2]
+      x-nullable: false
+
+    ImageInspect:
+      description: |
+        Information about an image in the local image cache.
+      type: "object"
+      properties:
+        Id:
+          description: |
+            ID is the content-addressable ID of an image.
+
+            This identifier is a content-addressable digest calculated from the
+            image's configuration (which includes the digests of layers used by
+            the image).
+
+            Note that this digest differs from the `RepoDigests` below, which
+            holds digests of image manifests that reference the image.
+          type: "string"
+          x-nullable: false
+          example: "sha256:ec3f0931a6e6b6855d76b2d7b0be30e81860baccd891b2e243280bf1cd8ad710"
+        Descriptor:
+          description: |
+            Descriptor is an OCI descriptor of the image target.
+            In case of a multi-platform image, this descriptor points to the OCI index
+            or a manifest list.
+
+            This field is only present if the daemon provides a multi-platform image store.
+
+            WARNING: This is experimental and may change at any time without any backward
+            compatibility.
+          x-nullable: true
+          $ref: "#/components/schemas/OCIDescriptor"
+        Manifests:
+          description: |
+            Manifests is a list of image manifests available in this image. It
+            provides a more detailed view of the platform-specific image manifests or
+            other image-attached data like build attestations.
+
+            Only available if the daemon provides a multi-platform image store
+            and the `manifests` option is set in the inspect request.
+
+            WARNING: This is experimental and may change at any time without any backward
+            compatibility.
+          type: "array"
+          x-nullable: true
+          items:
+            $ref: "#/components/schemas/ImageManifestSummary"
+        Identity:
+          description: |-
+            Identity holds information about the identity and origin of the image.
+            This is trusted information verified by the daemon and cannot be modified
+            by tagging an image to a different name.
+          x-nullable: true
+          $ref: "#/components/schemas/Identity"
+        RepoTags:
+          description: |
+            List of image names/tags in the local image cache that reference this
+            image.
+
+            Multiple image tags can refer to the same image, and this list may be
+            empty if no tags reference the image, in which case the image is
+            "untagged", in which case it can still be referenced by its ID.
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "example:1.0"
+            - "example:latest"
+            - "example:stable"
+            - "internal.registry.example.com:5000/example:1.0"
+        RepoDigests:
+          description: |
+            List of content-addressable digests of locally available image manifests
+            that the image is referenced from. Multiple manifests can refer to the
+            same image.
+
+            These digests are usually only available if the image was either pulled
+            from a registry, or if the image was pushed to a registry, which is when
+            the manifest is generated and its digest calculated.
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb"
+            - "internal.registry.example.com:5000/example@sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578"
+        Comment:
+          description: |
+            Optional message that was set when committing or importing the image.
+          type: "string"
+          x-nullable: true
+          example: ""
+        Created:
+          description: |
+            Date and time at which the image was created, formatted in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+
+            This information is only available if present in the image,
+            and omitted otherwise.
+          type: "string"
+          format: "dateTime"
+          x-nullable: true
+          example: "2022-02-04T21:20:12.497794809Z"
+        Author:
+          description: |
+            Name of the author that was specified when committing the image, or as
+            specified through MAINTAINER (deprecated) in the Dockerfile.
+          type: "string"
+          x-nullable: true
+          example: ""
+        Config:
+          $ref: "#/components/schemas/ImageConfig"
+        Architecture:
+          description: |
+            Hardware CPU architecture that the image runs on.
+          type: "string"
+          x-nullable: false
+          example: "arm"
+        Variant:
+          description: |
+            CPU architecture variant (presently ARM-only).
+          type: "string"
+          x-nullable: true
+          example: "v7"
+        Os:
+          description: |
+            Operating System the image is built to run on.
+          type: "string"
+          x-nullable: false
+          example: "linux"
+        OsVersion:
+          description: |
+            Operating System version the image is built to run on (especially
+            for Windows).
+          type: "string"
+          example: ""
+          x-nullable: true
+        Size:
+          description: |
+            Total size of the image variant, including all layers it is composed of.
+
+            For multi-platform images, this is the size of the platform variant
+            selected by the `platform` query parameter. If no platform is specified,
+            the daemon selects a platform as described in the `platform` parameter.
+
+            When using the containerd image store, this includes both the image content
+            that's present locally and the unpacked snapshot data for the selected
+            variant.
+
+            Image data may be shared between images, so this size does not indicate
+            how much space would be reclaimed by deleting the image.
+          type: "integer"
+          format: "int64"
+          x-nullable: false
+          example: 1239828
+        GraphDriver:
+          x-nullable: true
+          $ref: "#/components/schemas/DriverData"
+        RootFS:
+          description: |
+            Information about the image's RootFS, including the layer IDs.
+          type: "object"
+          required: [Type]
+          properties:
+            Type:
+              type: "string"
+              x-nullable: false
+              example: "layers"
+            Layers:
+              type: "array"
+              items:
+                type: "string"
+              example:
+                - "sha256:1834950e52ce4d5a88a1bbd131c537f4d0e56d10ff0dd69e66be3b7dfa9df7e6"
+                - "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+        Metadata:
+          description: |
+            Additional metadata of the image in the local cache. This information
+            is local to the daemon, and not part of the image itself.
+          type: "object"
+          properties:
+            LastTagTime:
+              description: |
+                Date and time at which the image was last tagged in
+                [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+
+                This information is only available if the image was tagged locally,
+                and omitted otherwise.
+              type: "string"
+              format: "dateTime"
+              example: "2022-02-28T14:40:02.623929178Z"
+              x-nullable: true
+
+    Identity:
+      description: |-
+        Identity holds information about the identity and origin of the image.
+        This is trusted information verified by the daemon and cannot be modified
+        by tagging an image to a different name.
+      type: "object"
+      properties:
+        Signature:
+          description: |-
+            Signature contains the properties of verified signatures for the image.
+          type: "array"
+          items:
+            $ref: "#/components/schemas/SignatureIdentity"
+        Pull:
+          description: |-
+            Pull contains remote location information if image was created via pull.
+            If image was pulled via mirror, this contains the original repository location.
+            After successful push this images also contains the pushed repository location.
+          type: "array"
+          items:
+            $ref: "#/components/schemas/PullIdentity"
+        Build:
+          description: |-
+            Build contains build reference information if image was created via build.
+          type: "array"
+          items:
+            $ref: "#/components/schemas/BuildIdentity"
+
+    BuildIdentity:
+      description: |-
+        BuildIdentity contains build reference information if image was created via build.
+      type: "object"
+      properties:
+        Ref:
+          description: |-
+            Ref is the identifier for the build request. This reference can be used to
+            look up the build details in BuildKit history API.
+          type: "string"
+        CreatedAt:
+          description: |-
+            CreatedAt is the time when the build ran.
+          type: "string"
+          format: "date-time"
+
+    PullIdentity:
+      description: |-
+        PullIdentity contains remote location information if image was created via pull.
+        If image was pulled via mirror, this contains the original repository location.
+      type: "object"
+      properties:
+        Repository:
+          description: |-
+            Repository is the remote repository location the image was pulled from.
+          type: "string"
+
+    SignatureIdentity:
+      description: |-
+        SignatureIdentity contains the properties of verified signatures for the image.
+      type: "object"
+      properties:
+        Name:
+          description: |-
+            Name is a textual description summarizing the type of signature.
+          type: "string"
+        Timestamps:
+          description: |-
+            Timestamps contains a list of verified signed timestamps for the signature.
+          type: "array"
+          items:
+            $ref: "#/components/schemas/SignatureTimestamp"
+        KnownSigner:
+          description: |-
+            KnownSigner is an identifier for a special signer identity that is known to the implementation.
+          $ref: "#/components/schemas/KnownSignerIdentity"
+        DockerReference:
+          description: |-
+            DockerReference is the Docker image reference associated with the signature.
+            This is an optional field only present in older hashedrecord signatures.
+          type: "string"
+        Signer:
+          description: |-
+            Signer contains information about the signer certificate used to sign the image.
+          $ref: "#/components/schemas/SignerIdentity"
+        SignatureType:
+          description: |-
+            SignatureType is the type of signature format. E.g. "bundle-v0.3" or "hashedrecord".
+          $ref: "#/components/schemas/SignatureType"
+        Error:
+          description: |-
+            Error contains error information if signature verification failed.
+            Other fields will be empty in this case.
+          type: "string"
+        Warnings:
+          description: |-
+            Warnings contains any warnings that occurred during signature verification.
+            For example, if there was no internet connectivity and cached trust roots were used.
+            Warning does not indicate a failed verification but may point to configuration issues.
+          type: "array"
+          items:
+            type: "string"
+
+    SignatureTimestamp:
+      description: |-
+        SignatureTimestamp contains information about a verified signed timestamp for an image signature.
+      type: "object"
+      properties:
+        Type:
+          $ref: "#/components/schemas/SignatureTimestampType"
+        URI:
+          type: "string"
+        Timestamp:
+          type: "string"
+          format: "date-time"
+
+    SignatureTimestampType:
+      description: |-
+        SignatureTimestampType is the type of timestamp used in the signature.
+      type: "string"
+      enum:
+        - "Tlog"
+        - "TimestampAuthority"
+
+    SignatureType:
+      description: |-
+        SignatureType is the type of signature format.
+      type: "string"
+      enum:
+        - "bundle-v0.3"
+        - "simplesigning-v1"
+
+    KnownSignerIdentity:
+      description: |-
+        KnownSignerIdentity is an identifier for a special signer identity that is known to the implementation.
+      type: "string"
+      enum:
+        - "DHI"
+
+    SignerIdentity:
+      description: |-
+        SignerIdentity contains information about the signer certificate used to sign the image.
+      type: "object"
+      properties:
+        CertificateIssuer:
+          type: "string"
+          description: |-
+            CertificateIssuer is the certificate issuer.
+        SubjectAlternativeName:
+          type: "string"
+          description: |-
+            SubjectAlternativeName is the certificate subject alternative name.
+        Issuer:
+          type: "string"
+          description: |-
+            The OIDC issuer. Should match `iss` claim of ID token or, in the case of
+            a federated login like Dex it should match the issuer URL of the
+            upstream issuer. The issuer is not set the extensions are invalid and
+            will fail to render.
+        BuildSignerURI:
+          type: "string"
+          description: |-
+            Reference to specific build instructions that are responsible for signing.
+        BuildSignerDigest:
+          type: "string"
+          description: |-
+            Immutable reference to the specific version of the build instructions that is responsible for signing.
+        RunnerEnvironment:
+          type: "string"
+          description: |-
+            Specifies whether the build took place in platform-hosted cloud infrastructure or customer/self-hosted infrastructure.
+        SourceRepositoryURI:
+          type: "string"
+          description: |-
+            Source repository URL that the build was based on.
+        SourceRepositoryDigest:
+          type: "string"
+          description: |-
+            Immutable reference to a specific version of the source code that the build was based upon.
+        SourceRepositoryRef:
+          type: "string"
+          description: |-
+            Source Repository Ref that the build run was based upon.
+        SourceRepositoryIdentifier:
+          type: "string"
+          description: |-
+            Immutable identifier for the source repository the workflow was based upon.
+        SourceRepositoryOwnerURI:
+          type: "string"
+          description: |-
+            Source repository owner URL of the owner of the source repository that the build was based on.
+        SourceRepositoryOwnerIdentifier:
+          type: "string"
+          description: |-
+            Immutable identifier for the owner of the source repository that the workflow was based upon.
+        BuildConfigURI:
+          type: "string"
+          description: |-
+            Build Config URL to the top-level/initiating build instructions.
+        BuildConfigDigest:
+          type: "string"
+          description: |-
+            Immutable reference to the specific version of the top-level/initiating build instructions.
+        BuildTrigger:
+          type: "string"
+          description: |-
+            Event or action that initiated the build.
+        RunInvocationURI:
+          type: "string"
+          description: |-
+            Run Invocation URL to uniquely identify the build execution.
+        SourceRepositoryVisibilityAtSigning:
+          type: "string"
+          description: |-
+            Source repository visibility at the time of signing the certificate.
+
+    ImageSummary:
+      type: "object"
+      x-go-name: "Summary"
+      required:
+        - Id
+        - ParentId
+        - RepoTags
+        - RepoDigests
+        - Created
+        - Size
+        - SharedSize
+        - Labels
+        - Containers
+      properties:
+        Id:
+          description: |
+            ID is the content-addressable ID of an image.
+
+            This identifier is a content-addressable digest calculated from the
+            image's configuration (which includes the digests of layers used by
+            the image).
+
+            Note that this digest differs from the `RepoDigests` below, which
+            holds digests of image manifests that reference the image.
+          type: "string"
+          x-nullable: false
+          example: "sha256:ec3f0931a6e6b6855d76b2d7b0be30e81860baccd891b2e243280bf1cd8ad710"
+        ParentId:
+          description: |
+            ID of the parent image.
+
+            Depending on how the image was created, this field may be empty and
+            is only set for images that were built/created locally. This field
+            is empty if the image was pulled from an image registry.
+          type: "string"
+          x-nullable: false
+          example: ""
+        RepoTags:
+          description: |
+            List of image names/tags in the local image cache that reference this
+            image.
+
+            Multiple image tags can refer to the same image, and this list may be
+            empty if no tags reference the image, in which case the image is
+            "untagged", in which case it can still be referenced by its ID.
+          type: "array"
+          x-nullable: false
+          items:
+            type: "string"
+          example:
+            - "example:1.0"
+            - "example:latest"
+            - "example:stable"
+            - "internal.registry.example.com:5000/example:1.0"
+        RepoDigests:
+          description: |
+            List of content-addressable digests of locally available image manifests
+            that the image is referenced from. Multiple manifests can refer to the
+            same image.
+
+            These digests are usually only available if the image was either pulled
+            from a registry, or if the image was pushed to a registry, which is when
+            the manifest is generated and its digest calculated.
+          type: "array"
+          x-nullable: false
+          items:
+            type: "string"
+          example:
+            - "example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb"
+            - "internal.registry.example.com:5000/example@sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578"
+        Created:
+          description: |
+            Date and time at which the image was created as a Unix timestamp
+            (number of seconds since EPOCH).
+          type: "integer"
+          x-nullable: false
+          example: "1644009612"
+        Size:
+          description: |
+            Total size of the image including all layers it is composed of.
+          type: "integer"
+          format: "int64"
+          x-nullable: false
+          example: 172064416
+        SharedSize:
+          description: |
+            Total size of image layers that are shared between this image and other
+            images.
+
+            This size is not calculated by default. `-1` indicates that the value
+            has not been set / calculated.
+          type: "integer"
+          format: "int64"
+          x-nullable: false
+          example: 1239828
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          x-nullable: false
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.some-label: "some-value"
+            com.example.some-other-label: "some-other-value"
+        Containers:
+          description: |
+            Number of containers using this image. Includes both stopped and running
+            containers.
+
+            `-1` indicates that the value has not been set / calculated.
+          x-nullable: false
+          type: "integer"
+          example: 2
+        Manifests:
+          description: |
+            Manifests is a list of manifests available in this image.
+            It provides a more detailed view of the platform-specific image manifests
+            or other image-attached data like build attestations.
+
+            WARNING: This is experimental and may change at any time without any backward
+            compatibility.
+          type: "array"
+          x-nullable: false
+          x-omitempty: true
+          items:
+            $ref: "#/components/schemas/ImageManifestSummary"
+        Descriptor:
+          description: |
+            Descriptor is an OCI descriptor of the image target.
+            In case of a multi-platform image, this descriptor points to the OCI index
+            or a manifest list.
+
+            This field is only present if the daemon provides a multi-platform image store.
+
+            WARNING: This is experimental and may change at any time without any backward
+            compatibility.
+          x-nullable: true
+          $ref: "#/components/schemas/OCIDescriptor"
+
+    ImagesDiskUsage:
+      type: "object"
+      x-go-name: "DiskUsage"
+      x-go-package: "github.com/moby/moby/api/types/image"
+      description: |
+        represents system data usage for image resources.
+      properties:
+        ActiveCount:
+          description: |
+            Count of active images.
+          type: "integer"
+          format: "int64"
+          example: 1
+        TotalCount:
+          description: |
+            Count of all images.
+          type: "integer"
+          format: "int64"
+          example: 4
+        Reclaimable:
+          description: |
+            Disk space that can be reclaimed by removing unused images.
+          type: "integer"
+          format: "int64"
+          example: 12345678
+        TotalSize:
+          description: |
+            Disk space in use by images.
+          type: "integer"
+          format: "int64"
+          example: 98765432
+        Items:
+          description: |
+            List of image summaries.
+          type: "array"
+          x-omitempty: true
+          items:
+            x-go-type:
+              type: Summary
+
+    AuthConfig:
+      type: "object"
+      properties:
+        username:
+          type: "string"
+        password:
+          type: "string"
+        serveraddress:
+          type: "string"
+      example:
+        username: "hannibal"
+        password: "xxxx"
+        serveraddress: "https://index.docker.io/v1/"
+
+    AuthResponse:
+      description: |
+        An identity token was generated successfully.
+      type: "object"
+      required: [Status]
+      properties:
+        Status:
+          description: "The status of the authentication"
+          type: "string"
+          example: "Login Succeeded"
+          x-nullable: false
+        IdentityToken:
+          description: "An opaque token used to authenticate a user after a successful login"
+          type: "string"
+          example: "9cbaf023786cd7..."
+          x-nullable: false
+
+    ProcessConfig:
+      type: "object"
+      properties:
+        privileged:
+          type: "boolean"
+        user:
+          type: "string"
+        tty:
+          type: "boolean"
+        entrypoint:
+          type: "string"
+        arguments:
+          type: "array"
+          items:
+            type: "string"
+
+    Volume:
+      type: "object"
+      required: [Name, Driver, Mountpoint, Labels, Scope, Options]
+      x-nullable: false
+      properties:
+        Name:
+          type: "string"
+          description: "Name of the volume."
+          x-nullable: false
+          example: "tardis"
+        Driver:
+          type: "string"
+          description: "Name of the volume driver used by the volume."
+          x-nullable: false
+          example: "custom"
+        Mountpoint:
+          type: "string"
+          description: "Mount path of the volume on the host."
+          x-nullable: false
+          example: "/var/lib/docker/volumes/tardis"
+        CreatedAt:
+          type: "string"
+          format: "dateTime"
+          description: "Date/Time the volume was created."
+          example: "2016-06-07T20:31:11.853781916Z"
+        Status:
+          type: "object"
+          description: |
+            Low-level details about the volume, provided by the volume driver.
+            Details are returned as a map with key/value pairs:
+            `{"key":"value","key2":"value2"}`.
+
+            The `Status` field is optional, and is omitted if the volume driver
+            does not support this feature.
+          additionalProperties:
+            type: "object"
+          example:
+            hello: "world"
+        Labels:
+          type: "object"
+          description: "User-defined key/value metadata."
+          x-nullable: false
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.some-label: "some-value"
+            com.example.some-other-label: "some-other-value"
+        Scope:
+          type: "string"
+          description: |
+            The level at which the volume exists. Either `global` for cluster-wide,
+            or `local` for machine level.
+          default: "local"
+          x-nullable: false
+          enum: ["local", "global"]
+          example: "local"
+        ClusterVolume:
+          $ref: "#/components/schemas/ClusterVolume"
+        Options:
+          type: "object"
+          description: |
+            The driver specific options used when creating the volume.
+          additionalProperties:
+            type: "string"
+          example:
+            device: "tmpfs"
+            o: "size=100m,uid=1000"
+            type: "tmpfs"
+        UsageData:
+          type: "object"
+          x-nullable: true
+          x-go-name: "UsageData"
+          required: [Size, RefCount]
+          description: |
+            Usage details about the volume. This information is used by the
+            `GET /system/df` endpoint, and omitted in other endpoints.
+          properties:
+            Size:
+              type: "integer"
+              format: "int64"
+              default: -1
+              description: |
+                Amount of disk space used by the volume (in bytes). This information
+                is only available for volumes created with the `"local"` volume
+                driver. For volumes created with other volume drivers, this field
+                is set to `-1` ("not available")
+              x-nullable: false
+            RefCount:
+              type: "integer"
+              format: "int64"
+              default: -1
+              description: |
+                The number of containers referencing this volume. This field
+                is set to `-1` if the reference-count is not available.
+              x-nullable: false
+
+    VolumesDiskUsage:
+      type: "object"
+      x-go-name: "DiskUsage"
+      x-go-package: "github.com/moby/moby/api/types/volume"
+      description: |
+        represents system data usage for volume resources.
+      properties:
+        ActiveCount:
+          description: |
+            Count of active volumes.
+          type: "integer"
+          format: "int64"
+          example: 1
+        TotalCount:
+          description: |
+            Count of all volumes.
+          type: "integer"
+          format: "int64"
+          example: 4
+        Reclaimable:
+          description: |
+            Disk space that can be reclaimed by removing inactive volumes.
+          type: "integer"
+          format: "int64"
+          example: 12345678
+        TotalSize:
+          description: |
+            Disk space in use by volumes.
+          type: "integer"
+          format: "int64"
+          example: 98765432
+        Items:
+          description: |
+            List of volumes.
+          type: "array"
+          x-omitempty: true
+          items:
+            x-go-type:
+              type: Volume
+
+    VolumeCreateRequest:
+      description: "Volume configuration"
+      type: "object"
+      title: "VolumeConfig"
+      x-go-name: "CreateRequest"
+      properties:
+        Name:
+          description: |
+            The new volume's name. If not specified, Docker generates a name.
+          type: "string"
+          x-nullable: false
+          example: "tardis"
+        Driver:
+          description: "Name of the volume driver to use."
+          type: "string"
+          default: "local"
+          x-nullable: false
+          example: "custom"
+        DriverOpts:
+          description: |
+            A mapping of driver options and values. These options are
+            passed directly to the driver and are driver specific.
+          type: "object"
+          additionalProperties:
+            type: "string"
+          example:
+            device: "tmpfs"
+            o: "size=100m,uid=1000"
+            type: "tmpfs"
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.some-label: "some-value"
+            com.example.some-other-label: "some-other-value"
+        ClusterVolumeSpec:
+          $ref: "#/components/schemas/ClusterVolumeSpec"
+
+    VolumeListResponse:
+      type: "object"
+      title: "VolumeListResponse"
+      x-go-name: "ListResponse"
+      description: "Volume list response"
+      properties:
+        Volumes:
+          type: "array"
+          description: "List of volumes"
+          items:
+            $ref: "#/components/schemas/Volume"
+        Warnings:
+          type: "array"
+          description: |
+            Warnings that occurred when fetching the list of volumes.
+          items:
+            type: "string"
+          example: []
+
+    Network:
+      type: "object"
+      properties:
+        Name:
+          description: |
+            Name of the network.
+          type: "string"
+          example: "my_network"
+          x-omitempty: false
+        Id:
+          description: |
+            ID that uniquely identifies a network on a single machine.
+          type: "string"
+          x-go-name: "ID"
+          x-omitempty: false
+          example: "7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99"
+        Created:
+          description: |
+            Date and time at which the network was created in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "dateTime"
+          x-omitempty: false
+          x-go-type:
+            type: Time
+            import:
+              package: time
+            hints:
+              nullable: false
+          example: "2016-10-19T04:33:30.360899459Z"
+        Scope:
+          description: |
+            The level at which the network exists (e.g. `swarm` for cluster-wide
+            or `local` for machine level)
+          type: "string"
+          x-omitempty: false
+          example: "local"
+        Driver:
+          description: |
+            The name of the driver used to create the network (e.g. `bridge`,
+            `overlay`).
+          type: "string"
+          x-omitempty: false
+          example: "overlay"
+        EnableIPv4:
+          description: |
+            Whether the network was created with IPv4 enabled.
+          type: "boolean"
+          x-omitempty: false
+          example: true
+        EnableIPv6:
+          description: |
+            Whether the network was created with IPv6 enabled.
+          type: "boolean"
+          x-omitempty: false
+          example: false
+        IPAM:
+          description: |
+            The network's IP Address Management.
+          $ref: "#/components/schemas/IPAM"
+          x-nullable: false
+          x-omitempty: false
+        Internal:
+          description: |
+            Whether the network is created to only allow internal networking
+            connectivity.
+          type: "boolean"
+          x-nullable: false
+          x-omitempty: false
+          default: false
+          example: false
+        Attachable:
+          description: |
+            Whether a global / swarm scope network is manually attachable by regular
+            containers from workers in swarm mode.
+          type: "boolean"
+          x-nullable: false
+          x-omitempty: false
+          default: false
+          example: false
+        Ingress:
+          description: |
+            Whether the network is providing the routing-mesh for the swarm cluster.
+          type: "boolean"
+          x-nullable: false
+          x-omitempty: false
+          default: false
+          example: false
+        ConfigFrom:
+          $ref: "#/components/schemas/ConfigReference"
+          x-nullable: false
+          x-omitempty: false
+        ConfigOnly:
+          description: |
+            Whether the network is a config-only network. Config-only networks are
+            placeholder networks for network configurations to be used by other
+            networks. Config-only networks cannot be used directly to run containers
+            or services.
+          type: "boolean"
+          x-omitempty: false
+          x-nullable: false
+          default: false
+        Options:
+          description: |
+            Network-specific options uses when creating the network.
+          type: "object"
+          x-omitempty: false
+          additionalProperties:
+            type: "string"
+          example:
+            com.docker.network.bridge.default_bridge: "true"
+            com.docker.network.bridge.enable_icc: "true"
+            com.docker.network.bridge.enable_ip_masquerade: "true"
+            com.docker.network.bridge.host_binding_ipv4: "0.0.0.0"
+            com.docker.network.bridge.name: "docker0"
+            com.docker.network.driver.mtu: "1500"
+        Labels:
+          description: |
+            Metadata specific to the network being created.
+          type: "object"
+          x-omitempty: false
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.some-label: "some-value"
+            com.example.some-other-label: "some-other-value"
+        Peers:
+          description: |
+            List of peer nodes for an overlay network. This field is only present
+            for overlay networks, and omitted for other network types.
+          type: "array"
+          x-omitempty: true
+          items:
+            $ref: "#/components/schemas/PeerInfo"
+
+    NetworkSummary:
+      description: "Network list response item"
+      x-go-name: Summary
+      type: "object"
+      allOf:
+        - $ref: "#/components/schemas/Network"
+
+    NetworkInspect:
+      description: 'The body of the "get network" http response message.'
+      x-go-name: Inspect
+      type: "object"
+      allOf:
+        - $ref: "#/components/schemas/Network"
+      properties:
+        Containers:
+          description: |
+            Contains endpoints attached to the network.
+          type: "object"
+          x-omitempty: false
+          additionalProperties:
+            $ref: "#/components/schemas/EndpointResource"
+          example:
+            19a4d5d687db25203351ed79d478946f861258f018fe384f229f2efa4b23513c:
+              Name: "test"
+              EndpointID: "628cadb8bcb92de107b2a1e516cbffe463e321f548feb37697cce00ad694f21a"
+              MacAddress: "02:42:ac:13:00:02"
+              IPv4Address: "172.19.0.2/16"
+              IPv6Address: ""
+        Services:
+          description: |
+            List of services using the network. This field is only present for
+            swarm scope networks, and omitted for local scope networks.
+          type: "object"
+          x-omitempty: true
+          additionalProperties:
+            x-go-type:
+              type: ServiceInfo
+              hints:
+                nullable: false
+        Status:
+          description: >
+            provides runtime information about the network
+            such as the number of allocated IPs.
+          $ref: "#/components/schemas/NetworkStatus"
+
+    NetworkStatus:
+      description: >
+        provides runtime information about the network
+        such as the number of allocated IPs.
+      type: "object"
+      x-go-name: Status
+      properties:
+        IPAM:
+          $ref: "#/components/schemas/IPAMStatus"
+
+    ServiceInfo:
+      x-nullable: false
+      x-omitempty: false
+      description: >
+        represents service parameters with the list of service's tasks
+      type: "object"
+      properties:
+        VIP:
+          type: "string"
+          x-omitempty: false
+          x-go-type:
+            type: Addr
+            import:
+              package: net/netip
+        Ports:
+          type: "array"
+          x-omitempty: false
+          items:
+            type: "string"
+        LocalLBIndex:
+          type: "integer"
+          format: "int"
+          x-omitempty: false
+          x-go-type:
+            type: int
+        Tasks:
+          type: "array"
+          x-omitempty: false
+          items:
+            $ref: "#/components/schemas/NetworkTaskInfo"
+
+    NetworkTaskInfo:
+      x-nullable: false
+      x-omitempty: false
+      x-go-name: Task
+      description: >
+        carries the information about one backend task
+      type: "object"
+      properties:
+        Name:
+          type: "string"
+          x-omitempty: false
+        EndpointID:
+          type: "string"
+          x-omitempty: false
+        EndpointIP:
+          type: "string"
+          x-omitempty: false
+          x-go-type:
+            type: Addr
+            import:
+              package: net/netip
+        Info:
+          type: "object"
+          x-omitempty: false
+          additionalProperties:
+            type: "string"
+
+    ConfigReference:
+      x-nullable: false
+      x-omitempty: false
+      description: |
+        The config-only network source to provide the configuration for
+        this network.
+      type: "object"
+      properties:
+        Network:
+          description: |
+            The name of the config-only network that provides the network's
+            configuration. The specified network must be an existing config-only
+            network. Only network names are allowed, not network IDs.
+          type: "string"
+          x-omitempty: false
+          example: "config_only_network_01"
+
+    IPAM:
+      type: "object"
+      x-nullable: false
+      x-omitempty: false
+      properties:
+        Driver:
+          description: "Name of the IPAM driver to use."
+          type: "string"
+          default: "default"
+          example: "default"
+        Config:
+          description: |
+            List of IPAM configuration options, specified as a map:
+
+            ```
+            {"Subnet": <CIDR>, "IPRange": <CIDR>, "Gateway": <IP address>, "AuxAddress": <device_name:IP address>}
+            ```
+          type: "array"
+          items:
+            $ref: "#/components/schemas/IPAMConfig"
+        Options:
+          description: "Driver-specific options, specified as a map."
+          type: "object"
+          additionalProperties:
+            type: "string"
+          example:
+            foo: "bar"
+
+    IPAMConfig:
+      type: "object"
+      properties:
+        Subnet:
+          type: "string"
+          example: "172.20.0.0/16"
+        IPRange:
+          type: "string"
+          example: "172.20.10.0/24"
+        Gateway:
+          type: "string"
+          example: "172.20.10.11"
+        AuxiliaryAddresses:
+          type: "object"
+          additionalProperties:
+            type: "string"
+
+    IPAMStatus:
+      type: "object"
+      x-nullable: false
+      x-omitempty: false
+      properties:
+        Subnets:
+          type: "object"
+          additionalProperties:
+            $ref: "#/components/schemas/SubnetStatus"
+          example:
+            "172.16.0.0/16":
+              IPsInUse: 3
+              DynamicIPsAvailable: 65533
+            "2001:db8:abcd:0012::0/96":
+              IPsInUse: 5
+              DynamicIPsAvailable: 4294967291
+          x-go-type:
+            type: SubnetStatuses
+            kind: map
+
+    SubnetStatus:
+      type: "object"
+      x-nullable: false
+      x-omitempty: false
+      properties:
+        IPsInUse:
+          description: >
+            Number of IP addresses in the subnet that are in use or reserved and
+            are therefore unavailable for allocation, saturating at 2<sup>64</sup> - 1.
+          type: integer
+          format: uint64
+          x-omitempty: false
+        DynamicIPsAvailable:
+          description: >
+            Number of IP addresses within the network's IPRange for the subnet
+            that are available for allocation, saturating at 2<sup>64</sup> - 1.
+          type: integer
+          format: uint64
+          x-omitempty: false
+
+    EndpointResource:
+      type: "object"
+      description: >
+        contains network resources allocated and used for a
+        container in a network.
+      properties:
+        Name:
+          type: "string"
+          x-omitempty: false
+          example: "container_1"
+        EndpointID:
+          type: "string"
+          x-omitempty: false
+          example: "628cadb8bcb92de107b2a1e516cbffe463e321f548feb37697cce00ad694f21a"
+        MacAddress:
+          type: "string"
+          x-omitempty: false
+          example: "02:42:ac:13:00:02"
+          x-go-type:
+            type: HardwareAddr
+        IPv4Address:
+          type: "string"
+          x-omitempty: false
+          example: "172.19.0.2/16"
+          x-go-type:
+            type: Prefix
+            import:
+              package: net/netip
+        IPv6Address:
+          type: "string"
+          x-omitempty: false
+          example: ""
+          x-go-type:
+            type: Prefix
+            import:
+              package: net/netip
+
+    PeerInfo:
+      description: >
+        represents one peer of an overlay network.
+      type: "object"
+      x-nullable: false
+      properties:
+        Name:
+          description:
+            ID of the peer-node in the Swarm cluster.
+          type: "string"
+          x-omitempty: false
+          example: "6869d7c1732b"
+        IP:
+          description:
+            IP-address of the peer-node in the Swarm cluster.
+          type: "string"
+          x-omitempty: false
+          example: "10.133.77.91"
+          x-go-type:
+            type: Addr
+            import:
+              package: net/netip
+
+    NetworkCreateResponse:
+      description: "OK response to NetworkCreate operation"
+      type: "object"
+      title: "NetworkCreateResponse"
+      x-go-name: "CreateResponse"
+      required: [Id, Warning]
+      properties:
+        Id:
+          description: "The ID of the created network."
+          type: "string"
+          x-nullable: false
+          example: "b5c4fc71e8022147cd25de22b22173de4e3b170134117172eb595cb91b4e7e5d"
+        Warning:
+          description: "Warnings encountered when creating the container"
+          type: "string"
+          x-nullable: false
+          example: ""
+
+    BuildInfo:
+      type: "object"
+      properties:
+        id:
+          type: "string"
+        stream:
+          type: "string"
+        errorDetail:
+          $ref: "#/components/schemas/ErrorDetail"
+        status:
+          type: "string"
+        progressDetail:
+          $ref: "#/components/schemas/ProgressDetail"
+        aux:
+          $ref: "#/components/schemas/ImageID"
+
+    BuildCache:
+      type: "object"
+      description: |
+        BuildCache contains information about a build cache record.
+      properties:
+        ID:
+          type: "string"
+          description: |
+            Unique ID of the build cache record.
+          example: "ndlpt0hhvkqcdfkputsk4cq9c"
+        Parents:
+          description: |
+            List of parent build cache record IDs.
+          type: "array"
+          items:
+            type: "string"
+          x-nullable: true
+          example: ["hw53o5aio51xtltp5xjp8v7fx"]
+        Type:
+          type: "string"
+          description: |
+            Cache record type.
+          example: "regular"
+          # see https://github.com/moby/buildkit/blob/fce4a32258dc9d9664f71a4831d5de10f0670677/client/diskusage.go#L75-L84
+          enum:
+            - "internal"
+            - "frontend"
+            - "source.local"
+            - "source.git.checkout"
+            - "exec.cachemount"
+            - "regular"
+        Description:
+          type: "string"
+          description: |
+            Description of the build-step that produced the build cache.
+          example: "mount / from exec /bin/sh -c echo 'Binary::apt::APT::Keep-Downloaded-Packages \"true\";' > /etc/apt/apt.conf.d/keep-cache"
+        InUse:
+          type: "boolean"
+          description: |
+            Indicates if the build cache is in use.
+          example: false
+        Shared:
+          type: "boolean"
+          description: |
+            Indicates if the build cache is shared.
+          example: true
+        Size:
+          description: |
+            Amount of disk space used by the build cache (in bytes).
+          type: "integer"
+          example: 51
+        CreatedAt:
+          description: |
+            Date and time at which the build cache was created in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "dateTime"
+          example: "2016-08-18T10:44:24.496525531Z"
+        LastUsedAt:
+          description: |
+            Date and time at which the build cache was last used in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "dateTime"
+          x-nullable: true
+          example: "2017-08-09T07:09:37.632105588Z"
+        UsageCount:
+          type: "integer"
+          example: 26
+
+    BuildCacheDiskUsage:
+      type: "object"
+      x-go-name: "DiskUsage"
+      x-go-package: "github.com/moby/moby/api/types/build"
+      description: |
+        represents system data usage for build cache resources.
+      properties:
+        ActiveCount:
+          description: |
+            Count of active build cache records.
+          type: "integer"
+          format: "int64"
+          example: 1
+        TotalCount:
+          description: |
+            Count of all build cache records.
+          type: "integer"
+          format: "int64"
+          example: 4
+        Reclaimable:
+          description: |
+            Disk space that can be reclaimed by removing inactive build cache records.
+          type: "integer"
+          format: "int64"
+          example: 12345678
+        TotalSize:
+          description: |
+            Disk space in use by build cache records.
+          type: "integer"
+          format: "int64"
+          example: 98765432
+        Items:
+          description: |
+            List of build cache records.
+          type: "array"
+          x-omitempty: true
+          items:
+            x-go-type:
+              type: CacheRecord
+
+    ImageID:
+      type: "object"
+      description: "Image ID or Digest"
+      properties:
+        ID:
+          type: "string"
+      example:
+        ID: "sha256:85f05633ddc1c50679be2b16a0479ab6f7637f8884e0cfe0f4d20e1ebb3d6e7c"
+
+    CreateImageInfo:
+      type: "object"
+      properties:
+        id:
+          type: "string"
+        errorDetail:
+          $ref: "#/components/schemas/ErrorDetail"
+        status:
+          type: "string"
+        progressDetail:
+          $ref: "#/components/schemas/ProgressDetail"
+
+    PushImageInfo:
+      type: "object"
+      properties:
+        errorDetail:
+          $ref: "#/components/schemas/ErrorDetail"
+        status:
+          type: "string"
+        progressDetail:
+          $ref: "#/components/schemas/ProgressDetail"
+
+    DeviceInfo:
+      type: "object"
+      description: |
+        DeviceInfo represents a device that can be used by a container.
+      properties:
+        Source:
+          type: "string"
+          example: "cdi"
+          description: |
+            The origin device driver.
+        ID:
+          type: "string"
+          example: "vendor.com/gpu=0"
+          description: |
+            The unique identifier for the device within its source driver.
+            For CDI devices, this would be an FQDN like "vendor.com/gpu=0".
+
+    NRIInfo:
+      description: |
+        Information about the Node Resource Interface (NRI).
+
+        This field is only present if NRI is enabled.
+      type: "object"
+      x-nullable: true
+      properties:
+        Info:
+          description: |
+            Information about NRI, provided as "label" / "value" pairs.
+
+            <p><br /></p>
+
+            > **Note**: The information returned in this field, including the
+            > formatting of values and labels, should not be considered stable,
+            > and may change without notice.
+          type: "array"
+          items:
+            type: "array"
+            items:
+              type: "string"
+          example:
+            - ["plugin-path", "/opt/docker/nri/plugins"]
+
+    ErrorDetail:
+      type: "object"
+      properties:
+        code:
+          type: "integer"
+        message:
+          type: "string"
+
+    ProgressDetail:
+      type: "object"
+      properties:
+        current:
+          type: "integer"
+        total:
+          type: "integer"
+
+    ErrorResponse:
+      description: "Represents an error."
+      type: "object"
+      required: ["message"]
+      properties:
+        message:
+          description: "The error message."
+          type: "string"
+          x-nullable: false
+      example:
+        message: "Something went wrong."
+
+    IDResponse:
+      description: "Response to an API call that returns just an Id"
+      type: "object"
+      x-go-name: "IDResponse"
+      required: ["Id"]
+      properties:
+        Id:
+          description: "The id of the newly created object."
+          type: "string"
+          x-nullable: false
+
+    NetworkConnectRequest:
+      description: |
+        NetworkConnectRequest represents the data to be used to connect a container to a network.
+      type: "object"
+      x-go-name: "ConnectRequest"
+      required: ["Container"]
+      properties:
+        Container:
+          type: "string"
+          description: "The ID or name of the container to connect to the network."
+          x-nullable: false
+          example: "3613f73ba0e4"
+        EndpointConfig:
+          $ref: "#/components/schemas/EndpointSettings"
+          x-nullable: true
+
+    NetworkDisconnectRequest:
+      description: |
+        NetworkDisconnectRequest represents the data to be used to disconnect a container from a network.
+      type: "object"
+      x-go-name: "DisconnectRequest"
+      required: ["Container"]
+      properties:
+        Container:
+          type: "string"
+          description: "The ID or name of the container to disconnect from the network."
+          x-nullable: false
+          example: "3613f73ba0e4"
+        Force:
+          type: "boolean"
+          description: "Force the container to disconnect from the network."
+          default: false
+          x-nullable: false
+          x-omitempty: false
+          example: false
+
+    EndpointSettings:
+      description: "Configuration for a network endpoint."
+      type: "object"
+      properties:
+        # Configurations
+        IPAMConfig:
+          $ref: "#/components/schemas/EndpointIPAMConfig"
+        Links:
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "container_1"
+            - "container_2"
+        MacAddress:
+          description: |
+            MAC address for the endpoint on this network. The network driver might ignore this parameter.
+          type: "string"
+          example: "02:42:ac:11:00:04"
+          x-go-type:
+            type: HardwareAddr
+        Aliases:
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "server_x"
+            - "server_y"
+        DriverOpts:
+          description: |
+            DriverOpts is a mapping of driver options and values. These options
+            are passed directly to the driver and are driver specific.
+          type: "object"
+          x-nullable: true
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.some-label: "some-value"
+            com.example.some-other-label: "some-other-value"
+        GwPriority:
+          description: |
+            This property determines which endpoint will provide the default
+            gateway for a container. The endpoint with the highest priority will
+            be used. If multiple endpoints have the same priority, endpoints are
+            lexicographically sorted based on their network name, and the one
+            that sorts first is picked.
+          type: "integer"
+          format: "int64"
+          example:
+            - 10
+
+        # Operational data
+        NetworkID:
+          description: |
+            Unique ID of the network.
+          type: "string"
+          example: "08754567f1f40222263eab4102e1c733ae697e8e354aa9cd6e18d7402835292a"
+        EndpointID:
+          description: |
+            Unique ID for the service endpoint in a Sandbox.
+          type: "string"
+          example: "b88f5b905aabf2893f3cbc4ee42d1ea7980bbc0a92e2c8922b1e1795298afb0b"
+        Gateway:
+          description: |
+            Gateway address for this network.
+          type: "string"
+          example: "172.17.0.1"
+        IPAddress:
+          description: |
+            IPv4 address.
+          type: "string"
+          example: "172.17.0.4"
+          x-go-type:
+            type: Addr
+            import:
+              package: net/netip
+        IPPrefixLen:
+          description: |
+            Mask length of the IPv4 address.
+          type: "integer"
+          example: 16
+        IPv6Gateway:
+          description: |
+            IPv6 gateway address.
+          type: "string"
+          example: "2001:db8:2::100"
+          x-go-type:
+            type: Addr
+            import:
+              package: net/netip
+        GlobalIPv6Address:
+          description: |
+            Global IPv6 address.
+          type: "string"
+          example: "2001:db8::5689"
+          x-go-type:
+            type: Addr
+            import:
+              package: net/netip
+        GlobalIPv6PrefixLen:
+          description: |
+            Mask length of the global IPv6 address.
+          type: "integer"
+          format: "int64"
+          example: 64
+        DNSNames:
+          description: |
+            List of all DNS names an endpoint has on a specific network. This
+            list is based on the container name, network aliases, container short
+            ID, and hostname.
+
+            These DNS names are non-fully qualified but can contain several dots.
+            You can get fully qualified DNS names by appending `.<network-name>`.
+            For instance, if container name is `my.ctr` and the network is named
+            `testnet`, `DNSNames` will contain `my.ctr` and the FQDN will be
+            `my.ctr.testnet`.
+          type: array
+          items:
+            type: string
+          example: ["foobar", "server_x", "server_y", "my.ctr"]
+
+    EndpointIPAMConfig:
+      description: |
+        EndpointIPAMConfig represents an endpoint's IPAM configuration.
+      type: "object"
+      x-nullable: true
+      properties:
+        IPv4Address:
+          type: "string"
+          example: "172.20.30.33"
+          x-go-type:
+            type: Addr
+            import:
+              package: net/netip
+        IPv6Address:
+          type: "string"
+          example: "2001:db8:abcd::3033"
+          x-go-type:
+            type: Addr
+            import:
+              package: net/netip
+        LinkLocalIPs:
+          type: "array"
+          items:
+            type: "string"
+            x-go-type:
+              type: Addr
+              import:
+                package: net/netip
+          example:
+            - "169.254.34.68"
+            - "fe80::3468"
+
+    PluginMount:
+      type: "object"
+      x-go-name: "Mount"
+      x-nullable: false
+      required: [Name, Description, Settable, Source, Destination, Type, Options]
+      properties:
+        Name:
+          type: "string"
+          x-nullable: false
+          example: "some-mount"
+        Description:
+          type: "string"
+          x-nullable: false
+          example: "This is a mount that's used by the plugin."
+        Settable:
+          type: "array"
+          items:
+            type: "string"
+        Source:
+          type: "string"
+          example: "/var/lib/docker/plugins/"
+        Destination:
+          type: "string"
+          x-nullable: false
+          example: "/mnt/state"
+        Type:
+          type: "string"
+          x-nullable: false
+          example: "bind"
+        Options:
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "rbind"
+            - "rw"
+
+    PluginDevice:
+      type: "object"
+      x-go-name: "Device"
+      required: [Name, Description, Settable, Path]
+      x-nullable: false
+      properties:
+        Name:
+          type: "string"
+          x-nullable: false
+        Description:
+          type: "string"
+          x-nullable: false
+        Settable:
+          type: "array"
+          items:
+            type: "string"
+        Path:
+          type: "string"
+          example: "/dev/fuse"
+
+    PluginEnv:
+      type: "object"
+      x-go-name: "Env"
+      x-nullable: false
+      required: [Name, Description, Settable, Value]
+      properties:
+        Name:
+          x-nullable: false
+          type: "string"
+        Description:
+          x-nullable: false
+          type: "string"
+        Settable:
+          type: "array"
+          items:
+            type: "string"
+        Value:
+          type: "string"
+
+    PluginPrivilege:
+      description: |
+        Describes a permission the user has to accept upon installing
+        the plugin.
+      type: "object"
+      x-go-name: "Privilege"
+      properties:
+        Name:
+          type: "string"
+          example: "network"
+        Description:
+          type: "string"
+        Value:
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "host"
+
+    Plugin:
+      description: "A plugin for the Engine API"
+      type: "object"
+      x-go-name: "Plugin"
+      required: [Settings, Enabled, Config, Name]
+      properties:
+        Id:
+          type: "string"
+          example: "5724e2c8652da337ab2eedd19fc6fc0ec908e4bd907c7421bf6a8dfc70c4c078"
+        Name:
+          type: "string"
+          x-nullable: false
+          example: "tiborvass/sample-volume-plugin"
+        Enabled:
+          description:
+            True if the plugin is running. False if the plugin is not running,
+            only installed.
+          type: "boolean"
+          x-nullable: false
+          example: true
+        Settings:
+          description: "user-configurable settings for the plugin."
+          type: "object"
+          x-go-name: "Settings"
+          x-nullable: false
+          required: [Args, Devices, Env, Mounts]
+          properties:
+            Mounts:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/PluginMount"
+            Env:
+              type: "array"
+              items:
+                type: "string"
+              example:
+                - "DEBUG=0"
+            Args:
+              type: "array"
+              items:
+                type: "string"
+            Devices:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/PluginDevice"
+        PluginReference:
+          description: "plugin remote reference used to push/pull the plugin"
+          type: "string"
+          x-go-name: "PluginReference"
+          x-nullable: false
+          example: "localhost:5000/tiborvass/sample-volume-plugin:latest"
+        Config:
+          description: "The config of a plugin."
+          type: "object"
+          x-go-name: "Config"
+          x-nullable: false
+          required:
+            - Description
+            - Documentation
+            - Interface
+            - Entrypoint
+            - WorkDir
+            - Network
+            - Linux
+            - PidHost
+            - PropagatedMount
+            - IpcHost
+            - Mounts
+            - Env
+            - Args
+          properties:
+            Description:
+              type: "string"
+              x-nullable: false
+              example: "A sample volume plugin for Docker"
+            Documentation:
+              type: "string"
+              x-nullable: false
+              example: "https://docs.docker.com/engine/extend/plugins/"
+            Interface:
+              description: "The interface between Docker and the plugin"
+              x-nullable: false
+              type: "object"
+              x-go-name: "Interface"
+              required: [Types, Socket]
+              properties:
+                Types:
+                  type: "array"
+                  items:
+                    type: "string"
+                    x-go-type:
+                      type: "CapabilityID"
+                  example:
+                    - "docker.volumedriver/1.0"
+                Socket:
+                  type: "string"
+                  x-nullable: false
+                  example: "plugins.sock"
+                ProtocolScheme:
+                  type: "string"
+                  example: "some.protocol/v1.0"
+                  description: "Protocol to use for clients connecting to the plugin."
+                  enum:
+                    - ""
+                    - "moby.plugins.http/v1"
+            Entrypoint:
+              type: "array"
+              items:
+                type: "string"
+              example:
+                - "/usr/bin/sample-volume-plugin"
+                - "/data"
+            WorkDir:
+              type: "string"
+              x-nullable: false
+              example: "/bin/"
+            User:
+              type: "object"
+              x-go-name: "User"
+              x-nullable: false
+              properties:
+                UID:
+                  type: "integer"
+                  format: "uint32"
+                  example: 1000
+                GID:
+                  type: "integer"
+                  format: "uint32"
+                  example: 1000
+            Network:
+              type: "object"
+              x-go-name: "NetworkConfig"
+              x-nullable: false
+              required: [Type]
+              properties:
+                Type:
+                  x-nullable: false
+                  type: "string"
+                  example: "host"
+            Linux:
+              type: "object"
+              x-go-name: "LinuxConfig"
+              x-nullable: false
+              required: [Capabilities, AllowAllDevices, Devices]
+              properties:
+                Capabilities:
+                  type: "array"
+                  items:
+                    type: "string"
+                  example:
+                    - "CAP_SYS_ADMIN"
+                    - "CAP_SYSLOG"
+                AllowAllDevices:
+                  type: "boolean"
+                  x-nullable: false
+                  example: false
+                Devices:
+                  type: "array"
+                  items:
+                    $ref: "#/components/schemas/PluginDevice"
+            PropagatedMount:
+              type: "string"
+              x-nullable: false
+              example: "/mnt/volumes"
+            IpcHost:
+              type: "boolean"
+              x-nullable: false
+              example: false
+            PidHost:
+              type: "boolean"
+              x-nullable: false
+              example: false
+            Mounts:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/PluginMount"
+            Env:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/PluginEnv"
+              example:
+                - Name: "DEBUG"
+                  Description: "If set, prints debug messages"
+                  Settable: null
+                  Value: "0"
+            Args:
+              type: "object"
+              x-go-name: "Args"
+              x-nullable: false
+              required: [Name, Description, Settable, Value]
+              properties:
+                Name:
+                  x-nullable: false
+                  type: "string"
+                  example: "args"
+                Description:
+                  x-nullable: false
+                  type: "string"
+                  example: "command line arguments"
+                Settable:
+                  type: "array"
+                  items:
+                    type: "string"
+                Value:
+                  type: "array"
+                  items:
+                    type: "string"
+            rootfs:
+              type: "object"
+              x-go-name: "RootFS"
+              properties:
+                type:
+                  type: "string"
+                  example: "layers"
+                diff_ids:
+                  type: "array"
+                  items:
+                    type: "string"
+                  example:
+                    - "sha256:675532206fbf3030b8458f88d6e26d4eb1577688a25efec97154c94e8b6b4887"
+                    - "sha256:e216a057b1cb1efc11f8a268f37ef62083e70b1b38323ba252e25ac88904a7e8"
+
+    ObjectVersion:
+      description: |
+        The version number of the object such as node, service, etc. This is needed
+        to avoid conflicting writes. The client must send the version number along
+        with the modified specification when updating these objects.
+
+        This approach ensures safe concurrency and determinism in that the change
+        on the object may not be applied if the version number has changed from the
+        last read. In other words, if two update requests specify the same base
+        version, only one of the requests can succeed. As a result, two separate
+        update requests that happen at the same time will not unintentionally
+        overwrite each other.
+      type: "object"
+      properties:
+        Index:
+          type: "integer"
+          format: "uint64"
+          example: 373531
+
+    NodeSpec:
+      type: "object"
+      properties:
+        Name:
+          description: "Name for the node."
+          type: "string"
+          example: "my-node"
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
+            type: "string"
+        Role:
+          description: "Role of the node."
+          type: "string"
+          enum:
+            - "worker"
+            - "manager"
+          example: "manager"
+        Availability:
+          description: "Availability of the node."
+          type: "string"
+          enum:
+            - "active"
+            - "pause"
+            - "drain"
+          example: "active"
+      example:
+        Availability: "active"
+        Name: "node-name"
+        Role: "manager"
+        Labels:
+          foo: "bar"
+
+    Node:
+      type: "object"
+      properties:
+        ID:
+          type: "string"
+          example: "24ifsmvkjbyhk"
+        Version:
+          $ref: "#/components/schemas/ObjectVersion"
+        CreatedAt:
+          description: |
+            Date and time at which the node was added to the swarm in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "dateTime"
+          example: "2016-08-18T10:44:24.496525531Z"
+        UpdatedAt:
+          description: |
+            Date and time at which the node was last updated in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "dateTime"
+          example: "2017-08-09T07:09:37.632105588Z"
+        Spec:
+          $ref: "#/components/schemas/NodeSpec"
+        Description:
+          $ref: "#/components/schemas/NodeDescription"
+        Status:
+          $ref: "#/components/schemas/NodeStatus"
+        ManagerStatus:
+          $ref: "#/components/schemas/ManagerStatus"
+
+    NodeDescription:
+      description: |
+        NodeDescription encapsulates the properties of the Node as reported by the
+        agent.
+      type: "object"
+      properties:
+        Hostname:
+          type: "string"
+          example: "bf3067039e47"
+        Platform:
+          $ref: "#/components/schemas/Platform"
+        Resources:
+          $ref: "#/components/schemas/ResourceObject"
+        Engine:
+          $ref: "#/components/schemas/EngineDescription"
+        TLSInfo:
+          $ref: "#/components/schemas/TLSInfo"
+
+    Platform:
+      description: |
+        Platform represents the platform (Arch/OS).
+      type: "object"
+      properties:
+        Architecture:
+          description: |
+            Architecture represents the hardware architecture (for example,
+            `x86_64`).
+          type: "string"
+          example: "x86_64"
+        OS:
+          description: |
+            OS represents the Operating System (for example, `linux` or `windows`).
+          type: "string"
+          example: "linux"
+
+    EngineDescription:
+      description: "EngineDescription provides information about an engine."
+      type: "object"
+      properties:
+        EngineVersion:
+          type: "string"
+          example: "17.06.0"
+        Labels:
+          type: "object"
+          additionalProperties:
+            type: "string"
+          example:
+            foo: "bar"
+        Plugins:
+          type: "array"
+          items:
+            type: "object"
+            properties:
+              Type:
+                type: "string"
+              Name:
+                type: "string"
+          example:
+            - Type: "Log"
+              Name: "awslogs"
+            - Type: "Log"
+              Name: "fluentd"
+            - Type: "Log"
+              Name: "gcplogs"
+            - Type: "Log"
+              Name: "gelf"
+            - Type: "Log"
+              Name: "journald"
+            - Type: "Log"
+              Name: "json-file"
+            - Type: "Log"
+              Name: "splunk"
+            - Type: "Log"
+              Name: "syslog"
+            - Type: "Network"
+              Name: "bridge"
+            - Type: "Network"
+              Name: "host"
+            - Type: "Network"
+              Name: "ipvlan"
+            - Type: "Network"
+              Name: "macvlan"
+            - Type: "Network"
+              Name: "null"
+            - Type: "Network"
+              Name: "overlay"
+            - Type: "Volume"
+              Name: "local"
+            - Type: "Volume"
+              Name: "localhost:5000/vieux/sshfs:latest"
+            - Type: "Volume"
+              Name: "vieux/sshfs:latest"
+
+    TLSInfo:
+      description: |
+        Information about the issuer of leaf TLS certificates and the trusted root
+        CA certificate.
+      type: "object"
+      properties:
+        TrustRoot:
+          description: |
+            The root CA certificate(s) that are used to validate leaf TLS
+            certificates.
+          type: "string"
+        CertIssuerSubject:
+          description:
+            The base64-url-safe-encoded raw subject bytes of the issuer.
+          type: "string"
+        CertIssuerPublicKey:
+          description: |
+            The base64-url-safe-encoded raw public key bytes of the issuer.
+          type: "string"
+      example:
+        TrustRoot: |
+          -----BEGIN CERTIFICATE-----
+          MIIBajCCARCgAwIBAgIUbYqrLSOSQHoxD8CwG6Bi2PJi9c8wCgYIKoZIzj0EAwIw
+          EzERMA8GA1UEAxMIc3dhcm0tY2EwHhcNMTcwNDI0MjE0MzAwWhcNMzcwNDE5MjE0
+          MzAwWjATMREwDwYDVQQDEwhzd2FybS1jYTBZMBMGByqGSM49AgEGCCqGSM49AwEH
+          A0IABJk/VyMPYdaqDXJb/VXh5n/1Yuv7iNrxV3Qb3l06XD46seovcDWs3IZNV1lf
+          3Skyr0ofcchipoiHkXBODojJydSjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
+          Af8EBTADAQH/MB0GA1UdDgQWBBRUXxuRcnFjDfR/RIAUQab8ZV/n4jAKBggqhkjO
+          PQQDAgNIADBFAiAy+JTe6Uc3KyLCMiqGl2GyWGQqQDEcO3/YG36x7om65AIhAJvz
+          pxv6zFeVEkAEEkqIYi0omA9+CjanB/6Bz4n1uw8H
+          -----END CERTIFICATE-----
+        CertIssuerSubject: "MBMxETAPBgNVBAMTCHN3YXJtLWNh"
+        CertIssuerPublicKey: "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmT9XIw9h1qoNclv9VeHmf/Vi6/uI2vFXdBveXTpcPjqx6i9wNazchk1XWV/dKTKvSh9xyGKmiIeRcE4OiMnJ1A=="
+
+    NodeStatus:
+      description: |
+        NodeStatus represents the status of a node.
+
+        It provides the current status of the node, as seen by the manager.
+      type: "object"
+      properties:
+        State:
+          $ref: "#/components/schemas/NodeState"
+        Message:
+          type: "string"
+          example: ""
+        Addr:
+          description: "IP address of the node."
+          type: "string"
+          example: "172.17.0.2"
+
+    NodeState:
+      description: "NodeState represents the state of a node."
+      type: "string"
+      enum:
+        - "unknown"
+        - "down"
+        - "ready"
+        - "disconnected"
+      example: "ready"
+
+    ManagerStatus:
+      description: |
+        ManagerStatus represents the status of a manager.
+
+        It provides the current status of a node's manager component, if the node
+        is a manager.
+      x-nullable: true
+      type: "object"
+      properties:
+        Leader:
+          type: "boolean"
+          default: false
+          example: true
+        Reachability:
+          $ref: "#/components/schemas/Reachability"
+        Addr:
+          description: |
+            The IP address and port at which the manager is reachable.
+          type: "string"
+          example: "10.0.0.46:2377"
+
+    Reachability:
+      description: "Reachability represents the reachability of a node."
+      type: "string"
+      enum:
+        - "unknown"
+        - "unreachable"
+        - "reachable"
+      example: "reachable"
+
+    SwarmSpec:
+      description: "User modifiable swarm configuration."
+      type: "object"
+      properties:
+        Name:
+          description: "Name of the swarm."
+          type: "string"
+          example: "default"
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.corp.type: "production"
+            com.example.corp.department: "engineering"
+        Orchestration:
+          description: "Orchestration configuration."
+          type: "object"
+          x-nullable: true
+          properties:
+            TaskHistoryRetentionLimit:
+              description: |
+                The number of historic tasks to keep per instance or node. If
+                negative, never remove completed or failed tasks.
+              type: "integer"
+              format: "int64"
+              example: 10
+        Raft:
+          description: "Raft configuration."
+          type: "object"
+          properties:
+            SnapshotInterval:
+              description: "The number of log entries between snapshots."
+              type: "integer"
+              format: "uint64"
+              example: 10000
+            KeepOldSnapshots:
+              description: |
+                The number of snapshots to keep beyond the current snapshot.
+              type: "integer"
+              format: "uint64"
+            LogEntriesForSlowFollowers:
+              description: |
+                The number of log entries to keep around to sync up slow followers
+                after a snapshot is created.
+              type: "integer"
+              format: "uint64"
+              example: 500
+            ElectionTick:
+              description: |
+                The number of ticks that a follower will wait for a message from
+                the leader before becoming a candidate and starting an election.
+                `ElectionTick` must be greater than `HeartbeatTick`.
+
+                A tick currently defaults to one second, so these translate
+                directly to seconds currently, but this is NOT guaranteed.
+              type: "integer"
+              example: 3
+            HeartbeatTick:
+              description: |
+                The number of ticks between heartbeats. Every HeartbeatTick ticks,
+                the leader will send a heartbeat to the followers.
+
+                A tick currently defaults to one second, so these translate
+                directly to seconds currently, but this is NOT guaranteed.
+              type: "integer"
+              example: 1
+        Dispatcher:
+          description: "Dispatcher configuration."
+          type: "object"
+          x-nullable: true
+          properties:
+            HeartbeatPeriod:
+              description: |
+                The delay for an agent to send a heartbeat to the dispatcher.
+              type: "integer"
+              format: "int64"
+              example: 5000000000
+        CAConfig:
+          description: "CA configuration."
+          type: "object"
+          x-nullable: true
+          properties:
+            NodeCertExpiry:
+              description: "The duration node certificates are issued for."
+              type: "integer"
+              format: "int64"
+              example: 7776000000000000
+            ExternalCAs:
+              description: |
+                Configuration for forwarding signing requests to an external
+                certificate authority.
+              type: "array"
+              items:
+                type: "object"
+                properties:
+                  Protocol:
+                    description: |
+                      Protocol for communication with the external CA (currently
+                      only `cfssl` is supported).
+                    type: "string"
+                    enum:
+                      - "cfssl"
+                    default: "cfssl"
+                  URL:
+                    description: |
+                      URL where certificate signing requests should be sent.
+                    type: "string"
+                  Options:
+                    description: |
+                      An object with key/value pairs that are interpreted as
+                      protocol-specific options for the external CA driver.
+                    type: "object"
+                    additionalProperties:
+                      type: "string"
+                  CACert:
+                    description: |
+                      The root CA certificate (in PEM format) this external CA uses
+                      to issue TLS certificates (assumed to be to the current swarm
+                      root CA certificate if not provided).
+                    type: "string"
+            SigningCACert:
+              description: |
+                The desired signing CA certificate for all swarm node TLS leaf
+                certificates, in PEM format.
+              type: "string"
+            SigningCAKey:
+              description: |
+                The desired signing CA key for all swarm node TLS leaf certificates,
+                in PEM format.
+              type: "string"
+            ForceRotate:
+              description: |
+                An integer whose purpose is to force swarm to generate a new
+                signing CA certificate and key, if none have been specified in
+                `SigningCACert` and `SigningCAKey`
+              format: "uint64"
+              type: "integer"
+        EncryptionConfig:
+          description: "Parameters related to encryption-at-rest."
+          type: "object"
+          properties:
+            AutoLockManagers:
+              description: |
+                If set, generate a key and use it to lock data stored on the
+                managers.
+              type: "boolean"
+              example: false
+        TaskDefaults:
+          description: "Defaults for creating tasks in this cluster."
+          type: "object"
+          properties:
+            LogDriver:
+              description: |
+                The log driver to use for tasks created in the orchestrator if
+                unspecified by a service.
+
+                Updating this value only affects new tasks. Existing tasks continue
+                to use their previously configured log driver until recreated.
+              type: "object"
+              properties:
+                Name:
+                  description: |
+                    The log driver to use as a default for new tasks.
+                  type: "string"
+                  example: "json-file"
+                Options:
+                  description: |
+                    Driver-specific options for the selected log driver, specified
+                    as key/value pairs.
+                  type: "object"
+                  additionalProperties:
+                    type: "string"
+                  example:
+                    "max-file": "10"
+                    "max-size": "100m"
+
+    # The Swarm information for `GET /info`. It is the same as `GET /swarm`, but
+    # without `JoinTokens`.
+    ClusterInfo:
+      description: |
+        ClusterInfo represents information about the swarm as is returned by the
+        "/info" endpoint. Join-tokens are not included.
+      x-nullable: true
+      type: "object"
+      properties:
+        ID:
+          description: "The ID of the swarm."
+          type: "string"
+          example: "abajmipo7b4xz5ip2nrla6b11"
+        Version:
+          $ref: "#/components/schemas/ObjectVersion"
+        CreatedAt:
+          description: |
+            Date and time at which the swarm was initialised in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "dateTime"
+          example: "2016-08-18T10:44:24.496525531Z"
+        UpdatedAt:
+          description: |
+            Date and time at which the swarm was last updated in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "dateTime"
+          example: "2017-08-09T07:09:37.632105588Z"
+        Spec:
+          $ref: "#/components/schemas/SwarmSpec"
+        TLSInfo:
+          $ref: "#/components/schemas/TLSInfo"
+        RootRotationInProgress:
+          description: |
+            Whether there is currently a root CA rotation in progress for the swarm
+          type: "boolean"
+          example: false
+        DataPathPort:
+          description: |
+            DataPathPort specifies the data path port number for data traffic.
+            Acceptable port range is 1024 to 49151.
+            If no port is set or is set to 0, the default port (4789) is used.
+          type: "integer"
+          format: "uint32"
+          default: 4789
+          example: 4789
+        DefaultAddrPool:
+          description: |
+            Default Address Pool specifies default subnet pools for global scope
+            networks.
+          type: "array"
+          items:
+            type: "string"
+            format: "CIDR"
+            example: ["10.10.0.0/16", "20.20.0.0/16"]
+        SubnetSize:
+          description: |
+            SubnetSize specifies the subnet size of the networks created from the
+            default subnet pool.
+          type: "integer"
+          format: "uint32"
+          maximum: 29
+          default: 24
+          example: 24
+
+    JoinTokens:
+      description: |
+        JoinTokens contains the tokens workers and managers need to join the swarm.
+      type: "object"
+      properties:
+        Worker:
+          description: |
+            The token workers can use to join the swarm.
+          type: "string"
+          example: "SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-1awxwuwd3z9j1z3puu7rcgdbx"
+        Manager:
+          description: |
+            The token managers can use to join the swarm.
+          type: "string"
+          example: "SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-7p73s1dx5in4tatdymyhg9hu2"
+
+    Swarm:
+      type: "object"
+      allOf:
+        - $ref: "#/components/schemas/ClusterInfo"
+        - type: "object"
+          properties:
+            JoinTokens:
+              $ref: "#/components/schemas/JoinTokens"
+
+    TaskSpec:
+      description: "User modifiable task configuration."
+      type: "object"
+      properties:
+        PluginSpec:
+          type: "object"
+          description: |
+            Plugin spec for the service.  *(Experimental release only.)*
+
+            <p><br /></p>
+
+            > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are
+            > mutually exclusive. PluginSpec is only used when the Runtime field
+            > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime
+            > field is set to `attachment`.
+          properties:
+            Name:
+              description: "The name or 'alias' to use for the plugin."
+              type: "string"
+            Remote:
+              description: "The plugin image reference to use."
+              type: "string"
+            Disabled:
+              description: "Disable the plugin once scheduled."
+              type: "boolean"
+            PluginPrivilege:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/PluginPrivilege"
+        ContainerSpec:
+          type: "object"
+          description: |
+            Container spec for the service.
+
+            <p><br /></p>
+
+            > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are
+            > mutually exclusive. PluginSpec is only used when the Runtime field
+            > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime
+            > field is set to `attachment`.
+          properties:
+            Image:
+              description: "The image name to use for the container"
+              type: "string"
+            Labels:
+              description: "User-defined key/value data."
+              type: "object"
+              additionalProperties:
+                type: "string"
+            Command:
+              description: "The command to be run in the image."
+              type: "array"
+              items:
+                type: "string"
+            Args:
+              description: "Arguments to the command."
+              type: "array"
+              items:
+                type: "string"
+            Hostname:
+              description: |
+                The hostname to use for the container, as a valid
+                [RFC 1123](https://tools.ietf.org/html/rfc1123) hostname.
+              type: "string"
+            Env:
+              description: |
+                A list of environment variables in the form `VAR=value`.
+              type: "array"
+              items:
+                type: "string"
+            Dir:
+              description: "The working directory for commands to run in."
+              type: "string"
+            User:
+              description: "The user inside the container."
+              type: "string"
+            Groups:
+              type: "array"
+              description: |
+                A list of additional groups that the container process will run as.
+              items:
+                type: "string"
+            Privileges:
+              type: "object"
+              description: "Security options for the container"
+              properties:
+                CredentialSpec:
+                  type: "object"
+                  description: "CredentialSpec for managed service account (Windows only)"
+                  properties:
+                    Config:
+                      type: "string"
+                      example: "0bt9dmxjvjiqermk6xrop3ekq"
+                      description: |
+                        Load credential spec from a Swarm Config with the given ID.
+                        The specified config must also be present in the Configs
+                        field with the Runtime property set.
+
+                        <p><br /></p>
+
+
+                        > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`,
+                        > and `CredentialSpec.Config` are mutually exclusive.
+                    File:
+                      type: "string"
+                      example: "spec.json"
+                      description: |
+                        Load credential spec from this file. The file is read by
+                        the daemon, and must be present in the `CredentialSpecs`
+                        subdirectory in the docker data directory, which defaults
+                        to `C:\ProgramData\Docker\` on Windows.
+
+                        For example, specifying `spec.json` loads
+                        `C:\ProgramData\Docker\CredentialSpecs\spec.json`.
+
+                        <p><br /></p>
+
+                        > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`,
+                        > and `CredentialSpec.Config` are mutually exclusive.
+                    Registry:
+                      type: "string"
+                      description: |
+                        Load credential spec from this value in the Windows
+                        registry. The specified registry value must be located in:
+
+                        `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization\Containers\CredentialSpecs`
+
+                        <p><br /></p>
+
+
+                        > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`,
+                        > and `CredentialSpec.Config` are mutually exclusive.
+                SELinuxContext:
+                  type: "object"
+                  description: "SELinux labels of the container"
+                  properties:
+                    Disable:
+                      type: "boolean"
+                      description: "Disable SELinux"
+                    User:
+                      type: "string"
+                      description: "SELinux user label"
+                    Role:
+                      type: "string"
+                      description: "SELinux role label"
+                    Type:
+                      type: "string"
+                      description: "SELinux type label"
+                    Level:
+                      type: "string"
+                      description: "SELinux level label"
+                Seccomp:
+                  type: "object"
+                  description: "Options for configuring seccomp on the container"
+                  properties:
+                    Mode:
+                      type: "string"
+                      enum:
+                        - "default"
+                        - "unconfined"
+                        - "custom"
+                    Profile:
+                      description: "The custom seccomp profile as a json object"
+                      type: "string"
+                AppArmor:
+                  type: "object"
+                  description: "Options for configuring AppArmor on the container"
+                  properties:
+                    Mode:
+                      type: "string"
+                      enum:
+                        - "default"
+                        - "disabled"
+                NoNewPrivileges:
+                  type: "boolean"
+                  description: "Configuration of the no_new_privs bit in the container"
+
+            TTY:
+              description: "Whether a pseudo-TTY should be allocated."
+              type: "boolean"
+            OpenStdin:
+              description: "Open `stdin`"
+              type: "boolean"
+            ReadOnly:
+              description: "Mount the container's root filesystem as read only."
+              type: "boolean"
+            Mounts:
+              description: |
+                Specification for mounts to be added to containers created as part
+                of the service.
+              type: "array"
+              items:
+                $ref: "#/components/schemas/Mount"
+            StopSignal:
+              description: "Signal to stop the container."
+              type: "string"
+            StopGracePeriod:
+              description: |
+                Amount of time to wait for the container to terminate before
+                forcefully killing it.
+              type: "integer"
+              format: "int64"
+            Healthcheck:
+              $ref: "#/components/schemas/HealthConfig"
+            Hosts:
+              type: "array"
+              description: |
+                A list of hostname/IP mappings to add to the container's `hosts`
+                file. The format of extra hosts is specified in the
+                [hosts(5)](http://man7.org/linux/man-pages/man5/hosts.5.html)
+                man page:
+
+                    IP_address canonical_hostname [aliases...]
+              items:
+                type: "string"
+            DNSConfig:
+              description: |
+                Specification for DNS related configurations in resolver configuration
+                file (`resolv.conf`).
+              type: "object"
+              properties:
+                Nameservers:
+                  description: "The IP addresses of the name servers."
+                  type: "array"
+                  items:
+                    type: "string"
+                Search:
+                  description: "A search list for host-name lookup."
+                  type: "array"
+                  items:
+                    type: "string"
+                Options:
+                  description: |
+                    A list of internal resolver variables to be modified (e.g.,
+                    `debug`, `ndots:3`, etc.).
+                  type: "array"
+                  items:
+                    type: "string"
+            Secrets:
+              description: |
+                Secrets contains references to zero or more secrets that will be
+                exposed to the service.
+              type: "array"
+              items:
+                type: "object"
+                properties:
+                  File:
+                    description: |
+                      File represents a specific target that is backed by a file.
+                    type: "object"
+                    properties:
+                      Name:
+                        description: |
+                          Name represents the final filename in the filesystem.
+                        type: "string"
+                      UID:
+                        description: "UID represents the file UID."
+                        type: "string"
+                      GID:
+                        description: "GID represents the file GID."
+                        type: "string"
+                      Mode:
+                        description: "Mode represents the FileMode of the file."
+                        type: "integer"
+                        format: "uint32"
+                  SecretID:
+                    description: |
+                      SecretID represents the ID of the specific secret that we're
+                      referencing.
+                    type: "string"
+                  SecretName:
+                    description: |
+                      SecretName is the name of the secret that this references,
+                      but this is just provided for lookup/display purposes. The
+                      secret in the reference will be identified by its ID.
+                    type: "string"
+            OomScoreAdj:
+              type: "integer"
+              format: "int64"
+              description: |
+                An integer value containing the score given to the container in
+                order to tune OOM killer preferences.
+              example: 0
+            Configs:
+              description: |
+                Configs contains references to zero or more configs that will be
+                exposed to the service.
+              type: "array"
+              items:
+                type: "object"
+                properties:
+                  File:
+                    description: |
+                      File represents a specific target that is backed by a file.
+
+                      <p><br /><p>
+
+                      > **Note**: `Configs.File` and `Configs.Runtime` are mutually exclusive
+                    type: "object"
+                    properties:
+                      Name:
+                        description: |
+                          Name represents the final filename in the filesystem.
+                        type: "string"
+                      UID:
+                        description: "UID represents the file UID."
+                        type: "string"
+                      GID:
+                        description: "GID represents the file GID."
+                        type: "string"
+                      Mode:
+                        description: "Mode represents the FileMode of the file."
+                        type: "integer"
+                        format: "uint32"
+                  Runtime:
+                    description: |
+                      Runtime represents a target that is not mounted into the
+                      container but is used by the task
+
+                      <p><br /><p>
+
+                      > **Note**: `Configs.File` and `Configs.Runtime` are mutually
+                      > exclusive
+                    type: "object"
+                  ConfigID:
+                    description: |
+                      ConfigID represents the ID of the specific config that we're
+                      referencing.
+                    type: "string"
+                  ConfigName:
+                    description: |
+                      ConfigName is the name of the config that this references,
+                      but this is just provided for lookup/display purposes. The
+                      config in the reference will be identified by its ID.
+                    type: "string"
+            Isolation:
+              type: "string"
+              description: |
+                Isolation technology of the containers running the service.
+                (Windows only)
+              enum:
+                - "default"
+                - "process"
+                - "hyperv"
+                - ""
+            Init:
+              description: |
+                Run an init inside the container that forwards signals and reaps
+                processes. This field is omitted if empty, and the default (as
+                configured on the daemon) is used.
+              type: "boolean"
+              x-nullable: true
+            Sysctls:
+              description: |
+                Set kernel namedspaced parameters (sysctls) in the container.
+                The Sysctls option on services accepts the same sysctls as the
+                are supported on containers. Note that while the same sysctls are
+                supported, no guarantees or checks are made about their
+                suitability for a clustered environment, and it's up to the user
+                to determine whether a given sysctl will work properly in a
+                Service.
+              type: "object"
+              additionalProperties:
+                type: "string"
+            # This option is not used by Windows containers
+            CapabilityAdd:
+              type: "array"
+              description: |
+                A list of kernel capabilities to add to the default set
+                for the container.
+              items:
+                type: "string"
+              example:
+                - "CAP_NET_RAW"
+                - "CAP_SYS_ADMIN"
+                - "CAP_SYS_CHROOT"
+                - "CAP_SYSLOG"
+            CapabilityDrop:
+              type: "array"
+              description: |
+                A list of kernel capabilities to drop from the default set
+                for the container.
+              items:
+                type: "string"
+              example:
+                - "CAP_NET_RAW"
+            Ulimits:
+              description: |
+                A list of resource limits to set in the container. For example: `{"Name": "nofile", "Soft": 1024, "Hard": 2048}`"
+              type: "array"
+              items:
+                type: "object"
+                properties:
+                  Name:
+                    description: "Name of ulimit"
+                    type: "string"
+                  Soft:
+                    description: "Soft limit"
+                    type: "integer"
+                  Hard:
+                    description: "Hard limit"
+                    type: "integer"
+        NetworkAttachmentSpec:
+          description: |
+            Read-only spec type for non-swarm containers attached to swarm overlay
+            networks.
+
+            <p><br /></p>
+
+            > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are
+            > mutually exclusive. PluginSpec is only used when the Runtime field
+            > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime
+            > field is set to `attachment`.
+          type: "object"
+          properties:
+            ContainerID:
+              description: "ID of the container represented by this task"
+              type: "string"
+        Resources:
+          description: |
+            Resource requirements which apply to each individual container created
+            as part of the service.
+          type: "object"
+          properties:
+            Limits:
+              description: "Define resources limits."
+              $ref: "#/components/schemas/Limit"
+            Reservations:
+              description: "Define resources reservation."
+              $ref: "#/components/schemas/ResourceObject"
+            SwapBytes:
+              description: |
+                Amount of swap in bytes - can only be used together with a memory limit.
+                If not specified, the default behaviour is to grant a swap space twice
+                as big as the memory limit.
+                Set to -1 to enable unlimited swap.
+              type: "integer"
+              format: "int64"
+              minimum: -1
+              x-nullable: true
+              x-omitempty: true
+            MemorySwappiness:
+              description: |
+                Tune the service's containers' memory swappiness (0 to 100).
+                If not specified, defaults to the containers' OS' default, generally 60,
+                or whatever value was predefined in the image.
+                Set to -1 to unset a previously set value.
+              type: "integer"
+              format: "int64"
+              minimum: -1
+              maximum: 100
+              x-nullable: true
+              x-omitempty: true
+        RestartPolicy:
+          description: |
+            Specification for the restart policy which applies to containers
+            created as part of this service.
+          type: "object"
+          properties:
+            Condition:
+              description: "Condition for restart."
+              type: "string"
+              enum:
+                - "none"
+                - "on-failure"
+                - "any"
+            Delay:
+              description: "Delay between restart attempts."
+              type: "integer"
+              format: "int64"
+            MaxAttempts:
+              description: |
+                Maximum attempts to restart a given container before giving up
+                (default value is 0, which is ignored).
+              type: "integer"
+              format: "int64"
+              default: 0
+            Window:
+              description: |
+                Windows is the time window used to evaluate the restart policy
+                (default value is 0, which is unbounded).
+              type: "integer"
+              format: "int64"
+              default: 0
+        Placement:
+          type: "object"
+          properties:
+            Constraints:
+              description: |
+                An array of constraint expressions to limit the set of nodes where
+                a task can be scheduled. Constraint expressions can either use a
+                _match_ (`==`) or _exclude_ (`!=`) rule. Multiple constraints find
+                nodes that satisfy every expression (AND match). Constraints can
+                match node or Docker Engine labels as follows:
+
+                node attribute       | matches                        | example
+                ---------------------|--------------------------------|-----------------------------------------------
+                `node.id`            | Node ID                        | `node.id==2ivku8v2gvtg4`
+                `node.hostname`      | Node hostname                  | `node.hostname!=node-2`
+                `node.role`          | Node role (`manager`/`worker`) | `node.role==manager`
+                `node.platform.os`   | Node operating system          | `node.platform.os==windows`
+                `node.platform.arch` | Node architecture              | `node.platform.arch==x86_64`
+                `node.labels`        | User-defined node labels       | `node.labels.security==high`
+                `engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-24.04`
+
+                `engine.labels` apply to Docker Engine labels like operating system,
+                drivers, etc. Swarm administrators add `node.labels` for operational
+                purposes by using the [`node update endpoint`](#operation/NodeUpdate).
+
+              type: "array"
+              items:
+                type: "string"
+              example:
+                - "node.hostname!=node3.corp.example.com"
+                - "node.role!=manager"
+                - "node.labels.type==production"
+                - "node.platform.os==linux"
+                - "node.platform.arch==x86_64"
+            Preferences:
+              description: |
+                Preferences provide a way to make the scheduler aware of factors
+                such as topology. They are provided in order from highest to
+                lowest precedence.
+              type: "array"
+              items:
+                type: "object"
+                properties:
+                  Spread:
+                    type: "object"
+                    properties:
+                      SpreadDescriptor:
+                        description: |
+                          label descriptor, such as `engine.labels.az`.
+                        type: "string"
+              example:
+                - Spread:
+                    SpreadDescriptor: "node.labels.datacenter"
+                - Spread:
+                    SpreadDescriptor: "node.labels.rack"
+            MaxReplicas:
+              description: |
+                Maximum number of replicas for per node (default value is 0, which
+                is unlimited)
+              type: "integer"
+              format: "int64"
+              default: 0
+            Platforms:
+              description: |
+                Platforms stores all the platforms that the service's image can
+                run on. This field is used in the platform filter for scheduling.
+                If empty, then the platform filter is off, meaning there are no
+                scheduling restrictions.
+              type: "array"
+              items:
+                $ref: "#/components/schemas/Platform"
+        ForceUpdate:
+          description: |
+            A counter that triggers an update even if no relevant parameters have
+            been changed.
+          type: "integer"
+          format: "uint64"
+        Runtime:
+          description: |
+            Runtime is the type of runtime specified for the task executor.
+          type: "string"
+        Networks:
+          description: "Specifies which networks the service should attach to."
+          type: "array"
+          items:
+            $ref: "#/components/schemas/NetworkAttachmentConfig"
+        LogDriver:
+          description: |
+            Specifies the log driver to use for tasks created from this spec. If
+            not present, the default one for the swarm will be used, finally
+            falling back to the engine default if not specified.
+          type: "object"
+          properties:
+            Name:
+              type: "string"
+            Options:
+              type: "object"
+              additionalProperties:
+                type: "string"
+
+    TaskState:
+      type: "string"
+      enum:
+        - "new"
+        - "allocated"
+        - "pending"
+        - "assigned"
+        - "accepted"
+        - "preparing"
+        - "ready"
+        - "starting"
+        - "running"
+        - "complete"
+        - "shutdown"
+        - "failed"
+        - "rejected"
+        - "remove"
+        - "orphaned"
+
+    ContainerStatus:
+      type: "object"
+      description: "represents the status of a container."
+      properties:
+        ContainerID:
+          type: "string"
+        PID:
+          type: "integer"
+        ExitCode:
+          type: "integer"
+
+    PortStatus:
+      type: "object"
+      description: "represents the port status of a task's host ports whose service has published host ports"
+      properties:
+        Ports:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/EndpointPortConfig"
+
+    TaskStatus:
+      type: "object"
+      description: "represents the status of a task."
+      properties:
+        Timestamp:
+          type: "string"
+          format: "dateTime"
+        State:
+          $ref: "#/components/schemas/TaskState"
+        Message:
+          type: "string"
+        Err:
+          type: "string"
+        ContainerStatus:
+          $ref: "#/components/schemas/ContainerStatus"
+        PortStatus:
+          $ref: "#/components/schemas/PortStatus"
+
+    NetworkAttachment:
+      description: |
+        Specifies how a task is attached to a network, and the addresses the
+        task was assigned on that network.
+      type: "object"
+      properties:
+        Network:
+          $ref: "#/components/schemas/Network"
+        Addresses:
+          description: |
+            The IP addresses (in CIDR notation) assigned to the task on this
+            network. To maintain backward compatibility this field accepts CIDR
+            notation, but only the IP address is used.
+          type: "array"
+          items:
+            type: "string"
+            format: "cidr"
+      example:
+        Network:
+          ID: "4qvuz4ko70xaltuqbt8956gd1"
+        Addresses:
+          - "10.255.0.10/16"
+
+    Task:
+      type: "object"
+      properties:
+        ID:
+          description: "The ID of the task."
+          type: "string"
+        Version:
+          $ref: "#/components/schemas/ObjectVersion"
+        CreatedAt:
+          type: "string"
+          format: "dateTime"
+        UpdatedAt:
+          type: "string"
+          format: "dateTime"
+        Name:
+          description: "Name of the task."
+          type: "string"
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
+            type: "string"
+        Spec:
+          $ref: "#/components/schemas/TaskSpec"
+        ServiceID:
+          description: "The ID of the service this task is part of."
+          type: "string"
+        Slot:
+          type: "integer"
+        NodeID:
+          description: "The ID of the node that this task is on."
+          type: "string"
+        AssignedGenericResources:
+          $ref: "#/components/schemas/GenericResources"
+        Status:
+          $ref: "#/components/schemas/TaskStatus"
+        DesiredState:
+          $ref: "#/components/schemas/TaskState"
+        JobIteration:
+          description: |
+            If the Service this Task belongs to is a job-mode service, contains
+            the JobIteration of the Service this Task was created for. Absent if
+            the Task was created for a Replicated or Global Service.
+          $ref: "#/components/schemas/ObjectVersion"
+        NetworksAttachments:
+          description: |
+            The networks that this task is attached to, and the addresses the
+            task was assigned on each of them.
+          type: "array"
+          items:
+            $ref: "#/components/schemas/NetworkAttachment"
+      example:
+        ID: "0kzzo1i0y4jz6027t0k7aezc7"
+        Version:
+          Index: 71
+        CreatedAt: "2016-06-07T21:07:31.171892745Z"
+        UpdatedAt: "2016-06-07T21:07:31.376370513Z"
+        Spec:
+          ContainerSpec:
+            Image: "redis"
+          Resources:
+            Limits: {}
+            Reservations: {}
+          RestartPolicy:
+            Condition: "any"
+            MaxAttempts: 0
+          Placement: {}
+        ServiceID: "9mnpnzenvg8p8tdbtq4wvbkcz"
+        Slot: 1
+        NodeID: "60gvrl6tm78dmak4yl7srz94v"
+        Status:
+          Timestamp: "2016-06-07T21:07:31.290032978Z"
+          State: "running"
+          Message: "started"
+          ContainerStatus:
+            ContainerID: "e5d62702a1b48d01c3e02ca1e0212a250801fa8d67caca0b6f35919ebc12f035"
+            PID: 677
+        DesiredState: "running"
+        NetworksAttachments:
+          - Network:
+              ID: "4qvuz4ko70xaltuqbt8956gd1"
+              Version:
+                Index: 18
+              CreatedAt: "2016-06-07T20:31:11.912919752Z"
+              UpdatedAt: "2016-06-07T21:07:29.955277358Z"
+              Spec:
+                Name: "ingress"
+                Labels:
+                  com.docker.swarm.internal: "true"
+                DriverConfiguration: {}
+                IPAMOptions:
+                  Driver: {}
+                  Configs:
+                    - Subnet: "10.255.0.0/16"
+                      Gateway: "10.255.0.1"
+              DriverState:
+                Name: "overlay"
+                Options:
+                  com.docker.network.driver.overlay.vxlanid_list: "256"
+              IPAMOptions:
+                Driver:
+                  Name: "default"
+                Configs:
+                  - Subnet: "10.255.0.0/16"
+                    Gateway: "10.255.0.1"
+            Addresses:
+              - "10.255.0.10/16"
+        AssignedGenericResources:
+          - DiscreteResourceSpec:
+              Kind: "SSD"
+              Value: 3
+          - NamedResourceSpec:
+              Kind: "GPU"
+              Value: "UUID1"
+          - NamedResourceSpec:
+              Kind: "GPU"
+              Value: "UUID2"
+
+    ServiceSpec:
+      description: "User modifiable configuration for a service."
+      type: object
+      properties:
+        Name:
+          description: "Name of the service."
+          type: "string"
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
+            type: "string"
+        TaskTemplate:
+          $ref: "#/components/schemas/TaskSpec"
+        Mode:
+          description: "Scheduling mode for the service."
+          type: "object"
+          properties:
+            Replicated:
+              type: "object"
+              properties:
+                Replicas:
+                  type: "integer"
+                  format: "int64"
+            Global:
+              type: "object"
+            ReplicatedJob:
+              description: |
+                The mode used for services with a finite number of tasks that run
+                to a completed state.
+              type: "object"
+              properties:
+                MaxConcurrent:
+                  description: |
+                    The maximum number of replicas to run simultaneously.
+                  type: "integer"
+                  format: "int64"
+                  default: 1
+                TotalCompletions:
+                  description: |
+                    The total number of replicas desired to reach the Completed
+                    state. If unset, will default to the value of `MaxConcurrent`
+                  type: "integer"
+                  format: "int64"
+            GlobalJob:
+              description: |
+                The mode used for services which run a task to the completed state
+                on each valid node.
+              type: "object"
+        UpdateConfig:
+          description: "Specification for the update strategy of the service."
+          type: "object"
+          properties:
+            Parallelism:
+              description: |
+                Maximum number of tasks to be updated in one iteration (0 means
+                unlimited parallelism).
+              type: "integer"
+              format: "int64"
+            Delay:
+              description: "Amount of time between updates, in nanoseconds."
+              type: "integer"
+              format: "int64"
+            FailureAction:
+              description: |
+                Action to take if an updated task fails to run, or stops running
+                during the update.
+              type: "string"
+              enum:
+                - "continue"
+                - "pause"
+                - "rollback"
+            Monitor:
+              description: |
+                Amount of time to monitor each updated task for failures, in
+                nanoseconds.
+              type: "integer"
+              format: "int64"
+            MaxFailureRatio:
+              description: |
+                The fraction of tasks that may fail during an update before the
+                failure action is invoked, specified as a floating point number
+                between 0 and 1.
+              type: "number"
+              default: 0
+            Order:
+              description: |
+                The order of operations when rolling out an updated task. Either
+                the old task is shut down before the new task is started, or the
+                new task is started before the old task is shut down.
+              type: "string"
+              enum:
+                - "stop-first"
+                - "start-first"
+        RollbackConfig:
+          description: "Specification for the rollback strategy of the service."
+          type: "object"
+          properties:
+            Parallelism:
+              description: |
+                Maximum number of tasks to be rolled back in one iteration (0 means
+                unlimited parallelism).
+              type: "integer"
+              format: "int64"
+            Delay:
+              description: |
+                Amount of time between rollback iterations, in nanoseconds.
+              type: "integer"
+              format: "int64"
+            FailureAction:
+              description: |
+                Action to take if an rolled back task fails to run, or stops
+                running during the rollback.
+              type: "string"
+              enum:
+                - "continue"
+                - "pause"
+            Monitor:
+              description: |
+                Amount of time to monitor each rolled back task for failures, in
+                nanoseconds.
+              type: "integer"
+              format: "int64"
+            MaxFailureRatio:
+              description: |
+                The fraction of tasks that may fail during a rollback before the
+                failure action is invoked, specified as a floating point number
+                between 0 and 1.
+              type: "number"
+              default: 0
+            Order:
+              description: |
+                The order of operations when rolling back a task. Either the old
+                task is shut down before the new task is started, or the new task
+                is started before the old task is shut down.
+              type: "string"
+              enum:
+                - "stop-first"
+                - "start-first"
+        Networks:
+          description: |
+            Specifies which networks the service should attach to.
+
+            Deprecated: This field is deprecated since v1.44. The Networks field in TaskSpec should be used instead.
+          type: "array"
+          items:
+            $ref: "#/components/schemas/NetworkAttachmentConfig"
+
+        EndpointSpec:
+          $ref: "#/components/schemas/EndpointSpec"
+
+    EndpointPortConfig:
+      type: "object"
+      properties:
+        Name:
+          type: "string"
+        Protocol:
+          type: "string"
+          enum:
+            - "tcp"
+            - "udp"
+            - "sctp"
+        TargetPort:
+          description: "The port inside the container."
+          type: "integer"
+        PublishedPort:
+          description: "The port on the swarm hosts."
+          type: "integer"
+        PublishMode:
+          description: |
+            The mode in which port is published.
+
+            <p><br /></p>
+
+            - "ingress" makes the target port accessible on every node,
+              regardless of whether there is a task for the service running on
+              that node or not.
+            - "host" bypasses the routing mesh and publish the port directly on
+              the swarm node where that service is running.
+
+          type: "string"
+          enum:
+            - "ingress"
+            - "host"
+          default: "ingress"
+          example: "ingress"
+
+    EndpointSpec:
+      description: "Properties that can be configured to access and load balance a service."
+      type: "object"
+      properties:
+        Mode:
+          description: |
+            The mode of resolution to use for internal load balancing between tasks.
+          type: "string"
+          enum:
+            - "vip"
+            - "dnsrr"
+          default: "vip"
+        Ports:
+          description: |
+            List of exposed ports that this service is accessible on from the
+            outside. Ports can only be provided if `vip` resolution mode is used.
+          type: "array"
+          items:
+            $ref: "#/components/schemas/EndpointPortConfig"
+
+    Service:
+      type: "object"
+      properties:
+        ID:
+          type: "string"
+        Version:
+          $ref: "#/components/schemas/ObjectVersion"
+        CreatedAt:
+          type: "string"
+          format: "dateTime"
+        UpdatedAt:
+          type: "string"
+          format: "dateTime"
+        Spec:
+          $ref: "#/components/schemas/ServiceSpec"
+        Endpoint:
+          type: "object"
+          properties:
+            Spec:
+              $ref: "#/components/schemas/EndpointSpec"
+            Ports:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/EndpointPortConfig"
+            VirtualIPs:
+              type: "array"
+              items:
+                type: "object"
+                properties:
+                  NetworkID:
+                    type: "string"
+                  Addr:
+                    type: "string"
+        UpdateStatus:
+          description: "The status of a service update."
+          type: "object"
+          properties:
+            State:
+              type: "string"
+              enum:
+                - "updating"
+                - "paused"
+                - "completed"
+            StartedAt:
+              type: "string"
+              format: "dateTime"
+            CompletedAt:
+              type: "string"
+              format: "dateTime"
+            Message:
+              type: "string"
+        ServiceStatus:
+          description: |
+            The status of the service's tasks. Provided only when requested as
+            part of a ServiceList operation.
+          type: "object"
+          properties:
+            RunningTasks:
+              description: |
+                The number of tasks for the service currently in the Running state.
+              type: "integer"
+              format: "uint64"
+              example: 7
+            DesiredTasks:
+              description: |
+                The number of tasks for the service desired to be running.
+                For replicated services, this is the replica count from the
+                service spec. For global services, this is computed by taking
+                count of all tasks for the service with a Desired State other
+                than Shutdown.
+              type: "integer"
+              format: "uint64"
+              example: 10
+            CompletedTasks:
+              description: |
+                The number of tasks for a job that are in the Completed state.
+                This field must be cross-referenced with the service type, as the
+                value of 0 may mean the service is not in a job mode, or it may
+                mean the job-mode service has no tasks yet Completed.
+              type: "integer"
+              format: "uint64"
+        JobStatus:
+          description: |
+            The status of the service when it is in one of ReplicatedJob or
+            GlobalJob modes. Absent on Replicated and Global mode services. The
+            JobIteration is an ObjectVersion, but unlike the Service's version,
+            does not need to be sent with an update request.
+          type: "object"
+          properties:
+            JobIteration:
+              description: |
+                JobIteration is a value increased each time a Job is executed,
+                successfully or otherwise. "Executed", in this case, means the
+                job as a whole has been started, not that an individual Task has
+                been launched. A job is "Executed" when its ServiceSpec is
+                updated. JobIteration can be used to disambiguate Tasks belonging
+                to different executions of a job.  Though JobIteration will
+                increase with each subsequent execution, it may not necessarily
+                increase by 1, and so JobIteration should not be used to
+              $ref: "#/components/schemas/ObjectVersion"
+            LastExecution:
+              description: |
+                The last time, as observed by the server, that this job was
+                started.
+              type: "string"
+              format: "dateTime"
+      example:
+        ID: "9mnpnzenvg8p8tdbtq4wvbkcz"
+        Version:
+          Index: 19
+        CreatedAt: "2016-06-07T21:05:51.880065305Z"
+        UpdatedAt: "2016-06-07T21:07:29.962229872Z"
+        Spec:
+          Name: "hopeful_cori"
+          TaskTemplate:
+            ContainerSpec:
+              Image: "redis"
+            Resources:
+              Limits: {}
+              Reservations: {}
+            RestartPolicy:
+              Condition: "any"
+              MaxAttempts: 0
+            Placement: {}
+            ForceUpdate: 0
+          Mode:
+            Replicated:
+              Replicas: 1
+          UpdateConfig:
+            Parallelism: 1
+            Delay: 1000000000
+            FailureAction: "pause"
+            Monitor: 15000000000
+            MaxFailureRatio: 0.15
+          RollbackConfig:
+            Parallelism: 1
+            Delay: 1000000000
+            FailureAction: "pause"
+            Monitor: 15000000000
+            MaxFailureRatio: 0.15
+          EndpointSpec:
+            Mode: "vip"
+            Ports:
+              -
+                Protocol: "tcp"
+                TargetPort: 6379
+                PublishedPort: 30001
+        Endpoint:
+          Spec:
+            Mode: "vip"
+            Ports:
+              -
+                Protocol: "tcp"
+                TargetPort: 6379
+                PublishedPort: 30001
+          Ports:
+            -
+              Protocol: "tcp"
+              TargetPort: 6379
+              PublishedPort: 30001
+          VirtualIPs:
+            -
+              NetworkID: "4qvuz4ko70xaltuqbt8956gd1"
+              Addr: "10.255.0.2/16"
+            -
+              NetworkID: "4qvuz4ko70xaltuqbt8956gd1"
+              Addr: "10.255.0.3/16"
+
+    ImageDeleteResponseItem:
+      type: "object"
+      x-go-name: "DeleteResponse"
+      properties:
+        Untagged:
+          description: "The image ID of an image that was untagged"
+          type: "string"
+        Deleted:
+          description: "The image ID of an image that was deleted"
+          type: "string"
+
+    ServiceCreateResponse:
+      type: "object"
+      description: |
+        contains the information returned to a client on the
+        creation of a new service.
+      properties:
+        ID:
+          description: "The ID of the created service."
+          type: "string"
+          x-nullable: false
+          example: "ak7w3gjqoa3kuz8xcpnyy0pvl"
+        Warnings:
+          description: |
+            Optional warning message.
+
+            FIXME(thaJeztah): this should have "omitempty" in the generated type.
+          type: "array"
+          x-nullable: true
+          items:
+            type: "string"
+          example:
+            - "unable to pin image doesnotexist:latest to digest: image library/doesnotexist:latest not found"
+
+    ServiceUpdateResponse:
+      type: "object"
+      properties:
+        Warnings:
+          description: "Optional warning messages"
+          type: "array"
+          items:
+            type: "string"
+      example:
+        Warnings:
+          - "unable to pin image doesnotexist:latest to digest: image library/doesnotexist:latest not found"
+
+    ContainerInspectResponse:
+      type: "object"
+      title: "ContainerInspectResponse"
+      x-go-name: "InspectResponse"
+      properties:
+        Id:
+          description: |-
+            The ID of this container as a 128-bit (64-character) hexadecimal string (32 bytes).
+          type: "string"
+          x-go-name: "ID"
+          minLength: 64
+          maxLength: 64
+          pattern: "^[0-9a-fA-F]{64}$"
+          example: "aa86eacfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf"
+        Created:
+          description: |-
+            Date and time at which the container was created, formatted in
+            [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+          type: "string"
+          format: "dateTime"
+          x-nullable: true
+          example: "2025-02-17T17:43:39.64001363Z"
+        Path:
+          description: |-
+            The path to the command being run
+          type: "string"
+          example: "/bin/sh"
+        Args:
+          description: "The arguments to the command being run"
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "-c"
+            - "exit 9"
+        State:
+          $ref: "#/components/schemas/ContainerState"
+        Image:
+          description: |-
+            The ID (digest) of the image that this container was created from.
+          type: "string"
+          example: "sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782"
+        ResolvConfPath:
+          description: |-
+            Location of the `/etc/resolv.conf` generated for the container on the
+            host.
+
+            This file is managed through the docker daemon, and should not be
+            accessed or modified by other tools.
+          type: "string"
+          example: "/var/lib/docker/containers/aa86eacfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf/resolv.conf"
+        HostnamePath:
+          description: |-
+            Location of the `/etc/hostname` generated for the container on the
+            host.
+
+            This file is managed through the docker daemon, and should not be
+            accessed or modified by other tools.
+          type: "string"
+          example: "/var/lib/docker/containers/aa86eacfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf/hostname"
+        HostsPath:
+          description: |-
+            Location of the `/etc/hosts` generated for the container on the
+            host.
+
+            This file is managed through the docker daemon, and should not be
+            accessed or modified by other tools.
+          type: "string"
+          example: "/var/lib/docker/containers/aa86eacfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf/hosts"
+        LogPath:
+          description: |-
+            Location of the file used to buffer the container's logs. Depending on
+            the logging-driver used for the container, this field may be omitted.
+
+            This file is managed through the docker daemon, and should not be
+            accessed or modified by other tools.
+          type: "string"
+          x-nullable: true
+          example: "/var/lib/docker/containers/5b7c7e2b992aa426584ce6c47452756066be0e503a08b4516a433a54d2f69e59/5b7c7e2b992aa426584ce6c47452756066be0e503a08b4516a433a54d2f69e59-json.log"
+        Name:
+          description: |-
+            The name associated with this container.
+
+            For historic reasons, the name may be prefixed with a forward-slash (`/`).
+          type: "string"
+          example: "/funny_chatelet"
+        RestartCount:
+          description: |-
+            Number of times the container was restarted since it was created,
+            or since daemon was started.
+          type: "integer"
+          example: 0
+        Driver:
+          description: |-
+            The storage-driver used for the container's filesystem (graph-driver
+            or snapshotter).
+          type: "string"
+          example: "overlayfs"
+        Platform:
+          description: |-
+            The platform (operating system) for which the container was created.
+
+            This field was introduced for the experimental "LCOW" (Linux Containers
+            On Windows) features, which has been removed. In most cases, this field
+            is equal to the host's operating system (`linux` or `windows`).
+          type: "string"
+          example: "linux"
+        ImageManifestDescriptor:
+          $ref: "#/components/schemas/OCIDescriptor"
+          description: |-
+            OCI descriptor of the platform-specific manifest of the image
+            the container was created from.
+
+            Note: Only available if the daemon provides a multi-platform
+            image store.
+        MountLabel:
+          description: |-
+            SELinux mount label set for the container.
+          type: "string"
+          example: ""
+        ProcessLabel:
+          description: |-
+            SELinux process label set for the container.
+          type: "string"
+          example: ""
+        AppArmorProfile:
+          description: |-
+            The AppArmor profile set for the container.
+          type: "string"
+          example: ""
+        ExecIDs:
+          description: |-
+            IDs of exec instances that are running in the container.
+          type: "array"
+          items:
+            type: "string"
+          x-nullable: true
+          example:
+            - "b35395de42bc8abd327f9dd65d913b9ba28c74d2f0734eeeae84fa1c616a0fca"
+            - "3fc1232e5cd20c8de182ed81178503dc6437f4e7ef12b52cc5e8de020652f1c4"
+        HostConfig:
+          $ref: "#/components/schemas/HostConfig"
+        GraphDriver:
+          $ref: "#/components/schemas/DriverData"
+          x-nullable: true
+        Storage:
+          $ref: "#/components/schemas/Storage"
+          x-nullable: true
+        SizeRw:
+          description: |-
+            The size of files that have been created or changed by this container.
+
+            This field is omitted by default, and only set when size is requested
+            in the API request.
+          type: "integer"
+          format: "int64"
+          x-nullable: true
+          example: "122880"
+        SizeRootFs:
+          description: |-
+            The total size of all files in the read-only layers from the image
+            that the container uses. These layers can be shared between containers.
+
+            This field is omitted by default, and only set when size is requested
+            in the API request.
+          type: "integer"
+          format: "int64"
+          x-nullable: true
+          example: "1653948416"
+        Mounts:
+          description: |-
+            List of mounts used by the container.
+          type: "array"
+          items:
+            $ref: "#/components/schemas/MountPoint"
+        Config:
+          $ref: "#/components/schemas/ContainerConfig"
+        NetworkSettings:
+          $ref: "#/components/schemas/NetworkSettings"
+
+    ContainerSummary:
+      type: "object"
+      properties:
+        Id:
+          description: |-
+            The ID of this container as a 128-bit (64-character) hexadecimal string (32 bytes).
+          type: "string"
+          x-go-name: "ID"
+          minLength: 64
+          maxLength: 64
+          pattern: "^[0-9a-fA-F]{64}$"
+          example: "aa86eacfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf"
+        Names:
+          description: |-
+            The names associated with this container. Most containers have a single
+            name, but when using legacy "links", the container can have multiple
+            names.
+
+            For historic reasons, names are prefixed with a forward-slash (`/`).
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "/funny_chatelet"
+        Image:
+          description: |-
+            The name or ID of the image used to create the container.
+
+            This field shows the image reference as was specified when creating the container,
+            which can be in its canonical form (e.g., `docker.io/library/ubuntu:latest`
+            or `docker.io/library/ubuntu@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782`),
+            short form (e.g., `ubuntu:latest`)), or the ID(-prefix) of the image (e.g., `72297848456d`).
+
+            The content of this field can be updated at runtime if the image used to
+            create the container is untagged, in which case the field is updated to
+            contain the the image ID (digest) it was resolved to in its canonical,
+            non-truncated form (e.g., `sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782`).
+          type: "string"
+          example: "docker.io/library/ubuntu:latest"
+        ImageID:
+          description: |-
+            The ID (digest) of the image that this container was created from.
+          type: "string"
+          example: "sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782"
+        ImageManifestDescriptor:
+          $ref: "#/components/schemas/OCIDescriptor"
+          x-nullable: true
+          description: |
+            OCI descriptor of the platform-specific manifest of the image
+            the container was created from.
+
+            Note: Only available if the daemon provides a multi-platform
+            image store.
+
+            This field is not populated in the `GET /system/df` endpoint.
+        Command:
+          description: "Command to run when starting the container"
+          type: "string"
+          example: "/bin/bash"
+        Created:
+          description: |-
+            Date and time at which the container was created as a Unix timestamp
+            (number of seconds since EPOCH).
+          type: "integer"
+          format: "int64"
+          example: "1739811096"
+        Ports:
+          description: |-
+            Port-mappings for the container.
+          type: "array"
+          items:
+            $ref: "#/components/schemas/PortSummary"
+        SizeRw:
+          description: |-
+            The size of files that have been created or changed by this container.
+
+            This field is omitted by default, and only set when size is requested
+            in the API request.
+          type: "integer"
+          format: "int64"
+          x-nullable: true
+          example: "122880"
+        SizeRootFs:
+          description: |-
+            The total size of all files in the read-only layers from the image
+            that the container uses. These layers can be shared between containers.
+
+            This field is omitted by default, and only set when size is requested
+            in the API request.
+          type: "integer"
+          format: "int64"
+          x-nullable: true
+          example: "1653948416"
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.vendor: "Acme"
+            com.example.license: "GPL"
+            com.example.version: "1.0"
+        State:
+          description: |
+            The state of this container.
+          type: "string"
+          enum:
+            - "created"
+            - "running"
+            - "paused"
+            - "restarting"
+            - "exited"
+            - "removing"
+            - "dead"
+          example: "running"
+        Status:
+          description: |-
+            Additional human-readable status of this container (e.g. `Exit 0`)
+          type: "string"
+          example: "Up 4 days"
+        HostConfig:
+          type: "object"
+          description: |-
+            Summary of host-specific runtime information of the container. This
+            is a reduced set of information in the container's "HostConfig" as
+            available in the container "inspect" response.
+          properties:
+            NetworkMode:
+              description: |-
+                Networking mode (`host`, `none`, `container:<id>`) or name of the
+                primary network the container is using.
+
+                This field is primarily for backward compatibility. The container
+                can be connected to multiple networks for which information can be
+                found in the `NetworkSettings.Networks` field, which enumerates
+                settings per network.
+              type: "string"
+              example: "mynetwork"
+            Annotations:
+              description: |-
+                Arbitrary key-value metadata attached to the container.
+              type: "object"
+              x-nullable: true
+              additionalProperties:
+                type: "string"
+              example:
+                io.kubernetes.docker.type: "container"
+                io.kubernetes.sandbox.id: "3befe639bed0fd6afdd65fd1fa84506756f59360ec4adc270b0fdac9be22b4d3"
+        NetworkSettings:
+          description: |-
+            Summary of the container's network settings
+          type: "object"
+          properties:
+            Networks:
+              type: "object"
+              description: |-
+                Summary of network-settings for each network the container is
+                attached to.
+              additionalProperties:
+                $ref: "#/components/schemas/EndpointSettings"
+        Mounts:
+          type: "array"
+          description: |-
+            List of mounts used by the container.
+          items:
+            $ref: "#/components/schemas/MountPoint"
+        Health:
+          type: "object"
+          description: |-
+            Summary of health status
+
+            Added in v1.52, before that version all container summary not include Health.
+            After this attribute introduced, it includes containers with no health checks configured,
+            or containers that are not running with none
+          properties:
+            Status:
+              type: "string"
+              description: |-
+                the health status of the container
+              enum:
+                - "none"
+                - "starting"
+                - "healthy"
+                - "unhealthy"
+              example: "healthy"
+            FailingStreak:
+              description: "FailingStreak is the number of consecutive failures"
+              type: "integer"
+              example: 0
+
+    ContainersDiskUsage:
+      type: "object"
+      x-go-name: "DiskUsage"
+      x-go-package: "github.com/moby/moby/api/types/container"
+      description: |
+        represents system data usage information for container resources.
+      properties:
+        ActiveCount:
+          description: |
+            Count of active containers.
+          type: "integer"
+          format: "int64"
+          example: 1
+        TotalCount:
+          description: |
+            Count of all containers.
+          type: "integer"
+          format: "int64"
+          example: 4
+        Reclaimable:
+          description: |
+            Disk space that can be reclaimed by removing inactive containers.
+          type: "integer"
+          format: "int64"
+          example: 12345678
+        TotalSize:
+          description: |
+            Disk space in use by containers.
+          type: "integer"
+          format: "int64"
+          example: 98765432
+        Items:
+          description: |
+            List of container summaries.
+          type: "array"
+          x-omitempty: true
+          items:
+            x-go-type:
+              type: Summary
+
+    Driver:
+      description: "Driver represents a driver (network, logging, secrets)."
+      type: "object"
+      required: [Name]
+      properties:
+        Name:
+          description: "Name of the driver."
+          type: "string"
+          x-nullable: false
+          example: "some-driver"
+        Options:
+          description: "Key/value map of driver-specific options."
+          type: "object"
+          x-nullable: false
+          additionalProperties:
+            type: "string"
+          example:
+            OptionA: "value for driver-specific option A"
+            OptionB: "value for driver-specific option B"
+
+    SecretSpec:
+      type: "object"
+      properties:
+        Name:
+          description: "User-defined name of the secret."
+          type: "string"
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.some-label: "some-value"
+            com.example.some-other-label: "some-other-value"
+        Data:
+          description: |
+            Data is the data to store as a secret, formatted as a standard base64-encoded
+            ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-4)) string.
+            It must be empty if the Driver field is set, in which case the data is
+            loaded from an external secret store. The maximum allowed size is 500KB,
+            as defined in [MaxSecretSize](https://pkg.go.dev/github.com/moby/swarmkit/v2@v2.0.0/api/validation#MaxSecretSize).
+
+            This field is only used to _create_ a secret, and is not returned by
+            other endpoints.
+          type: "string"
+          example: ""
+        Driver:
+          description: |
+            Name of the secrets driver used to fetch the secret's value from an
+            external secret store.
+          $ref: "#/components/schemas/Driver"
+        Templating:
+          description: |
+            Templating driver, if applicable
+
+            Templating controls whether and how to evaluate the config payload as
+            a template. If no driver is set, no templating is used.
+          $ref: "#/components/schemas/Driver"
+
+    Secret:
+      type: "object"
+      properties:
+        ID:
+          type: "string"
+          example: "blt1owaxmitz71s9v5zh81zun"
+        Version:
+          $ref: "#/components/schemas/ObjectVersion"
+        CreatedAt:
+          type: "string"
+          format: "dateTime"
+          example: "2017-07-20T13:55:28.678958722Z"
+        UpdatedAt:
+          type: "string"
+          format: "dateTime"
+          example: "2017-07-20T13:55:28.678958722Z"
+        Spec:
+          $ref: "#/components/schemas/SecretSpec"
+
+    ConfigSpec:
+      type: "object"
+      properties:
+        Name:
+          description: "User-defined name of the config."
+          type: "string"
+        Labels:
+          description: "User-defined key/value metadata."
+          type: "object"
+          additionalProperties:
+            type: "string"
+        Data:
+          description: |
+            Data is the data to store as a config, formatted as a standard base64-encoded
+            ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-4)) string.
+            The maximum allowed size is 1000KB, as defined in [MaxConfigSize](https://pkg.go.dev/github.com/moby/swarmkit/v2@v2.0.0-20250103191802-8c1959736554/manager/controlapi#MaxConfigSize).
+          type: "string"
+        Templating:
+          description: |
+            Templating driver, if applicable
+
+            Templating controls whether and how to evaluate the config payload as
+            a template. If no driver is set, no templating is used.
+          $ref: "#/components/schemas/Driver"
+
+    Config:
+      type: "object"
+      properties:
+        ID:
+          type: "string"
+        Version:
+          $ref: "#/components/schemas/ObjectVersion"
+        CreatedAt:
+          type: "string"
+          format: "dateTime"
+        UpdatedAt:
+          type: "string"
+          format: "dateTime"
+        Spec:
+          $ref: "#/components/schemas/ConfigSpec"
+
+    ContainerState:
+      description: |
+        ContainerState stores container's running state. It's part of ContainerJSONBase
+        and will be returned by the "inspect" command.
+      type: "object"
+      x-nullable: true
+      properties:
+        Status:
+          description: |
+            String representation of the container state. Can be one of "created",
+            "running", "paused", "restarting", "removing", "exited", or "dead".
+          type: "string"
+          enum: ["created", "running", "paused", "restarting", "removing", "exited", "dead"]
+          example: "running"
+        Running:
+          description: |
+            Whether this container is running.
+
+            Note that a running container can be _paused_. The `Running` and `Paused`
+            booleans are not mutually exclusive:
+
+            When pausing a container (on Linux), the freezer cgroup is used to suspend
+            all processes in the container. Freezing the process requires the process to
+            be running. As a result, paused containers are both `Running` _and_ `Paused`.
+
+            Use the `Status` field instead to determine if a container's state is "running".
+          type: "boolean"
+          example: true
+        Paused:
+          description: "Whether this container is paused."
+          type: "boolean"
+          example: false
+        Restarting:
+          description: "Whether this container is restarting."
+          type: "boolean"
+          example: false
+        OOMKilled:
+          description: |
+            Whether a process within this container has been killed because it ran
+            out of memory since the container was last started.
+          type: "boolean"
+          example: false
+        Dead:
+          type: "boolean"
+          example: false
+        Pid:
+          description: "The process ID of this container"
+          type: "integer"
+          example: 1234
+        ExitCode:
+          description: "The last exit code of this container"
+          type: "integer"
+          example: 0
+        Error:
+          type: "string"
+        StartedAt:
+          description: "The time when this container was last started."
+          type: "string"
+          example: "2020-01-06T09:06:59.461876391Z"
+        FinishedAt:
+          description: "The time when this container last exited."
+          type: "string"
+          example: "2020-01-06T09:07:59.461876391Z"
+        Health:
+          $ref: "#/components/schemas/Health"
+
+    ContainerCreateResponse:
+      description: "OK response to ContainerCreate operation"
+      type: "object"
+      title: "ContainerCreateResponse"
+      x-go-name: "CreateResponse"
+      required: [Id, Warnings]
+      properties:
+        Id:
+          description: "The ID of the created container"
+          type: "string"
+          x-nullable: false
+          example: "ede54ee1afda366ab42f824e8a5ffd195155d853ceaec74a927f249ea270c743"
+        Warnings:
+          description: "Warnings encountered when creating the container"
+          type: "array"
+          x-nullable: false
+          items:
+            type: "string"
+          example: []
+
+    ContainerUpdateResponse:
+      type: "object"
+      title: "ContainerUpdateResponse"
+      x-go-name: "UpdateResponse"
+      description: |-
+        Response for a successful container-update.
+      properties:
+        Warnings:
+          type: "array"
+          description: |-
+            Warnings encountered when updating the container.
+          items:
+            type: "string"
+          example: ["Published ports are discarded when using host network mode"]
+
+    ContainerStatsResponse:
+      description: |
+        Statistics sample for a container.
+      type: "object"
+      x-go-name: "StatsResponse"
+      title: "ContainerStatsResponse"
+      properties:
+        id:
+          description: |
+            ID of the container for which the stats were collected.
+          type: "string"
+          x-nullable: true
+          example: "ede54ee1afda366ab42f824e8a5ffd195155d853ceaec74a927f249ea270c743"
+        name:
+          description: |
+            Name of the container for which the stats were collected.
+          type: "string"
+          x-nullable: true
+          example: "boring_wozniak"
+        os_type:
+          description: |
+            OSType is the OS of the container ("linux" or "windows") to allow
+            platform-specific handling of stats.
+          type: "string"
+          x-nullable: true
+          example: "linux"
+        read:
+          description: |
+            Date and time at which this sample was collected.
+            The value is formatted as [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt)
+            with nano-seconds.
+          type: "string"
+          format: "date-time"
+          example: "2025-01-16T13:55:22.165243637Z"
+        cpu_stats:
+          $ref: "#/components/schemas/ContainerCPUStats"
+        memory_stats:
+          $ref: "#/components/schemas/ContainerMemoryStats"
+        networks:
+          description: |
+            Network statistics for the container per interface.
+
+            This field is omitted if the container has no networking enabled.
+          x-nullable: true
+          additionalProperties:
+            $ref: "#/components/schemas/ContainerNetworkStats"
+          example:
+            eth0:
+              rx_bytes: 5338
+              rx_dropped: 0
+              rx_errors: 0
+              rx_packets: 36
+              tx_bytes: 648
+              tx_dropped: 0
+              tx_errors: 0
+              tx_packets: 8
+            eth5:
+              rx_bytes: 4641
+              rx_dropped: 0
+              rx_errors: 0
+              rx_packets: 26
+              tx_bytes: 690
+              tx_dropped: 0
+              tx_errors: 0
+              tx_packets: 9
+        pids_stats:
+          $ref: "#/components/schemas/ContainerPidsStats"
+        blkio_stats:
+          $ref: "#/components/schemas/ContainerBlkioStats"
+        num_procs:
+          description: |
+            The number of processors on the system.
+
+            This field is Windows-specific and always zero for Linux containers.
+          type: "integer"
+          format: "uint32"
+          example: 16
+        storage_stats:
+          $ref: "#/components/schemas/ContainerStorageStats"
+        preread:
+          description: |
+            Date and time at which this first sample was collected. This field
+            is not propagated if the "one-shot" option is set. If the "one-shot"
+            option is set, this field may be omitted, empty, or set to a default
+            date (`0001-01-01T00:00:00Z`).
+
+            The value is formatted as [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt)
+            with nano-seconds.
+          type: "string"
+          format: "date-time"
+          example: "2025-01-16T13:55:21.160452595Z"
+        precpu_stats:
+          $ref: "#/components/schemas/ContainerCPUStats"
+
+    ContainerBlkioStats:
+      description: |
+        BlkioStats stores all IO service stats for data read and write.
+
+        This type is Linux-specific and holds many fields that are specific to cgroups v1.
+        On a cgroup v2 host, all fields other than `io_service_bytes_recursive`
+        are omitted or `null`.
+
+        This type is only populated on Linux and omitted for Windows containers.
+      type: "object"
+      x-go-name: "BlkioStats"
+      x-nullable: true
+      properties:
+        io_service_bytes_recursive:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ContainerBlkioStatEntry"
+        io_serviced_recursive:
+          description: |
+            This field is only available when using Linux containers with
+            cgroups v1. It is omitted or `null` when using cgroups v2.
+          x-nullable: true
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ContainerBlkioStatEntry"
+        io_queue_recursive:
+          description: |
+            This field is only available when using Linux containers with
+            cgroups v1. It is omitted or `null` when using cgroups v2.
+          x-nullable: true
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ContainerBlkioStatEntry"
+        io_service_time_recursive:
+          description: |
+            This field is only available when using Linux containers with
+            cgroups v1. It is omitted or `null` when using cgroups v2.
+          x-nullable: true
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ContainerBlkioStatEntry"
+        io_wait_time_recursive:
+          description: |
+            This field is only available when using Linux containers with
+            cgroups v1. It is omitted or `null` when using cgroups v2.
+          x-nullable: true
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ContainerBlkioStatEntry"
+        io_merged_recursive:
+          description: |
+            This field is only available when using Linux containers with
+            cgroups v1. It is omitted or `null` when using cgroups v2.
+          x-nullable: true
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ContainerBlkioStatEntry"
+        io_time_recursive:
+          description: |
+            This field is only available when using Linux containers with
+            cgroups v1. It is omitted or `null` when using cgroups v2.
+          x-nullable: true
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ContainerBlkioStatEntry"
+        sectors_recursive:
+          description: |
+            This field is only available when using Linux containers with
+            cgroups v1. It is omitted or `null` when using cgroups v2.
+          x-nullable: true
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ContainerBlkioStatEntry"
+      example:
+        io_service_bytes_recursive: [
+          {"major": 254, "minor": 0, "op": "read", "value": 7593984},
+          {"major": 254, "minor": 0, "op": "write", "value": 100}
+        ]
+        io_serviced_recursive: null
+        io_queue_recursive: null
+        io_service_time_recursive: null
+        io_wait_time_recursive: null
+        io_merged_recursive: null
+        io_time_recursive: null
+        sectors_recursive: null
+
+    ContainerBlkioStatEntry:
+      description: |
+        Blkio stats entry.
+
+        This type is Linux-specific and omitted for Windows containers.
+      type: "object"
+      x-go-name: "BlkioStatEntry"
+      x-nullable: true
+      properties:
+        major:
+          type: "integer"
+          format: "uint64"
+          example: 254
+        minor:
+          type: "integer"
+          format: "uint64"
+          example: 0
+        op:
+          type: "string"
+          example: "read"
+        value:
+          type: "integer"
+          format: "uint64"
+          example: 7593984
+
+    ContainerCPUStats:
+      description: |
+        CPU related info of the container
+      type: "object"
+      x-go-name: "CPUStats"
+      x-nullable: true
+      properties:
+        cpu_usage:
+          $ref: "#/components/schemas/ContainerCPUUsage"
+        system_cpu_usage:
+          description: |
+            System Usage.
+
+            This field is Linux-specific and omitted for Windows containers.
+          type: "integer"
+          format: "uint64"
+          x-nullable: true
+          example: 5
+        online_cpus:
+          description: |
+            Number of online CPUs.
+
+            This field is Linux-specific and omitted for Windows containers.
+          type: "integer"
+          format: "uint32"
+          x-nullable: true
+          example: 5
+        throttling_data:
+          $ref: "#/components/schemas/ContainerThrottlingData"
+
+    ContainerCPUUsage:
+      description: |
+        All CPU stats aggregated since container inception.
+      type: "object"
+      x-go-name: "CPUUsage"
+      x-nullable: true
+      properties:
+        total_usage:
+          description: |
+            Total CPU time consumed in nanoseconds (Linux) or 100's of nanoseconds (Windows).
+          type: "integer"
+          format: "uint64"
+          example: 29912000
+        percpu_usage:
+          description: |
+            Total CPU time (in nanoseconds) consumed per core (Linux).
+
+            This field is Linux-specific when using cgroups v1. It is omitted
+            when using cgroups v2 and Windows containers.
+          type: "array"
+          x-nullable: true
+          items:
+            type: "integer"
+            format: "uint64"
+            example: 29912000
+
+        usage_in_kernelmode:
+          description: |
+            Time (in nanoseconds) spent by tasks of the cgroup in kernel mode (Linux),
+            or time spent (in 100's of nanoseconds) by all container processes in
+            kernel mode (Windows).
+
+            Not populated for Windows containers using Hyper-V isolation.
+          type: "integer"
+          format: "uint64"
+          example: 21994000
+        usage_in_usermode:
+          description: |
+            Time (in nanoseconds) spent by tasks of the cgroup in user mode (Linux),
+            or time spent (in 100's of nanoseconds) by all container processes in
+            kernel mode (Windows).
+
+            Not populated for Windows containers using Hyper-V isolation.
+          type: "integer"
+          format: "uint64"
+          example: 7918000
+
+    ContainerPidsStats:
+      description: |
+        PidsStats contains Linux-specific stats of a container's process-IDs (PIDs).
+
+        This type is Linux-specific and omitted for Windows containers.
+      type: "object"
+      x-go-name: "PidsStats"
+      x-nullable: true
+      properties:
+        current:
+          description: |
+            Current is the number of PIDs in the cgroup.
+          type: "integer"
+          format: "uint64"
+          x-nullable: true
+          example: 5
+        limit:
+          description: |
+            Limit is the hard limit on the number of pids in the cgroup.
+            A "Limit" of 0 means that there is no limit.
+          type: "integer"
+          format: "uint64"
+          x-nullable: true
+          example: "18446744073709551615"
+
+    ContainerThrottlingData:
+      description: |
+        CPU throttling stats of the container.
+
+        This type is Linux-specific and omitted for Windows containers.
+      type: "object"
+      x-go-name: "ThrottlingData"
+      x-nullable: true
+      properties:
+        periods:
+          description: |
+            Number of periods with throttling active.
+          type: "integer"
+          format: "uint64"
+          example: 0
+        throttled_periods:
+          description: |
+            Number of periods when the container hit its throttling limit.
+          type: "integer"
+          format: "uint64"
+          example: 0
+        throttled_time:
+          description: |
+            Aggregated time (in nanoseconds) the container was throttled for.
+          type: "integer"
+          format: "uint64"
+          example: 0
+
+    ContainerMemoryStats:
+      description: |
+        Aggregates all memory stats since container inception on Linux.
+        Windows returns stats for commit and private working set only.
+      type: "object"
+      x-go-name: "MemoryStats"
+      properties:
+        usage:
+          description: |
+            Current `res_counter` usage for memory.
+
+            This field is Linux-specific and omitted for Windows containers.
+          type: "integer"
+          format: "uint64"
+          x-nullable: true
+          example: 0
+        max_usage:
+          description: |
+            Maximum usage ever recorded.
+
+            This field is Linux-specific and only supported on cgroups v1.
+            It is omitted when using cgroups v2 and for Windows containers.
+          type: "integer"
+          format: "uint64"
+          x-nullable: true
+          example: 0
+        stats:
+          description: |
+            All the stats exported via memory.stat.
+
+            The fields in this object differ between cgroups v1 and v2.
+            On cgroups v1, fields such as `cache`, `rss`, `mapped_file` are available.
+            On cgroups v2, fields such as `file`, `anon`, `inactive_file` are available.
+
+            This field is Linux-specific and omitted for Windows containers.
+          type: "object"
+          additionalProperties:
+            type: "integer"
+            format: "uint64"
+            x-nullable: true
+          example:
+            {
+              "active_anon": 1572864,
+              "active_file": 5115904,
+              "anon": 1572864,
+              "anon_thp": 0,
+              "file": 7626752,
+              "file_dirty": 0,
+              "file_mapped": 2723840,
+              "file_writeback": 0,
+              "inactive_anon": 0,
+              "inactive_file": 2510848,
+              "kernel_stack": 16384,
+              "pgactivate": 0,
+              "pgdeactivate": 0,
+              "pgfault": 2042,
+              "pglazyfree": 0,
+              "pglazyfreed": 0,
+              "pgmajfault": 45,
+              "pgrefill": 0,
+              "pgscan": 0,
+              "pgsteal": 0,
+              "shmem": 0,
+              "slab": 1180928,
+              "slab_reclaimable": 725576,
+              "slab_unreclaimable": 455352,
+              "sock": 0,
+              "thp_collapse_alloc": 0,
+              "thp_fault_alloc": 1,
+              "unevictable": 0,
+              "workingset_activate": 0,
+              "workingset_nodereclaim": 0,
+              "workingset_refault": 0
+            }
+        failcnt:
+          description: |
+            Number of times memory usage hits limits.
+
+            This field is Linux-specific and only supported on cgroups v1.
+            It is omitted when using cgroups v2 and for Windows containers.
+          type: "integer"
+          format: "uint64"
+          x-nullable: true
+          example: 0
+        limit:
+          description: |
+            This field is Linux-specific and omitted for Windows containers.
+          type: "integer"
+          format: "uint64"
+          x-nullable: true
+          example: 8217579520
+        commitbytes:
+          description: |
+            Committed bytes.
+
+            This field is Windows-specific and omitted for Linux containers.
+          type: "integer"
+          format: "uint64"
+          x-nullable: true
+          example: 0
+        commitpeakbytes:
+          description: |
+            Peak committed bytes.
+
+            This field is Windows-specific and omitted for Linux containers.
+          type: "integer"
+          format: "uint64"
+          x-nullable: true
+          example: 0
+        privateworkingset:
+          description: |
+            Private working set.
+
+            This field is Windows-specific and omitted for Linux containers.
+          type: "integer"
+          format: "uint64"
+          x-nullable: true
+          example: 0
+
+    ContainerNetworkStats:
+      description: |
+        Aggregates the network stats of one container
+      type: "object"
+      x-go-name: "NetworkStats"
+      x-nullable: true
+      properties:
+        rx_bytes:
+          description: |
+            Bytes received. Windows and Linux.
+          type: "integer"
+          format: "uint64"
+          example: 5338
+        rx_packets:
+          description: |
+            Packets received. Windows and Linux.
+          type: "integer"
+          format: "uint64"
+          example: 36
+        rx_errors:
+          description: |
+            Received errors. Not used on Windows.
+
+            This field is Linux-specific and always zero for Windows containers.
+          type: "integer"
+          format: "uint64"
+          example: 0
+        rx_dropped:
+          description: |
+            Incoming packets dropped. Windows and Linux.
+          type: "integer"
+          format: "uint64"
+          example: 0
+        tx_bytes:
+          description: |
+            Bytes sent. Windows and Linux.
+          type: "integer"
+          format: "uint64"
+          example: 1200
+        tx_packets:
+          description: |
+            Packets sent. Windows and Linux.
+          type: "integer"
+          format: "uint64"
+          example: 12
+        tx_errors:
+          description: |
+            Sent errors. Not used on Windows.
+
+            This field is Linux-specific and always zero for Windows containers.
+          type: "integer"
+          format: "uint64"
+          example: 0
+        tx_dropped:
+          description: |
+            Outgoing packets dropped. Windows and Linux.
+          type: "integer"
+          format: "uint64"
+          example: 0
+        endpoint_id:
+          description: |
+            Endpoint ID. Not used on Linux.
+
+            This field is Windows-specific and omitted for Linux containers.
+          type: "string"
+          x-nullable: true
+        instance_id:
+          description: |
+            Instance ID. Not used on Linux.
+
+            This field is Windows-specific and omitted for Linux containers.
+          type: "string"
+          x-nullable: true
+
+    ContainerStorageStats:
+      description: |
+        StorageStats is the disk I/O stats for read/write on Windows.
+
+        This type is Windows-specific and omitted for Linux containers.
+      type: "object"
+      x-go-name: "StorageStats"
+      x-nullable: true
+      properties:
+        read_count_normalized:
+          type: "integer"
+          format: "uint64"
+          x-nullable: true
+          example: 7593984
+        read_size_bytes:
+          type: "integer"
+          format: "uint64"
+          x-nullable: true
+          example: 7593984
+        write_count_normalized:
+          type: "integer"
+          format: "uint64"
+          x-nullable: true
+          example: 7593984
+        write_size_bytes:
+          type: "integer"
+          format: "uint64"
+          x-nullable: true
+          example: 7593984
+
+    ContainerTopResponse:
+      type: "object"
+      x-go-name: "TopResponse"
+      title: "ContainerTopResponse"
+      description: |-
+        Container "top" response.
+      properties:
+        Titles:
+          description: "The ps column titles"
+          type: "array"
+          items:
+            type: "string"
+          example:
+            Titles:
+              - "UID"
+              - "PID"
+              - "PPID"
+              - "C"
+              - "STIME"
+              - "TTY"
+              - "TIME"
+              - "CMD"
+        Processes:
+          description: |-
+            Each process running in the container, where each process
+            is an array of values corresponding to the titles.
+          type: "array"
+          items:
+            type: "array"
+            items:
+              type: "string"
+          example:
+            Processes:
+              -
+                - "root"
+                - "13642"
+                - "882"
+                - "0"
+                - "17:03"
+                - "pts/0"
+                - "00:00:00"
+                - "/bin/bash"
+              -
+                - "root"
+                - "13735"
+                - "13642"
+                - "0"
+                - "17:06"
+                - "pts/0"
+                - "00:00:00"
+                - "sleep 10"
+
+    ContainerWaitResponse:
+      description: "OK response to ContainerWait operation"
+      type: "object"
+      x-go-name: "WaitResponse"
+      title: "ContainerWaitResponse"
+      required: [StatusCode]
+      properties:
+        StatusCode:
+          description: "Exit code of the container"
+          type: "integer"
+          format: "int64"
+          x-nullable: false
+        Error:
+          $ref: "#/components/schemas/ContainerWaitExitError"
+
+    ContainerWaitExitError:
+      description: "container waiting error, if any"
+      type: "object"
+      x-go-name: "WaitExitError"
+      properties:
+        Message:
+          description: "Details of an error"
+          type: "string"
+
+    SystemVersion:
+      type: "object"
+      description: |
+        Response of Engine API: GET "/version"
+      properties:
+        Platform:
+          type: "object"
+          required: [Name]
+          properties:
+            Name:
+              type: "string"
+        Components:
+          type: "array"
+          description: |
+            Information about system components
+          items:
+            type: "object"
+            x-go-name: ComponentVersion
+            required: [Name, Version]
+            properties:
+              Name:
+                description: |
+                  Name of the component
+                type: "string"
+                example: "Engine"
+              Version:
+                description: |
+                  Version of the component
+                type: "string"
+                x-nullable: false
+                example: "27.0.1"
+              Details:
+                description: |
+                  Key/value pairs of strings with additional information about the
+                  component. These values are intended for informational purposes
+                  only, and their content is not defined, and not part of the API
+                  specification.
+
+                  These messages can be printed by the client as information to the user.
+                type: "object"
+                x-nullable: true
+        Version:
+          description: "The version of the daemon"
+          type: "string"
+          example: "27.0.1"
+        ApiVersion:
+          description: |
+            The default (and highest) API version that is supported by the daemon
+          type: "string"
+          example: "1.47"
+        MinAPIVersion:
+          description: |
+            The minimum API version that is supported by the daemon
+          type: "string"
+          example: "1.24"
+        GitCommit:
+          description: |
+            The Git commit of the source code that was used to build the daemon
+          type: "string"
+          example: "48a66213fe"
+        GoVersion:
+          description: |
+            The version Go used to compile the daemon, and the version of the Go
+            runtime in use.
+          type: "string"
+          example: "go1.22.7"
+        Os:
+          description: |
+            The operating system that the daemon is running on ("linux" or "windows")
+          type: "string"
+          example: "linux"
+        Arch:
+          description: |
+            Architecture of the daemon, as returned by the Go runtime (`GOARCH`).
+
+            A full list of possible values can be found in the [Go documentation](https://go.dev/doc/install/source#environment).
+          type: "string"
+          example: "amd64"
+        KernelVersion:
+          description: |
+            The kernel version (`uname -r`) that the daemon is running on.
+
+            This field is omitted when empty.
+          type: "string"
+          example: "6.8.0-31-generic"
+        Experimental:
+          description: |
+            Indicates if the daemon is started with experimental features enabled.
+
+            This field is omitted when empty / false.
+          type: "boolean"
+          example: true
+        BuildTime:
+          description: |
+            The date and time that the daemon was compiled.
+          type: "string"
+          example: "2020-06-22T15:49:27.000000000+00:00"
+
+    SystemInfo:
+      type: "object"
+      properties:
+        ID:
+          description: |
+            Unique identifier of the daemon.
+
+            <p><br /></p>
+
+            > **Note**: The format of the ID itself is not part of the API, and
+            > should not be considered stable.
+          type: "string"
+          example: "7TRN:IPZB:QYBB:VPBQ:UMPP:KARE:6ZNR:XE6T:7EWV:PKF4:ZOJD:TPYS"
+        Containers:
+          description: "Total number of containers on the host."
+          type: "integer"
+          example: 14
+        ContainersRunning:
+          description: |
+            Number of containers with status `"running"`.
+          type: "integer"
+          example: 3
+        ContainersPaused:
+          description: |
+            Number of containers with status `"paused"`.
+          type: "integer"
+          example: 1
+        ContainersStopped:
+          description: |
+            Number of containers with status `"stopped"`.
+          type: "integer"
+          example: 10
+        Images:
+          description: |
+            Total number of images on the host.
+
+            Both _tagged_ and _untagged_ (dangling) images are counted.
+          type: "integer"
+          example: 508
+        Driver:
+          description: "Name of the storage driver in use."
+          type: "string"
+          example: "overlay2"
+        DriverStatus:
+          description: |
+            Information specific to the storage driver, provided as
+            "label" / "value" pairs.
+
+            This information is provided by the storage driver, and formatted
+            in a way consistent with the output of `docker info` on the command
+            line.
+
+            <p><br /></p>
+
+            > **Note**: The information returned in this field, including the
+            > formatting of values and labels, should not be considered stable,
+            > and may change without notice.
+          type: "array"
+          items:
+            type: "array"
+            items:
+              type: "string"
+          example:
+            - ["Backing Filesystem", "extfs"]
+            - ["Supports d_type", "true"]
+            - ["Native Overlay Diff", "true"]
+        DockerRootDir:
+          description: |
+            Root directory of persistent Docker state.
+
+            Defaults to `/var/lib/docker` on Linux, and `C:\ProgramData\docker`
+            on Windows.
+          type: "string"
+          example: "/var/lib/docker"
+        Plugins:
+          $ref: "#/components/schemas/PluginsInfo"
+        MemoryLimit:
+          description: "Indicates if the host has memory limit support enabled."
+          type: "boolean"
+          example: true
+        SwapLimit:
+          description: "Indicates if the host has memory swap limit support enabled."
+          type: "boolean"
+          example: true
+        CpuCfsPeriod:
+          description: |
+            Indicates if CPU CFS(Completely Fair Scheduler) period is supported by
+            the host.
+          type: "boolean"
+          example: true
+        CpuCfsQuota:
+          description: |
+            Indicates if CPU CFS(Completely Fair Scheduler) quota is supported by
+            the host.
+          type: "boolean"
+          example: true
+        CPUShares:
+          description: |
+            Indicates if CPU Shares limiting is supported by the host.
+          type: "boolean"
+          example: true
+        CPUSet:
+          description: |
+            Indicates if CPUsets (cpuset.cpus, cpuset.mems) are supported by the host.
+
+            See [cpuset(7)](https://www.kernel.org/doc/Documentation/cgroup-v1/cpusets.txt)
+          type: "boolean"
+          example: true
+        PidsLimit:
+          description: "Indicates if the host kernel has PID limit support enabled."
+          type: "boolean"
+          example: true
+        OomKillDisable:
+          description: "Indicates if OOM killer disable is supported on the host."
+          type: "boolean"
+        IPv4Forwarding:
+          description: "Indicates IPv4 forwarding is enabled."
+          type: "boolean"
+          example: true
+        Debug:
+          description: |
+            Indicates if the daemon is running in debug-mode / with debug-level
+            logging enabled.
+          type: "boolean"
+          example: true
+        NFd:
+          description: |
+            The total number of file Descriptors in use by the daemon process.
+
+            This information is only returned if debug-mode is enabled.
+          type: "integer"
+          example: 64
+        NGoroutines:
+          description: |
+            The  number of goroutines that currently exist.
+
+            This information is only returned if debug-mode is enabled.
+          type: "integer"
+          example: 174
+        SystemTime:
+          description: |
+            Current system-time in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt)
+            format with nano-seconds.
+          type: "string"
+          example: "2017-08-08T20:28:29.06202363Z"
+        LoggingDriver:
+          description: |
+            The logging driver to use as a default for new containers.
+          type: "string"
+        CgroupDriver:
+          description: |
+            The driver to use for managing cgroups.
+          type: "string"
+          enum: ["cgroupfs", "systemd", "none"]
+          default: "cgroupfs"
+          example: "cgroupfs"
+        CgroupVersion:
+          description: |
+            The version of the cgroup.
+          type: "string"
+          enum: ["1", "2"]
+          default: "1"
+          example: "1"
+        NEventsListener:
+          description: "Number of event listeners subscribed."
+          type: "integer"
+          example: 30
+        KernelVersion:
+          description: |
+            Kernel version of the host.
+
+            On Linux, this information obtained from `uname`. On Windows this
+            information is queried from the <kbd>HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\</kbd>
+            registry value, for example _"10.0 14393 (14393.1198.amd64fre.rs1_release_sec.170427-1353)"_.
+          type: "string"
+          example: "6.8.0-31-generic"
+        OperatingSystem:
+          description: |
+            Name of the host's operating system, for example: "Ubuntu 24.04 LTS"
+            or "Windows Server 2016 Datacenter"
+          type: "string"
+          example: "Ubuntu 24.04 LTS"
+        OSVersion:
+          description: |
+            Version of the host's operating system
+
+            <p><br /></p>
+
+            > **Note**: The information returned in this field, including its
+            > very existence, and the formatting of values, should not be considered
+            > stable, and may change without notice.
+          type: "string"
+          example: "24.04"
+        OSType:
+          description: |
+            Generic type of the operating system of the host, as returned by the
+            Go runtime (`GOOS`).
+
+            Currently returned values are "linux" and "windows". A full list of
+            possible values can be found in the [Go documentation](https://go.dev/doc/install/source#environment).
+          type: "string"
+          example: "linux"
+        Architecture:
+          description: |
+            Hardware architecture of the host, as returned by the operating system.
+            This is equivalent to the output of `uname -m` on Linux.
+
+            Unlike `Arch` (from `/version`), this reports the machine's native
+            architecture, which can differ from the Go runtime architecture when
+            running a binary compiled for a different architecture (for example,
+            a 32-bit binary running on 64-bit hardware).
+          type: "string"
+          example: "x86_64"
+        NCPU:
+          description: |
+            The number of logical CPUs usable by the daemon.
+
+            The number of available CPUs is checked by querying the operating
+            system when the daemon starts. Changes to operating system CPU
+            allocation after the daemon is started are not reflected.
+          type: "integer"
+          example: 4
+        MemTotal:
+          description: |
+            Total amount of physical memory available on the host, in bytes.
+          type: "integer"
+          format: "int64"
+          example: 2095882240
+
+        IndexServerAddress:
+          description: |
+            Address / URL of the index server that is used for image search,
+            and as a default for user authentication for Docker Hub and Docker Cloud.
+          default: "https://index.docker.io/v1/"
+          type: "string"
+          example: "https://index.docker.io/v1/"
+        RegistryConfig:
+          $ref: "#/components/schemas/RegistryServiceConfig"
+        GenericResources:
+          $ref: "#/components/schemas/GenericResources"
+        HttpProxy:
+          description: |
+            HTTP-proxy configured for the daemon. This value is obtained from the
+            [`HTTP_PROXY`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html) environment variable.
+            Credentials ([user info component](https://tools.ietf.org/html/rfc3986#section-3.2.1)) in the proxy URL
+            are masked in the API response.
+
+            Containers do not automatically inherit this configuration.
+          type: "string"
+          example: "http://xxxxx:xxxxx@proxy.corp.example.com:8080"
+        HttpsProxy:
+          description: |
+            HTTPS-proxy configured for the daemon. This value is obtained from the
+            [`HTTPS_PROXY`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html) environment variable.
+            Credentials ([user info component](https://tools.ietf.org/html/rfc3986#section-3.2.1)) in the proxy URL
+            are masked in the API response.
+
+            Containers do not automatically inherit this configuration.
+          type: "string"
+          example: "https://xxxxx:xxxxx@proxy.corp.example.com:4443"
+        NoProxy:
+          description: |
+            Comma-separated list of domain extensions for which no proxy should be
+            used. This value is obtained from the [`NO_PROXY`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html)
+            environment variable.
+
+            Containers do not automatically inherit this configuration.
+          type: "string"
+          example: "*.local, 169.254/16"
+        Name:
+          description: "Hostname of the host."
+          type: "string"
+          example: "node5.corp.example.com"
+        Labels:
+          description: |
+            User-defined labels (key/value metadata) as set on the daemon.
+
+            <p><br /></p>
+
+            > **Note**: When part of a Swarm, nodes can both have _daemon_ labels,
+            > set through the daemon configuration, and _node_ labels, set from a
+            > manager node in the Swarm. Node labels are not included in this
+            > field. Node labels can be retrieved using the `/nodes/(id)` endpoint
+            > on a manager node in the Swarm.
+          type: "array"
+          items:
+            type: "string"
+          example: ["storage=ssd", "production"]
+        ExperimentalBuild:
+          description: |
+            Indicates if experimental features are enabled on the daemon.
+          type: "boolean"
+          example: true
+        ServerVersion:
+          description: |
+            Version string of the daemon.
+          type: "string"
+          example: "27.0.1"
+        Runtimes:
+          description: |
+            List of [OCI compliant](https://github.com/opencontainers/runtime-spec)
+            runtimes configured on the daemon. Keys hold the "name" used to
+            reference the runtime.
+
+            The Docker daemon relies on an OCI compliant runtime (invoked via the
+            `containerd` daemon) as its interface to the Linux kernel namespaces,
+            cgroups, and SELinux.
+
+            The default runtime is `runc`, and automatically configured. Additional
+            runtimes can be configured by the user and will be listed here.
+          type: "object"
+          additionalProperties:
+            $ref: "#/components/schemas/Runtime"
+          default:
+            runc:
+              path: "runc"
+          example:
+            runc:
+              path: "runc"
+            runc-master:
+              path: "/go/bin/runc"
+            custom:
+              path: "/usr/local/bin/my-oci-runtime"
+              runtimeArgs: ["--debug", "--systemd-cgroup=false"]
+        DefaultRuntime:
+          description: |
+            Name of the default OCI runtime that is used when starting containers.
+
+            The default can be overridden per-container at create time.
+          type: "string"
+          default: "runc"
+          example: "runc"
+        Swarm:
+          $ref: "#/components/schemas/SwarmInfo"
+        LiveRestoreEnabled:
+          description: |
+            Indicates if live restore is enabled.
+
+            If enabled, containers are kept running when the daemon is shutdown
+            or upon daemon start if running containers are detected.
+          type: "boolean"
+          default: false
+          example: false
+        Isolation:
+          description: |
+            Represents the isolation technology to use as a default for containers.
+            The supported values are platform-specific.
+
+            If no isolation value is specified on daemon start, on Windows client,
+            the default is `hyperv`, and on Windows server, the default is `process`.
+
+            This option is currently not used on other platforms.
+          default: "default"
+          type: "string"
+          enum:
+            - "default"
+            - "hyperv"
+            - "process"
+            - ""
+        InitBinary:
+          description: |
+            Name and, optional, path of the `docker-init` binary.
+
+            If the path is omitted, the daemon searches the host's `$PATH` for the
+            binary and uses the first result.
+          type: "string"
+          example: "docker-init"
+        ContainerdCommit:
+          $ref: "#/components/schemas/Commit"
+        RuncCommit:
+          $ref: "#/components/schemas/Commit"
+        InitCommit:
+          $ref: "#/components/schemas/Commit"
+        SecurityOptions:
+          description: |
+            List of security features that are enabled on the daemon, such as
+            apparmor, seccomp, SELinux, user-namespaces (userns), rootless and
+            no-new-privileges.
+
+            Additional configuration options for each security feature may
+            be present, and are included as a comma-separated list of key/value
+            pairs.
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "name=apparmor"
+            - "name=seccomp,profile=default"
+            - "name=selinux"
+            - "name=userns"
+            - "name=rootless"
+        ProductLicense:
+          description: |
+            Reports a summary of the product license on the daemon.
+
+            If a commercial license has been applied to the daemon, information
+            such as number of nodes, and expiration are included.
+          type: "string"
+          example: "Community Engine"
+        DefaultAddressPools:
+          description: |
+            List of custom default address pools for local networks, which can be
+            specified in the daemon.json file or dockerd option.
+
+            Example: a Base "10.10.0.0/16" with Size 24 will define the set of 256
+            10.10.[0-255].0/24 address pools.
+          type: "array"
+          items:
+            type: "object"
+            properties:
+              Base:
+                description: "The network address in CIDR format"
+                type: "string"
+                example: "10.10.0.0/16"
+              Size:
+                description: "The network pool size"
+                type: "integer"
+                example: "24"
+        FirewallBackend:
+          $ref: "#/components/schemas/FirewallInfo"
+        DiscoveredDevices:
+          description: |
+            List of devices discovered by device drivers.
+
+            Each device includes information about its source driver, kind, name,
+            and additional driver-specific attributes.
+          type: "array"
+          items:
+            $ref: "#/components/schemas/DeviceInfo"
+        NRI:
+          $ref: "#/components/schemas/NRIInfo"
+        Warnings:
+          description: |
+            List of warnings / informational messages about missing features, or
+            issues related to the daemon configuration.
+
+            These messages can be printed by the client as information to the user.
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "WARNING: No memory limit support"
+        CDISpecDirs:
+          description: |
+            List of directories where (Container Device Interface) CDI
+            specifications are located.
+
+            These specifications define vendor-specific modifications to an OCI
+            runtime specification for a container being created.
+
+            An empty list indicates that CDI device injection is disabled.
+
+            Note that since using CDI device injection requires the daemon to have
+            experimental enabled. For non-experimental daemons an empty list will
+            always be returned.
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "/etc/cdi"
+            - "/var/run/cdi"
+        Containerd:
+          $ref: "#/components/schemas/ContainerdInfo"
+
+    ContainerdInfo:
+      description: |
+        Information for connecting to the containerd instance that is used by the daemon.
+        This is included for debugging purposes only.
+      type: "object"
+      x-nullable: true
+      properties:
+        Address:
+          description: "The address of the containerd socket."
+          type: "string"
+          example: "/run/containerd/containerd.sock"
+        Namespaces:
+          description: |
+            The namespaces that the daemon uses for running containers and
+            plugins in containerd. These namespaces can be configured in the
+            daemon configuration, and are considered to be used exclusively
+            by the daemon, Tampering with the containerd instance may cause
+            unexpected behavior.
+
+            As these namespaces are considered to be exclusively accessed
+            by the daemon, it is not recommended to change these values,
+            or to change them to a value that is used by other systems,
+            such as cri-containerd.
+          type: "object"
+          properties:
+            Containers:
+              description: |
+                The default containerd namespace used for containers managed
+                by the daemon.
+
+                The default namespace for containers is "moby", but will be
+                suffixed with the `<uid>.<gid>` of the remapped `root` if
+                user-namespaces are enabled and the containerd image-store
+                is used.
+              type: "string"
+              default: "moby"
+              example: "moby"
+            Plugins:
+              description: |
+                The default containerd namespace used for plugins managed by
+                the daemon.
+
+                The default namespace for plugins is "plugins.moby", but will be
+                suffixed with the `<uid>.<gid>` of the remapped `root` if
+                user-namespaces are enabled and the containerd image-store
+                is used.
+              type: "string"
+              default: "plugins.moby"
+              example: "plugins.moby"
+
+    FirewallInfo:
+      description: |
+        Information about the daemon's firewalling configuration.
+
+        This field is currently only used on Linux, and omitted on other platforms.
+      type: "object"
+      x-nullable: true
+      properties:
+        Driver:
+          description: |
+            The name of the firewall backend driver.
+          type: "string"
+          example: "nftables"
+        Info:
+          description: |
+            Information about the firewall backend, provided as
+            "label" / "value" pairs.
+
+            <p><br /></p>
+
+            > **Note**: The information returned in this field, including the
+            > formatting of values and labels, should not be considered stable,
+            > and may change without notice.
+          type: "array"
+          items:
+            type: "array"
+            items:
+              type: "string"
+          example:
+            - ["ReloadedAt", "2025-01-01T00:00:00Z"]
+
+    # PluginsInfo is a temp struct holding Plugins name
+    # registered with docker daemon. It is used by Info struct
+    PluginsInfo:
+      description: |
+        Available plugins per type.
+
+        <p><br /></p>
+
+        > **Note**: Only unmanaged (V1) plugins are included in this list.
+        > V1 plugins are "lazily" loaded, and are not returned in this list
+        > if there is no resource using the plugin.
+      type: "object"
+      properties:
+        Volume:
+          description: "Names of available volume-drivers, and network-driver plugins."
+          type: "array"
+          items:
+            type: "string"
+          example: ["local"]
+        Network:
+          description: "Names of available network-drivers, and network-driver plugins."
+          type: "array"
+          items:
+            type: "string"
+          example: ["bridge", "host", "ipvlan", "macvlan", "null", "overlay"]
+        Authorization:
+          description: "Names of available authorization plugins."
+          type: "array"
+          items:
+            type: "string"
+          example: ["img-authz-plugin", "hbm"]
+        Log:
+          description: "Names of available logging-drivers, and logging-driver plugins."
+          type: "array"
+          items:
+            type: "string"
+          example: ["awslogs", "fluentd", "gcplogs", "gelf", "journald", "json-file", "splunk", "syslog"]
+
+
+    RegistryServiceConfig:
+      description: |
+        RegistryServiceConfig stores daemon registry services configuration.
+      type: "object"
+      x-nullable: true
+      properties:
+        InsecureRegistryCIDRs:
+          description: |
+            List of IP ranges of insecure registries, using the CIDR syntax
+            ([RFC 4632](https://tools.ietf.org/html/4632)). Insecure registries
+            accept un-encrypted (HTTP) and/or untrusted (HTTPS with certificates
+            from unknown CAs) communication.
+
+            By default, local registries (`::1/128` and `127.0.0.0/8`) are configured as
+            insecure. All other registries are secure. Communicating with an
+            insecure registry is not possible if the daemon assumes that registry
+            is secure.
+
+            This configuration override this behavior, insecure communication with
+            registries whose resolved IP address is within the subnet described by
+            the CIDR syntax.
+
+            Registries can also be marked insecure by hostname. Those registries
+            are listed under `IndexConfigs` and have their `Secure` field set to
+            `false`.
+
+            > **Warning**: Using this option can be useful when running a local
+            > registry, but introduces security vulnerabilities. This option
+            > should therefore ONLY be used for testing purposes. For increased
+            > security, users should add their CA to their system's list of trusted
+            > CAs instead of enabling this option.
+          type: "array"
+          items:
+            type: "string"
+          example: ["::1/128", "127.0.0.0/8"]
+        IndexConfigs:
+          type: "object"
+          additionalProperties:
+            $ref: "#/components/schemas/IndexInfo"
+          example:
+            "127.0.0.1:5000":
+              "Name": "127.0.0.1:5000"
+              "Mirrors": []
+              "Secure": false
+              "Official": false
+            "[2001:db8:a0b:12f0::1]:80":
+              "Name": "[2001:db8:a0b:12f0::1]:80"
+              "Mirrors": []
+              "Secure": false
+              "Official": false
+            "docker.io":
+              Name: "docker.io"
+              Mirrors: ["https://hub-mirror.corp.example.com:5000/"]
+              Secure: true
+              Official: true
+            "registry.internal.corp.example.com:3000":
+              Name: "registry.internal.corp.example.com:3000"
+              Mirrors: []
+              Secure: false
+              Official: false
+        Mirrors:
+          description: |
+            List of registry URLs that act as a mirror for the official
+            (`docker.io`) registry.
+
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "https://hub-mirror.corp.example.com:5000/"
+            - "https://[2001:db8:a0b:12f0::1]/"
+
+    IndexInfo:
+      description:
+        IndexInfo contains information about a registry.
+      type: "object"
+      x-nullable: true
+      properties:
+        Name:
+          description: |
+            Name of the registry, such as "docker.io".
+          type: "string"
+          example: "docker.io"
+        Mirrors:
+          description: |
+            List of mirrors, expressed as URIs.
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "https://hub-mirror.corp.example.com:5000/"
+            - "https://registry-2.docker.io/"
+            - "https://registry-3.docker.io/"
+        Secure:
+          description: |
+            Indicates if the registry is part of the list of insecure
+            registries.
+
+            If `false`, the registry is insecure. Insecure registries accept
+            un-encrypted (HTTP) and/or untrusted (HTTPS with certificates from
+            unknown CAs) communication.
+
+            > **Warning**: Insecure registries can be useful when running a local
+            > registry. However, because its use creates security vulnerabilities
+            > it should ONLY be enabled for testing purposes. For increased
+            > security, users should add their CA to their system's list of
+            > trusted CAs instead of enabling this option.
+          type: "boolean"
+          example: true
+        Official:
+          description: |
+            Indicates whether this is an official registry (i.e., Docker Hub / docker.io)
+          type: "boolean"
+          example: true
+
+    Runtime:
+      description: |
+        Runtime describes an [OCI compliant](https://github.com/opencontainers/runtime-spec)
+        runtime.
+
+        The runtime is invoked by the daemon via the `containerd` daemon. OCI
+        runtimes act as an interface to the Linux kernel namespaces, cgroups,
+        and SELinux.
+      type: "object"
+      properties:
+        path:
+          description: |
+            Name and, optional, path, of the OCI executable binary.
+
+            If the path is omitted, the daemon searches the host's `$PATH` for the
+            binary and uses the first result.
+          type: "string"
+          example: "/usr/local/bin/my-oci-runtime"
+        runtimeArgs:
+          description: |
+            List of command-line arguments to pass to the runtime when invoked.
+          type: "array"
+          x-nullable: true
+          items:
+            type: "string"
+          example: ["--debug", "--systemd-cgroup=false"]
+        status:
+          description: |
+            Information specific to the runtime.
+
+            While this API specification does not define data provided by runtimes,
+            the following well-known properties may be provided by runtimes:
+
+            `org.opencontainers.runtime-spec.features`: features structure as defined
+            in the [OCI Runtime Specification](https://github.com/opencontainers/runtime-spec/blob/main/features.md),
+            in a JSON string representation.
+
+            <p><br /></p>
+
+            > **Note**: The information returned in this field, including the
+            > formatting of values and labels, should not be considered stable,
+            > and may change without notice.
+          type: "object"
+          x-nullable: true
+          additionalProperties:
+            type: "string"
+          example:
+            "org.opencontainers.runtime-spec.features": "{\"ociVersionMin\":\"1.0.0\",\"ociVersionMax\":\"1.1.0\",\"...\":\"...\"}"
+
+    Commit:
+      description: |
+        Commit holds the Git-commit (SHA1) that a binary was built from, as
+        reported in the version-string of external tools, such as `containerd`,
+        or `runC`.
+      type: "object"
+      properties:
+        ID:
+          description: "Actual commit ID of external tool."
+          type: "string"
+          example: "cfb82a876ecc11b5ca0977d1733adbe58599088a"
+
+    SwarmInfo:
+      description: |
+        Represents generic information about swarm.
+      type: "object"
+      properties:
+        NodeID:
+          description: "Unique identifier of for this node in the swarm."
+          type: "string"
+          default: ""
+          example: "k67qz4598weg5unwwffg6z1m1"
+        NodeAddr:
+          description: |
+            IP address at which this node can be reached by other nodes in the
+            swarm.
+          type: "string"
+          default: ""
+          example: "10.0.0.46"
+        LocalNodeState:
+          $ref: "#/components/schemas/LocalNodeState"
+        ControlAvailable:
+          type: "boolean"
+          default: false
+          example: true
+        Error:
+          type: "string"
+          default: ""
+        RemoteManagers:
+          description: |
+            List of ID's and addresses of other managers in the swarm.
+          type: "array"
+          x-nullable: true
+          items:
+            $ref: "#/components/schemas/PeerNode"
+          example:
+            - NodeID: "71izy0goik036k48jg985xnds"
+              Addr: "10.0.0.158:2377"
+            - NodeID: "79y6h1o4gv8n120drcprv5nmc"
+              Addr: "10.0.0.159:2377"
+            - NodeID: "k67qz4598weg5unwwffg6z1m1"
+              Addr: "10.0.0.46:2377"
+        Nodes:
+          description: "Total number of nodes in the swarm."
+          type: "integer"
+          x-nullable: true
+          example: 4
+        Managers:
+          description: "Total number of managers in the swarm."
+          type: "integer"
+          x-nullable: true
+          example: 3
+        Cluster:
+          $ref: "#/components/schemas/ClusterInfo"
+
+    LocalNodeState:
+      description: "Current local status of this node."
+      type: "string"
+      default: ""
+      enum:
+        - ""
+        - "inactive"
+        - "pending"
+        - "active"
+        - "error"
+        - "locked"
+      example: "active"
+
+    PeerNode:
+      description: "Represents a peer-node in the swarm"
+      type: "object"
+      properties:
+        NodeID:
+          description: "Unique identifier of for this node in the swarm."
+          type: "string"
+        Addr:
+          description: |
+            IP address and ports at which this node can be reached.
+          type: "string"
+
+    NetworkAttachmentConfig:
+      description: |
+        Specifies how a service should be attached to a particular network.
+      type: "object"
+      properties:
+        Target:
+          description: |
+            The target network for attachment. Must be a network name or ID.
+          type: "string"
+        Aliases:
+          description: |
+            Discoverable alternate names for the service on this network.
+          type: "array"
+          items:
+            type: "string"
+        DriverOpts:
+          description: |
+            Driver attachment options for the network target.
+          type: "object"
+          additionalProperties:
+            type: "string"
+
+    EventActor:
+      description: |
+        Actor describes something that generates events, like a container, network,
+        or a volume.
+      type: "object"
+      properties:
+        ID:
+          description: "The ID of the object emitting the event"
+          type: "string"
+          example: "ede54ee1afda366ab42f824e8a5ffd195155d853ceaec74a927f249ea270c743"
+        Attributes:
+          description: |
+            Various key/value attributes of the object, depending on its type.
+          type: "object"
+          additionalProperties:
+            type: "string"
+          example:
+            com.example.some-label: "some-label-value"
+            image: "alpine:latest"
+            name: "my-container"
+
+    EventMessage:
+      description: |
+        EventMessage represents the information an event contains.
+      type: "object"
+      title: "SystemEventsResponse"
+      properties:
+        Type:
+          description: "The type of object emitting the event"
+          type: "string"
+          enum: ["builder", "config", "container", "daemon", "image", "network", "node", "plugin", "secret", "service", "volume"]
+          example: "container"
+        Action:
+          description: "The type of event"
+          type: "string"
+          example: "create"
+        Actor:
+          $ref: "#/components/schemas/EventActor"
+        scope:
+          description: |
+            Scope of the event. Engine events are `local` scope. Cluster (Swarm)
+            events are `swarm` scope.
+          type: "string"
+          enum: ["local", "swarm"]
+        time:
+          description: "Timestamp of event"
+          type: "integer"
+          format: "int64"
+          example: 1629574695
+        timeNano:
+          description: "Timestamp of event, with nanosecond accuracy"
+          type: "integer"
+          format: "int64"
+          example: 1629574695515050031
+
+    OCIDescriptor:
+      type: "object"
+      x-go-name: Descriptor
+      description: |
+        A descriptor struct containing digest, media type, and size, as defined in
+        the [OCI Content Descriptors Specification](https://github.com/opencontainers/image-spec/blob/v1.0.1/descriptor.md).
+      properties:
+        mediaType:
+          description: |
+            The media type of the object this schema refers to.
+          type: "string"
+          example: "application/vnd.oci.image.manifest.v1+json"
+        digest:
+          description: |
+            The digest of the targeted content.
+          type: "string"
+          example: "sha256:c0537ff6a5218ef531ece93d4984efc99bbf3f7497c0a7726c88e2bb7584dc96"
+        size:
+          description: |
+            The size in bytes of the blob.
+          type: "integer"
+          format: "int64"
+          example: 424
+        urls:
+          description: |-
+            List of URLs from which this object MAY be downloaded.
+          type: "array"
+          items:
+            type: "string"
+            format: "uri"
+          x-nullable: true
+        annotations:
+          description: |-
+            Arbitrary metadata relating to the targeted content.
+          type: "object"
+          x-nullable: true
+          additionalProperties:
+            type: "string"
+          example:
+            "com.docker.official-images.bashbrew.arch": "amd64"
+            "org.opencontainers.image.base.digest": "sha256:0d0ef5c914d3ea700147da1bd050c59edb8bb12ca312f3800b29d7c8087eabd8"
+            "org.opencontainers.image.base.name": "scratch"
+            "org.opencontainers.image.created": "2025-01-27T00:00:00Z"
+            "org.opencontainers.image.revision": "9fabb4bad5138435b01857e2fe9363e2dc5f6a79"
+            "org.opencontainers.image.source": "https://git.launchpad.net/cloud-images/+oci/ubuntu-base"
+            "org.opencontainers.image.url": "https://hub.docker.com/_/ubuntu"
+            "org.opencontainers.image.version": "24.04"
+        data:
+          type: string
+          x-nullable: true
+          description: |-
+            Data is an embedding of the targeted content. This is encoded as a base64
+            string when marshalled to JSON (automatically, by encoding/json). If
+            present, Data can be used directly to avoid fetching the targeted content.
+          example: null
+        platform:
+          $ref: "#/components/schemas/OCIPlatform"
+        artifactType:
+          description: |-
+            ArtifactType is the IANA media type of this artifact.
+          type: "string"
+          x-nullable: true
+          example: null
+
+    OCIPlatform:
+      type: "object"
+      x-go-name: Platform
+      x-nullable: true
+      description: |
+        Describes the platform which the image in the manifest runs on, as defined
+        in the [OCI Image Index Specification](https://github.com/opencontainers/image-spec/blob/v1.0.1/image-index.md).
+      properties:
+        architecture:
+          description: |
+            The CPU architecture, for example `amd64` or `ppc64`.
+          type: "string"
+          example: "arm"
+        os:
+          description: |
+            The operating system, for example `linux` or `windows`.
+          type: "string"
+          example: "windows"
+        os.version:
+          description: |
+            Optional field specifying the operating system version, for example on
+            Windows `10.0.19041.1165`.
+          type: "string"
+          example: "10.0.19041.1165"
+        os.features:
+          description: |
+            Optional field specifying an array of strings, each listing a required
+            OS feature (for example on Windows `win32k`).
+          type: "array"
+          items:
+            type: "string"
+          example:
+            - "win32k"
+        variant:
+          description: |
+            Optional field specifying a variant of the CPU, for example `v7` to
+            specify ARMv7 when architecture is `arm`.
+          type: "string"
+          example: "v7"
+
+    DistributionInspect:
+      type: "object"
+      x-go-name: DistributionInspect
+      title: "DistributionInspectResponse"
+      required: [Descriptor, Platforms]
+      description: |
+        Describes the result obtained from contacting the registry to retrieve
+        image metadata.
+      properties:
+        Descriptor:
+          $ref: "#/components/schemas/OCIDescriptor"
+        Platforms:
+          type: "array"
+          description: |
+            An array containing all platforms supported by the image.
+          items:
+            $ref: "#/components/schemas/OCIPlatform"
+
+    ClusterVolume:
+      type: "object"
+      description: |
+        Options and information specific to, and only present on, Swarm CSI
+        cluster volumes.
+      properties:
+        ID:
+          type: "string"
+          description: |
+            The Swarm ID of this volume. Because cluster volumes are Swarm
+            objects, they have an ID, unlike non-cluster volumes. This ID can
+            be used to refer to the Volume instead of the name.
+        Version:
+          $ref: "#/components/schemas/ObjectVersion"
+        CreatedAt:
+          type: "string"
+          format: "dateTime"
+        UpdatedAt:
+          type: "string"
+          format: "dateTime"
+        Spec:
+          $ref: "#/components/schemas/ClusterVolumeSpec"
+        Info:
+          type: "object"
+          description: |
+            Information about the global status of the volume.
+          properties:
+            CapacityBytes:
+              type: "integer"
+              format: "int64"
+              description: |
+                The capacity of the volume in bytes. A value of 0 indicates that
+                the capacity is unknown.
+            VolumeContext:
+              type: "object"
+              description: |
+                A map of strings to strings returned from the storage plugin when
+                the volume is created.
+              additionalProperties:
+                type: "string"
+            VolumeID:
+              type: "string"
+              description: |
+                The ID of the volume as returned by the CSI storage plugin. This
+                is distinct from the volume's ID as provided by Docker. This ID
+                is never used by the user when communicating with Docker to refer
+                to this volume. If the ID is blank, then the Volume has not been
+                successfully created in the plugin yet.
+            AccessibleTopology:
+              type: "array"
+              description: |
+                The topology this volume is actually accessible from.
+              items:
+                $ref: "#/components/schemas/Topology"
+        PublishStatus:
+          type: "array"
+          description: |
+            The status of the volume as it pertains to its publishing and use on
+            specific nodes
+          items:
+            type: "object"
+            properties:
+              NodeID:
+                type: "string"
+                description: |
+                  The ID of the Swarm node the volume is published on.
+              State:
+                type: "string"
+                description: |
+                  The published state of the volume.
+                  * `pending-publish` The volume should be published to this node, but the call to the controller plugin to do so has not yet been successfully completed.
+                  * `published` The volume is published successfully to the node.
+                  * `pending-node-unpublish` The volume should be unpublished from the node, and the manager is awaiting confirmation from the worker that it has done so.
+                  * `pending-controller-unpublish` The volume is successfully unpublished from the node, but has not yet been successfully unpublished on the controller.
+                enum:
+                  - "pending-publish"
+                  - "published"
+                  - "pending-node-unpublish"
+                  - "pending-controller-unpublish"
+              PublishContext:
+                type: "object"
+                description: |
+                  A map of strings to strings returned by the CSI controller
+                  plugin when a volume is published.
+                additionalProperties:
+                  type: "string"
+
+    ClusterVolumeSpec:
+      type: "object"
+      description: |
+        Cluster-specific options used to create the volume.
+      properties:
+        Group:
+          type: "string"
+          description: |
+            Group defines the volume group of this volume. Volumes belonging to
+            the same group can be referred to by group name when creating
+            Services.  Referring to a volume by group instructs Swarm to treat
+            volumes in that group interchangeably for the purpose of scheduling.
+            Volumes with an empty string for a group technically all belong to
+            the same, emptystring group.
+        AccessMode:
+          type: "object"
+          description: |
+            Defines how the volume is used by tasks.
+          properties:
+            Scope:
+              type: "string"
+              description: |
+                The set of nodes this volume can be used on at one time.
+                - `single` The volume may only be scheduled to one node at a time.
+                - `multi` the volume may be scheduled to any supported number of nodes at a time.
+              default: "single"
+              enum: ["single", "multi"]
+              x-nullable: false
+            Sharing:
+              type: "string"
+              description: |
+                The number and way that different tasks can use this volume
+                at one time.
+                - `none` The volume may only be used by one task at a time.
+                - `readonly` The volume may be used by any number of tasks, but they all must mount the volume as readonly
+                - `onewriter` The volume may be used by any number of tasks, but only one may mount it as read/write.
+                - `all` The volume may have any number of readers and writers.
+              default: "none"
+              enum: ["none", "readonly", "onewriter", "all"]
+              x-nullable: false
+            MountVolume:
+              type: "object"
+              description: |
+                Options for using this volume as a Mount-type volume.
+
+                    Either MountVolume or BlockVolume, but not both, must be
+                    present.
+                  properties:
+                    FsType:
+                      type: "string"
+                      description: |
+                        Specifies the filesystem type for the mount volume.
+                        Optional.
+                    MountFlags:
+                      type: "array"
+                      description: |
+                        Flags to pass when mounting the volume. Optional.
+                      items:
+                        type: "string"
+                BlockVolume:
+                  type: "object"
+                  description: |
+                    Options for using this volume as a Block-type volume.
+                    Intentionally empty.
+            Secrets:
+              type: "array"
+              description: |
+                Swarm Secrets that are passed to the CSI storage plugin when
+                operating on this volume.
+              items:
+                type: "object"
+                description: |
+                  One cluster volume secret entry. Defines a key-value pair that
+                  is passed to the plugin.
+                properties:
+                  Key:
+                    type: "string"
+                    description: |
+                      Key is the name of the key of the key-value pair passed to
+                      the plugin.
+                  Secret:
+                    type: "string"
+                    description: |
+                      Secret is the swarm Secret object from which to read data.
+                      This can be a Secret name or ID. The Secret data is
+                      retrieved by swarm and used as the value of the key-value
+                      pair passed to the plugin.
+            AccessibilityRequirements:
+              type: "object"
+              description: |
+                Requirements for the accessible topology of the volume. These
+                fields are optional. For an in-depth description of what these
+                fields mean, see the CSI specification.
+              properties:
+                Requisite:
+                  type: "array"
+                  description: |
+                    A list of required topologies, at least one of which the
+                    volume must be accessible from.
+                  items:
+                    $ref: "#/components/schemas/Topology"
+                Preferred:
+                  type: "array"
+                  description: |
+                    A list of topologies that the volume should attempt to be
+                    provisioned in.
+                  items:
+                    $ref: "#/components/schemas/Topology"
+            CapacityRange:
+              type: "object"
+              description: |
+                The desired capacity that the volume should be created with. If
+                empty, the plugin will decide the capacity.
+              properties:
+                RequiredBytes:
+                  type: "integer"
+                  format: "int64"
+                  description: |
+                    The volume must be at least this big. The value of 0
+                    indicates an unspecified minimum
+                LimitBytes:
+                  type: "integer"
+                  format: "int64"
+                  description: |
+                    The volume must not be bigger than this. The value of 0
+                    indicates an unspecified maximum.
+            Availability:
+              type: "string"
+              description: |
+                The availability of the volume for use in tasks.
+                - `active` The volume is fully available for scheduling on the cluster
+                - `pause` No new workloads should use the volume, but existing workloads are not stopped.
+                - `drain` All workloads using this volume should be stopped and rescheduled, and no new ones should be started.
+              default: "active"
+              x-nullable: false
+              enum:
+                - "active"
+                - "pause"
+                - "drain"
+
+    Topology:
+      description: |
+        A map of topological domains to topological segments. For in depth
+        details, see documentation for the Topology object in the CSI
+        specification.
+      type: "object"
+      properties:
+        Segments:
+          type: "object"
+          additionalProperties:
+            type: "string"
+
+    AttestationStatement:
+      x-go-name: "AttestationStatement"
+      description: |
+        AttestationStatement is a single in-toto statement attached to an image.
+      type: "object"
+      required: ["Descriptor", "PredicateType"]
+      properties:
+        Descriptor:
+          $ref: "#/components/schemas/OCIDescriptor"
+        PredicateType:
+          description: The in-toto predicate type URI of this statement.
+          type: "string"
+          example: "https://slsa.dev/provenance/v0.2"
+        Statement:
+          description: |
+            The verbatim in-toto statement JSON. Only included when the caller
+            opts in via the `statement=true` query parameter; otherwise absent.
+          type: "object"
+          x-nullable: true
+
+    ImageManifestSummary:
+      x-go-name: "ManifestSummary"
+      description: |
+        ImageManifestSummary represents a summary of an image manifest.
+      type: "object"
+      required: ["ID", "Descriptor", "Available", "Size", "Kind"]
+      properties:
+        ID:
+          description: |
+            ID is the content-addressable ID of an image and is the same as the
+            digest of the image manifest.
+          type: "string"
+          example: "sha256:95869fbcf224d947ace8d61d0e931d49e31bb7fc67fffbbe9c3198c33aa8e93f"
+        Descriptor:
+          $ref: "#/components/schemas/OCIDescriptor"
+        Available:
+          description: Indicates whether all the child content (image config, layers) is fully available locally.
+          type: "boolean"
+          example: true
+        Size:
+          type: "object"
+          x-nullable: false
+          required: ["Content", "Total"]
+          properties:
+            Total:
+              type: "integer"
+              format: "int64"
+              example: 8213251
+              description: |
+                Total is the total size (in bytes) of all the locally present
+                data (both distributable and non-distributable) that's related to
+                this manifest and its children.
+                This equal to the sum of [Content] size AND all the sizes in the
+                [Size] struct present in the Kind-specific data struct.
+                For example, for an image kind (Kind == "image")
+                this would include the size of the image content and unpacked
+                image snapshots ([Size.Content] + [ImageData.Size.Unpacked]).
+            Content:
+              description: |
+                Content is the size (in bytes) of all the locally present
+                content in the content store (e.g. image config, layers)
+                referenced by this manifest and its children.
+                This only includes blobs in the content store.
+              type: "integer"
+              format: "int64"
+              example: 3987495
+        Kind:
+          type: "string"
+          example: "image"
+          enum:
+            - "image"
+            - "attestation"
+            - "unknown"
+          description: |
+            The kind of the manifest.
+
+            kind         | description
+            -------------|-----------------------------------------------------------
+            image        | Image manifest that can be used to start a container.
+            attestation  | Attestation manifest produced by the Buildkit builder for a specific image manifest.
+        ImageData:
+          description: |
+            The image data for the image manifest.
+            This field is only populated when Kind is "image".
+          type: "object"
+          x-nullable: true
+          x-omitempty: true
+          required: ["Platform", "Containers", "Size", "UnpackedSize"]
+          properties:
+            Platform:
+              $ref: "#/components/schemas/OCIPlatform"
+              description: |
+                OCI platform of the image. This will be the platform specified in the
+                manifest descriptor from the index/manifest list.
+                If it's not available, it will be obtained from the image config.
+            Identity:
+              description: |
+                Identity holds information about the identity and origin of this image.
+                For image list responses, this can duplicate Build/Pull fields across
+                image manifests, because those parts are image-level metadata.
+              x-nullable: true
+              $ref: "#/components/schemas/Identity"
+            Containers:
+              description: |
+                The IDs of the containers that are using this image.
+              type: "array"
+              items:
+                type: "string"
+              example: ["ede54ee1fda366ab42f824e8a5ffd195155d853ceaec74a927f249ea270c7430", "abadbce344c096744d8d6071a90d474d28af8f1034b5ea9fb03c3f4bfc6d005e"]
+            Size:
+              type: "object"
+              x-nullable: false
+              required: ["Unpacked"]
+              properties:
+                Unpacked:
+                  type: "integer"
+                  format: "int64"
+                  example: 3987495
+                  description: |
+                    Unpacked is the size (in bytes) of the locally unpacked
+                    (uncompressed) image content that's directly usable by the containers
+                    running this image.
+                    It's independent of the distributable content - e.g.
+                    the image might still have an unpacked data that's still used by
+                    some container even when the distributable/compressed content is
+                    already gone.
+        AttestationData:
+          description: |
+            The image data for the attestation manifest.
+            This field is only populated when Kind is "attestation".
+          type: "object"
+          x-nullable: true
+          x-omitempty: true
+          required: ["For"]
+          properties:
+            For:
+              description: |
+                The digest of the image manifest that this attestation is for.
+              type: "string"
+              example: "sha256:95869fbcf224d947ace8d61d0e931d49e31bb7fc67fffbbe9c3198c33aa8e93f"
+
+paths:
+  /containers/json:
+    get:
+      summary: "List containers"
+      description: |
+        Returns a list of containers. For details on the format, see the
+        [inspect endpoint](#operation/ContainerInspect).
+
+        Note that it uses a different, smaller representation of a container
+        than inspecting a single container. For example, the list of linked
+        containers is not propagated .
+      operationId: "ContainerList"
+      parameters:
+        - name: "all"
+          in: "query"
+          description: |
+            Return all containers. By default, only running containers are shown.
+          schema:
+            type: "boolean"
+            default: false
+        - name: "limit"
+          in: "query"
+          description: |
+            Return this number of most recently created containers, including
+            non-running ones.
+          schema:
+            type: "integer"
+        - name: "size"
+          in: "query"
+          description: |
+            Return the size of container as fields `SizeRw` and `SizeRootFs`.
+          schema:
+            type: "boolean"
+            default: false
+        - name: "filters"
+          in: "query"
+          description: |
+            Filters to process on the container list, encoded as JSON (a
+            `map[string][]string`). For example, `{"status": ["paused"]}` will
+            only return paused containers.
+
+            Available filters:
+
+            - `ancestor`=(`<image-name>[:<tag>]`, `<image id>`, or `<image@digest>`)
+            - `annotation=key` or `annotation="key=value"` of a container annotation
+            - `before`=(`<container id>` or `<container name>`)
+            - `expose`=(`<port>[/<proto>]`|`<startport-endport>/[<proto>]`)
+            - `exited=<int>` containers with exit code of `<int>`
+            - `health`=(`starting`|`healthy`|`unhealthy`|`none`)
+            - `id=<ID>` a container's ID
+            - `isolation=`(`default`|`process`|`hyperv`) (Windows daemon only)
+            - `is-task=`(`true`|`false`)
+            - `label=key` or `label="key=value"` of a container label
+            - `name=<name>` a container's name
+            - `network`=(`<network id>` or `<network name>`)
+            - `publish`=(`<port>[/<proto>]`|`<startport-endport>/[<proto>]`)
+            - `since`=(`<container id>` or `<container name>`)
+            - `status=`(`created`|`restarting`|`running`|`removing`|`paused`|`exited`|`dead`)
+            - `volume`=(`<volume name>` or `<mount point destination>`)
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/ContainerSummary"
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Container"]
+  /containers/create:
+    post:
+      summary: "Create a container"
+      operationId: "ContainerCreate"
+      parameters:
+        - name: "name"
+          in: "query"
+          description: |
+            Assign the specified name to the container. Must match
+            `/?[a-zA-Z0-9][a-zA-Z0-9_.-]+`.
+          schema:
+            type: "string"
+            pattern: "^/?[a-zA-Z0-9][a-zA-Z0-9_.-]+$"
+        - name: "platform"
+          in: "query"
+          description: |
+            Platform in the format `os[/arch[/variant]]` used for image lookup.
+
+            When specified, the daemon checks if the requested image is present
+            in the local image cache with the given OS and Architecture, and
+            otherwise returns a `404` status.
+
+            If the option is not set, the host's native OS and Architecture are
+            used to look up the image in the image cache. However, if no platform
+            is passed and the given image does exist in the local image cache,
+            but its OS or architecture does not match, the container is created
+            with the available image, and a warning is added to the `Warnings`
+            field in the response, for example;
+
+                WARNING: The requested image's platform (linux/arm64/v8) does not
+                         match the detected host platform (linux/amd64) and no
+                         specific platform was requested
+
+          schema:
+            type: "string"
+            default: ""
+      responses:
+        "201":
+          description: "Container created successfully"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ContainerCreateResponse"
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "no such image"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such image: c2ada9df5af8"
+        "409":
+          description: "conflict"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Container"]
+      requestBody:
+        x-codegen-request-body-name: "body"
+        description: "Container to create"
+        content:
+          "application/json":
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/ContainerConfig"
+                - type: "object"
+                  properties:
+                    HostConfig:
+                      $ref: "#/components/schemas/HostConfig"
+                    NetworkingConfig:
+                      $ref: "#/components/schemas/NetworkingConfig"
+              example:
+                Hostname: ""
+                Domainname: ""
+                User: ""
+                AttachStdin: false
+                AttachStdout: true
+                AttachStderr: true
+                Tty: false
+                OpenStdin: false
+                StdinOnce: false
+                Env:
+                  - "FOO=bar"
+                  - "BAZ=quux"
+                Cmd:
+                  - "date"
+                Entrypoint: ""
+                Image: "ubuntu"
+                Labels:
+                  com.example.vendor: "Acme"
+                  com.example.license: "GPL"
+                  com.example.version: "1.0"
+                Volumes:
+                  /volumes/data: {}
+                WorkingDir: ""
+                NetworkDisabled: false
+                ExposedPorts:
+                  22/tcp: {}
+                StopSignal: "SIGTERM"
+                StopTimeout: 10
+                HostConfig:
+                  Binds:
+                    - "/tmp:/tmp"
+                  Links:
+                    - "redis3:redis"
+                  Memory: 0
+                  MemorySwap: 0
+                  MemoryReservation: 0
+                  NanoCpus: 500000
+                  CpuPercent: 80
+                  CpuShares: 512
+                  CpuPeriod: 100000
+                  CpuRealtimePeriod: 1000000
+                  CpuRealtimeRuntime: 10000
+                  CpuQuota: 50000
+                  CpusetCpus: "0,1"
+                  CpusetMems: "0,1"
+                  MaximumIOps: 0
+                  MaximumIOBps: 0
+                  BlkioWeight: 300
+                  BlkioWeightDevice:
+                    - {}
+                  BlkioDeviceReadBps:
+                    - {}
+                  BlkioDeviceReadIOps:
+                    - {}
+                  BlkioDeviceWriteBps:
+                    - {}
+                  BlkioDeviceWriteIOps:
+                    - {}
+                  DeviceRequests:
+                    - Driver: "nvidia"
+                      Count: -1
+                      DeviceIDs": ["0", "1", "GPU-fef8089b-4820-abfc-e83e-94318197576e"]
+                      Capabilities: [["gpu", "nvidia", "compute"]]
+                      Options:
+                        property1: "string"
+                        property2: "string"
+                  MemorySwappiness: 60
+                  OomKillDisable: false
+                  OomScoreAdj: 500
+                  PidMode: ""
+                  PidsLimit: 0
+                  PortBindings:
+                    22/tcp:
+                      - HostPort: "11022"
+                  PublishAllPorts: false
+                  Privileged: false
+                  ReadonlyRootfs: false
+                  Dns:
+                    - "8.8.8.8"
+                  DnsOptions:
+                    - ""
+                  DnsSearch:
+                    - ""
+                  VolumesFrom:
+                    - "parent"
+                    - "other:ro"
+                  CapAdd:
+                    - "NET_ADMIN"
+                  CapDrop:
+                    - "MKNOD"
+                  GroupAdd:
+                    - "newgroup"
+                  RestartPolicy:
+                    Name: ""
+                    MaximumRetryCount: 0
+                  AutoRemove: true
+                  NetworkMode: "bridge"
+                  Devices: []
+                  Ulimits:
+                    - {}
+                  LogConfig:
+                    Type: "json-file"
+                    Config: {}
+                  SecurityOpt: []
+                  StorageOpt: {}
+                  CgroupParent: ""
+                  VolumeDriver: ""
+                  ShmSize: 67108864
+                NetworkingConfig:
+                  EndpointsConfig:
+                    isolated_nw:
+                      IPAMConfig:
+                        IPv4Address: "172.20.30.33"
+                        IPv6Address: "2001:db8:abcd::3033"
+                        LinkLocalIPs:
+                          - "169.254.34.68"
+                          - "fe80::3468"
+                      Links:
+                        - "container_1"
+                        - "container_2"
+                      Aliases:
+                        - "server_x"
+                        - "server_y"
+                    database_nw: {}
+          "application/octet-stream":
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/ContainerConfig"
+                - type: "object"
+                  properties:
+                    HostConfig:
+                      $ref: "#/components/schemas/HostConfig"
+                    NetworkingConfig:
+                      $ref: "#/components/schemas/NetworkingConfig"
+              example:
+                Hostname: ""
+                Domainname: ""
+                User: ""
+                AttachStdin: false
+                AttachStdout: true
+                AttachStderr: true
+                Tty: false
+                OpenStdin: false
+                StdinOnce: false
+                Env:
+                  - "FOO=bar"
+                  - "BAZ=quux"
+                Cmd:
+                  - "date"
+                Entrypoint: ""
+                Image: "ubuntu"
+                Labels:
+                  com.example.vendor: "Acme"
+                  com.example.license: "GPL"
+                  com.example.version: "1.0"
+                Volumes:
+                  /volumes/data: {}
+                WorkingDir: ""
+                NetworkDisabled: false
+                ExposedPorts:
+                  22/tcp: {}
+                StopSignal: "SIGTERM"
+                StopTimeout: 10
+                HostConfig:
+                  Binds:
+                    - "/tmp:/tmp"
+                  Links:
+                    - "redis3:redis"
+                  Memory: 0
+                  MemorySwap: 0
+                  MemoryReservation: 0
+                  NanoCpus: 500000
+                  CpuPercent: 80
+                  CpuShares: 512
+                  CpuPeriod: 100000
+                  CpuRealtimePeriod: 1000000
+                  CpuRealtimeRuntime: 10000
+                  CpuQuota: 50000
+                  CpusetCpus: "0,1"
+                  CpusetMems: "0,1"
+                  MaximumIOps: 0
+                  MaximumIOBps: 0
+                  BlkioWeight: 300
+                  BlkioWeightDevice:
+                    - {}
+                  BlkioDeviceReadBps:
+                    - {}
+                  BlkioDeviceReadIOps:
+                    - {}
+                  BlkioDeviceWriteBps:
+                    - {}
+                  BlkioDeviceWriteIOps:
+                    - {}
+                  DeviceRequests:
+                    - Driver: "nvidia"
+                      Count: -1
+                      DeviceIDs": ["0", "1", "GPU-fef8089b-4820-abfc-e83e-94318197576e"]
+                      Capabilities: [["gpu", "nvidia", "compute"]]
+                      Options:
+                        property1: "string"
+                        property2: "string"
+                  MemorySwappiness: 60
+                  OomKillDisable: false
+                  OomScoreAdj: 500
+                  PidMode: ""
+                  PidsLimit: 0
+                  PortBindings:
+                    22/tcp:
+                      - HostPort: "11022"
+                  PublishAllPorts: false
+                  Privileged: false
+                  ReadonlyRootfs: false
+                  Dns:
+                    - "8.8.8.8"
+                  DnsOptions:
+                    - ""
+                  DnsSearch:
+                    - ""
+                  VolumesFrom:
+                    - "parent"
+                    - "other:ro"
+                  CapAdd:
+                    - "NET_ADMIN"
+                  CapDrop:
+                    - "MKNOD"
+                  GroupAdd:
+                    - "newgroup"
+                  RestartPolicy:
+                    Name: ""
+                    MaximumRetryCount: 0
+                  AutoRemove: true
+                  NetworkMode: "bridge"
+                  Devices: []
+                  Ulimits:
+                    - {}
+                  LogConfig:
+                    Type: "json-file"
+                    Config: {}
+                  SecurityOpt: []
+                  StorageOpt: {}
+                  CgroupParent: ""
+                  VolumeDriver: ""
+                  ShmSize: 67108864
+                NetworkingConfig:
+                  EndpointsConfig:
+                    isolated_nw:
+                      IPAMConfig:
+                        IPv4Address: "172.20.30.33"
+                        IPv6Address: "2001:db8:abcd::3033"
+                        LinkLocalIPs:
+                          - "169.254.34.68"
+                          - "fe80::3468"
+                      Links:
+                        - "container_1"
+                        - "container_2"
+                      Aliases:
+                        - "server_x"
+                        - "server_y"
+                    database_nw: {}
+        required: true
+  /containers/{id}/json:
+    get:
+      summary: "Inspect a container"
+      description: "Return low-level information about a container."
+      operationId: "ContainerInspect"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ContainerInspectResponse"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "size"
+          in: "query"
+          description: "Return the size of container as fields `SizeRw` and `SizeRootFs`"
+          schema:
+            type: "boolean"
+            default: false
+      tags: ["Container"]
+  /containers/{id}/top:
+    get:
+      summary: "List processes running inside a container"
+      description: |
+        On Unix systems, this is done by running the `ps` command. This endpoint
+        is not supported on Windows.
+      operationId: "ContainerTop"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ContainerTopResponse"
+            "text/plain":
+              schema:
+                $ref: "#/components/schemas/ContainerTopResponse"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "ps_args"
+          in: "query"
+          description: "The arguments to pass to `ps`. For example, `aux`"
+          schema:
+            type: "string"
+            default: "-ef"
+      tags: ["Container"]
+  /containers/{id}/logs:
+    get:
+      summary: "Get container logs"
+      description: |
+        Get `stdout` and `stderr` logs from a container.
+
+        Note: This endpoint works only for containers with the `json-file` or
+        `journald` logging driver.
+      operationId: "ContainerLogs"
+      responses:
+        "200":
+          description: |
+            logs returned as a stream in response body.
+            For the stream format, [see the documentation for the attach endpoint](#operation/ContainerAttach).
+            Note that unlike the attach endpoint, the logs endpoint does not
+            upgrade the connection and does not set Content-Type.
+          content:
+            "application/vnd.docker.raw-stream":
+              schema:
+                type: "string"
+                format: "binary"
+            "application/vnd.docker.multiplexed-stream":
+              schema:
+                type: "string"
+                format: "binary"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "follow"
+          in: "query"
+          description: "Keep connection after returning logs."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "stdout"
+          in: "query"
+          description: "Return logs from `stdout`"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "stderr"
+          in: "query"
+          description: "Return logs from `stderr`"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "since"
+          in: "query"
+          description: "Only return logs since this time, as a UNIX timestamp"
+          schema:
+            type: "integer"
+            default: 0
+        - name: "until"
+          in: "query"
+          description: "Only return logs before this time, as a UNIX timestamp"
+          schema:
+            type: "integer"
+            default: 0
+        - name: "timestamps"
+          in: "query"
+          description: "Add timestamps to every log line"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "tail"
+          in: "query"
+          description: |
+            Only return this number of log lines from the end of the logs.
+            Specify as an integer or `all` to output all log lines.
+          schema:
+            type: "string"
+            default: "all"
+      tags: ["Container"]
+  /containers/{id}/changes:
+    get:
+      summary: "Get changes on a container’s filesystem"
+      description: |
+        Returns which files in a container's filesystem have been added, deleted,
+        or modified. The `Kind` of modification can be one of:
+
+        - `0`: Modified ("C")
+        - `1`: Added ("A")
+        - `2`: Deleted ("D")
+      operationId: "ContainerChanges"
+      responses:
+        "200":
+          description: "The list of changes"
+          content:
+            "application/json":
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/FilesystemChange"
+              example:
+                - Path: "/dev"
+                  Kind: 0
+                - Path: "/dev/kmsg"
+                  Kind: 1
+                - Path: "/test"
+                  Kind: 1
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+      tags: ["Container"]
+  /containers/{id}/export:
+    get:
+      summary: "Export a container"
+      description: "Export the contents of a container as a tarball."
+      operationId: "ContainerExport"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/octet-stream": {}
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+      tags: ["Container"]
+  /containers/{id}/stats:
+    get:
+      summary: "Get container stats based on resource usage"
+      description: |
+        This endpoint returns a live stream of a container’s resource usage
+        statistics.
+
+        The `precpu_stats` is the CPU statistic of the *previous* read, and is
+        used to calculate the CPU usage percentage. It is not an exact copy
+        of the `cpu_stats` field.
+
+        If either `precpu_stats.online_cpus` or `cpu_stats.online_cpus` is
+        nil then for compatibility with older daemons the length of the
+        corresponding `cpu_usage.percpu_usage` array should be used.
+
+        On a cgroup v2 host, the following fields are not set
+        * `blkio_stats`: all fields other than `io_service_bytes_recursive`
+        * `cpu_stats`: `cpu_usage.percpu_usage`
+        * `memory_stats`: `max_usage` and `failcnt`
+        Also, `memory_stats.stats` fields are incompatible with cgroup v1.
+
+        To calculate the values shown by the `stats` command of the docker cli tool
+        the following formulas can be used:
+        * used_memory = `memory_stats.usage - memory_stats.stats.cache` (cgroups v1)
+        * used_memory = `memory_stats.usage - memory_stats.stats.inactive_file` (cgroups v2)
+        * available_memory = `memory_stats.limit`
+        * Memory usage % = `(used_memory / available_memory) * 100.0`
+        * cpu_delta = `cpu_stats.cpu_usage.total_usage - precpu_stats.cpu_usage.total_usage`
+        * system_cpu_delta = `cpu_stats.system_cpu_usage - precpu_stats.system_cpu_usage`
+        * number_cpus = `length(cpu_stats.cpu_usage.percpu_usage)` or `cpu_stats.online_cpus`
+        * CPU usage % = `(cpu_delta / system_cpu_delta) * number_cpus * 100.0`
+      operationId: "ContainerStats"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ContainerStatsResponse"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "stream"
+          in: "query"
+          description: |
+            Stream the output. If false, the stats will be output once and then
+            it will disconnect.
+          schema:
+            type: "boolean"
+            default: true
+        - name: "one-shot"
+          in: "query"
+          description: |
+            Only get a single stat instead of waiting for 2 cycles. Must be used
+            with `stream=false`.
+          schema:
+            type: "boolean"
+            default: false
+      tags: ["Container"]
+  /containers/{id}/resize:
+    post:
+      summary: "Resize a container TTY"
+      description: "Resize the TTY for a container."
+      operationId: "ContainerResize"
+      responses:
+        "200":
+          description: "no error"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "cannot resize container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "h"
+          in: "query"
+          required: true
+          description: "Height of the TTY session in characters"
+          schema:
+            type: "integer"
+        - name: "w"
+          in: "query"
+          required: true
+          description: "Width of the TTY session in characters"
+          schema:
+            type: "integer"
+      tags: ["Container"]
+      x-consumes:
+        - "application/octet-stream"
+  /containers/{id}/start:
+    post:
+      summary: "Start a container"
+      operationId: "ContainerStart"
+      responses:
+        "204":
+          description: "no error"
+        "304":
+          description: "container already started"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        '400':
+          description: bad parameter, including an invalid checkpoint ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "detachKeys"
+          in: "query"
+          description: |
+            Override the key sequence for detaching a container. Format is a
+            single character `[a-Z]` or `ctrl-<value>` where `<value>` is one
+            of: `a-z`, `@`, `^`, `[`, `,` or `_`.
+          schema:
+            type: "string"
+      tags: ["Container"]
+  /containers/{id}/stop:
+    post:
+      summary: "Stop a container"
+      operationId: "ContainerStop"
+      responses:
+        "204":
+          description: "no error"
+        "304":
+          description: "container already stopped"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "signal"
+          in: "query"
+          description: |
+            Signal to send to the container as an integer or string (e.g. `SIGINT`).
+          schema:
+            type: "string"
+        - name: "t"
+          in: "query"
+          description: "Number of seconds to wait before killing the container"
+          schema:
+            type: "integer"
+      tags: ["Container"]
+  /containers/{id}/restart:
+    post:
+      summary: "Restart a container"
+      operationId: "ContainerRestart"
+      responses:
+        "204":
+          description: "no error"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "signal"
+          in: "query"
+          description: |
+            Signal to send to the container as an integer or string (e.g. `SIGINT`).
+          schema:
+            type: "string"
+        - name: "t"
+          in: "query"
+          description: "Number of seconds to wait before killing the container"
+          schema:
+            type: "integer"
+      tags: ["Container"]
+  /containers/{id}/kill:
+    post:
+      summary: "Kill a container"
+      description: |
+        Send a POSIX signal to a container, defaulting to killing to the
+        container.
+      operationId: "ContainerKill"
+      responses:
+        "204":
+          description: "no error"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "409":
+          description: "container is not running"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "Container d37cde0fe4ad63c3a7252023b2f9800282894247d145cb5933ddf6e52cc03a28 is not running"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "signal"
+          in: "query"
+          description: |
+            Signal to send to the container as an integer or string (e.g. `SIGINT`).
+          schema:
+            type: "string"
+            default: "SIGKILL"
+      tags: ["Container"]
+  /containers/{id}/update:
+    post:
+      summary: "Update a container"
+      description: |
+        Change various configuration options of a container without having to
+        recreate it.
+      operationId: "ContainerUpdate"
+      responses:
+        "200":
+          description: "The container has been updated."
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ContainerUpdateResponse"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+      tags: ["Container"]
+      requestBody:
+        x-codegen-request-body-name: "update"
+        required: true
+        content:
+          "application/json":
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/Resources"
+                - type: "object"
+                  properties:
+                    RestartPolicy:
+                      $ref: "#/components/schemas/RestartPolicy"
+              example:
+                BlkioWeight: 300
+                CpuShares: 512
+                CpuPeriod: 100000
+                CpuQuota: 50000
+                CpuRealtimePeriod: 1000000
+                CpuRealtimeRuntime: 10000
+                CpusetCpus: "0,1"
+                CpusetMems: "0"
+                Memory: 314572800
+                MemorySwap: 514288000
+                MemoryReservation: 209715200
+                RestartPolicy:
+                  MaximumRetryCount: 4
+                  Name: "on-failure"
+  /containers/{id}/rename:
+    post:
+      summary: "Rename a container"
+      operationId: "ContainerRename"
+      responses:
+        "204":
+          description: "no error"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "409":
+          description: "name already in use"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "name"
+          in: "query"
+          required: true
+          description: "New name for the container"
+          schema:
+            type: "string"
+      tags: ["Container"]
+  /containers/{id}/pause:
+    post:
+      summary: "Pause a container"
+      description: |
+        Use the freezer cgroup to suspend all processes in a container.
+
+        Traditionally, when suspending a process the `SIGSTOP` signal is used,
+        which is observable by the process being suspended. With the freezer
+        cgroup the process is unaware, and unable to capture, that it is being
+        suspended, and subsequently resumed.
+      operationId: "ContainerPause"
+      responses:
+        "204":
+          description: "no error"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+      tags: ["Container"]
+  /containers/{id}/unpause:
+    post:
+      summary: "Unpause a container"
+      description: "Resume a container which has been paused."
+      operationId: "ContainerUnpause"
+      responses:
+        "204":
+          description: "no error"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+      tags: ["Container"]
+  /containers/{id}/attach:
+    post:
+      summary: "Attach to a container"
+      description: |
+        Attach to a container to read its output or send it input. You can attach
+        to the same container multiple times and you can reattach to containers
+        that have been detached.
+
+        Either the `stream` or `logs` parameter must be `true` for this endpoint
+        to do anything.
+
+        See the [documentation for the `docker attach` command](https://docs.docker.com/engine/reference/commandline/attach/)
+        for more details.
+
+        ### Hijacking
+
+        This endpoint hijacks the HTTP connection to transport `stdin`, `stdout`,
+        and `stderr` on the same socket.
+
+        This is the response from the daemon for an attach request:
+
+        ```
+        HTTP/1.1 200 OK
+        Content-Type: application/vnd.docker.raw-stream
+
+        [STREAM]
+        ```
+
+        After the headers and two new lines, the TCP connection can now be used
+        for raw, bidirectional communication between the client and server.
+
+        To hint potential proxies about connection hijacking, the Docker client
+        can also optionally send connection upgrade headers.
+
+        For example, the client sends this request to upgrade the connection:
+
+        ```
+        POST /containers/16253994b7c4/attach?stream=1&stdout=1 HTTP/1.1
+        Upgrade: tcp
+        Connection: Upgrade
+        ```
+
+        The Docker daemon will respond with a `101 UPGRADED` response, and will
+        similarly follow with the raw stream:
+
+        ```
+        HTTP/1.1 101 UPGRADED
+        Content-Type: application/vnd.docker.raw-stream
+        Connection: Upgrade
+        Upgrade: tcp
+
+        [STREAM]
+        ```
+
+        ### Stream format
+
+        When the TTY setting is disabled in [`POST /containers/create`](#operation/ContainerCreate),
+        the HTTP Content-Type header is set to application/vnd.docker.multiplexed-stream
+        and the stream over the hijacked connected is multiplexed to separate out
+        `stdout` and `stderr`. The stream consists of a series of frames, each
+        containing a header and a payload.
+
+        The header contains the information which the stream writes (`stdout` or
+        `stderr`). It also contains the size of the associated frame encoded in
+        the last four bytes (`uint32`).
+
+        It is encoded on the first eight bytes like this:
+
+        ```go
+        header := [8]byte{STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4}
+        ```
+
+        `STREAM_TYPE` can be:
+
+        - 0: `stdin` (is written on `stdout`)
+        - 1: `stdout`
+        - 2: `stderr`
+
+        `SIZE1, SIZE2, SIZE3, SIZE4` are the four bytes of the `uint32` size
+        encoded as big endian.
+
+        Following the header is the payload, which is the specified number of
+        bytes of `STREAM_TYPE`.
+
+        The simplest way to implement this protocol is the following:
+
+        1. Read 8 bytes.
+        2. Choose `stdout` or `stderr` depending on the first byte.
+        3. Extract the frame size from the last four bytes.
+        4. Read the extracted size and output it on the correct output.
+        5. Goto 1.
+
+        ### Stream format when using a TTY
+
+        When the TTY setting is enabled in [`POST /containers/create`](#operation/ContainerCreate),
+        the stream is not multiplexed. The data exchanged over the hijacked
+        connection is simply the raw data from the process PTY and client's
+        `stdin`.
+
+      operationId: "ContainerAttach"
+      responses:
+        "101":
+          description: "no error, hints proxy about hijacking"
+          content:
+            "application/vnd.docker.raw-stream": {}
+            "application/vnd.docker.multiplexed-stream": {}
+        "200":
+          description: "no error, no upgrade header found"
+          content:
+            "application/vnd.docker.raw-stream": {}
+            "application/vnd.docker.multiplexed-stream": {}
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "detachKeys"
+          in: "query"
+          description: |
+            Override the key sequence for detaching a container.Format is a single
+            character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`,
+            `@`, `^`, `[`, `,` or `_`.
+          schema:
+            type: "string"
+        - name: "logs"
+          in: "query"
+          description: |
+            Replay previous logs from the container.
+
+            This is useful for attaching to a container that has started and you
+            want to output everything since the container started.
+
+            If `stream` is also enabled, once all the previous output has been
+            returned, it will seamlessly transition into streaming current
+            output.
+          schema:
+            type: "boolean"
+            default: false
+        - name: "stream"
+          in: "query"
+          description: |
+            Stream attached streams from the time the request was made onwards.
+          schema:
+            type: "boolean"
+            default: false
+        - name: "stdin"
+          in: "query"
+          description: "Attach to `stdin`"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "stdout"
+          in: "query"
+          description: "Attach to `stdout`"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "stderr"
+          in: "query"
+          description: "Attach to `stderr`"
+          schema:
+            type: "boolean"
+            default: false
+      tags: ["Container"]
+  /containers/{id}/attach/ws:
+    get:
+      summary: "Attach to a container via a websocket"
+      operationId: "ContainerAttachWebsocket"
+      responses:
+        "101":
+          description: "no error, hints proxy about hijacking"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "200":
+          description: "no error, no upgrade header found"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "detachKeys"
+          in: "query"
+          description: |
+            Override the key sequence for detaching a container.Format is a single
+            character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`,
+            `@`, `^`, `[`, `,`, or `_`.
+          schema:
+            type: "string"
+        - name: "logs"
+          in: "query"
+          description: "Return logs"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "stream"
+          in: "query"
+          description: "Return stream"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "stdin"
+          in: "query"
+          description: "Attach to `stdin`"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "stdout"
+          in: "query"
+          description: "Attach to `stdout`"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "stderr"
+          in: "query"
+          description: "Attach to `stderr`"
+          schema:
+            type: "boolean"
+            default: false
+      tags: ["Container"]
+  /containers/{id}/wait:
+    post:
+      summary: "Wait for a container"
+      description: "Block until a container stops, then returns the exit code."
+      operationId: "ContainerWait"
+      responses:
+        "200":
+          description: "The container has exit."
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ContainerWaitResponse"
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "condition"
+          in: "query"
+          description: |
+            Wait until a container state reaches the given condition.
+
+            Defaults to `not-running` if omitted or empty.
+          schema:
+            type: "string"
+            enum:
+              - "not-running"
+              - "next-exit"
+              - "removed"
+            default: "not-running"
+      tags: ["Container"]
+  /containers/{id}:
+    delete:
+      summary: "Remove a container"
+      operationId: "ContainerDelete"
+      responses:
+        "204":
+          description: "no error"
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "409":
+          description: "conflict"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: |
+                  You cannot remove a running container: c2ada9df5af8. Stop the
+                  container before attempting removal or force remove
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "v"
+          in: "query"
+          description: "Remove anonymous volumes associated with the container."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "force"
+          in: "query"
+          description: "If the container is running, kill it before removing it."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "link"
+          in: "query"
+          description: "Remove the specified link associated with the container."
+          schema:
+            type: "boolean"
+            default: false
+      tags: ["Container"]
+  /containers/{id}/archive:
+    head:
+      summary: "Get information about files in a container"
+      description: |
+        A response header `X-Docker-Container-Path-Stat` is returned, containing
+        a base64 - encoded JSON object with some filesystem header information
+        about the path.
+      operationId: "ContainerArchiveInfo"
+      responses:
+        "200":
+          description: "no error"
+          headers:
+            X-Docker-Container-Path-Stat:
+              description: |
+                A base64 - encoded JSON object with some filesystem header
+                information about the path
+              schema:
+                type: "string"
+        "400":
+          description: "Bad parameter"
+        "404":
+          description: "Container or path does not exist"
+        "500":
+          description: "Server error"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "path"
+          in: "query"
+          required: true
+          description: "Resource in the container’s filesystem to archive."
+          schema:
+            type: "string"
+      tags: ["Container"]
+    get:
+      summary: "Get an archive of a filesystem resource in a container"
+      description: "Get a tar archive of a resource in the filesystem of container id."
+      operationId: "ContainerArchive"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/x-tar": {}
+        "400":
+          description: "Bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Container or path does not exist"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "path"
+          in: "query"
+          required: true
+          description: "Resource in the container’s filesystem to archive."
+          schema:
+            type: "string"
+      tags: ["Container"]
+    put:
+      summary: "Extract an archive of files or folders to a directory in a container"
+      description: |
+        Upload a tar archive to be extracted to a path in the filesystem of container id.
+        `path` parameter is asserted to be a directory. If it exists as a file, 400 error
+        will be returned with message "not a directory".
+      operationId: "PutContainerArchive"
+      responses:
+        "200":
+          description: "The content was extracted successfully"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "400":
+          description: "Bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "not a directory"
+        "403":
+          description: "Permission denied, the volume or container rootfs is marked as read-only."
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "No such container or path does not exist inside the container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the container"
+          schema:
+            type: "string"
+        - name: "path"
+          in: "query"
+          required: true
+          description: "Path to a directory in the container to extract the archive’s contents into. "
+          schema:
+            type: "string"
+        - name: "noOverwriteDirNonDir"
+          in: "query"
+          description: |
+            If `1`, `true`, or `True` then it will be an error if unpacking the
+            given content would cause an existing directory to be replaced with
+            a non-directory and vice versa.
+          schema:
+            type: "string"
+        - name: "copyUIDGID"
+          in: "query"
+          description: |
+            If `1`, `true`, then it will copy UID/GID maps to the dest file or
+            dir
+          schema:
+            type: "string"
+      tags: ["Container"]
+      requestBody:
+        x-codegen-request-body-name: "inputStream"
+        required: true
+        description: |
+          The input stream must be a tar archive compressed with one of the
+          following algorithms: `identity` (no compression), `gzip`, `bzip2`,
+          or `xz`.
+        content:
+          "application/x-tar":
+            schema:
+              type: "string"
+              format: "binary"
+          "application/octet-stream":
+            schema:
+              type: "string"
+              format: "binary"
+  /containers/prune:
+    post:
+      summary: "Delete stopped containers"
+      operationId: "ContainerPrune"
+      parameters:
+        - name: "filters"
+          in: "query"
+          description: |
+            Filters to process on the prune list, encoded as JSON (a `map[string][]string`).
+
+            Available filters:
+            - `until=<timestamp>` Prune containers created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
+            - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune containers with (or without, in case `label!=...` is used) the specified labels.
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json":
+              schema:
+                type: "object"
+                title: "ContainerPruneResponse"
+                properties:
+                  ContainersDeleted:
+                    description: "Container IDs that were deleted"
+                    type: "array"
+                    items:
+                      type: "string"
+                  SpaceReclaimed:
+                    description: "Disk space reclaimed in bytes"
+                    type: "integer"
+                    format: "int64"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Container"]
+  /images/json:
+    get:
+      summary: "List Images"
+      description: "Returns a list of images on the server. Note that it uses a different, smaller representation of an image than inspecting a single image."
+      operationId: "ImageList"
+      responses:
+        "200":
+          description: "Summary image data for the images matching the query"
+          content:
+            "application/json":
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/ImageSummary"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "all"
+          in: "query"
+          description: "Show all images. Only images from a final layer (no children) are shown by default."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "filters"
+          in: "query"
+          description: |
+            A JSON encoded value of the filters (a `map[string][]string`) to
+            process on the images list.
+
+            Available filters:
+
+            - `before`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
+            - `dangling=true`
+            - `label=key` or `label="key=value"` of an image label
+            - `reference`=(`<image-name>[:<tag>]`)
+            - `since`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
+            - `until=<timestamp>`
+          schema:
+            type: "string"
+        - name: "shared-size"
+          in: "query"
+          description: "Compute and show shared size as a `SharedSize` field on each image."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "digests"
+          in: "query"
+          description: "Show digest information as a `RepoDigests` field on each image."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "manifests"
+          in: "query"
+          description: "Include `Manifests` in the image summary."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "identity"
+          in: "query"
+          description: "Include `Identity` in each manifest summary. Requires `manifests=1`."
+          schema:
+            type: "boolean"
+            default: false
+      tags: ["Image"]
+  /build:
+    post:
+      summary: "Build an image"
+      description: |
+        Build an image from a tar archive with a `Dockerfile` in it.
+
+        The `Dockerfile` specifies how the image is built from the tar archive. It is typically in the archive's root, but can be at a different path or have a different name by specifying the `dockerfile` parameter. [See the `Dockerfile` reference for more information](https://docs.docker.com/engine/reference/builder/).
+
+        The Docker daemon performs a preliminary validation of the `Dockerfile` before starting the build, and returns an error if the syntax is incorrect. After that, each instruction is run one-by-one until the ID of the new image is output.
+
+        The build is canceled if the client drops the connection by quitting or being killed.
+      operationId: "ImageBuild"
+      parameters:
+        - name: "dockerfile"
+          in: "query"
+          description: "Path within the build context to the `Dockerfile`. This is ignored if `remote` is specified and points to an external `Dockerfile`."
+          schema:
+            type: "string"
+            default: "Dockerfile"
+        - name: "t"
+          in: "query"
+          description: "A name and optional tag to apply to the image in the `name:tag` format. If you omit the tag the default `latest` value is assumed. You can provide several `t` parameters."
+          schema:
+            type: "string"
+        - name: "extrahosts"
+          in: "query"
+          description: "Extra hosts to add to /etc/hosts"
+          schema:
+            type: "string"
+        - name: "remote"
+          in: "query"
+          description: "A Git repository URI or HTTP/HTTPS context URI. If the URI points to a single text file, the file’s contents are placed into a file called `Dockerfile` and the image is built from that file. If the URI points to a tarball, the file is downloaded by the daemon and the contents therein used as the context for the build. If the URI points to a tarball and the `dockerfile` parameter is also specified, there must be a file with the corresponding path inside the tarball."
+          schema:
+            type: "string"
+        - name: "q"
+          in: "query"
+          description: "Suppress verbose build output."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "nocache"
+          in: "query"
+          description: "Do not use the cache when building the image."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "cachefrom"
+          in: "query"
+          description: "JSON array of images used for build cache resolution."
+          schema:
+            type: "string"
+        - name: "pull"
+          in: "query"
+          description: "Attempt to pull the image even if an older image exists locally."
+          schema:
+            type: "string"
+        - name: "rm"
+          in: "query"
+          description: "Remove intermediate containers after a successful build."
+          schema:
+            type: "boolean"
+            default: true
+        - name: "forcerm"
+          in: "query"
+          description: "Always remove intermediate containers, even upon failure."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "memory"
+          in: "query"
+          description: "Set memory limit for build."
+          schema:
+            type: "integer"
+            format: int64
+        - name: "memswap"
+          in: "query"
+          description: "Total memory (memory + swap). Set as `-1` to disable swap."
+          schema:
+            type: "integer"
+            format: int64
+        - name: "cpushares"
+          in: "query"
+          description: "CPU shares (relative weight)."
+          schema:
+            type: "integer"
+            format: int64
+        - name: "cpusetcpus"
+          in: "query"
+          description: "CPUs in which to allow execution (e.g., `0-3`, `0,1`)."
+          schema:
+            type: "string"
+        - name: "cpuperiod"
+          in: "query"
+          description: "The length of a CPU period in microseconds."
+          schema:
+            type: "integer"
+            format: int64
+        - name: "cpuquota"
+          in: "query"
+          description: "Microseconds of CPU time that the container can get in a CPU period."
+          schema:
+            type: "integer"
+            format: int64
+        - name: "buildargs"
+          in: "query"
+          description: >
+            JSON map of string pairs for build-time variables. Users pass these values at build-time. Docker
+            uses the buildargs as the environment context for commands run via the `Dockerfile` RUN
+            instruction, or for variable expansion in other `Dockerfile` instructions. This is not meant for
+            passing secret values.
+
+
+            For example, the build arg `FOO=bar` would become `{"FOO":"bar"}` in JSON. This would result in the
+            query parameter `buildargs={"FOO":"bar"}`. Note that `{"FOO":"bar"}` should be URI component encoded.
+
+
+            [Read more about the buildargs instruction.](https://docs.docker.com/engine/reference/builder/#arg)
+          schema:
+            type: "string"
+        - name: "shmsize"
+          in: "query"
+          description: "Size of `/dev/shm` in bytes. The size must be greater than 0. If omitted the system uses 64MB."
+          schema:
+            type: "integer"
+            format: int64
+        - name: "squash"
+          in: "query"
+          description: "Squash the resulting images layers into a single layer. *(Experimental release only.)*"
+          schema:
+            type: "boolean"
+        - name: "labels"
+          in: "query"
+          description: "Arbitrary key/value labels to set on the image, as a JSON map of string pairs."
+          schema:
+            type: "string"
+        - name: "networkmode"
+          in: "query"
+          description: |
+            Sets the networking mode for the run commands during build. Supported
+            standard values are: `bridge`, `host`, `none`, and `container:<name|id>`.
+            Any other value is taken as a custom network's name or ID to which this
+            container should connect to.
+          schema:
+            type: "string"
+        - name: "Content-type"
+          in: "header"
+          schema:
+            type: "string"
+            enum:
+              - "application/x-tar"
+            default: "application/x-tar"
+        - name: "X-Registry-Config"
+          in: "header"
+          description: |
+            This is a base64-encoded JSON object with auth configurations for multiple registries that a build may refer to.
+
+            The key is a registry URL, and the value is an auth configuration object, [as described in the authentication section](#section/Authentication). For example:
+
+            ```
+            {
+              "docker.example.com": {
+                "username": "janedoe",
+                "password": "hunter2"
+              },
+              "https://index.docker.io/v1/": {
+                "username": "mobydock",
+                "password": "conta1n3rize14"
+              }
+            }
+            ```
+
+            Only the registry domain name (and port if not the default 443) are required. However, for legacy reasons, the Docker Hub registry must be specified with both a `https://` prefix and a `/v1/` suffix even though Docker will prefer to use the v2 registry API.
+          schema:
+            type: "string"
+        - name: "platform"
+          in: "query"
+          description: "Platform in the format os[/arch[/variant]]"
+          schema:
+            type: "string"
+            default: ""
+        - name: "target"
+          in: "query"
+          description: "Target build stage"
+          schema:
+            type: "string"
+            default: ""
+        - name: "outputs"
+          in: "query"
+          description: |
+            BuildKit output configuration in the format of a stringified JSON array of objects.
+            Each object must have two top-level properties: `Type` and `Attrs`.
+            The `Type` property must be set to 'moby'.
+            The `Attrs` property is a map of attributes for the BuildKit output configuration.
+            See https://docs.docker.com/build/exporters/oci-docker/ for more information.
+
+            Example:
+
+            ```
+            [{"Type":"moby","Attrs":{"type":"image","force-compression":"true","compression":"zstd"}}]
+            ```
+          schema:
+            type: "string"
+            default: ""
+        - name: "version"
+          in: "query"
+          description: |
+            Version of the builder backend to use.
+
+            - `1` is the first generation classic (deprecated) builder in the Docker daemon (default)
+            - `2` is [BuildKit](https://github.com/moby/buildkit)
+          schema:
+            type: "string"
+            default: "1"
+            enum: ["1", "2"]
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json": {}
+        "400":
+          description: "Bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Image"]
+      requestBody:
+        x-codegen-request-body-name: "inputStream"
+        description: "A tar archive compressed with one of the following algorithms: identity (no compression), gzip, bzip2, xz."
+        content:
+          "application/octet-stream":
+            schema:
+              type: "string"
+              format: "binary"
+  /build/prune:
+    post:
+      summary: "Delete builder cache"
+      operationId: "BuildPrune"
+      parameters:
+        - name: "reserved-space"
+          in: "query"
+          description: "Amount of disk space in bytes to keep for cache"
+          schema:
+            type: "integer"
+            format: "int64"
+        - name: "max-used-space"
+          in: "query"
+          description: "Maximum amount of disk space allowed to keep for cache"
+          schema:
+            type: "integer"
+            format: "int64"
+        - name: "min-free-space"
+          in: "query"
+          description: "Target amount of free disk space after pruning"
+          schema:
+            type: "integer"
+            format: "int64"
+        - name: "all"
+          in: "query"
+          description: "Remove all types of build cache"
+          schema:
+            type: "boolean"
+        - name: "filters"
+          in: "query"
+          description: |
+            A JSON encoded value of the filters (a `map[string][]string`) to
+            process on the list of build cache objects.
+
+            Available filters:
+
+            - `until=<timestamp>` remove cache older than `<timestamp>`. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon's local time.
+            - `id=<id>`
+            - `parent=<id>`
+            - `type=<string>`
+            - `description=<string>`
+            - `inuse`
+            - `shared`
+            - `private`
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json":
+              schema:
+                type: "object"
+                title: "BuildPruneResponse"
+                properties:
+                  CachesDeleted:
+                    type: "array"
+                    items:
+                      description: "ID of build cache object"
+                      type: "string"
+                  SpaceReclaimed:
+                    description: "Disk space reclaimed in bytes"
+                    type: "integer"
+                    format: "int64"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Image"]
+  /images/create:
+    post:
+      summary: "Create an image"
+      description: "Pull or import an image."
+      operationId: "ImageCreate"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json": {}
+        "404":
+          description: "repository does not exist or no read access"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "fromImage"
+          in: "query"
+          description: |
+            Name of the image to pull. If the name includes a tag or digest, specific behavior applies:
+
+            - If only `fromImage` includes a tag, that tag is used.
+            - If both `fromImage` and `tag` are provided, `tag` takes precedence.
+            - If `fromImage` includes a digest, the image is pulled by digest, and `tag` is ignored.
+            - If neither a tag nor digest is specified, all tags are pulled.
+          schema:
+            type: "string"
+        - name: "fromSrc"
+          in: "query"
+          description: "Source to import. The value may be a URL from which the image can be retrieved or `-` to read the image from the request body. This parameter may only be used when importing an image."
+          schema:
+            type: "string"
+        - name: "repo"
+          in: "query"
+          description: "Repository name given to an image when it is imported. The repo may include a tag. This parameter may only be used when importing an image."
+          schema:
+            type: "string"
+        - name: "tag"
+          in: "query"
+          description: "Tag or digest. If empty when pulling an image, this causes all tags for the given image to be pulled."
+          schema:
+            type: "string"
+        - name: "message"
+          in: "query"
+          description: "Set commit message for imported image."
+          schema:
+            type: "string"
+        - name: "X-Registry-Auth"
+          in: "header"
+          description: |
+            A base64url-encoded auth configuration.
+
+            Refer to the [authentication section](#section/Authentication) for
+            details.
+          schema:
+            type: "string"
+        - name: "changes"
+          in: "query"
+          description: |
+            Apply `Dockerfile` instructions to the image that is created,
+            for example: `changes=ENV DEBUG=true`.
+            Note that `ENV DEBUG=true` should be URI component encoded.
+            Repeat the parameter to apply multiple instructions.
+
+            Supported `Dockerfile` instructions:
+            `CMD`|`ENTRYPOINT`|`ENV`|`EXPOSE`|`ONBUILD`|`USER`|`VOLUME`|`WORKDIR`
+          schema:
+            type: "array"
+            items:
+              type: "string"
+          style: form
+          explode: true
+        - name: "platform"
+          in: "query"
+          description: |
+            Platform in the format os[/arch[/variant]].
+
+            When used in combination with the `fromImage` option, the daemon checks
+            if the given image is present in the local image cache with the given
+            OS and Architecture, and otherwise attempts to pull the image. If the
+            option is not set, the host's native OS and Architecture are used.
+            If the given image does not exist in the local image cache, the daemon
+            attempts to pull the image with the host's native OS and Architecture.
+            If the given image does exists in the local image cache, but its OS or
+            architecture does not match, a warning is produced.
+
+            When used with the `fromSrc` option to import an image from an archive,
+            this option sets the platform information for the imported image. If
+            the option is not set, the host's native OS and Architecture are used
+            for the imported image.
+          schema:
+            type: "string"
+            default: ""
+      tags: ["Image"]
+      requestBody:
+        x-codegen-request-body-name: "inputImage"
+        description: "Image content if the value `-` has been specified in fromSrc query parameter"
+        content:
+          "text/plain":
+            schema:
+              type: "string"
+          "application/octet-stream":
+            schema:
+              type: "string"
+        required: false
+  /images/{name}/json:
+    get:
+      summary: "Inspect an image"
+      description: "Return low-level information about an image."
+      operationId: "ImageInspect"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ImageInspect"
+        "404":
+          description: "No such image"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such image: someimage (tag: latest)"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "path"
+          description: "Image name or id"
+          required: true
+          schema:
+            type: "string"
+        - name: "manifests"
+          in: "query"
+          description: |-
+            Include Manifests in the image summary.
+
+            The `manifests` and `platform` options are mutually exclusive, and
+            an error is produced if both are set.
+          required: false
+          schema:
+            type: "boolean"
+            default: false
+        - name: "platform"
+          in: "query"
+          description: |-
+            JSON-encoded OCI platform to select the platform-variant.
+            If omitted, it defaults to any locally available platform,
+            prioritizing the daemon's host platform.
+
+            If the daemon provides a multi-platform image store, this selects
+            the platform-variant to show inspect. If the image is
+            a single-platform image, or if the multi-platform image does not
+            provide a variant matching the given platform, an error is returned.
+
+            The `platform` and `manifests` options are mutually exclusive, and
+            an error is produced if both are set.
+
+            Example: `{"os": "linux", "architecture": "arm", "variant": "v5"}`
+          schema:
+            type: "string"
+      tags: ["Image"]
+
+  /images/{name}/attestations:
+    get:
+      summary: Get attestation statements for an image
+      description: |
+        Return the in-toto attestation statements attached to the image for the
+        given platform. The daemon locates the attestation manifest(s) that
+        reference the matching platform image manifest, reads their statement
+        layers, and returns the verbatim statement JSON together with layer
+        metadata.
+
+        If the image has no attestations an empty array is returned.
+      operationId: ImageAttestations
+      tags:
+        - Image
+      parameters:
+        - name: name
+          in: path
+          description: Image name or id
+          required: true
+          schema:
+            type: string
+        - name: platform
+          in: query
+          description: |-
+            JSON-encoded OCI platform to select the image variant whose
+            attestations to return.
+            If omitted, the daemon's default (host) platform is used.
+
+            Only one platform value is currently accepted; passing more than
+            one returns an error. The parameter is declared as an array so the
+            wire shape can accept multiple values in the future without an
+            API version bump.
+
+            Example: `{"os": "linux", "architecture": "amd64"}`
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: type
+          in: query
+          description: |-
+            In-toto predicate type URI to filter returned statements. May be
+            repeated to accept any of several predicate types. If omitted, all
+            statements are returned.
+
+            Example: `type=https://slsa.dev/provenance/v0.2&type=https://spdx.dev/Document`
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: statement
+          in: query
+          description: |-
+            Include the verbatim in-toto statement body in each returned
+            entry. Defaults to false; when omitted or false, only the
+            descriptor and predicate type are returned and statement blobs
+            are not read.
+          required: false
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: No error
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AttestationStatement'
+        '400':
+          description: Bad parameter (e.g. malformed `platform` value)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: No such image, or no manifest found for the requested platform
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '501':
+          description: |
+            The daemon's image backend does not support attestations. This
+            is returned by the legacy (graphdriver) image store, which does
+            not preserve OCI image indexes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /images/{name}/history:
+    get:
+      summary: "Get the history of an image"
+      description: "Return parent layers of an image."
+      operationId: "ImageHistory"
+      responses:
+        "200":
+          description: "List of image layers"
+          content:
+            "application/json":
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/ImageHistoryResponseItem"
+              example:
+                - Id: "3db9c44f45209632d6050b35958829c3a2aa256d81b9a7be45b362ff85c54710"
+                  Created: 1398108230
+                  CreatedBy: "/bin/sh -c #(nop) ADD file:eb15dbd63394e063b805a3c32ca7bf0266ef64676d5a6fab4801f2e81e2a5148 in /"
+                  Tags:
+                    - "ubuntu:lucid"
+                    - "ubuntu:10.04"
+                  Size: 182964289
+                  Comment: ""
+                - Id: "6cfa4d1f33fb861d4d114f43b25abd0ac737509268065cdfd69d544a59c85ab8"
+                  Created: 1398108222
+                  CreatedBy: "/bin/sh -c #(nop) MAINTAINER Tianon Gravi <admwiggin@gmail.com> - mkimage-debootstrap.sh -i iproute,iputils-ping,ubuntu-minimal -t lucid.tar.xz lucid http://archive.ubuntu.com/ubuntu/"
+                  Tags: []
+                  Size: 0
+                  Comment: ""
+                - Id: "511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158"
+                  Created: 1371157430
+                  CreatedBy: ""
+                  Tags:
+                    - "scratch12:latest"
+                    - "scratch:latest"
+                  Size: 0
+                  Comment: "Imported from -"
+        "404":
+          description: "No such image"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "path"
+          description: "Image name or ID"
+          required: true
+          schema:
+            type: "string"
+        - name: "platform"
+          in: "query"
+          description: |
+            JSON-encoded OCI platform to select the platform-variant.
+            If omitted, it defaults to any locally available platform,
+            prioritizing the daemon's host platform.
+
+            If the daemon provides a multi-platform image store, this selects
+            the platform-variant to show the history for. If the image is
+            a single-platform image, or if the multi-platform image does not
+            provide a variant matching the given platform, an error is returned.
+
+            Example: `{"os": "linux", "architecture": "arm", "variant": "v5"}`
+          schema:
+            type: "string"
+      tags: ["Image"]
+  /images/{name}/push:
+    post:
+      summary: "Push an image"
+      description: |
+        Push an image to a registry.
+
+        If you wish to push an image on to a private registry, that image must
+        already have a tag which references the registry. For example,
+        `registry.example.com/myimage:latest`.
+
+        The push is cancelled if the HTTP connection is closed.
+      operationId: "ImagePush"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "404":
+          description: "No such image"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "path"
+          description: |
+            Name of the image to push. For example, `registry.example.com/myimage`.
+            The image must be present in the local image store with the same name.
+
+            The name should be provided without tag; if a tag is provided, it
+            is ignored. For example, `registry.example.com/myimage:latest` is
+            considered equivalent to `registry.example.com/myimage`.
+
+            Use the `tag` parameter to specify the tag to push.
+          required: true
+          schema:
+            type: "string"
+        - name: "tag"
+          in: "query"
+          description: |
+            Tag of the image to push. For example, `latest`. If no tag is provided,
+            all tags of the given image that are present in the local image store
+            are pushed.
+          schema:
+            type: "string"
+        - name: "platform"
+          in: "query"
+          description: |
+            JSON-encoded OCI platform to select the platform-variant to push.
+            If not provided, all available variants will attempt to be pushed.
+
+            If the daemon provides a multi-platform image store, this selects
+            the platform-variant to push to the registry. If the image is
+            a single-platform image, or if the multi-platform image does not
+            provide a variant matching the given platform, an error is returned.
+
+            Example: `{"os": "linux", "architecture": "arm", "variant": "v5"}`
+          schema:
+            type: "string"
+        - name: "X-Registry-Auth"
+          in: "header"
+          description: |
+            A base64url-encoded auth configuration.
+
+            Refer to the [authentication section](#section/Authentication) for
+            details.
+          required: true
+          schema:
+            type: "string"
+      tags: ["Image"]
+      x-consumes:
+        - "application/octet-stream"
+  /images/{name}/tag:
+    post:
+      summary: "Tag an image"
+      description: |
+        Create a tag that refers to a source image.
+
+        This creates an additional reference (tag) to the source image. The tag
+        can include a different repository name and/or tag. If the repository
+        or tag already exists, it will be overwritten.
+      operationId: "ImageTag"
+      responses:
+        "201":
+          description: "No error"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "400":
+          description: "Bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "No such image"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: "Conflict"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "path"
+          description: "Image name or ID to tag."
+          required: true
+          schema:
+            type: "string"
+        - name: "repo"
+          in: "query"
+          description: "The repository to tag in. For example, `someuser/someimage`."
+          schema:
+            type: "string"
+        - name: "tag"
+          in: "query"
+          description: "The name of the new tag."
+          schema:
+            type: "string"
+      tags: ["Image"]
+  /images/{name}:
+    delete:
+      summary: "Remove an image"
+      description: |
+        Remove an image, along with any untagged parent images that were
+        referenced by that image.
+
+        Images can't be removed if they have descendant images, are being
+        used by a running container or are being used by a build.
+      operationId: "ImageDelete"
+      responses:
+        "200":
+          description: "The image was deleted successfully"
+          content:
+            "application/json":
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/ImageDeleteResponseItem"
+              example:
+                - Untagged: "3e2f21a89f"
+                - Deleted: "3e2f21a89f"
+                - Deleted: "53b4f83ac9"
+        "404":
+          description: "No such image"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: "Conflict"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "path"
+          description: "Image name or ID"
+          required: true
+          schema:
+            type: "string"
+        - name: "force"
+          in: "query"
+          description: "Remove the image even if it is being used by stopped containers or has other tags"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "noprune"
+          in: "query"
+          description: "Do not delete untagged parent images"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "platforms"
+          in: "query"
+          description: |
+            Select platform-specific content to delete.
+            Repeat the parameter to select multiple platforms.
+            Each platform is a OCI platform encoded as a JSON string.
+          schema:
+            type: "array"
+            items:
+              # Preserve the Swagger 2.0 string encoding of OCIPlatform.
+              # These are JSON strings, not query-serialized objects.
+              type: "string"
+          style: form
+          explode: true
+      tags: ["Image"]
+  /images/search:
+    get:
+      summary: "Search images"
+      description: "Search for an image on Docker Hub."
+      operationId: "ImageSearch"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json":
+              schema:
+                type: "array"
+                items:
+                  type: "object"
+                  title: "ImageSearchResponseItem"
+                  properties:
+                    description:
+                      type: "string"
+                    is_official:
+                      type: "boolean"
+                    is_automated:
+                      description: |
+                        Whether this repository has automated builds enabled.
+
+                        <p><br /></p>
+
+                        > **Deprecated**: This field is deprecated and will always be "false".
+                      type: "boolean"
+                      example: false
+                    name:
+                      type: "string"
+                    star_count:
+                      type: "integer"
+              example:
+                - description: "A minimal Docker image based on Alpine Linux with a complete package index and only 5 MB in size!"
+                  is_official: true
+                  is_automated: false
+                  name: "alpine"
+                  star_count: 10093
+                - description: "Busybox base image."
+                  is_official: true
+                  is_automated: false
+                  name: "Busybox base image."
+                  star_count: 3037
+                - description: "The PostgreSQL object-relational database system provides reliability and data integrity."
+                  is_official: true
+                  is_automated: false
+                  name: "postgres"
+                  star_count: 12408
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "term"
+          in: "query"
+          description: "Term to search"
+          required: true
+          schema:
+            type: "string"
+        - name: "limit"
+          in: "query"
+          description: "Maximum number of results to return"
+          schema:
+            type: "integer"
+        - name: "filters"
+          in: "query"
+          description: |
+            A JSON encoded value of the filters (a `map[string][]string`) to process on the images list. Available filters:
+
+            - `is-official=(true|false)`
+            - `stars=<number>` Matches images that has at least 'number' stars.
+          schema:
+            type: "string"
+      tags: ["Image"]
+  /images/prune:
+    post:
+      summary: "Delete unused images"
+      operationId: "ImagePrune"
+      parameters:
+        - name: "filters"
+          in: "query"
+          description: |
+            Filters to process on the prune list, encoded as JSON (a `map[string][]string`). Available filters:
+
+            - `dangling=<boolean>` When set to `true` (or `1`), prune only
+               unused *and* untagged images. When set to `false`
+               (or `0`), all unused images are pruned.
+            - `until=<string>` Prune images created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
+            - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune images with (or without, in case `label!=...` is used) the specified labels.
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json":
+              schema:
+                type: "object"
+                title: "ImagePruneResponse"
+                properties:
+                  ImagesDeleted:
+                    description: "Images that were deleted"
+                    type: "array"
+                    items:
+                      $ref: "#/components/schemas/ImageDeleteResponseItem"
+                  SpaceReclaimed:
+                    description: "Disk space reclaimed in bytes"
+                    type: "integer"
+                    format: "int64"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Image"]
+  /auth:
+    post:
+      summary: "Check auth configuration"
+      description: |
+        Validate credentials for a registry and, if available, get an identity
+        token for accessing the registry without password.
+      operationId: "SystemAuth"
+      responses:
+        "200":
+          description: "An identity token was generated successfully."
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/AuthResponse"
+        "204":
+          description: "No error"
+        "401":
+          description: "Auth error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["System"]
+      requestBody:
+        x-codegen-request-body-name: "authConfig"
+        description: "Authentication to check"
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/AuthConfig"
+  /info:
+    get:
+      summary: "Get system information"
+      operationId: "SystemInfo"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/SystemInfo"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["System"]
+  /version:
+    get:
+      summary: "Get version"
+      description: "Returns the version of Docker that is running and various information about the system that Docker is running on."
+      operationId: "SystemVersion"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/SystemVersion"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["System"]
+  /_ping:
+    get:
+      summary: "Ping"
+      description: "This is a dummy endpoint you can use to test if the server is accessible."
+      operationId: "SystemPing"
+      responses:
+        "200":
+          description: "no error"
+          headers:
+            Api-Version:
+              description: "Max API Version the server supports"
+              schema:
+                type: "string"
+            Builder-Version:
+              description: |
+                Default version of docker image builder
+
+                The default on Linux is version "2" (BuildKit), but the daemon
+                can be configured to recommend version "1" (classic Builder).
+                Windows does not yet support BuildKit for native Windows images,
+                and uses "1" (classic builder) as a default.
+
+                This value is a recommendation as advertised by the daemon, and
+                it is up to the client to choose which builder to use.
+              schema:
+                type: "string"
+                default: "2"
+            Docker-Experimental:
+              description: "If the server is running with experimental mode enabled"
+              schema:
+                type: "boolean"
+            Swarm:
+              description: |
+                Contains information about Swarm status of the daemon,
+                and if the daemon is acting as a manager or worker node.
+              schema:
+                type: "string"
+                enum: ["inactive", "pending", "error", "locked", "active/worker", "active/manager"]
+                default: "inactive"
+            Cache-Control:
+              schema:
+                type: "string"
+                default: "no-cache, no-store, must-revalidate"
+            Pragma:
+              schema:
+                type: "string"
+                default: "no-cache"
+          content:
+            "text/plain":
+              schema:
+                type: "string"
+                example: "OK"
+        "500":
+          description: "server error"
+          headers:
+            Cache-Control:
+              schema:
+                type: "string"
+                default: "no-cache, no-store, must-revalidate"
+            Pragma:
+              schema:
+                type: "string"
+                default: "no-cache"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["System"]
+    head:
+      summary: "Ping"
+      description: "This is a dummy endpoint you can use to test if the server is accessible."
+      operationId: "SystemPingHead"
+      responses:
+        "200":
+          description: "no error"
+          headers:
+            Api-Version:
+              description: "Max API Version the server supports"
+              schema:
+                type: "string"
+            Builder-Version:
+              description: "Default version of docker image builder"
+              schema:
+                type: "string"
+            Docker-Experimental:
+              description: "If the server is running with experimental mode enabled"
+              schema:
+                type: "boolean"
+            Swarm:
+              description: |
+                Contains information about Swarm status of the daemon,
+                and if the daemon is acting as a manager or worker node.
+              schema:
+                type: "string"
+                enum: ["inactive", "pending", "error", "locked", "active/worker", "active/manager"]
+                default: "inactive"
+            Cache-Control:
+              schema:
+                type: "string"
+                default: "no-cache, no-store, must-revalidate"
+            Pragma:
+              schema:
+                type: "string"
+                default: "no-cache"
+        "500":
+          description: "server error"
+      tags: ["System"]
+  /commit:
+    post:
+      summary: "Create a new image from a container"
+      operationId: "ImageCommit"
+      responses:
+        "201":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/IDResponse"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "container"
+          in: "query"
+          description: "The ID or name of the container to commit"
+          schema:
+            type: "string"
+        - name: "repo"
+          in: "query"
+          description: "Repository name for the created image"
+          schema:
+            type: "string"
+        - name: "tag"
+          in: "query"
+          description: "Tag name for the create image"
+          schema:
+            type: "string"
+        - name: "comment"
+          in: "query"
+          description: "Commit message"
+          schema:
+            type: "string"
+        - name: "author"
+          in: "query"
+          description: "Author of the image (e.g., `John Hannibal Smith <hannibal@a-team.com>`)"
+          schema:
+            type: "string"
+        - name: "pause"
+          in: "query"
+          description: "Whether to pause the container before committing"
+          schema:
+            type: "boolean"
+            default: true
+        - name: "changes"
+          in: "query"
+          description: "`Dockerfile` instructions to apply while committing"
+          schema:
+            type: "string"
+      tags: ["Image"]
+      requestBody:
+        x-codegen-request-body-name: "containerConfig"
+        description: "The container configuration"
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/ContainerConfig"
+  /events:
+    get:
+      summary: "Monitor events"
+      description: |
+        Stream real-time events from the server.
+
+        Various objects within Docker report events when something happens to them.
+
+        Containers report these events: `attach`, `commit`, `copy`, `create`, `destroy`, `detach`, `die`, `exec_create`, `exec_detach`, `exec_start`, `exec_die`, `export`, `health_status`, `kill`, `oom`, `pause`, `rename`, `resize`, `restart`, `start`, `stop`, `top`, `unpause`, `update`, and `prune`
+
+        Images report these events: `create`, `delete`, `import`, `load`, `pull`, `push`, `save`, `tag`, `untag`, and `prune`
+
+        Volumes report these events: `create`, `mount`, `unmount`, `destroy`, and `prune`
+
+        Networks report these events: `create`, `connect`, `disconnect`, `destroy`, `update`, `remove`, and `prune`
+
+        The Docker daemon reports these events: `reload`
+
+        Services report these events: `create`, `update`, and `remove`
+
+        Nodes report these events: `create`, `update`, and `remove`
+
+        Secrets report these events: `create`, `update`, and `remove`
+
+        Configs report these events: `create`, `update`, and `remove`
+
+        The Builder reports `prune` events
+
+      operationId: "SystemEvents"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/jsonl":
+              schema:
+                $ref: "#/components/schemas/EventMessage"
+            "application/x-ndjson":
+              schema:
+                $ref: "#/components/schemas/EventMessage"
+            "application/json-seq":
+              schema:
+                $ref: "#/components/schemas/EventMessage"
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "since"
+          in: "query"
+          description: "Show events created since this timestamp then stream new events."
+          schema:
+            type: "string"
+        - name: "until"
+          in: "query"
+          description: "Show events created until this timestamp then stop streaming."
+          schema:
+            type: "string"
+        - name: "filters"
+          in: "query"
+          description: |
+            A JSON encoded value of filters (a `map[string][]string`) to process on the event list. Available filters:
+
+            - `config=<string>` config name or ID
+            - `container=<string>` container name or ID
+            - `daemon=<string>` daemon name or ID
+            - `event=<string>` event type
+            - `image=<string>` image name or ID
+            - `label=<string>` image or container label
+            - `network=<string>` network name or ID
+            - `node=<string>` node ID
+            - `plugin`=<string> plugin name or ID
+            - `scope`=<string> local or swarm
+            - `secret=<string>` secret name or ID
+            - `service=<string>` service name or ID
+            - `type=<string>` object to filter by, one of `container`, `image`, `volume`, `network`, `daemon`, `plugin`, `node`, `service`, `secret` or `config`
+            - `volume=<string>` volume name
+          schema:
+            type: "string"
+      tags: ["System"]
+  /system/df:
+    get:
+      summary: "Get data usage information"
+      operationId: "SystemDataUsage"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                type: "object"
+                title: "SystemDataUsageResponse"
+                properties:
+                  ImageUsage:
+                    $ref: "#/components/schemas/ImagesDiskUsage"
+                  ContainerUsage:
+                    $ref: "#/components/schemas/ContainersDiskUsage"
+                  VolumeUsage:
+                    $ref: "#/components/schemas/VolumesDiskUsage"
+                  BuildCacheUsage:
+                    $ref: "#/components/schemas/BuildCacheDiskUsage"
+            "text/plain":
+              schema:
+                type: "object"
+                title: "SystemDataUsageResponse"
+                properties:
+                  ImageUsage:
+                    $ref: "#/components/schemas/ImagesDiskUsage"
+                  ContainerUsage:
+                    $ref: "#/components/schemas/ContainersDiskUsage"
+                  VolumeUsage:
+                    $ref: "#/components/schemas/VolumesDiskUsage"
+                  BuildCacheUsage:
+                    $ref: "#/components/schemas/BuildCacheDiskUsage"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "type"
+          in: "query"
+          description: |
+            Object types, for which to compute and return data.
+          schema:
+            type: "array"
+            items:
+              type: "string"
+              enum: ["container", "image", "volume", "build-cache"]
+          style: form
+          explode: true
+        - name: "verbose"
+          in: "query"
+          description: |
+            Show detailed information on space usage.
+          schema:
+            type: "boolean"
+            default: false
+      tags: ["System"]
+  /images/{name}/get:
+    get:
+      summary: "Export an image"
+      description: |
+        Get a tarball containing all images and metadata for a repository.
+
+        If `name` is a specific name and tag (e.g. `ubuntu:latest`), then only that image (and its parents) are returned. If `name` is an image ID, similarly only that image (and its parents) are returned, but with the exclusion of the `repositories` file in the tarball, as there were no image names referenced.
+
+        ### Image tarball format
+
+        An image tarball contains [Content as defined in the OCI Image Layout Specification](https://github.com/opencontainers/image-spec/blob/v1.1.1/image-layout.md#content).
+
+        Additionally, includes the manifest.json file associated with a backwards compatible docker save format.
+
+        If the tarball defines a repository, the tarball should also include a `repositories` file at the root that contains a list of repository and tag names mapped to layer IDs.
+
+        ```json
+        {
+          "hello-world": {
+            "latest": "565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"
+          }
+        }
+        ```
+      operationId: "ImageGet"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/x-tar":
+              schema:
+                type: "string"
+                format: "binary"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "path"
+          description: "Image name or ID"
+          required: true
+          schema:
+            type: "string"
+        - name: "platform"
+          in: "query"
+          description: |
+            JSON encoded OCI platform describing a platform which will be used
+            to select a platform-specific image to be saved if the image is
+            multi-platform.
+            If not provided, the full multi-platform image will be saved.
+
+            Example: `{"os": "linux", "architecture": "arm", "variant": "v5"}`
+          schema:
+            type: "array"
+            items:
+              type: "string"
+          style: form
+          explode: true
+      tags: ["Image"]
+  /images/get:
+    get:
+      summary: "Export several images"
+      description: |
+        Get a tarball containing all images and metadata for several image
+        repositories.
+
+        For each value of the `names` parameter: if it is a specific name and
+        tag (e.g. `ubuntu:latest`), then only that image (and its parents) are
+        returned; if it is an image ID, similarly only that image (and its parents)
+        are returned and there would be no names referenced in the 'repositories'
+        file for this image ID.
+
+        For details on the format, see the [export image endpoint](#operation/ImageGet).
+      operationId: "ImageGetAll"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/x-tar":
+              schema:
+                type: "string"
+                format: "binary"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "names"
+          in: "query"
+          description: "Image names to filter by. Repeat the parameter for multiple images."
+          schema:
+            type: "array"
+            items:
+              type: "string"
+          style: form
+          explode: true
+        - name: "platform"
+          in: "query"
+          description: |
+            JSON encoded OCI platform(s) which will be used to select the
+            platform-specific image(s) to be saved if the image is
+            multi-platform. If not provided, the full multi-platform image
+            will be saved.
+
+            Example: `{"os": "linux", "architecture": "arm", "variant": "v5"}`
+          schema:
+            type: "array"
+            items:
+              type: "string"
+          style: form
+          explode: true
+      tags: ["Image"]
+  /images/load:
+    post:
+      summary: "Import images"
+      description: |
+        Load a set of images and tags into a repository.
+
+        For details on the format, see the [export image endpoint](#operation/ImageGet).
+      operationId: "ImageLoad"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json": {}
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "quiet"
+          in: "query"
+          description: "Suppress progress details during load."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "platform"
+          in: "query"
+          description: |
+            JSON encoded OCI platform(s) which will be used to select the
+            platform-specific image(s) to load if the image is
+            multi-platform. If not provided, the full multi-platform image
+            will be loaded.
+
+            Example: `{"os": "linux", "architecture": "arm", "variant": "v5"}`
+          schema:
+            type: "array"
+            items:
+              type: "string"
+          style: form
+          explode: true
+      tags: ["Image"]
+      requestBody:
+        x-codegen-request-body-name: "imagesTarball"
+        description: "Tar archive containing images"
+        content:
+          "application/x-tar":
+            schema:
+              type: "string"
+              format: "binary"
+  /containers/{id}/exec:
+    post:
+      summary: "Create an exec instance"
+      description: "Run a command inside a running container."
+      operationId: "ContainerExec"
+      responses:
+        "201":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/IDResponse"
+        "404":
+          description: "no such container"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such container: c2ada9df5af8"
+        "409":
+          description: "container is paused"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "ID or name of container"
+          required: true
+          schema:
+            type: "string"
+      tags: ["Exec"]
+      requestBody:
+        x-codegen-request-body-name: "execConfig"
+        description: "Exec configuration"
+        content:
+          "application/json":
+            schema:
+              type: "object"
+              title: "ExecConfig"
+              properties:
+                AttachStdin:
+                  type: "boolean"
+                  description: "Attach to `stdin` of the exec command."
+                AttachStdout:
+                  type: "boolean"
+                  description: "Attach to `stdout` of the exec command."
+                AttachStderr:
+                  type: "boolean"
+                  description: "Attach to `stderr` of the exec command."
+                ConsoleSize:
+                  type: "array"
+                  description: "Initial console size, as an `[height, width]` array."
+                  x-nullable: true
+                  minItems: 2
+                  maxItems: 2
+                  items:
+                    type: "integer"
+                    minimum: 0
+                  example: [80, 64]
+                DetachKeys:
+                  type: "string"
+                  description: |
+                    Override the key sequence for detaching a container. Format is
+                    a single character `[a-Z]` or `ctrl-<value>` where `<value>`
+                    is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
+                Tty:
+                  type: "boolean"
+                  description: "Allocate a pseudo-TTY."
+                Env:
+                  description: |
+                    A list of environment variables in the form `["VAR=value", ...]`.
+                  type: "array"
+                  items:
+                    type: "string"
+                Cmd:
+                  type: "array"
+                  description: "Command to run, as a string or array of strings."
+                  items:
+                    type: "string"
+                Privileged:
+                  type: "boolean"
+                  description: "Runs the exec process with extended privileges."
+                  default: false
+                User:
+                  type: "string"
+                  description: |
+                    The user, and optionally, group to run the exec process inside
+                    the container. Format is one of: `user`, `user:group`, `uid`,
+                    or `uid:gid`.
+                WorkingDir:
+                  type: "string"
+                  description: |
+                    The working directory for the exec process inside the container.
+              example:
+                AttachStdin: false
+                AttachStdout: true
+                AttachStderr: true
+                DetachKeys: "ctrl-p,ctrl-q"
+                Tty: false
+                Cmd:
+                  - "date"
+                Env:
+                  - "FOO=bar"
+                  - "BAZ=quux"
+        required: true
+  /exec/{id}/start:
+    post:
+      summary: "Start an exec instance"
+      description: |
+        Starts a previously set up exec instance. If detach is true, this endpoint
+        returns immediately after starting the command. Otherwise, it sets up an
+        interactive session with the command.
+      operationId: "ExecStart"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/vnd.docker.raw-stream": {}
+            "application/vnd.docker.multiplexed-stream": {}
+        "404":
+          description: "No such exec instance"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: "Container is stopped or paused"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "Exec instance ID"
+          required: true
+          schema:
+            type: "string"
+      tags: ["Exec"]
+      requestBody:
+        x-codegen-request-body-name: "execStartConfig"
+        content:
+          "application/json":
+            schema:
+              type: "object"
+              title: "ExecStartConfig"
+              properties:
+                Detach:
+                  type: "boolean"
+                  description: "Detach from the command."
+                  example: false
+                Tty:
+                  type: "boolean"
+                  description: "Allocate a pseudo-TTY."
+                  example: true
+                ConsoleSize:
+                  type: "array"
+                  description: "Initial console size, as an `[height, width]` array."
+                  x-nullable: true
+                  minItems: 2
+                  maxItems: 2
+                  items:
+                    type: "integer"
+                    minimum: 0
+                  example: [80, 64]
+  /exec/{id}/resize:
+    post:
+      summary: "Resize an exec instance"
+      description: |
+        Resize the TTY session used by an exec instance. This endpoint only works
+        if `tty` was specified as part of creating and starting the exec instance.
+      operationId: "ExecResize"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "No such exec instance"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "Exec instance ID"
+          required: true
+          schema:
+            type: "string"
+        - name: "h"
+          in: "query"
+          required: true
+          description: "Height of the TTY session in characters"
+          schema:
+            type: "integer"
+        - name: "w"
+          in: "query"
+          required: true
+          description: "Width of the TTY session in characters"
+          schema:
+            type: "integer"
+      tags: ["Exec"]
+  /exec/{id}/json:
+    get:
+      summary: "Inspect an exec instance"
+      description: "Return low-level information about an exec instance."
+      operationId: "ExecInspect"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json":
+              schema:
+                type: "object"
+                title: "ExecInspectResponse"
+                properties:
+                  CanRemove:
+                    type: "boolean"
+                  DetachKeys:
+                    type: "string"
+                  ID:
+                    type: "string"
+                  Running:
+                    type: "boolean"
+                  ExitCode:
+                    type: "integer"
+                  ProcessConfig:
+                    $ref: "#/components/schemas/ProcessConfig"
+                  OpenStdin:
+                    type: "boolean"
+                  OpenStderr:
+                    type: "boolean"
+                  OpenStdout:
+                    type: "boolean"
+                  ContainerID:
+                    type: "string"
+                  Pid:
+                    type: "integer"
+                    description: "The system process ID for the exec process."
+              example:
+                CanRemove: false
+                ContainerID: "b53ee82b53a40c7dca428523e34f741f3abc51d9f297a14ff874bf761b995126"
+                DetachKeys: ""
+                ExitCode: 2
+                ID: "f33bbfb39f5b142420f4759b2348913bd4a8d1a6d7fd56499cb41a1bb91d7b3b"
+                OpenStderr: true
+                OpenStdin: true
+                OpenStdout: true
+                ProcessConfig:
+                  arguments:
+                    - "-c"
+                    - "exit 2"
+                  entrypoint: "sh"
+                  privileged: false
+                  tty: true
+                  user: "1000"
+                Running: false
+                Pid: 42000
+        "404":
+          description: "No such exec instance"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "Exec instance ID"
+          required: true
+          schema:
+            type: "string"
+      tags: ["Exec"]
+
+  /volumes:
+    get:
+      summary: "List volumes"
+      operationId: "VolumeList"
+      responses:
+        "200":
+          description: "Summary volume data that matches the query"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/VolumeListResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "filters"
+          in: "query"
+          description: |
+            JSON encoded value of the filters (a `map[string][]string`) to
+            process on the volumes list. Available filters:
+
+            - `dangling=<boolean>` When set to `true` (or `1`), returns all
+               volumes that are not in use by a container. When set to `false`
+               (or `0`), only volumes that are in use by one or more
+               containers are returned.
+            - `driver=<volume-driver-name>` Matches volumes based on their driver.
+            - `label=<key>` or `label=<key>:<value>` Matches volumes based on
+               the presence of a `label` alone or a `label` and a value.
+            - `name=<volume-name>` Matches all or part of a volume name.
+          schema:
+            type: "string"
+            format: "json"
+      tags: ["Volume"]
+
+  /volumes/create:
+    post:
+      summary: "Create a volume"
+      operationId: "VolumeCreate"
+      responses:
+        "201":
+          description: "The volume was created successfully"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/Volume"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Volume"]
+      requestBody:
+        x-codegen-request-body-name: "volumeConfig"
+        required: true
+        description: "Volume configuration"
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/VolumeCreateRequest"
+
+  /volumes/{name}:
+    get:
+      summary: "Inspect a volume"
+      operationId: "VolumeInspect"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/Volume"
+        "404":
+          description: "No such volume"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "path"
+          required: true
+          description: "Volume name or ID"
+          schema:
+            type: "string"
+      tags: ["Volume"]
+
+    put:
+      summary: |
+        "Update a volume. Valid only for Swarm cluster volumes"
+      operationId: "VolumeUpdate"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json": {}
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "no such volume"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "path"
+          description: "The name or ID of the volume"
+          required: true
+          schema:
+            type: "string"
+        - name: "version"
+          in: "query"
+          description: |
+            The version number of the volume being updated. This is required to
+            avoid conflicting writes. Found in the volume's `ClusterVolume`
+            field.
+          required: true
+          schema:
+            type: "integer"
+            format: "int64"
+      tags: ["Volume"]
+      requestBody:
+        x-codegen-request-body-name: "body"
+        content:
+          "application/json":
+            schema:
+              # though the schema for is an object that contains only a
+              # ClusterVolumeSpec, wrapping the ClusterVolumeSpec in this object
+              # means that if, later on, we support things like changing the
+              # labels, we can do so without duplicating that information to the
+              # ClusterVolumeSpec.
+              type: "object"
+              description: "Volume configuration"
+              properties:
+                Spec:
+                  $ref: "#/components/schemas/ClusterVolumeSpec"
+        description: |
+          The spec of the volume to update. Currently, only Availability may
+          change. All other fields must remain unchanged.
+
+    delete:
+      summary: "Remove a volume"
+      description: "Instruct the driver to remove the volume."
+      operationId: "VolumeDelete"
+      responses:
+        "204":
+          description: "The volume was removed"
+        "404":
+          description: "No such volume or volume driver"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: "Volume is in use and cannot be removed"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "path"
+          required: true
+          description: "Volume name or ID"
+          schema:
+            type: "string"
+        - name: "force"
+          in: "query"
+          description: "Force the removal of the volume"
+          schema:
+            type: "boolean"
+            default: false
+      tags: ["Volume"]
+
+  /volumes/prune:
+    post:
+      summary: "Delete unused volumes"
+      operationId: "VolumePrune"
+      parameters:
+        - name: "filters"
+          in: "query"
+          description: |
+            Filters to process on the prune list, encoded as JSON (a `map[string][]string`).
+
+            Available filters:
+            - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune volumes with (or without, in case `label!=...` is used) the specified labels.
+            - `all` (`all=true`) - Consider all (local) volumes for pruning and not just anonymous volumes.
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json":
+              schema:
+                type: "object"
+                title: "VolumePruneResponse"
+                properties:
+                  VolumesDeleted:
+                    description: "Volumes that were deleted"
+                    type: "array"
+                    items:
+                      type: "string"
+                  SpaceReclaimed:
+                    description: "Disk space reclaimed in bytes"
+                    type: "integer"
+                    format: "int64"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Volume"]
+  /networks:
+    get:
+      summary: "List networks"
+      description: |
+        Returns a list of networks. For details on the format, see the
+        [network inspect endpoint](#operation/NetworkInspect).
+
+        Note that it uses a different, smaller representation of a network than
+        inspecting a single network. For example, the list of containers attached
+        to the network is not propagated in API versions 1.28 and up.
+      operationId: "NetworkList"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json":
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/NetworkSummary"
+              example:
+                - Name: "bridge"
+                  Id: "f2de39df4171b0dc801e8002d1d999b77256983dfc63041c0f34030aa3977566"
+                  Created: "2016-10-19T06:21:00.416543526Z"
+                  Scope: "local"
+                  Driver: "bridge"
+                  EnableIPv4: true
+                  EnableIPv6: false
+                  Internal: false
+                  Attachable: false
+                  Ingress: false
+                  IPAM:
+                    Driver: "default"
+                    Config:
+                      - Subnet: "172.17.0.0/16"
+                  Options:
+                    com.docker.network.bridge.default_bridge: "true"
+                    com.docker.network.bridge.enable_icc: "true"
+                    com.docker.network.bridge.enable_ip_masquerade: "true"
+                    com.docker.network.bridge.host_binding_ipv4: "0.0.0.0"
+                    com.docker.network.bridge.name: "docker0"
+                    com.docker.network.driver.mtu: "1500"
+                - Name: "none"
+                  Id: "e086a3893b05ab69242d3c44e49483a3bbbd3a26b46baa8f61ab797c1088d794"
+                  Created: "0001-01-01T00:00:00Z"
+                  Scope: "local"
+                  Driver: "null"
+                  EnableIPv4: false
+                  EnableIPv6: false
+                  Internal: false
+                  Attachable: false
+                  Ingress: false
+                  IPAM:
+                    Driver: "default"
+                    Config: []
+                  Containers: {}
+                  Options: {}
+                - Name: "host"
+                  Id: "13e871235c677f196c4e1ecebb9dc733b9b2d2ab589e30c539efeda84a24215e"
+                  Created: "0001-01-01T00:00:00Z"
+                  Scope: "local"
+                  Driver: "host"
+                  EnableIPv4: false
+                  EnableIPv6: false
+                  Internal: false
+                  Attachable: false
+                  Ingress: false
+                  IPAM:
+                    Driver: "default"
+                    Config: []
+                  Containers: {}
+                  Options: {}
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "filters"
+          in: "query"
+          description: |
+            JSON encoded value of the filters (a `map[string][]string`) to process
+            on the networks list.
+
+            Available filters:
+
+            - `dangling=<boolean>` When set to `true` (or `1`), returns all
+               networks that are not in use by a container. When set to `false`
+               (or `0`), only networks that are in use by one or more
+               containers are returned.
+            - `driver=<driver-name>` Matches a network's driver.
+            - `id=<network-id>` Matches all or part of a network ID.
+            - `label=<key>` or `label=<key>=<value>` of a network label.
+            - `name=<network-name>` Matches all or part of a network name.
+            - `scope=["swarm"|"global"|"local"]` Filters networks by scope (`swarm`, `global`, or `local`).
+            - `type=["custom"|"builtin"]` Filters networks by type. The `custom` keyword returns all user-defined networks.
+          schema:
+            type: "string"
+      tags: ["Network"]
+
+  /networks/{id}:
+    get:
+      summary: "Inspect a network"
+      operationId: "NetworkInspect"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/NetworkInspect"
+        "404":
+          description: "Network not found"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "Network ID or name"
+          required: true
+          schema:
+            type: "string"
+        - name: "verbose"
+          in: "query"
+          description: "Detailed inspect output for troubleshooting"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "scope"
+          in: "query"
+          description: "Filter the network by scope (swarm, global, or local)"
+          schema:
+            type: "string"
+      tags: ["Network"]
+
+    delete:
+      summary: "Remove a network"
+      operationId: "NetworkDelete"
+      responses:
+        "204":
+          description: "No error"
+        "403":
+          description: "operation not supported for pre-defined networks"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "no such network"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "Network ID or name"
+          required: true
+          schema:
+            type: "string"
+      tags: ["Network"]
+
+  /networks/create:
+    post:
+      summary: "Create a network"
+      operationId: "NetworkCreate"
+      responses:
+        "201":
+          description: "Network created successfully"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/NetworkCreateResponse"
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: |
+            Forbidden operation. This happens when trying to create a network named after a pre-defined network,
+            or when trying to create an overlay network on a daemon which is not part of a Swarm cluster.
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "plugin not found"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Network"]
+      requestBody:
+        x-codegen-request-body-name: "networkConfig"
+        description: "Network configuration"
+        required: true
+        content:
+          "application/json":
+            schema:
+              type: "object"
+              title: "NetworkCreateRequest"
+              required: ["Name"]
+              properties:
+                Name:
+                  description: "The network's name."
+                  type: "string"
+                  example: "my_network"
+                Driver:
+                  description: "Name of the network driver plugin to use."
+                  type: "string"
+                  default: "bridge"
+                  example: "bridge"
+                Scope:
+                  description: |
+                    The level at which the network exists (e.g. `swarm` for cluster-wide
+                    or `local` for machine level).
+                  type: "string"
+                Internal:
+                  description: "Restrict external access to the network."
+                  type: "boolean"
+                Attachable:
+                  description: |
+                    Globally scoped network is manually attachable by regular
+                    containers from workers in swarm mode.
+                  type: "boolean"
+                  example: true
+                Ingress:
+                  description: |
+                    Ingress network is the network which provides the routing-mesh
+                    in swarm mode.
+                  type: "boolean"
+                  example: false
+                ConfigOnly:
+                  description: |
+                    Creates a config-only network. Config-only networks are placeholder
+                    networks for network configurations to be used by other networks.
+                    Config-only networks cannot be used directly to run containers
+                    or services.
+                  type: "boolean"
+                  default: false
+                  example: false
+                ConfigFrom:
+                  description: |
+                    Specifies the source which will provide the configuration for
+                    this network. The specified network must be an existing
+                    config-only network; see ConfigOnly.
+                  $ref: "#/components/schemas/ConfigReference"
+                IPAM:
+                  description: "Optional custom IP scheme for the network."
+                  $ref: "#/components/schemas/IPAM"
+                EnableIPv4:
+                  description: "Enable IPv4 on the network."
+                  type: "boolean"
+                  example: true
+                EnableIPv6:
+                  description: "Enable IPv6 on the network."
+                  type: "boolean"
+                  example: true
+                Options:
+                  description: "Network specific options to be used by the drivers."
+                  type: "object"
+                  additionalProperties:
+                    type: "string"
+                  example:
+                    com.docker.network.bridge.default_bridge: "true"
+                    com.docker.network.bridge.enable_icc: "true"
+                    com.docker.network.bridge.enable_ip_masquerade: "true"
+                    com.docker.network.bridge.host_binding_ipv4: "0.0.0.0"
+                    com.docker.network.bridge.name: "docker0"
+                    com.docker.network.driver.mtu: "1500"
+                Labels:
+                  description: "User-defined key/value metadata."
+                  type: "object"
+                  additionalProperties:
+                    type: "string"
+                  example:
+                    com.example.some-label: "some-value"
+                    com.example.some-other-label: "some-other-value"
+
+  /networks/{id}/connect:
+    post:
+      summary: "Connect a container to a network"
+      description: "The network must be either a local-scoped network or a swarm-scoped network with the `attachable` option set. A network cannot be re-attached to a running container"
+      operationId: "NetworkConnect"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: "Operation forbidden"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Network or container not found"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "Network ID or name"
+          required: true
+          schema:
+            type: "string"
+      tags: ["Network"]
+      requestBody:
+        x-codegen-request-body-name: "container"
+        required: true
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/NetworkConnectRequest"
+
+  /networks/{id}/disconnect:
+    post:
+      summary: "Disconnect a container from a network"
+      operationId: "NetworkDisconnect"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "403":
+          description: "Operation not supported for swarm scoped networks"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Network or container not found"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "Network ID or name"
+          required: true
+          schema:
+            type: "string"
+      tags: ["Network"]
+      requestBody:
+        x-codegen-request-body-name: "container"
+        required: true
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/NetworkDisconnectRequest"
+  /networks/prune:
+    post:
+      summary: "Delete unused networks"
+      operationId: "NetworkPrune"
+      parameters:
+        - name: "filters"
+          in: "query"
+          description: |
+            Filters to process on the prune list, encoded as JSON (a `map[string][]string`).
+
+            Available filters:
+            - `until=<timestamp>` Prune networks created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
+            - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune networks with (or without, in case `label!=...` is used) the specified labels.
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json":
+              schema:
+                type: "object"
+                title: "NetworkPruneResponse"
+                properties:
+                  NetworksDeleted:
+                    description: "Networks that were deleted"
+                    type: "array"
+                    items:
+                      type: "string"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Network"]
+  /plugins:
+    get:
+      summary: "List plugins"
+      operationId: "PluginList"
+      description: "Returns information about installed plugins."
+      responses:
+        "200":
+          description: "No error"
+          content:
+            "application/json":
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Plugin"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "filters"
+          in: "query"
+          description: |
+            A JSON encoded value of the filters (a `map[string][]string`) to
+            process on the plugin list.
+
+            Available filters:
+
+            - `capability=<capability name>`
+            - `enable=<true>|<false>`
+          schema:
+            type: "string"
+      tags: ["Plugin"]
+
+  /plugins/privileges:
+    get:
+      summary: "Get plugin privileges"
+      operationId: "GetPluginPrivileges"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/PluginPrivilege"
+                example:
+                  - Name: "network"
+                    Description: ""
+                    Value:
+                      - "host"
+                  - Name: "mount"
+                    Description: ""
+                    Value:
+                      - "/data"
+                  - Name: "device"
+                    Description: ""
+                    Value:
+                      - "/dev/cpu_dma_latency"
+            "text/plain":
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/PluginPrivilege"
+                example:
+                  - Name: "network"
+                    Description: ""
+                    Value:
+                      - "host"
+                  - Name: "mount"
+                    Description: ""
+                    Value:
+                      - "/data"
+                  - Name: "device"
+                    Description: ""
+                    Value:
+                      - "/dev/cpu_dma_latency"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "remote"
+          in: "query"
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
+          required: true
+          schema:
+            type: "string"
+      tags:
+        - "Plugin"
+
+  /plugins/pull:
+    post:
+      summary: "Install a plugin"
+      operationId: "PluginPull"
+      description: |
+        Pulls and installs a plugin. After the plugin is installed, it can be
+        enabled using the [`POST /plugins/{name}/enable` endpoint](#operation/PostPluginsEnable).
+      responses:
+        "204":
+          description: "no error"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "remote"
+          in: "query"
+          description: |
+            Remote reference for plugin to install.
+
+            The `:latest` tag is optional, and is used as the default if omitted.
+          required: true
+          schema:
+            type: "string"
+        - name: "name"
+          in: "query"
+          description: |
+            Local name for the pulled plugin.
+
+            The `:latest` tag is optional, and is used as the default if omitted.
+          required: false
+          schema:
+            type: "string"
+        - name: "X-Registry-Auth"
+          in: "header"
+          description: |
+            A base64url-encoded auth configuration to use when pulling a plugin
+            from a registry.
+
+            Refer to the [authentication section](#section/Authentication) for
+            details.
+          schema:
+            type: "string"
+      tags: ["Plugin"]
+      requestBody:
+        x-codegen-request-body-name: "body"
+        content:
+          "application/json":
+            schema:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/PluginPrivilege"
+              example:
+                - Name: "network"
+                  Description: ""
+                  Value:
+                    - "host"
+                - Name: "mount"
+                  Description: ""
+                  Value:
+                    - "/data"
+                - Name: "device"
+                  Description: ""
+                  Value:
+                    - "/dev/cpu_dma_latency"
+          "text/plain":
+            schema:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/PluginPrivilege"
+              example:
+                - Name: "network"
+                  Description: ""
+                  Value:
+                    - "host"
+                - Name: "mount"
+                  Description: ""
+                  Value:
+                    - "/data"
+                - Name: "device"
+                  Description: ""
+                  Value:
+                    - "/dev/cpu_dma_latency"
+  /plugins/{name}/json:
+    get:
+      summary: "Inspect a plugin"
+      operationId: "PluginInspect"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/Plugin"
+            "text/plain":
+              schema:
+                $ref: "#/components/schemas/Plugin"
+        "404":
+          description: "plugin is not installed"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "path"
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
+          required: true
+          schema:
+            type: "string"
+      tags: ["Plugin"]
+  /plugins/{name}:
+    delete:
+      summary: "Remove a plugin"
+      operationId: "PluginDelete"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/Plugin"
+            "text/plain":
+              schema:
+                $ref: "#/components/schemas/Plugin"
+        "404":
+          description: "plugin is not installed"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "path"
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
+          required: true
+          schema:
+            type: "string"
+        - name: "force"
+          in: "query"
+          description: |
+            Disable the plugin before removing. This may result in issues if the
+            plugin is in use by a container.
+          schema:
+            type: "boolean"
+            default: false
+      tags: ["Plugin"]
+  /plugins/{name}/enable:
+    post:
+      summary: "Enable a plugin"
+      operationId: "PluginEnable"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "404":
+          description: "plugin is not installed"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "path"
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
+          required: true
+          schema:
+            type: "string"
+        - name: "timeout"
+          in: "query"
+          description: "Set the HTTP client timeout (in seconds)"
+          schema:
+            type: "integer"
+            default: 0
+      tags: ["Plugin"]
+  /plugins/{name}/disable:
+    post:
+      summary: "Disable a plugin"
+      operationId: "PluginDisable"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "404":
+          description: "plugin is not installed"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "path"
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
+          required: true
+          schema:
+            type: "string"
+        - name: "force"
+          in: "query"
+          description: |
+            Force disable a plugin even if still in use.
+          required: false
+          schema:
+            type: "boolean"
+      tags: ["Plugin"]
+  /plugins/{name}/upgrade:
+    post:
+      summary: "Upgrade a plugin"
+      operationId: "PluginUpgrade"
+      responses:
+        "204":
+          description: "no error"
+        "404":
+          description: "plugin not installed"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "path"
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
+          required: true
+          schema:
+            type: "string"
+        - name: "remote"
+          in: "query"
+          description: |
+            Remote reference to upgrade to.
+
+            The `:latest` tag is optional, and is used as the default if omitted.
+          required: true
+          schema:
+            type: "string"
+        - name: "X-Registry-Auth"
+          in: "header"
+          description: |
+            A base64url-encoded auth configuration to use when pulling a plugin
+            from a registry.
+
+            Refer to the [authentication section](#section/Authentication) for
+            details.
+          schema:
+            type: "string"
+      tags: ["Plugin"]
+      requestBody:
+        x-codegen-request-body-name: "body"
+        content:
+          "application/json":
+            schema:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/PluginPrivilege"
+              example:
+                - Name: "network"
+                  Description: ""
+                  Value:
+                    - "host"
+                - Name: "mount"
+                  Description: ""
+                  Value:
+                    - "/data"
+                - Name: "device"
+                  Description: ""
+                  Value:
+                    - "/dev/cpu_dma_latency"
+          "text/plain":
+            schema:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/PluginPrivilege"
+              example:
+                - Name: "network"
+                  Description: ""
+                  Value:
+                    - "host"
+                - Name: "mount"
+                  Description: ""
+                  Value:
+                    - "/data"
+                - Name: "device"
+                  Description: ""
+                  Value:
+                    - "/dev/cpu_dma_latency"
+  /plugins/create:
+    post:
+      summary: "Create a plugin"
+      operationId: "PluginCreate"
+      responses:
+        "204":
+          description: "no error"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "query"
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
+          required: true
+          schema:
+            type: "string"
+      tags: ["Plugin"]
+      requestBody:
+        x-codegen-request-body-name: "tarContext"
+        description: "Path to tar containing plugin rootfs and manifest"
+        content:
+          "application/x-tar":
+            schema:
+              type: "string"
+              format: "binary"
+  /plugins/{name}/push:
+    post:
+      summary: "Push a plugin"
+      operationId: "PluginPush"
+      description: |
+        Push a plugin to the registry.
+      parameters:
+        - name: "name"
+          in: "path"
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "404":
+          description: "plugin not installed"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Plugin"]
+  /plugins/{name}/set:
+    post:
+      summary: "Configure a plugin"
+      operationId: "PluginSet"
+      parameters:
+        - name: "name"
+          in: "path"
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "204":
+          description: "No error"
+        "404":
+          description: "Plugin not installed"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Plugin"]
+      requestBody:
+        x-codegen-request-body-name: "body"
+        content:
+          "application/json":
+            schema:
+              type: "array"
+              items:
+                type: "string"
+              example: ["DEBUG=1"]
+  /nodes:
+    get:
+      summary: "List nodes"
+      operationId: "NodeList"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Node"
+            "text/plain":
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Node"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "filters"
+          in: "query"
+          description: |
+            Filters to process on the nodes list, encoded as JSON (a `map[string][]string`).
+
+            Available filters:
+            - `id=<node id>`
+            - `label=<engine label>`
+            - `membership=`(`accepted`|`pending`)`
+            - `name=<node name>`
+            - `node.label=<node label>`
+            - `role=`(`manager`|`worker`)`
+          schema:
+            type: "string"
+      tags: ["Node"]
+  /nodes/{id}:
+    get:
+      summary: "Inspect a node"
+      operationId: "NodeInspect"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/Node"
+            "text/plain":
+              schema:
+                $ref: "#/components/schemas/Node"
+        "404":
+          description: "no such node"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "The ID or name of the node"
+          required: true
+          schema:
+            type: "string"
+      tags: ["Node"]
+    delete:
+      summary: "Delete a node"
+      operationId: "NodeDelete"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "404":
+          description: "no such node"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "The ID or name of the node"
+          required: true
+          schema:
+            type: "string"
+        - name: "force"
+          in: "query"
+          description: "Force remove a node from the swarm"
+          schema:
+            default: false
+            type: "boolean"
+      tags: ["Node"]
+  /nodes/{id}/update:
+    post:
+      summary: "Update a node"
+      operationId: "NodeUpdate"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "no such node"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "The ID of the node"
+          required: true
+          schema:
+            type: "string"
+        - name: "version"
+          in: "query"
+          description: |
+            The version number of the node object being updated. This is required
+            to avoid conflicting writes.
+          required: true
+          schema:
+            type: "integer"
+            format: "int64"
+      tags: ["Node"]
+      requestBody:
+        x-codegen-request-body-name: "body"
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/NodeSpec"
+          "text/plain":
+            schema:
+              $ref: "#/components/schemas/NodeSpec"
+  /swarm:
+    get:
+      summary: "Inspect swarm"
+      operationId: "SwarmInspect"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/Swarm"
+            "text/plain":
+              schema:
+                $ref: "#/components/schemas/Swarm"
+        "404":
+          description: "no such swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Swarm"]
+  /swarm/init:
+    post:
+      summary: "Initialize a new swarm"
+      operationId: "SwarmInit"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                description: "The node ID"
+                type: "string"
+                example: "7v2t30z9blmxuhnyo6s4cpenp"
+            "text/plain":
+              schema:
+                description: "The node ID"
+                type: "string"
+                example: "7v2t30z9blmxuhnyo6s4cpenp"
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is already part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Swarm"]
+      requestBody:
+        x-codegen-request-body-name: "body"
+        required: true
+        content:
+          "application/json":
+            schema:
+              type: "object"
+              title: "SwarmInitRequest"
+              properties:
+                ListenAddr:
+                  description: |
+                    Listen address used for inter-manager communication, as well
+                    as determining the networking interface used for the VXLAN
+                    Tunnel Endpoint (VTEP). This can either be an address/port
+                    combination in the form `192.168.1.1:4567`, or an interface
+                    followed by a port number, like `eth0:4567`. If the port number
+                    is omitted, the default swarm listening port is used.
+                  type: "string"
+                AdvertiseAddr:
+                  description: |
+                    Externally reachable address advertised to other nodes. This
+                    can either be an address/port combination in the form
+                    `192.168.1.1:4567`, or an interface followed by a port number,
+                    like `eth0:4567`. If the port number is omitted, the port
+                    number from the listen address is used. If `AdvertiseAddr` is
+                    not specified, it will be automatically detected when possible.
+                  type: "string"
+                DataPathAddr:
+                  description: |
+                    Address or interface to use for data path traffic (format:
+                    `<ip|interface>`), for example,  `192.168.1.1`, or an interface,
+                    like `eth0`. If `DataPathAddr` is unspecified, the same address
+                    as `AdvertiseAddr` is used.
+
+                    The `DataPathAddr` specifies the address that global scope
+                    network drivers will publish towards other  nodes in order to
+                    reach the containers running on this node. Using this parameter
+                    it is possible to separate the container data traffic from the
+                    management traffic of the cluster.
+                  type: "string"
+                DataPathPort:
+                  description: |
+                    DataPathPort specifies the data path port number for data traffic.
+                    Acceptable port range is 1024 to 49151.
+                    if no port is set or is set to 0, default port 4789 will be used.
+                  type: "integer"
+                  format: "uint32"
+                DefaultAddrPool:
+                  description: |
+                    Default Address Pool specifies default subnet pools for global
+                    scope networks.
+                  type: "array"
+                  items:
+                    type: "string"
+                    example: ["10.10.0.0/16", "20.20.0.0/16"]
+                ForceNewCluster:
+                  description: "Force creation of a new swarm."
+                  type: "boolean"
+                SubnetSize:
+                  description: |
+                    SubnetSize specifies the subnet size of the networks created
+                    from the default subnet pool.
+                  type: "integer"
+                  format: "uint32"
+                Spec:
+                  $ref: "#/components/schemas/SwarmSpec"
+              example:
+                ListenAddr: "0.0.0.0:2377"
+                AdvertiseAddr: "192.168.1.1:2377"
+                DataPathPort: 4789
+                DefaultAddrPool: ["10.10.0.0/8", "20.20.0.0/8"]
+                SubnetSize: 24
+                ForceNewCluster: false
+                Spec:
+                  Orchestration: {}
+                  Raft: {}
+                  Dispatcher: {}
+                  CAConfig: {}
+                  EncryptionConfig:
+                    AutoLockManagers: false
+          "text/plain":
+            schema:
+              type: "object"
+              title: "SwarmInitRequest"
+              properties:
+                ListenAddr:
+                  description: |
+                    Listen address used for inter-manager communication, as well
+                    as determining the networking interface used for the VXLAN
+                    Tunnel Endpoint (VTEP). This can either be an address/port
+                    combination in the form `192.168.1.1:4567`, or an interface
+                    followed by a port number, like `eth0:4567`. If the port number
+                    is omitted, the default swarm listening port is used.
+                  type: "string"
+                AdvertiseAddr:
+                  description: |
+                    Externally reachable address advertised to other nodes. This
+                    can either be an address/port combination in the form
+                    `192.168.1.1:4567`, or an interface followed by a port number,
+                    like `eth0:4567`. If the port number is omitted, the port
+                    number from the listen address is used. If `AdvertiseAddr` is
+                    not specified, it will be automatically detected when possible.
+                  type: "string"
+                DataPathAddr:
+                  description: |
+                    Address or interface to use for data path traffic (format:
+                    `<ip|interface>`), for example,  `192.168.1.1`, or an interface,
+                    like `eth0`. If `DataPathAddr` is unspecified, the same address
+                    as `AdvertiseAddr` is used.
+
+                    The `DataPathAddr` specifies the address that global scope
+                    network drivers will publish towards other  nodes in order to
+                    reach the containers running on this node. Using this parameter
+                    it is possible to separate the container data traffic from the
+                    management traffic of the cluster.
+                  type: "string"
+                DataPathPort:
+                  description: |
+                    DataPathPort specifies the data path port number for data traffic.
+                    Acceptable port range is 1024 to 49151.
+                    if no port is set or is set to 0, default port 4789 will be used.
+                  type: "integer"
+                  format: "uint32"
+                DefaultAddrPool:
+                  description: |
+                    Default Address Pool specifies default subnet pools for global
+                    scope networks.
+                  type: "array"
+                  items:
+                    type: "string"
+                    example: ["10.10.0.0/16", "20.20.0.0/16"]
+                ForceNewCluster:
+                  description: "Force creation of a new swarm."
+                  type: "boolean"
+                SubnetSize:
+                  description: |
+                    SubnetSize specifies the subnet size of the networks created
+                    from the default subnet pool.
+                  type: "integer"
+                  format: "uint32"
+                Spec:
+                  $ref: "#/components/schemas/SwarmSpec"
+              example:
+                ListenAddr: "0.0.0.0:2377"
+                AdvertiseAddr: "192.168.1.1:2377"
+                DataPathPort: 4789
+                DefaultAddrPool: ["10.10.0.0/8", "20.20.0.0/8"]
+                SubnetSize: 24
+                ForceNewCluster: false
+                Spec:
+                  Orchestration: {}
+                  Raft: {}
+                  Dispatcher: {}
+                  CAConfig: {}
+                  EncryptionConfig:
+                    AutoLockManagers: false
+  /swarm/join:
+    post:
+      summary: "Join an existing swarm"
+      operationId: "SwarmJoin"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is already part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Swarm"]
+      requestBody:
+        x-codegen-request-body-name: "body"
+        required: true
+        content:
+          "application/json":
+            schema:
+              type: "object"
+              title: "SwarmJoinRequest"
+              properties:
+                ListenAddr:
+                  description: |
+                    Listen address used for inter-manager communication if the node
+                    gets promoted to manager, as well as determining the networking
+                    interface used for the VXLAN Tunnel Endpoint (VTEP). This is
+                    required for joining a swarm. If the port number is omitted,
+                    the default swarm listening port is used.
+                  type: "string"
+                AdvertiseAddr:
+                  description: |
+                    Externally reachable address advertised to other nodes. This
+                    can either be an address/port combination in the form
+                    `192.168.1.1:4567`, or an interface followed by a port number,
+                    like `eth0:4567`. If the port number is omitted, the port
+                    number from the listen address is used. If `AdvertiseAddr` is
+                    not specified, it will be automatically detected when possible.
+                  type: "string"
+                DataPathAddr:
+                  description: |
+                    Address or interface to use for data path traffic (format:
+                    `<ip|interface>`), for example,  `192.168.1.1`, or an interface,
+                    like `eth0`. If `DataPathAddr` is unspecified, the same address
+                    as `AdvertiseAddr` is used.
+
+                    The `DataPathAddr` specifies the address that global scope
+                    network drivers will publish towards other nodes in order to
+                    reach the containers running on this node. Using this parameter
+                    it is possible to separate the container data traffic from the
+                    management traffic of the cluster.
+
+                  type: "string"
+                RemoteAddrs:
+                  description: |
+                    Addresses of manager nodes already participating in the swarm.
+                  type: "array"
+                  items:
+                    type: "string"
+                JoinToken:
+                  description: "Secret token for joining this swarm."
+                  type: "string"
+              required: [ListenAddr, RemoteAddrs, JoinToken]
+              example:
+                ListenAddr: "0.0.0.0:2377"
+                AdvertiseAddr: "192.168.1.1:2377"
+                DataPathAddr: "192.168.1.1"
+                RemoteAddrs:
+                  - "node1:2377"
+                JoinToken: "SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-7p73s1dx5in4tatdymyhg9hu2"
+          "text/plain":
+            schema:
+              type: "object"
+              title: "SwarmJoinRequest"
+              properties:
+                ListenAddr:
+                  description: |
+                    Listen address used for inter-manager communication if the node
+                    gets promoted to manager, as well as determining the networking
+                    interface used for the VXLAN Tunnel Endpoint (VTEP). This is
+                    required for joining a swarm. If the port number is omitted,
+                    the default swarm listening port is used.
+                  type: "string"
+                AdvertiseAddr:
+                  description: |
+                    Externally reachable address advertised to other nodes. This
+                    can either be an address/port combination in the form
+                    `192.168.1.1:4567`, or an interface followed by a port number,
+                    like `eth0:4567`. If the port number is omitted, the port
+                    number from the listen address is used. If `AdvertiseAddr` is
+                    not specified, it will be automatically detected when possible.
+                  type: "string"
+                DataPathAddr:
+                  description: |
+                    Address or interface to use for data path traffic (format:
+                    `<ip|interface>`), for example,  `192.168.1.1`, or an interface,
+                    like `eth0`. If `DataPathAddr` is unspecified, the same address
+                    as `AdvertiseAddr` is used.
+
+                    The `DataPathAddr` specifies the address that global scope
+                    network drivers will publish towards other nodes in order to
+                    reach the containers running on this node. Using this parameter
+                    it is possible to separate the container data traffic from the
+                    management traffic of the cluster.
+
+                  type: "string"
+                RemoteAddrs:
+                  description: |
+                    Addresses of manager nodes already participating in the swarm.
+                  type: "array"
+                  items:
+                    type: "string"
+                JoinToken:
+                  description: "Secret token for joining this swarm."
+                  type: "string"
+              required: [ListenAddr, RemoteAddrs, JoinToken]
+              example:
+                ListenAddr: "0.0.0.0:2377"
+                AdvertiseAddr: "192.168.1.1:2377"
+                DataPathAddr: "192.168.1.1"
+                RemoteAddrs:
+                  - "node1:2377"
+                JoinToken: "SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-7p73s1dx5in4tatdymyhg9hu2"
+  /swarm/leave:
+    post:
+      summary: "Leave a swarm"
+      operationId: "SwarmLeave"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "force"
+          description: |
+            Force leave swarm, even if this is the last manager or that it will
+            break the cluster.
+          in: "query"
+          schema:
+            type: "boolean"
+            default: false
+      tags: ["Swarm"]
+  /swarm/update:
+    post:
+      summary: "Update a swarm"
+      operationId: "SwarmUpdate"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "version"
+          in: "query"
+          description: |
+            The version number of the swarm object being updated. This is
+            required to avoid conflicting writes.
+          required: true
+          schema:
+            type: "integer"
+            format: "int64"
+        - name: "rotateWorkerToken"
+          in: "query"
+          description: "Rotate the worker join token."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "rotateManagerToken"
+          in: "query"
+          description: "Rotate the manager join token."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "rotateManagerUnlockKey"
+          in: "query"
+          description: "Rotate the manager unlock key."
+          schema:
+            type: "boolean"
+            default: false
+      tags: ["Swarm"]
+      requestBody:
+        x-codegen-request-body-name: "body"
+        required: true
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/SwarmSpec"
+          "text/plain":
+            schema:
+              $ref: "#/components/schemas/SwarmSpec"
+  /swarm/unlockkey:
+    get:
+      summary: "Get the unlock key"
+      operationId: "SwarmUnlockkey"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                type: "object"
+                title: "UnlockKeyResponse"
+                properties:
+                  UnlockKey:
+                    description: "The swarm's unlock key."
+                    type: "string"
+                example:
+                  UnlockKey: "SWMKEY-1-7c37Cc8654o6p38HnroywCi19pllOnGtbdZEgtKxZu8"
+            "text/plain":
+              schema:
+                type: "object"
+                title: "UnlockKeyResponse"
+                properties:
+                  UnlockKey:
+                    description: "The swarm's unlock key."
+                    type: "string"
+                example:
+                  UnlockKey: "SWMKEY-1-7c37Cc8654o6p38HnroywCi19pllOnGtbdZEgtKxZu8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Swarm"]
+      x-consumes:
+        - "application/json"
+  /swarm/unlock:
+    post:
+      summary: "Unlock a locked manager"
+      operationId: "SwarmUnlock"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json": {}
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Swarm"]
+      requestBody:
+        x-codegen-request-body-name: "body"
+        required: true
+        content:
+          "application/json":
+            schema:
+              type: "object"
+              title: "SwarmUnlockRequest"
+              properties:
+                UnlockKey:
+                  description: "The swarm's unlock key."
+                  type: "string"
+              example:
+                UnlockKey: "SWMKEY-1-7c37Cc8654o6p38HnroywCi19pllOnGtbdZEgtKxZu8"
+  /services:
+    get:
+      summary: "List services"
+      operationId: "ServiceList"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Service"
+            "text/plain":
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Service"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "filters"
+          in: "query"
+          description: |
+            A JSON encoded value of the filters (a `map[string][]string`) to
+            process on the services list.
+
+            Available filters:
+
+            - `id=<service id>`
+            - `label=<service label>`
+            - `mode=["replicated"|"global"]`
+            - `name=<service name>`
+          schema:
+            type: "string"
+        - name: "status"
+          in: "query"
+          description: |
+            Include service status, with count of running and desired tasks.
+          schema:
+            type: "boolean"
+      tags: ["Service"]
+  /services/create:
+    post:
+      summary: "Create a service"
+      operationId: "ServiceCreate"
+      responses:
+        "201":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ServiceCreateResponse"
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: "network is not eligible for services"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: "name conflicts with an existing service"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "X-Registry-Auth"
+          in: "header"
+          description: |
+            A base64url-encoded auth configuration for pulling from private
+            registries.
+
+            Refer to the [authentication section](#section/Authentication) for
+            details.
+          schema:
+            type: "string"
+      tags: ["Service"]
+      requestBody:
+        x-codegen-request-body-name: "body"
+        required: true
+        content:
+          "application/json":
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/ServiceSpec"
+                - type: "object"
+                  example:
+                    Name: "web"
+                    TaskTemplate:
+                      ContainerSpec:
+                        Image: "nginx:alpine"
+                        Mounts:
+                          - ReadOnly: true
+                            Source: "web-data"
+                            Target: "/usr/share/nginx/html"
+                            Type: "volume"
+                            VolumeOptions:
+                              DriverConfig: {}
+                              Labels:
+                                com.example.something: "something-value"
+                        Hosts: ["10.10.10.10 host1", "ABCD:EF01:2345:6789:ABCD:EF01:2345:6789 host2"]
+                        User: "33"
+                        DNSConfig:
+                          Nameservers: ["8.8.8.8"]
+                          Search: ["example.org"]
+                          Options: ["timeout:3"]
+                        Secrets:
+                          - File:
+                              Name: "www.example.org.key"
+                              UID: "33"
+                              GID: "33"
+                              Mode: 384
+                            SecretID: "fpjqlhnwb19zds35k8wn80lq9"
+                            SecretName: "example_org_domain_key"
+                        OomScoreAdj: 0
+                      LogDriver:
+                        Name: "json-file"
+                        Options:
+                          max-file: "3"
+                          max-size: "10M"
+                      Placement: {}
+                      Resources:
+                        Limits:
+                          MemoryBytes: 104857600
+                        Reservations: {}
+                      RestartPolicy:
+                        Condition: "on-failure"
+                        Delay: 10000000000
+                        MaxAttempts: 10
+                    Mode:
+                      Replicated:
+                        Replicas: 4
+                    UpdateConfig:
+                      Parallelism: 2
+                      Delay: 1000000000
+                      FailureAction: "pause"
+                      Monitor: 15000000000
+                      MaxFailureRatio: 0.15
+                    RollbackConfig:
+                      Parallelism: 1
+                      Delay: 1000000000
+                      FailureAction: "pause"
+                      Monitor: 15000000000
+                      MaxFailureRatio: 0.15
+                    EndpointSpec:
+                      Ports:
+                        - Protocol: "tcp"
+                          PublishedPort: 8080
+                          TargetPort: 80
+                    Labels:
+                      foo: "bar"
+  /services/{id}:
+    get:
+      summary: "Inspect a service"
+      operationId: "ServiceInspect"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/Service"
+            "text/plain":
+              schema:
+                $ref: "#/components/schemas/Service"
+        "404":
+          description: "no such service"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "ID or name of service."
+          required: true
+          schema:
+            type: "string"
+        - name: "insertDefaults"
+          in: "query"
+          description: "Fill empty fields with default values."
+          schema:
+            type: "boolean"
+            default: false
+      tags: ["Service"]
+    delete:
+      summary: "Delete a service"
+      operationId: "ServiceDelete"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "404":
+          description: "no such service"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "ID or name of service."
+          required: true
+          schema:
+            type: "string"
+      tags: ["Service"]
+  /services/{id}/update:
+    post:
+      summary: "Update a service"
+      operationId: "ServiceUpdate"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ServiceUpdateResponse"
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "no such service"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "ID or name of service."
+          required: true
+          schema:
+            type: "string"
+        - name: "version"
+          in: "query"
+          description: |
+            The version number of the service object being updated. This is
+            required to avoid conflicting writes.
+            This version number should be the value as currently set on the
+            service *before* the update. You can find the current version by
+            calling `GET /services/{id}`
+          required: true
+          schema:
+            type: "integer"
+        - name: "registryAuthFrom"
+          in: "query"
+          description: |
+            If the `X-Registry-Auth` header is not specified, this parameter
+            indicates where to find registry authorization credentials.
+          schema:
+            type: "string"
+            enum: ["spec", "previous-spec"]
+            default: "spec"
+        - name: "rollback"
+          in: "query"
+          description: |
+            Set to this parameter to `previous` to cause a server-side rollback
+            to the previous service spec. The supplied spec will be ignored in
+            this case.
+          schema:
+            type: "string"
+        - name: "X-Registry-Auth"
+          in: "header"
+          description: |
+            A base64url-encoded auth configuration for pulling from private
+            registries.
+
+            Refer to the [authentication section](#section/Authentication) for
+            details.
+          schema:
+            type: "string"
+      tags: ["Service"]
+      requestBody:
+        x-codegen-request-body-name: "body"
+        required: true
+        content:
+          "application/json":
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/ServiceSpec"
+                - type: "object"
+                  example:
+                    Name: "top"
+                    TaskTemplate:
+                      ContainerSpec:
+                        Image: "busybox"
+                        Args:
+                          - "top"
+                        OomScoreAdj: 0
+                      Resources:
+                        Limits: {}
+                        Reservations: {}
+                      RestartPolicy:
+                        Condition: "any"
+                        MaxAttempts: 0
+                      Placement: {}
+                      ForceUpdate: 0
+                    Mode:
+                      Replicated:
+                        Replicas: 1
+                    UpdateConfig:
+                      Parallelism: 2
+                      Delay: 1000000000
+                      FailureAction: "pause"
+                      Monitor: 15000000000
+                      MaxFailureRatio: 0.15
+                    RollbackConfig:
+                      Parallelism: 1
+                      Delay: 1000000000
+                      FailureAction: "pause"
+                      Monitor: 15000000000
+                      MaxFailureRatio: 0.15
+                    EndpointSpec:
+                      Mode: "vip"
+
+  /services/{id}/logs:
+    get:
+      summary: "Get service logs"
+      description: |
+        Get `stdout` and `stderr` logs from a service. See also
+        [`/containers/{id}/logs`](#operation/ContainerLogs).
+
+        **Note**: This endpoint works only for services with the `local`,
+        `json-file` or `journald` logging drivers.
+      operationId: "ServiceLogs"
+      responses:
+        "200":
+          description: "logs returned as a stream in response body"
+          content:
+            "application/vnd.docker.raw-stream":
+              schema:
+                type: "string"
+                format: "binary"
+            "application/vnd.docker.multiplexed-stream":
+              schema:
+                type: "string"
+                format: "binary"
+        "404":
+          description: "no such service"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such service: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID or name of the service"
+          schema:
+            type: "string"
+        - name: "details"
+          in: "query"
+          description: "Show service context and extra details provided to logs."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "follow"
+          in: "query"
+          description: "Keep connection after returning logs."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "stdout"
+          in: "query"
+          description: "Return logs from `stdout`"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "stderr"
+          in: "query"
+          description: "Return logs from `stderr`"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "since"
+          in: "query"
+          description: "Only return logs since this time, as a UNIX timestamp"
+          schema:
+            type: "integer"
+            default: 0
+        - name: "timestamps"
+          in: "query"
+          description: "Add timestamps to every log line"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "tail"
+          in: "query"
+          description: |
+            Only return this number of log lines from the end of the logs.
+            Specify as an integer or `all` to output all log lines.
+          schema:
+            type: "string"
+            default: "all"
+      tags: ["Service"]
+  /tasks:
+    get:
+      summary: "List tasks"
+      operationId: "TaskList"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Task"
+                example:
+                  - ID: "0kzzo1i0y4jz6027t0k7aezc7"
+                    Version:
+                      Index: 71
+                    CreatedAt: "2016-06-07T21:07:31.171892745Z"
+                    UpdatedAt: "2016-06-07T21:07:31.376370513Z"
+                    Spec:
+                      ContainerSpec:
+                        Image: "redis"
+                      Resources:
+                        Limits: {}
+                        Reservations: {}
+                      RestartPolicy:
+                        Condition: "any"
+                        MaxAttempts: 0
+                      Placement: {}
+                    ServiceID: "9mnpnzenvg8p8tdbtq4wvbkcz"
+                    Slot: 1
+                    NodeID: "60gvrl6tm78dmak4yl7srz94v"
+                    Status:
+                      Timestamp: "2016-06-07T21:07:31.290032978Z"
+                      State: "running"
+                      Message: "started"
+                      ContainerStatus:
+                        ContainerID: "e5d62702a1b48d01c3e02ca1e0212a250801fa8d67caca0b6f35919ebc12f035"
+                        PID: 677
+                    DesiredState: "running"
+                    NetworksAttachments:
+                      - Network:
+                          ID: "4qvuz4ko70xaltuqbt8956gd1"
+                          Version:
+                            Index: 18
+                          CreatedAt: "2016-06-07T20:31:11.912919752Z"
+                          UpdatedAt: "2016-06-07T21:07:29.955277358Z"
+                          Spec:
+                            Name: "ingress"
+                            Labels:
+                              com.docker.swarm.internal: "true"
+                            DriverConfiguration: {}
+                            IPAMOptions:
+                              Driver: {}
+                              Configs:
+                                - Subnet: "10.255.0.0/16"
+                                  Gateway: "10.255.0.1"
+                          DriverState:
+                            Name: "overlay"
+                            Options:
+                              com.docker.network.driver.overlay.vxlanid_list: "256"
+                          IPAMOptions:
+                            Driver:
+                              Name: "default"
+                            Configs:
+                              - Subnet: "10.255.0.0/16"
+                                Gateway: "10.255.0.1"
+                        Addresses:
+                          - "10.255.0.10/16"
+                  - ID: "1yljwbmlr8er2waf8orvqpwms"
+                    Version:
+                      Index: 30
+                    CreatedAt: "2016-06-07T21:07:30.019104782Z"
+                    UpdatedAt: "2016-06-07T21:07:30.231958098Z"
+                    Name: "hopeful_cori"
+                    Spec:
+                      ContainerSpec:
+                        Image: "redis"
+                      Resources:
+                        Limits: {}
+                        Reservations: {}
+                      RestartPolicy:
+                        Condition: "any"
+                        MaxAttempts: 0
+                      Placement: {}
+                    ServiceID: "9mnpnzenvg8p8tdbtq4wvbkcz"
+                    Slot: 1
+                    NodeID: "60gvrl6tm78dmak4yl7srz94v"
+                    Status:
+                      Timestamp: "2016-06-07T21:07:30.202183143Z"
+                      State: "shutdown"
+                      Message: "shutdown"
+                      ContainerStatus:
+                        ContainerID: "1cf8d63d18e79668b0004a4be4c6ee58cddfad2dae29506d8781581d0688a213"
+                    DesiredState: "shutdown"
+                    NetworksAttachments:
+                      - Network:
+                          ID: "4qvuz4ko70xaltuqbt8956gd1"
+                          Version:
+                            Index: 18
+                          CreatedAt: "2016-06-07T20:31:11.912919752Z"
+                          UpdatedAt: "2016-06-07T21:07:29.955277358Z"
+                          Spec:
+                            Name: "ingress"
+                            Labels:
+                              com.docker.swarm.internal: "true"
+                            DriverConfiguration: {}
+                            IPAMOptions:
+                              Driver: {}
+                              Configs:
+                                - Subnet: "10.255.0.0/16"
+                                  Gateway: "10.255.0.1"
+                          DriverState:
+                            Name: "overlay"
+                            Options:
+                              com.docker.network.driver.overlay.vxlanid_list: "256"
+                          IPAMOptions:
+                            Driver:
+                              Name: "default"
+                            Configs:
+                              - Subnet: "10.255.0.0/16"
+                                Gateway: "10.255.0.1"
+                        Addresses:
+                          - "10.255.0.5/16"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "filters"
+          in: "query"
+          description: |
+            A JSON encoded value of the filters (a `map[string][]string`) to
+            process on the tasks list.
+
+            Available filters:
+
+            - `desired-state=(running | shutdown | accepted)`
+            - `id=<task id>`
+            - `label=key` or `label="key=value"`
+            - `name=<task name>`
+            - `node=<node id or name>`
+            - `service=<service name>`
+          schema:
+            type: "string"
+      tags: ["Task"]
+  /tasks/{id}:
+    get:
+      summary: "Inspect a task"
+      operationId: "TaskInspect"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/Task"
+        "404":
+          description: "no such task"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "ID of the task"
+          required: true
+          schema:
+            type: "string"
+      tags: ["Task"]
+  /tasks/{id}/logs:
+    get:
+      summary: "Get task logs"
+      description: |
+        Get `stdout` and `stderr` logs from a task.
+        See also [`/containers/{id}/logs`](#operation/ContainerLogs).
+
+        **Note**: This endpoint works only for services with the `local`,
+        `json-file` or `journald` logging drivers.
+      operationId: "TaskLogs"
+      responses:
+        "200":
+          description: "logs returned as a stream in response body"
+          content:
+            "application/vnd.docker.raw-stream":
+              schema:
+                type: "string"
+                format: "binary"
+            "application/vnd.docker.multiplexed-stream":
+              schema:
+                type: "string"
+                format: "binary"
+        "404":
+          description: "no such task"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such task: c2ada9df5af8"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID of the task"
+          schema:
+            type: "string"
+        - name: "details"
+          in: "query"
+          description: "Show task context and extra details provided to logs."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "follow"
+          in: "query"
+          description: "Keep connection after returning logs."
+          schema:
+            type: "boolean"
+            default: false
+        - name: "stdout"
+          in: "query"
+          description: "Return logs from `stdout`"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "stderr"
+          in: "query"
+          description: "Return logs from `stderr`"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "since"
+          in: "query"
+          description: "Only return logs since this time, as a UNIX timestamp"
+          schema:
+            type: "integer"
+            default: 0
+        - name: "timestamps"
+          in: "query"
+          description: "Add timestamps to every log line"
+          schema:
+            type: "boolean"
+            default: false
+        - name: "tail"
+          in: "query"
+          description: |
+            Only return this number of log lines from the end of the logs.
+            Specify as an integer or `all` to output all log lines.
+          schema:
+            type: "string"
+            default: "all"
+      tags: ["Task"]
+  /secrets:
+    get:
+      summary: "List secrets"
+      operationId: "SecretList"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Secret"
+                example:
+                  - ID: "blt1owaxmitz71s9v5zh81zun"
+                    Version:
+                      Index: 85
+                    CreatedAt: "2017-07-20T13:55:28.678958722Z"
+                    UpdatedAt: "2017-07-20T13:55:28.678958722Z"
+                    Spec:
+                      Name: "mysql-passwd"
+                      Labels:
+                        some.label: "some.value"
+                      Driver:
+                        Name: "secret-bucket"
+                        Options:
+                          OptionA: "value for driver option A"
+                          OptionB: "value for driver option B"
+                  - ID: "ktnbjxoalbkvbvedmg1urrz8h"
+                    Version:
+                      Index: 11
+                    CreatedAt: "2016-11-05T01:20:17.327670065Z"
+                    UpdatedAt: "2016-11-05T01:20:17.327670065Z"
+                    Spec:
+                      Name: "app-dev.crt"
+                      Labels:
+                        foo: "bar"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "filters"
+          in: "query"
+          description: |
+            A JSON encoded value of the filters (a `map[string][]string`) to
+            process on the secrets list.
+
+            Available filters:
+
+            - `id=<secret id>`
+            - `label=<key> or label=<key>=value`
+            - `name=<secret name>` matches all or part of a secret name (prefix match)
+            - `names=<secret name>` matches a secret name (exact match)
+          schema:
+            type: "string"
+      tags: ["Secret"]
+  /secrets/create:
+    post:
+      summary: "Create a secret"
+      operationId: "SecretCreate"
+      responses:
+        "201":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/IDResponse"
+        "409":
+          description: "name conflicts with an existing object"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Secret"]
+      requestBody:
+        x-codegen-request-body-name: "body"
+        content:
+          "application/json":
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/SecretSpec"
+                - type: "object"
+                  example:
+                    Name: "app-key.crt"
+                    Labels:
+                      foo: "bar"
+                    Data: "VEhJUyBJUyBOT1QgQSBSRUFMIENFUlRJRklDQVRFCg=="
+                    Driver:
+                      Name: "secret-bucket"
+                      Options:
+                        OptionA: "value for driver option A"
+                        OptionB: "value for driver option B"
+  /secrets/{id}:
+    get:
+      summary: "Inspect a secret"
+      operationId: "SecretInspect"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/Secret"
+              example:
+                ID: "ktnbjxoalbkvbvedmg1urrz8h"
+                Version:
+                  Index: 11
+                CreatedAt: "2016-11-05T01:20:17.327670065Z"
+                UpdatedAt: "2016-11-05T01:20:17.327670065Z"
+                Spec:
+                  Name: "app-dev.crt"
+                  Labels:
+                    foo: "bar"
+                  Driver:
+                    Name: "secret-bucket"
+                    Options:
+                      OptionA: "value for driver option A"
+                      OptionB: "value for driver option B"
+
+        "404":
+          description: "secret not found"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID of the secret"
+          schema:
+            type: "string"
+      tags: ["Secret"]
+    delete:
+      summary: "Delete a secret"
+      operationId: "SecretDelete"
+      responses:
+        "204":
+          description: "no error"
+        "404":
+          description: "secret not found"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID of the secret"
+          schema:
+            type: "string"
+      tags: ["Secret"]
+  /secrets/{id}/update:
+    post:
+      summary: "Update a Secret"
+      operationId: "SecretUpdate"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "no such secret"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "The ID or name of the secret"
+          required: true
+          schema:
+            type: "string"
+        - name: "version"
+          in: "query"
+          description: |
+            The version number of the secret object being updated. This is
+            required to avoid conflicting writes.
+          required: true
+          schema:
+            type: "integer"
+            format: "int64"
+      tags: ["Secret"]
+      requestBody:
+        x-codegen-request-body-name: "body"
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/SecretSpec"
+          "text/plain":
+            schema:
+              $ref: "#/components/schemas/SecretSpec"
+        description: |
+          The spec of the secret to update. Currently, only the Labels field
+          can be updated. All other fields must remain unchanged from the
+          [SecretInspect endpoint](#operation/SecretInspect) response values.
+  /configs:
+    get:
+      summary: "List configs"
+      operationId: "ConfigList"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Config"
+                example:
+                  - ID: "ktnbjxoalbkvbvedmg1urrz8h"
+                    Version:
+                      Index: 11
+                    CreatedAt: "2016-11-05T01:20:17.327670065Z"
+                    UpdatedAt: "2016-11-05T01:20:17.327670065Z"
+                    Spec:
+                      Name: "server.conf"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "filters"
+          in: "query"
+          description: |
+            A JSON encoded value of the filters (a `map[string][]string`) to
+            process on the configs list.
+
+            Available filters:
+
+            - `id=<config id>`
+            - `label=<key> or label=<key>=value`
+            - `name=<config name>` matches all or part of a config name (prefix match)
+          schema:
+            type: "string"
+      tags: ["Config"]
+  /configs/create:
+    post:
+      summary: "Create a config"
+      operationId: "ConfigCreate"
+      responses:
+        "201":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/IDResponse"
+        "409":
+          description: "name conflicts with an existing object"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Config"]
+      requestBody:
+        x-codegen-request-body-name: "body"
+        content:
+          "application/json":
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/ConfigSpec"
+                - type: "object"
+                  example:
+                    Name: "server.conf"
+                    Labels:
+                      foo: "bar"
+                    Data: "VEhJUyBJUyBOT1QgQSBSRUFMIENFUlRJRklDQVRFCg=="
+  /configs/{id}:
+    get:
+      summary: "Inspect a config"
+      operationId: "ConfigInspect"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/Config"
+              example:
+                ID: "ktnbjxoalbkvbvedmg1urrz8h"
+                Version:
+                  Index: 11
+                CreatedAt: "2016-11-05T01:20:17.327670065Z"
+                UpdatedAt: "2016-11-05T01:20:17.327670065Z"
+                Spec:
+                  Name: "app-dev.crt"
+        "404":
+          description: "config not found"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID of the config"
+          schema:
+            type: "string"
+      tags: ["Config"]
+    delete:
+      summary: "Delete a config"
+      operationId: "ConfigDelete"
+      responses:
+        "204":
+          description: "no error"
+        "404":
+          description: "config not found"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          description: "ID of the config"
+          schema:
+            type: "string"
+      tags: ["Config"]
+  /configs/{id}/update:
+    post:
+      summary: "Update a Config"
+      operationId: "ConfigUpdate"
+      responses:
+        "200":
+          description: "no error"
+          content:
+            "application/json": {}
+            "text/plain": {}
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "no such config"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: "node is not part of a swarm"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "The ID or name of the config"
+          required: true
+          schema:
+            type: "string"
+        - name: "version"
+          in: "query"
+          description: |
+            The version number of the config object being updated. This is
+            required to avoid conflicting writes.
+          required: true
+          schema:
+            type: "integer"
+            format: "int64"
+      tags: ["Config"]
+      requestBody:
+        x-codegen-request-body-name: "body"
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/ConfigSpec"
+          "text/plain":
+            schema:
+              $ref: "#/components/schemas/ConfigSpec"
+        description: |
+          The spec of the config to update. Currently, only the Labels field
+          can be updated. All other fields must remain unchanged from the
+          [ConfigInspect endpoint](#operation/ConfigInspect) response values.
+  /distribution/{name}/json:
+    get:
+      summary: "Get image information from the registry"
+      description: |
+        Return image digest and platform information by contacting the registry.
+      operationId: "DistributionInspect"
+      responses:
+        "200":
+          description: "descriptor and platform information"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/DistributionInspect"
+        "401":
+          description: "Failed authentication or no image found"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "No such image: someimage (tag: latest)"
+        "500":
+          description: "Server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "path"
+          description: "Image name or id"
+          required: true
+          schema:
+            type: "string"
+      tags: ["Distribution"]
+  /session:
+    post:
+      summary: "Initialize interactive session"
+      description: |
+        Start a new interactive session with a server. Session allows server to
+        call back to the client for advanced capabilities.
+
+        > **Deprecated**: This endpoint is deprecated and will be removed in a future version.
+        > Server should support gRPC directly on the listening socket.
+
+        ### Hijacking
+
+        This endpoint hijacks the HTTP connection to HTTP2 transport that allows
+        the client to expose gPRC services on that connection.
+
+        For example, the client sends this request to upgrade the connection:
+
+        ```
+        POST /session HTTP/1.1
+        Upgrade: h2c
+        Connection: Upgrade
+        ```
+
+        The Docker daemon responds with a `101 UPGRADED` response follow with
+        the raw stream:
+
+        ```
+        HTTP/1.1 101 UPGRADED
+        Connection: Upgrade
+        Upgrade: h2c
+        ```
+      operationId: "Session"
+      responses:
+        "101":
+          description: "no error, hijacking successful"
+          content:
+            "application/vnd.docker.raw-stream": {}
+        "400":
+          description: "bad parameter"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: "server error"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      tags: ["Session"]

--- a/api/scripts/generate-swagger-api.sh
+++ b/api/scripts/generate-swagger-api.sh
@@ -7,6 +7,8 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 API_DIR="${1:-${SCRIPT_DIR}/..}"
 
+"${SCRIPT_DIR}/generate-swagger-spec.sh" "${API_DIR}"
+
 generate_model() {
 	local package="$1"
 	shift

--- a/api/scripts/generate-swagger-api.sh
+++ b/api/scripts/generate-swagger-api.sh
@@ -3,7 +3,9 @@
 # -*- indent-tabs-mode: t -*-
 set -eu
 
-API_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Usage: generate-swagger-api.sh [api-directory]
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+API_DIR="${1:-${SCRIPT_DIR}/..}"
 
 generate_model() {
 	local package="$1"

--- a/api/scripts/generate-swagger-spec.sh
+++ b/api/scripts/generate-swagger-spec.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-API_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Usage: generate-swagger-spec.sh [api-directory]
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+API_DIR="${1:-${SCRIPT_DIR}/..}"
 
 # Replace the checked-in specification only after conversion succeeds.
 SPEC="$(mktemp "${API_DIR}/swagger.yaml.XXXXXX")"
 trap 'rm -f "${SPEC}"' EXIT
-python3 -B "${API_DIR}/scripts/swagger_spec.py" "${API_DIR}/openapi.yaml" \
+python3 -B "${SCRIPT_DIR}/swagger_spec.py" "${API_DIR}/openapi.yaml" \
 	"${API_DIR}/swagger.yaml" > "${SPEC}"
 chmod 644 "${SPEC}"
 mv "${SPEC}" "${API_DIR}/swagger.yaml"

--- a/api/scripts/generate-swagger-spec.sh
+++ b/api/scripts/generate-swagger-spec.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Replace the checked-in specification only after conversion succeeds.
+SPEC="$(mktemp "${API_DIR}/swagger.yaml.XXXXXX")"
+trap 'rm -f "${SPEC}"' EXIT
+python3 -B "${API_DIR}/scripts/swagger_spec.py" "${API_DIR}/openapi.yaml" \
+	"${API_DIR}/swagger.yaml" > "${SPEC}"
+chmod 644 "${SPEC}"
+mv "${SPEC}" "${API_DIR}/swagger.yaml"

--- a/api/scripts/swagger_model_spec.py
+++ b/api/scripts/swagger_model_spec.py
@@ -1,0 +1,63 @@
+"""Project Engine OpenAPI schemas for the Swagger 2 compatibility specification."""
+
+
+REF_PREFIX = "#/components/schemas/"
+OPENAPI_VERSION = "3.2.0"
+# JSON Schema 2020-12 keywords with no Swagger 2 equivalent. Nullability is
+# expressed only through the x-nullable generator extension, so the schemas
+# must not use type unions or the removed OpenAPI 3.0 nullable keyword.
+UNSUPPORTED = (
+    "anyOf",
+    "oneOf",
+    "not",
+    "const",
+    "examples",
+    "$defs",
+    "discriminator",
+    "nullable",
+    "writeOnly",
+    "deprecated",
+)
+
+
+def project_schema(schema):
+    """Preserve schema order and opaque examples/extensions while rewriting refs."""
+    if isinstance(schema, bool):
+        return schema  # additionalProperties
+    result = dict(schema)
+    for keyword in UNSUPPORTED:
+        if keyword in result:
+            raise ValueError(f"model projection does not support {keyword}")
+    if isinstance(result.get("type"), list):
+        raise ValueError("model projection does not support type unions")
+    if "$ref" in result:
+        ref = result["$ref"]
+        if not ref.startswith(REF_PREFIX):
+            raise ValueError(f"model projection requires a local schema reference: {ref}")
+        # Swagger 2 tooling (go-swagger) honors the description and generator
+        # extensions placed beside $ref, as JSON Schema 2020-12 does.
+        result["$ref"] = "#/definitions/" + ref[len(REF_PREFIX):]
+    if "properties" in result:
+        result["properties"] = {
+            name: project_schema(value) for name, value in result["properties"].items()
+        }
+    for keyword in ("items", "additionalProperties"):
+        if keyword in result:
+            result[keyword] = project_schema(result[keyword])
+    if "allOf" in result:
+        result["allOf"] = [project_schema(value) for value in result["allOf"]]
+    return result
+
+
+def project(spec):
+    if spec.get("openapi") != OPENAPI_VERSION:
+        raise ValueError(f"model projection requires OpenAPI {OPENAPI_VERSION}")
+    return {
+        "swagger": "2.0",
+        "info": spec["info"],
+        "paths": {},
+        "definitions": {
+            name: project_schema(schema)
+            for name, schema in spec["components"]["schemas"].items()
+        },
+    }

--- a/api/scripts/swagger_model_spec_test.py
+++ b/api/scripts/swagger_model_spec_test.py
@@ -1,0 +1,90 @@
+"""Regression tests for the Engine schema projection, not a general converter."""
+
+from copy import deepcopy
+from pathlib import Path
+import unittest
+
+import yaml
+
+from swagger_model_spec import project, project_schema
+
+
+class ModelSpecTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with (Path(__file__).resolve().parents[1] / "openapi.yaml").open() as source:
+            cls.spec = yaml.safe_load(source)
+        cls.schemas = cls.spec["components"]["schemas"]
+
+    def test_schema_only_and_ordered(self):
+        original = deepcopy(self.spec)
+        projected = project(self.spec)
+        self.assertEqual(projected["swagger"], "2.0")
+        self.assertEqual(projected["paths"], {})
+        self.assertEqual(list(projected["definitions"]), list(self.schemas))
+        for name, schema in self.schemas.items():
+            with self.subTest(schema=name):
+                self.assertEqual(
+                    list(projected["definitions"][name].get("properties", {})),
+                    list(schema.get("properties", {})),
+                )
+        self.assertEqual(self.spec, original)
+
+    def test_reference_siblings_are_kept(self):
+        ipam = self.schemas["Network"]["properties"]["IPAM"]
+        self.assertEqual(project_schema(ipam), {
+            "description": "The network's IP Address Management.\n",
+            "$ref": "#/definitions/IPAM",
+            "x-nullable": False,
+            "x-omitempty": False,
+        })
+
+    def test_nullable_reference_uses_generator_extension_only(self):
+        rootfs = self.schemas["Storage"]["properties"]["RootFS"]
+        self.assertEqual(project_schema(rootfs), {
+            "description": "Information about the storage used for the container's root filesystem.\n",
+            "type": "object",
+            "x-nullable": True,
+            "$ref": "#/definitions/RootFSStorage",
+        })
+
+    def test_original_allof_is_kept(self):
+        schema = self.schemas["MountPoint"]["properties"]["Type"]
+        projected = project_schema(schema)
+        self.assertNotIn("$ref", projected)
+        self.assertEqual(projected["allOf"], [{"$ref": "#/definitions/MountType"}])
+        self.assertEqual(projected["description"], schema["description"])
+
+    def test_examples_and_extensions_are_opaque(self):
+        data = {"$ref": "#/components/schemas/NotAReference", "nullable": True}
+        schema = {
+            "type": "object", "example": data, "default": data,
+            "x-custom": data, "additionalProperties": False,
+            "properties": {"nullable": {"type": "boolean", "x-nullable": False}},
+        }
+        projected = project_schema(schema)
+        for key in ("example", "default", "x-custom", "additionalProperties"):
+            self.assertEqual(projected[key], schema[key])
+        self.assertEqual(projected["properties"]["nullable"], {
+            "type": "boolean", "x-nullable": False,
+        })
+
+    def test_unsupported_schemas_fail(self):
+        for schema in (
+            {"oneOf": [{"type": "string"}]},
+            {"anyOf": [{"$ref": "#/components/schemas/Thing"}, {"type": "null"}]},
+            {"type": ["object", "null"]},
+            {"type": "object", "nullable": True},
+            {"type": "string", "examples": ["a"]},
+            {"$ref": "other.yaml#/Thing"},
+        ):
+            with self.subTest(schema=schema), self.assertRaises(ValueError):
+                project_schema(schema)
+
+    def test_requires_pinned_openapi_version(self):
+        with self.assertRaises(ValueError):
+            project({"openapi": "3.0.3", "info": {}, "components": {"schemas": {}}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/scripts/swagger_spec.py
+++ b/api/scripts/swagger_spec.py
@@ -1,0 +1,204 @@
+"""Generate the Engine's Swagger 2.0 compatibility specification from OpenAPI.
+
+Swagger 2 has operation-wide media types, not per-response media types. The
+compatibility document uses their union; openapi.yaml remains authoritative.
+"""
+
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import yaml
+
+from swagger_model_spec import project as project_models, project_schema
+
+
+def check_keys(value, allowed):
+    unsupported = value.keys() - set(allowed)
+    unsupported = {key for key in unsupported if not key.startswith("x-")}
+    if unsupported:
+        raise ValueError(f"unsupported OpenAPI fields: {sorted(unsupported)}")
+
+
+def extensions(value):
+    return {key: item for key, item in value.items() if key.startswith("x-")}
+
+
+def parameter(value):
+    check_keys(value, ("name", "in", "description", "required", "schema", "style", "explode"))
+    result = {key: item for key, item in value.items() if key not in ("schema", "style", "explode")}
+    schema = project_schema(value["schema"])
+    if schema.get("type") not in ("string", "integer", "number", "boolean", "array"):
+        raise ValueError("Swagger non-body parameters require a primitive or array type")
+    result.update(schema)
+    if schema["type"] == "array":
+        if value["in"] != "query" or value.get("style", "form") != "form":
+            raise ValueError("only form-style query arrays are supported")
+        result["collectionFormat"] = "multi" if value.get("explode", True) else "csv"
+    elif "style" in value or "explode" in value:
+        raise ValueError("serialization options are only supported on query arrays")
+    return result
+
+
+def content_schema(content):
+    schemas = []
+    for media in content.values():
+        check_keys(media, ("schema", "example"))
+        schemas.append(media.get("schema"))
+    if not schemas or any(schema != schemas[0] for schema in schemas):
+        raise ValueError("Swagger requires the same schema for all media types of a body")
+    if schemas[0] is None:
+        return None
+    return project_schema(schemas[0])
+
+
+def response(value):
+    check_keys(value, ("description", "headers", "content"))
+    result = {"description": value["description"], **extensions(value)}
+    if "headers" in value:
+        result["headers"] = {}
+        for name, header in value["headers"].items():
+            check_keys(header, ("description", "schema"))
+            result["headers"][name] = {
+                **{key: item for key, item in header.items() if key != "schema"},
+                **project_schema(header["schema"]),
+            }
+    if "content" in value:
+        schema = content_schema(value["content"])
+        if schema is not None:
+            result["schema"] = schema
+        examples = {
+            media_type: media["example"]
+            for media_type, media in value["content"].items() if "example" in media
+        }
+        if examples:
+            result["examples"] = examples
+    return result
+
+
+def operation(value, defaults):
+    check_keys(value, ("summary", "description", "operationId", "tags", "parameters", "requestBody", "responses", "deprecated"))
+    result = {key: item for key, item in value.items() if key not in ("requestBody", "responses", "parameters", "x-consumes")}
+    if "parameters" in value:
+        result["parameters"] = [parameter(item) for item in value["parameters"]]
+    consumes = value.get("x-consumes", defaults["consumes"])
+    if "requestBody" in value:
+        body = value["requestBody"]
+        check_keys(body, ("description", "required", "content"))
+        if "x-consumes" in value:
+            raise ValueError("requestBody and x-consumes cannot both specify media types")
+        consumes = list(body["content"])
+        schema = content_schema(body["content"])
+        if schema is None:
+            raise ValueError("request bodies require a schema")
+        body_parameter = {
+            "name": body["x-codegen-request-body-name"], "in": "body",
+            **{key: item for key, item in body.items() if key in ("description", "required")},
+            "schema": schema,
+        }
+        result.setdefault("parameters", []).append(body_parameter)
+    if consumes != defaults["consumes"]:
+        result["consumes"] = consumes
+    produces = list(dict.fromkeys(
+        media_type for item in value["responses"].values()
+        for media_type in item.get("content", {})
+    ))
+    if produces != defaults["produces"]:
+        result["produces"] = produces
+    result["responses"] = {str(code): response(item) for code, item in value["responses"].items()}
+    return result
+
+
+def project(spec):
+    check_keys(spec, ("openapi", "jsonSchemaDialect", "servers", "info", "tags", "components", "paths"))
+    if spec.get("openapi") != "3.2.0":
+        raise ValueError("Swagger projection requires OpenAPI 3.2.0")
+    if spec.get("jsonSchemaDialect") != "https://spec.openapis.org/oas/3.1/dialect/base":
+        raise ValueError("unsupported schema dialect")
+    if len(spec["servers"]) != 1 or set(spec["servers"][0]) != {"url"}:
+        raise ValueError("Swagger projection requires one relative server URL")
+    base_path = spec["servers"][0]["url"]
+    if not base_path.startswith("/") or base_path.startswith("//") or "{" in base_path:
+        raise ValueError("Swagger projection requires a relative server URL without variables")
+    check_keys(spec["components"], ("schemas",))
+    result = {
+        "swagger": "2.0",
+        "schemes": spec["x-schemes"],
+        "produces": spec["x-produces"],
+        "consumes": spec["x-consumes"],
+        "basePath": base_path,
+        "info": spec["info"],
+        "tags": spec["tags"],
+        "definitions": project_models(spec)["definitions"],
+        "paths": {},
+    }
+    for path, item in spec["paths"].items():
+        check_keys(item, ("get", "put", "post", "delete", "options", "head", "patch"))
+        result["paths"][path] = {
+            method: value if method.startswith("x-") else operation(value, result)
+            for method, value in item.items()
+        }
+    return result
+
+
+class Dumper(yaml.SafeDumper):
+    def ignore_aliases(self, data):
+        return True
+
+
+def represent_string(dumper, value):
+    return dumper.represent_scalar("tag:yaml.org,2002:str", value, style="|" if "\n" in value else None)
+
+
+Dumper.add_representer(str, represent_string)
+
+
+def comparison_spec(spec):
+    """Ignore parameter placement and YAML status-key types, but not schema order."""
+    spec = deepcopy(spec)
+
+    def schema_order(schema):
+        if isinstance(schema, bool):
+            return
+        if "properties" in schema:
+            for item in schema["properties"].values():
+                schema_order(item)
+            schema["properties"] = list(schema["properties"].items())
+        for key in ("items", "additionalProperties"):
+            if key in schema:
+                schema_order(schema[key])
+        for item in schema.get("allOf", []):
+            schema_order(item)
+
+    for schema in spec["definitions"].values():
+        schema_order(schema)
+    for methods in spec["paths"].values():
+        for method, op in methods.items():
+            if method.startswith("x-"):
+                continue
+            op["responses"] = {str(code): value for code, value in op["responses"].items()}
+            for value in op["responses"].values():
+                if "schema" in value:
+                    schema_order(value["schema"])
+            for value in op.get("parameters", []):
+                if "schema" in value:
+                    schema_order(value["schema"])
+            op["parameters"] = sorted(op.get("parameters", []), key=lambda p: (p["in"], p["name"]))
+    return spec
+
+
+def render(spec, previous=""):
+    projected = project(spec)
+    if previous and comparison_spec(yaml.safe_load(previous)) == comparison_spec(projected):
+        return previous
+    return "# Code generated from openapi.yaml; DO NOT EDIT.\n" + yaml.dump(
+        projected, Dumper=Dumper, sort_keys=False, allow_unicode=True, width=1000,
+    )
+
+
+if __name__ == "__main__":
+    previous = ""
+    if len(sys.argv) > 2 and Path(sys.argv[2]).exists():
+        previous = Path(sys.argv[2]).read_text(encoding="utf-8")
+    with open(sys.argv[1], encoding="utf-8") as source:
+        sys.stdout.write(render(yaml.safe_load(source), previous))

--- a/api/scripts/swagger_spec_test.py
+++ b/api/scripts/swagger_spec_test.py
@@ -1,0 +1,163 @@
+"""Regression tests for the complete Swagger 2 compatibility specification."""
+
+from copy import deepcopy
+from pathlib import Path
+import unittest
+
+import yaml
+
+from swagger_spec import comparison_spec, operation, parameter, project, render, response
+
+
+class SwaggerSpecTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.api_dir = Path(__file__).resolve().parents[1]
+        cls.spec = yaml.safe_load((cls.api_dir / "openapi.yaml").read_text())
+        cls.swagger = (cls.api_dir / "swagger.yaml").read_text()
+
+    def test_checked_in_swagger_is_up_to_date(self):
+        self.assertEqual(
+            comparison_spec(project(self.spec)), comparison_spec(yaml.safe_load(self.swagger)),
+            "Run make -C api swagger-spec and commit the generated swagger.yaml",
+        )
+
+    def test_unchanged_swagger_keeps_exact_layout(self):
+        self.assertEqual(render(self.spec, self.swagger), self.swagger)
+
+    def test_generation_without_existing_swagger_matches_checked_in_content(self):
+        self.assertEqual(
+            comparison_spec(yaml.safe_load(render(self.spec))),
+            comparison_spec(yaml.safe_load(self.swagger)),
+        )
+
+    def test_source_changes_are_not_hidden_by_existing_swagger(self):
+        source = deepcopy(self.spec)
+        source["info"]["title"] = "Updated Engine API"
+        result = render(source, self.swagger)
+        self.assertNotEqual(result, self.swagger)
+        self.assertEqual(yaml.safe_load(result)["info"]["title"], "Updated Engine API")
+
+    def test_source_property_order_changes_are_not_hidden(self):
+        source = deepcopy(self.spec)
+        schema = source["components"]["schemas"]["MountPoint"]
+        schema["properties"] = dict(reversed(list(schema["properties"].items())))
+        result = render(source, self.swagger)
+        self.assertNotEqual(result, self.swagger)
+        self.assertEqual(
+            list(yaml.safe_load(result)["definitions"]["MountPoint"]["properties"]),
+            list(schema["properties"]),
+        )
+
+    def test_repeated_parameters_and_omitted_array_default(self):
+        result = project(self.spec)
+        for path, method, name in (
+            ("/images/create", "post", "changes"),
+            ("/images/get", "get", "names"),
+            ("/images/{name}", "delete", "platforms"),
+        ):
+            with self.subTest(path=path):
+                param = next(p for p in result["paths"][path][method]["parameters"] if p["name"] == name)
+                self.assertEqual(param["collectionFormat"], "multi")
+        managers = result["definitions"]["SwarmInfo"]["properties"]["RemoteManagers"]
+        self.assertNotIn("default", managers)
+
+    def test_complete_api_and_schema_order(self):
+        original = deepcopy(self.spec)
+        result = project(self.spec)
+        self.assertEqual(result["swagger"], "2.0")
+        self.assertEqual(result["basePath"], "/v1.56")
+        self.assertEqual(result["info"]["version"], "1.56")
+        self.assertEqual(set(result["paths"]), set(self.spec["paths"]))
+        for path, methods in self.spec["paths"].items():
+            self.assertEqual(set(result["paths"][path]), set(methods))
+        self.assertEqual(list(result["definitions"]), list(self.spec["components"]["schemas"]))
+        self.assertEqual(self.spec, original)
+
+    def test_current_api_additions_survive_conversion(self):
+        result = project(self.spec)
+        attestations = result["paths"]["/images/{name}/attestations"]["get"]
+        self.assertEqual(attestations["responses"]["200"]["schema"], {
+            "type": "array", "items": {"$ref": "#/definitions/AttestationStatement"},
+        })
+        self.assertEqual(
+            result["paths"]["/containers/{id}/start"]["post"]["responses"]["400"]["schema"],
+            {"$ref": "#/definitions/ErrorResponse"},
+        )
+        self.assertIn("Umask", result["definitions"]["HostConfig"]["allOf"][1]["properties"])
+        self.assertEqual(
+            result["definitions"]["Task"]["properties"]["NetworksAttachments"]["items"],
+            {"$ref": "#/definitions/NetworkAttachment"},
+        )
+
+    def test_repeated_query_keys(self):
+        for explode, expected in ((True, "multi"), (False, "csv")):
+            with self.subTest(explode=explode):
+                self.assertEqual(parameter({
+                    "name": "names", "in": "query", "style": "form", "explode": explode,
+                    "schema": {"type": "array", "items": {"type": "string"}},
+                }), {
+                    "name": "names", "in": "query", "type": "array",
+                    "items": {"type": "string"}, "collectionFormat": expected,
+                })
+
+    def test_request_body_and_response_media_types(self):
+        result = operation({
+            "requestBody": {
+                "x-codegen-request-body-name": "archive", "required": True,
+                "description": "Archive to import",
+                "content": {"application/x-tar": {"schema": {"type": "string", "format": "binary"}}},
+            },
+            "responses": {
+                "200": {"description": "stream", "content": {"application/octet-stream": {}}},
+                "400": {"description": "bad request", "content": {"application/json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                    "example": {"message": "bad archive"},
+                }}},
+            },
+        }, {"consumes": ["application/json"], "produces": ["application/json"]})
+        self.assertEqual(result["consumes"], ["application/x-tar"])
+        self.assertEqual(result["parameters"], [{
+            "name": "archive", "in": "body", "required": True,
+            "description": "Archive to import", "schema": {"type": "string", "format": "binary"},
+        }])
+        self.assertEqual(result["produces"], ["application/octet-stream", "application/json"])
+        self.assertEqual(result["responses"]["200"], {"description": "stream"})
+        self.assertEqual(result["responses"]["400"], {
+            "description": "bad request", "schema": {"$ref": "#/definitions/ErrorResponse"},
+            "examples": {"application/json": {"message": "bad archive"}},
+        })
+
+    def test_head_responses_have_headers_but_no_bodies(self):
+        result = project(self.spec)
+        for path in ("/_ping", "/containers/{id}/archive"):
+            head = result["paths"][path]["head"]
+            self.assertEqual(head["produces"], [])
+            self.assertTrue(head["responses"]["200"]["headers"])
+            for item in head["responses"].values():
+                self.assertNotIn("schema", item)
+                self.assertNotIn("examples", item)
+
+    def test_json_errors_contribute_to_operation_media_types(self):
+        paths = project(self.spec)["paths"]
+        self.assertEqual(paths["/_ping"]["get"]["produces"], ["text/plain", "application/json"])
+        self.assertEqual(paths["/containers/{id}/archive"]["get"]["produces"], ["application/x-tar", "application/json"])
+        self.assertEqual(paths["/containers/{id}/start"]["post"]["produces"], ["application/json"])
+        self.assertEqual(paths["/containers/{id}/resize"]["post"]["produces"], ["application/json"])
+
+    def test_unrepresentable_content_fails(self):
+        for content in (
+            {"application/json": {"schema": {"type": "object"}}, "text/plain": {"schema": {"type": "string"}}},
+            {"application/json": {"schema": {"type": "object"}}, "text/plain": {}},
+            {"application/json": {"itemSchema": {"type": "object"}}},
+        ):
+            with self.subTest(content=content), self.assertRaises(ValueError):
+                response({"description": "response", "content": content})
+
+    def test_unsupported_operation_fields_fail(self):
+        with self.assertRaises(ValueError):
+            operation({"callbacks": {}, "responses": {}}, {"consumes": [], "produces": []})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/scripts/validate-swagger-gen.sh
+++ b/api/scripts/validate-swagger-gen.sh
@@ -22,12 +22,16 @@ done
 
 cp "${API_DIR}/swagger.yaml" "${TMP_DIR}/"
 cp "${API_DIR}/swagger-gen.yaml" "${TMP_DIR}/"
+cp "${API_DIR}/go.mod" "${TMP_DIR}/"
 cp -r "${API_DIR}/templates" "${TMP_DIR}/" 2> /dev/null || true
 
 echo "Generating swagger types in temporary folder..."
 (
 	cd "${TMP_DIR}"
-	"${SCRIPT_DIR}/generate-swagger-api.sh" > /dev/null 2>&1
+	"${SCRIPT_DIR}/generate-swagger-api.sh" "${TMP_DIR}" > "${TMP_DIR}/generate.log" 2>&1 || {
+		cat "${TMP_DIR}/generate.log" >&2
+		exit 1
+	}
 )
 
 echo "Run diff for all generated files..."

--- a/api/scripts/validate-swagger-gen.sh
+++ b/api/scripts/validate-swagger-gen.sh
@@ -20,6 +20,7 @@ for f in "${GEN_FILES[@]}"; do
 	cp "$f" "${TMP_DIR}/${f#${API_DIR}/}"
 done
 
+cp "${API_DIR}/openapi.yaml" "${TMP_DIR}/"
 cp "${API_DIR}/swagger.yaml" "${TMP_DIR}/"
 cp "${API_DIR}/swagger-gen.yaml" "${TMP_DIR}/"
 cp "${API_DIR}/go.mod" "${TMP_DIR}/"

--- a/api/scripts/validate-swagger.sh
+++ b/api/scripts/validate-swagger.sh
@@ -4,13 +4,18 @@ set -e
 # Expected to be in api directory
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-echo "Validating swagger.yaml..."
+echo "Validating openapi.yaml..."
 
-yamllint -f parsable -c validate/yamllint.yaml swagger.yaml
+yamllint -f parsable -c validate/yamllint.yaml openapi.yaml
 
-if out=$(swagger validate swagger.yaml); then
+python3 -B -m unittest discover -s scripts -p '*_test.py'
+
+if out=$(openapi-spec-validator --schema 3.2 openapi.yaml); then
 	echo "Validation done! ${out}"
 else
 	echo "${out}" >&2
 	false
 fi
+
+echo "Validating swagger.yaml..."
+swagger validate swagger.yaml

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -10157,10 +10157,12 @@ paths:
             Apply `Dockerfile` instructions to the image that is created,
             for example: `changes=ENV DEBUG=true`.
             Note that `ENV DEBUG=true` should be URI component encoded.
+            Repeat the parameter to apply multiple instructions.
 
             Supported `Dockerfile` instructions:
             `CMD`|`ENTRYPOINT`|`ENV`|`EXPOSE`|`ONBUILD`|`USER`|`VOLUME`|`WORKDIR`
           type: "array"
+          collectionFormat: "multi"
           items:
             type: "string"
         - name: "platform"
@@ -10563,9 +10565,10 @@ paths:
           in: "query"
           description: |
             Select platform-specific content to delete.
-            Multiple values are accepted.
+            Repeat the parameter to select multiple platforms.
             Each platform is a OCI platform encoded as a JSON string.
           type: "array"
+          collectionFormat: "multi"
           items:
             # This should be OCIPlatform
             # but $ref is not supported for array in query in Swagger 2.0
@@ -11105,8 +11108,9 @@ paths:
       parameters:
         - name: "names"
           in: "query"
-          description: "Image names to filter by"
+          description: "Image names to filter by. Repeat the parameter for multiple images."
           type: "array"
+          collectionFormat: "multi"
           items:
             type: "string"
         - name: "platform"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8693,6 +8693,7 @@ paths:
       produces:
         - "application/vnd.docker.raw-stream"
         - "application/vnd.docker.multiplexed-stream"
+        - "application/json"
       operationId: "ContainerLogs"
       responses:
         200:
@@ -8811,6 +8812,7 @@ paths:
       operationId: "ContainerExport"
       produces:
         - "application/octet-stream"
+        - "application/json"
       responses:
         200:
           description: "no error"
@@ -8910,7 +8912,7 @@ paths:
       consumes:
         - "application/octet-stream"
       produces:
-        - "text/plain"
+        - "application/json"
       responses:
         200:
           description: "no error"
@@ -8979,6 +8981,8 @@ paths:
             single character `[a-Z]` or `ctrl-<value>` where `<value>` is one
             of: `a-z`, `@`, `^`, `[`, `,` or `_`.
           type: "string"
+      produces:
+        - "application/json"
       tags: ["Container"]
   /containers/{id}/stop:
     post:
@@ -9015,6 +9019,8 @@ paths:
           in: "query"
           description: "Number of seconds to wait before killing the container"
           type: "integer"
+      produces:
+        - "application/json"
       tags: ["Container"]
   /containers/{id}/restart:
     post:
@@ -9049,6 +9055,8 @@ paths:
           in: "query"
           description: "Number of seconds to wait before killing the container"
           type: "integer"
+      produces:
+        - "application/json"
       tags: ["Container"]
   /containers/{id}/kill:
     post:
@@ -9090,6 +9098,8 @@ paths:
             Signal to send to the container as an integer or string (e.g. `SIGINT`).
           type: "string"
           default: "SIGKILL"
+      produces:
+        - "application/json"
       tags: ["Container"]
   /containers/{id}/update:
     post:
@@ -9181,6 +9191,8 @@ paths:
           required: true
           description: "New name for the container"
           type: "string"
+      produces:
+        - "application/json"
       tags: ["Container"]
   /containers/{id}/pause:
     post:
@@ -9213,6 +9225,8 @@ paths:
           required: true
           description: "ID or name of the container"
           type: "string"
+      produces:
+        - "application/json"
       tags: ["Container"]
   /containers/{id}/unpause:
     post:
@@ -9239,6 +9253,8 @@ paths:
           required: true
           description: "ID or name of the container"
           type: "string"
+      produces:
+        - "application/json"
       tags: ["Container"]
   /containers/{id}/attach:
     post:
@@ -9343,6 +9359,7 @@ paths:
       produces:
         - "application/vnd.docker.raw-stream"
         - "application/vnd.docker.multiplexed-stream"
+        - "application/json"
       responses:
         101:
           description: "no error, hints proxy about hijacking"
@@ -9571,6 +9588,8 @@ paths:
           description: "Remove the specified link associated with the container."
           type: "boolean"
           default: false
+      produces:
+        - "application/json"
       tags: ["Container"]
   /containers/{id}/archive:
     head:
@@ -9591,19 +9610,10 @@ paths:
                 information about the path
         400:
           description: "Bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
         404:
           description: "Container or path does not exist"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-          examples:
-            application/json:
-              message: "No such container: c2ada9df5af8"
         500:
           description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
@@ -9615,12 +9625,15 @@ paths:
           required: true
           description: "Resource in the container’s filesystem to archive."
           type: "string"
+      produces: []
       tags: ["Container"]
     get:
       summary: "Get an archive of a filesystem resource in a container"
       description: "Get a tar archive of a resource in the filesystem of container id."
       operationId: "ContainerArchive"
-      produces: ["application/x-tar"]
+      produces:
+        - "application/x-tar"
+        - "application/json"
       responses:
         200:
           description: "no error"
@@ -10755,7 +10768,9 @@ paths:
       summary: "Ping"
       description: "This is a dummy endpoint you can use to test if the server is accessible."
       operationId: "SystemPing"
-      produces: ["text/plain"]
+      produces:
+        - "text/plain"
+        - "application/json"
       responses:
         200:
           description: "no error"
@@ -10811,13 +10826,10 @@ paths:
       summary: "Ping"
       description: "This is a dummy endpoint you can use to test if the server is accessible."
       operationId: "SystemPingHead"
-      produces: ["text/plain"]
+      produces: []
       responses:
         200:
           description: "no error"
-          schema:
-            type: "string"
-            example: "(empty)"
           headers:
             Api-Version:
               type: "string"
@@ -10843,8 +10855,6 @@ paths:
               default: "no-cache"
         500:
           description: "server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
       tags: ["System"]
   /commit:
     post:
@@ -10939,6 +10949,7 @@ paths:
         - "application/jsonl"
         - "application/x-ndjson"
         - "application/json-seq"
+        - "application/json"
       responses:
         200:
           description: "no error"
@@ -11048,6 +11059,7 @@ paths:
       operationId: "ImageGet"
       produces:
         - "application/x-tar"
+        - "application/json"
       responses:
         200:
           description: "no error"
@@ -11095,6 +11107,7 @@ paths:
       operationId: "ImageGetAll"
       produces:
         - "application/x-tar"
+        - "application/json"
       responses:
         200:
           description: "no error"
@@ -11293,6 +11306,7 @@ paths:
       produces:
         - "application/vnd.docker.raw-stream"
         - "application/vnd.docker.multiplexed-stream"
+        - "application/json"
       responses:
         200:
           description: "No error"
@@ -11618,6 +11632,8 @@ paths:
           description: "Force the removal of the volume"
           type: "boolean"
           default: false
+      produces:
+        - "application/json"
       tags: ["Volume"]
 
   /volumes/prune:
@@ -11817,6 +11833,8 @@ paths:
           description: "Network ID or name"
           required: true
           type: "string"
+      produces:
+        - "application/json"
       tags: ["Network"]
 
   /networks/create:
@@ -12351,6 +12369,8 @@ paths:
                 Description: ""
                 Value:
                   - "/dev/cpu_dma_latency"
+      produces:
+        - "application/json"
       tags: ["Plugin"]
   /plugins/create:
     post:
@@ -12379,6 +12399,8 @@ paths:
           schema:
             type: "string"
             format: "binary"
+      produces:
+        - "application/json"
       tags: ["Plugin"]
   /plugins/{name}/push:
     post:
@@ -12438,6 +12460,8 @@ paths:
           description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
+      produces:
+        - "application/json"
       tags: ["Plugin"]
   /nodes:
     get:
@@ -13248,6 +13272,7 @@ paths:
       produces:
         - "application/vnd.docker.raw-stream"
         - "application/vnd.docker.multiplexed-stream"
+        - "application/json"
       operationId: "ServiceLogs"
       responses:
         200:
@@ -13506,6 +13531,7 @@ paths:
       produces:
         - "application/vnd.docker.raw-stream"
         - "application/vnd.docker.multiplexed-stream"
+        - "application/json"
       responses:
         200:
           description: "logs returned as a stream in response body"
@@ -14052,6 +14078,7 @@ paths:
       operationId: "Session"
       produces:
         - "application/vnd.docker.raw-stream"
+        - "application/json"
       responses:
         101:
           description: "no error, hijacking successful"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -12622,9 +12622,6 @@ paths:
     post:
       summary: "Initialize a new swarm"
       operationId: "SwarmInit"
-      produces:
-        - "application/json"
-        - "text/plain"
       responses:
         200:
           description: "no error"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -7707,7 +7707,6 @@ definitions:
         description: |
           List of ID's and addresses of other managers in the swarm.
         type: "array"
-        default: null
         x-nullable: true
         items:
           $ref: "#/definitions/PeerNode"

--- a/hack/validate/module-replace
+++ b/hack/validate/module-replace
@@ -17,6 +17,7 @@ api_diff=$(
 		':(exclude)api/Dockerfile' \
 		':(exclude)api/README.md' \
 		':(exclude)api/swagger.yaml' \
+		':(exclude)api/openapi.yaml' \
 		':(exclude)api/docs/' \
 		| filter_diff \
 		|| true


### PR DESCRIPTION
- needed by: https://github.com/docker/docs/pull/26048
- stacked on: https://github.com/moby/moby/pull/53629
- stacked on: https://github.com/moby/moby/pull/53626

## Summary

Make `api/openapi.yaml` the source of truth for the Engine API specification, using OpenAPI 3.2.0 with the OpenAPI 3.1 schema dialect.

- Generate the complete Swagger 2.0 compatibility specification at `api/swagger.yaml`, which remains the input to go-swagger.
- Preserve schema property order, custom formats, examples, and Go generator annotations. Generated Go models and historical `api/docs/v*.yaml` specifications remain unchanged.
- Validate both specifications and check that the checked-in Swagger matches the OpenAPI projection.
- Preserve existing Swagger formatting when its content is unchanged.
- Switch the documentation preview to OpenAPI and update Redoc to v2.5.3.
- Keep generation isolated during validation by passing a temporary API directory to the source-tree scripts.

This changes the specification format and tooling, not daemon behavior. Swagger 2.0 cannot express media types per response, so the compatibility document lists their union per operation.

### Validation

- OpenAPI and Swagger specification validation.
- All 21 converter tests, including specification equivalence, source updates, property-order preservation, and the resize response regression.
- Generated-model validation with the source tree mounted read-only.
- No-argument generation remains supported; generated Go models are unchanged.

## Release notes (optional)

```markdown changelog
Provide an OpenAPI 3.2 specification for the Engine API while retaining a generated Swagger 2.0 compatibility specification.
```

Assisted by: GPT 6 Astra