### PR TITLE
daemon/internal/stream: don't hold the broadcaster lock across writes

### DIFF
--- a/daemon/internal/stream/unbuffered.go
+++ b/daemon/internal/stream/unbuffered.go
@@ -2,48 +2,76 @@ package stream
 
 import (
 	"io"
+	"slices"
 	"sync"
 )
 
+// writerEntry wraps a writer so eviction can use pointer identity instead of
+// interface equality, which would panic on non-comparable dynamic types and
+// would collapse eviction of distinct-but-equal writer values.
+type writerEntry struct{ w io.WriteCloser }
+
 // unbuffered accumulates multiple io.WriteCloser by stream.
+//
+// mu guards only the writers slice: no I/O call (Write or Close) is ever
+// made while mu is held, so Clean is always bounded even if a writer's
+// Write blocks (e.g. a bytespipe under backpressure). writeMu serializes
+// Write calls so writes still reach writers in order; Clean never takes it.
 type unbuffered struct {
+	writeMu sync.Mutex
+
 	mu      sync.Mutex
-	writers []io.WriteCloser
+	writers []*writerEntry
 }
 
 // Add adds new io.WriteCloser.
 func (w *unbuffered) Add(writer io.WriteCloser) {
 	w.mu.Lock()
-	w.writers = append(w.writers, writer)
+	w.writers = append(w.writers, &writerEntry{writer})
 	w.mu.Unlock()
 }
 
 // Write writes bytes to all writers. Failed writers will be evicted during
-// this call.
+// this call. The write to each writer happens without w.mu held, so a
+// writer that blocks (e.g. backpressure on an attached client) does not
+// prevent a concurrent Clean from closing writers and returning.
 func (w *unbuffered) Write(p []byte) (int, error) {
+	w.writeMu.Lock()
+	defer w.writeMu.Unlock()
+
 	w.mu.Lock()
-	var evict []int
-	for i, sw := range w.writers {
-		if n, err := sw.Write(p); err != nil || n != len(p) {
+	writers := slices.Clone(w.writers)
+	w.mu.Unlock()
+
+	var failed []*writerEntry
+	for _, e := range writers {
+		if n, err := e.w.Write(p); err != nil || n != len(p) {
 			// On error, evict the writer
-			evict = append(evict, i)
+			failed = append(failed, e)
 		}
 	}
-	for n, i := range evict {
-		w.writers = append(w.writers[:i-n], w.writers[i-n+1:]...)
+	if len(failed) > 0 {
+		w.mu.Lock()
+		w.writers = slices.DeleteFunc(w.writers, func(e *writerEntry) bool {
+			return slices.Contains(failed, e)
+		})
+		w.mu.Unlock()
 	}
-	w.mu.Unlock()
 	return len(p), nil
 }
 
 // Clean closes and removes all writers. Last non-eol-terminated part of data
-// will be saved.
+// will be saved. Writers are closed without w.mu held, so a writer whose
+// Write is currently blocked in another goroutine does not make Clean
+// block: closing it is expected to unblock that Write instead.
 func (w *unbuffered) Clean() error {
 	w.mu.Lock()
-	for _, sw := range w.writers {
-		sw.Close()
-	}
+	writers := w.writers
 	w.writers = nil
 	w.mu.Unlock()
+
+	for _, e := range writers {
+		e.w.Close()
+	}
 	return nil
 }

--- a/daemon/internal/stream/unbuffered_test.go
+++ b/daemon/internal/stream/unbuffered_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 type dummyWriter struct {
@@ -125,6 +128,157 @@ func TestRaceUnbuffered(t *testing.T) {
 		t.Error(err)
 	}
 	<-c
+}
+
+// blockingWriter models bytespipe's backpressure behaviour: Write parks
+// until Close is called, then returns an error, exactly like BytesPipe.Write
+// unblocking with ErrClosed once the pipe is closed.
+type blockingWriter struct {
+	mu      sync.Mutex
+	cond    *sync.Cond
+	closed  bool
+	closes  atomic.Int32
+	started chan struct{}
+}
+
+func newBlockingWriter() *blockingWriter {
+	w := &blockingWriter{started: make(chan struct{}, 1)}
+	w.cond = sync.NewCond(&w.mu)
+	return w
+}
+
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	w.started <- struct{}{}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for !w.closed {
+		w.cond.Wait()
+	}
+	return 0, errClosedBlockingWriter
+}
+
+func (w *blockingWriter) Close() error {
+	w.mu.Lock()
+	w.closed = true
+	w.mu.Unlock()
+	w.cond.Broadcast()
+	w.closes.Add(1)
+	return nil
+}
+
+var errClosedBlockingWriter = errors.New("blockingWriter: closed")
+
+// waitOrFatal waits for done to close, or fails the test if it does not
+// happen within the timeout.
+func waitOrFatal(t *testing.T, done <-chan struct{}, timeout time.Duration, msg string) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal(msg)
+	}
+}
+
+// TestUnbufferedCleanWithBlockedWriter reproduces moby/moby#53614: an exec's
+// exit handler calls Config.CloseStreams -> unbuffered.Clean while a copier
+// goroutine is blocked inside Write on an attached client's bytespipe that
+// has hit backpressure (the client stopped reading). Clean must not hold
+// the same lock that the blocked Write holds, otherwise it never returns,
+// and because libcontainerd serialises events per container ID, every
+// subsequent event for that container wedges behind it.
+func TestUnbufferedCleanWithBlockedWriter(t *testing.T) {
+	w := new(unbuffered)
+	normal := &dummyWriter{}
+	blocked := newBlockingWriter()
+	w.Add(normal)
+	w.Add(blocked)
+
+	writeDone := make(chan struct{})
+	go func() {
+		w.Write([]byte("data"))
+		close(writeDone)
+	}()
+
+	waitOrFatal(t, blocked.started, 10*time.Second, "blockingWriter.Write never started")
+
+	cleanDone := make(chan struct{})
+	go func() {
+		w.Clean()
+		close(cleanDone)
+	}()
+	waitOrFatal(t, cleanDone, 10*time.Second, "Clean() blocked; see moby/moby#53614")
+
+	waitOrFatal(t, writeDone, 10*time.Second, "blocked Write did not unwind after Clean")
+
+	if got := blocked.closes.Load(); got != 1 {
+		t.Errorf("blockingWriter closed %d times, want 1", got)
+	}
+
+	if normal.String() != "data" {
+		t.Errorf("normal writer contains %q, want %q", normal.String(), "data")
+	}
+
+	if _, err := w.Write([]byte("x")); err != nil {
+		t.Errorf("Write after Clean returned error: %v", err)
+	}
+}
+
+// overlapWriter detects whether two Write calls ever ran concurrently
+// against it. inProgress is flipped on entry and cleared on exit; a short
+// sleep in between widens the window so a missing writeMu shows up as
+// observed overlap, not just as a race-detector-only issue.
+type overlapWriter struct {
+	inProgress atomic.Bool
+	overlap    atomic.Bool
+	count      atomic.Int64
+}
+
+func (w *overlapWriter) Write(p []byte) (int, error) {
+	if w.inProgress.Swap(true) {
+		w.overlap.Store(true)
+	}
+	time.Sleep(time.Millisecond)
+	w.inProgress.Store(false)
+	w.count.Add(1)
+	return len(p), nil
+}
+
+func (w *overlapWriter) Close() error { return nil }
+
+// TestUnbufferedConcurrentWrites exercises the writeMu ordering guarantee:
+// concurrent Write calls on unbuffered must serialize before reaching the
+// underlying writer, so the writer never observes two Write calls in
+// flight at once.
+func TestUnbufferedConcurrentWrites(t *testing.T) {
+	const goroutines = 8
+	const iterations = 20
+
+	rec := &overlapWriter{}
+	w := new(unbuffered)
+	w.Add(rec)
+
+	payload := []byte("payload")
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				if _, err := w.Write(payload); err != nil {
+					t.Error(err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got, want := rec.count.Load(), int64(goroutines*iterations); got != want {
+		t.Fatalf("got %d writes delivered, want %d", got, want)
+	}
+	if rec.overlap.Load() {
+		t.Error("concurrent Write calls overlapped in the underlying writer; writeMu did not serialize them")
+	}
 }
 
 func BenchmarkUnbuffered(b *testing.B) {


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/53614

## Summary

`unbuffered.Write` in `daemon/internal/stream` held the broadcaster mutex while writing to every attached writer. An attached client's writer is a `bytespipe`, which blocks its writer once the buffered data reaches `blockThreshold`. When a client attaches to an exec and stops reading, the stdout copier parks inside `Write` with the mutex held, and the exec exit handler then parks in `Clean` waiting for that mutex. Because libcontainerd serialises events per container, every later event for that container queues behind the wedged handler: no further exec completes and the container's own exit event never lands.

`Write` now snapshots the writers under the mutex, writes to them unlocked, and evicts the failed ones afterwards (by identity, through a small wrapper, since `io.WriteCloser` values are not always comparable). A second mutex keeps concurrent `Write` calls serialised so writers still see them in order. `Clean` detaches the writers under the mutex and closes them unlocked. Closing the `bytespipe` unblocks the parked copier, whose write then fails and is evicted as before.

Tests:
- `TestUnbufferedCleanWithBlockedWriter` reproduces the deadlock with a writer that blocks until closed. On master it fails at its 10 s bound (`Clean() blocked; see moby/moby#53614`); with this change it passes.
- `TestUnbufferedConcurrentWrites` checks that `Write` calls never overlap in the underlying writer. With the serialising mutex removed it fails; with it present it passes.
- `go test -race -count=3 ./daemon/internal/stream/` and `golangci-lint run ./daemon/internal/stream/...` (v2.8.0, the Dockerfile's pin) are clean.

## Release notes (optional)

```markdown changelog
- Fix the daemon no longer processing events for a container after a client stopped reading from an attached exec.
```

This change was produced with no_human (Claude models: claude-sonnet-5 coder, claude-opus-4-8 reviewer, claude-opus-5 planner). The operator read the full diff, ran `go test -race -count=1 -v ./daemon/internal/stream/...` on the squashed commit (`ok github.com/moby/moby/v2/daemon/internal/stream 1.868s`, `ok .../stream/bytespipe 2.284s`) and can explain every line.

Created with: no_human
